### PR TITLE
Enable storage of tobacco.

### DIFF
--- a/components/benefit_markets/app/models/benefit_markets/products/premium_tuple.rb
+++ b/components/benefit_markets/app/models/benefit_markets/products/premium_tuple.rb
@@ -9,6 +9,9 @@ module BenefitMarkets
     field :age,   type: Integer
     field :cost,  type: Float
 
+    # Allowed values are 'Y', 'N', or nil for 'NA'
+    field :tobacco_use, type: String
+
     validates_presence_of :age, :cost
 
     default_scope   ->{ order(:"age".asc) }
@@ -26,6 +29,10 @@ module BenefitMarkets
       else
         other.updated_at.blank? || (updated_at < other.updated_at) ? -1 : 1
       end
+    end
+
+    def tobacco_use_value
+      tobacco_use.blank? ? "NA" : tobacco_use
     end
   end
 end

--- a/components/benefit_markets/app/models/benefit_markets/products/product_rate_cache.rb
+++ b/components/benefit_markets/app/models/benefit_markets/products/product_rate_cache.rb
@@ -3,12 +3,17 @@ module BenefitMarkets
     # Provides a cached, efficient lookup for referencing rate values
     # by multiple keys.
     class ProductRateCache
+      # rubocop:disable Style/GlobalVars
       def self.initialize_rate_cache!
         $product_rate_age_bounding_cache = Hash.new 
         $product_rate_calculation_cache = Hash.new do |h, k|
           h[k] = (Hash.new do |h2, k2|
             h2[k2] = (Hash.new do |h3, k3|
-              h3[k3] = Array.new
+              h3[k3] = (Hash.new do |h4, k4|
+                # rubocop:disable Style/EmptyLiteral
+                h4[k4] = Array.new
+                # rubocop:enable Style/EmptyLiteral
+              end)
             end)
           end)
         end
@@ -24,8 +29,8 @@ module BenefitMarkets
           product.premium_tables.each do |pt|
             r_area_tag = rating_area_cache[pt.rating_area_id]
             pt.premium_tuples.each do |tuple|
-              $product_rate_calculation_cache[product.id][r_area_tag][tuple.age] = (
-                $product_rate_calculation_cache[product.id][r_area_tag][tuple.age] + 
+              $product_rate_calculation_cache[product.id][r_area_tag][tuple.age][tuple.tobacco_use_value] = (
+                $product_rate_calculation_cache[product.id][r_area_tag][tuple.age][tuple.tobacco_use_value] +
                 [{
                   start_on: pt.effective_period.min,
                   end_on: pt.effective_period.max,
@@ -45,7 +50,7 @@ module BenefitMarkets
       end
 
       #This one is only for manual lookup if age record is not found
-      def self.single_lookup_rate(product, rate_schedule_date, rating_area, coverage_age)
+      def self.single_lookup_rate(product, rate_schedule_date, rating_area, coverage_age, tobacco_use)
         calc_age = age_bounding(product.id, coverage_age)
         rate_calculation = product.premium_tables.collect do |pt|
           pt.premium_tuples.collect do |tuple|
@@ -54,13 +59,18 @@ module BenefitMarkets
               end_on: pt.effective_period.max,
               cost: tuple.cost,
               age: tuple.age,
+              tobacco_use: tuple.tobacco_use_value,
               rating_area: pt.rating_area.exchange_provided_code
             }]
           end
         end.flatten
 
         rate_calculation.detect do |rc|
-          rc[:age] == calc_age && rc[:rating_area] == rating_area && rc[:start_on] <= rate_schedule_date && rc[:end_on] >= rate_schedule_date
+          rc[:age] == calc_age &&
+            rc[:rating_area] == rating_area &&
+            rc[:start_on] <= rate_schedule_date &&
+            rc[:end_on] >= rate_schedule_date &&
+            rc[:tobacco_use] == tobacco_use
         end
       end
 
@@ -71,25 +81,28 @@ module BenefitMarkets
       # @param coverage_age [Integer] the age of the covered party on the
       #   applicable date
       # @param rating_area [String] the rating area in which the rates apply
+      # @param tobacco_use [String] the tobacco use, is 'NA', 'Y', or 'N'
       # @return [Float, BigDecimal] the basis rate
       def self.lookup_rate(
         product,
         rate_schedule_date,
         coverage_age,
-        rating_area
+        rating_area,
+        tobacco_use = 'NA'
       )
         calc_age = age_bounding(product.id, coverage_age)
-        age_record = $product_rate_calculation_cache[product.id][rating_area][calc_age].detect do |pt|
+        age_record = $product_rate_calculation_cache[product.id][rating_area][calc_age][tobacco_use].detect do |pt|
           (pt[:start_on] <= rate_schedule_date) && (pt[:end_on] >= rate_schedule_date)
         end
 
         unless age_record.present?
           #This one is only for manual lookup if age record is not found
-          age_record = single_lookup_rate(product, rate_schedule_date, rating_area, coverage_age)
+          age_record = single_lookup_rate(product, rate_schedule_date, rating_area, coverage_age, tobacco_use)
         end
 
         age_record[:cost]
       end
+      # rubocop:enable Style/GlobalVars
     end
   end
 end


### PR DESCRIPTION
This enables storage of tobacco rate lookup in products while:
* Allowing existing lookups to continue functioning
* Requiring no database updates to already existing data

https://www.pivotaltracker.com/story/show/177515562