### PR TITLE
GeneralAgencyProfilesControllerPolicy Fix

### DIFF
--- a/components/benefit_sponsors/app/policies/benefit_sponsors/profiles/general_agencies/general_agency_profiles_controller_policy.rb
+++ b/components/benefit_sponsors/app/policies/benefit_sponsors/profiles/general_agencies/general_agency_profiles_controller_policy.rb
@@ -4,6 +4,7 @@ module BenefitSponsors
       class GeneralAgencyProfilesControllerPolicy < ApplicationPolicy
 
         def families?
+          return false if user.blank?
           return user.has_hbx_staff_role? || user.has_general_agency_staff_role?
         end
 


### PR DESCRIPTION
The `GeneralAgencyProfilesControllerPolicy` `families?` method would break if user was blank. This should just return false instead of a raising an exception.