### PR TITLE
Benefit Sponsors Profile Registration Fix

### DIFF
--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/registrations_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/registrations_controller.rb
@@ -80,7 +80,7 @@ module BenefitSponsors
 
       def profile_type
         valid_profile_types = %w[benefit_sponsor broker_agency general_agency].freeze
-        profile_type_constant_name = params[:profile_type] || params[:agency][:profile_type] || @agency.profile_type
+        profile_type_constant_name = params[:profile_type] || params.dig(:agency, :profile_type) || @agency.profile_type
         @profile_type = (profile_type_constant_name if valid_profile_types.include?(profile_type_constant_name))
       end
 


### PR DESCRIPTION
There was an exception when profiles were registered without any agency type at all. The fallback is to use the instance's pre-existing profile_type however if the params hash is empty it wouldn't work.