### PR TITLE
Add tobacco check and rating area lookup.

### DIFF
--- a/app/models/hbx_enrollment_member.rb
+++ b/app/models/hbx_enrollment_member.rb
@@ -19,6 +19,9 @@ class HbxEnrollmentMember
   field :coverage_start_on, type: Date
   field :coverage_end_on, type: Date
 
+  # Allowed values are 'Y', 'N', or nil for 'NA'
+  field :tobacco_use, type: String
+
   validates_presence_of :applicant_id, :is_subscriber, :eligibility_date,# :premium_amount,
     :coverage_start_on
 
@@ -110,6 +113,10 @@ class HbxEnrollmentMember
       return false unless coverage_relationship_check(dental_relationship_benefits, family_member, hbx_enrollment.benefit_group.effective_on_for(hbx_enrollment.employee_role.hired_on))
     end
     true
+  end
+
+  def tobacco_use_value
+    tobacco_use.blank? ? "NA" : tobacco_use
   end
 
   private

--- a/app/models/unassisted_plan_cost_decorator.rb
+++ b/app/models/unassisted_plan_cost_decorator.rb
@@ -41,20 +41,17 @@ class UnassistedPlanCostDecorator < SimpleDelegator
   end
 
   def rating_area
-    used_address = hbx_enrollment.consumer_role.rating_address
-    rating_area = ::BenefitMarkets::Locations::RatingArea.rating_area_for(used_address, during: schedule_date)
-    #  .where(active_year: __getobj__.active_year).detect{|a| a.county_zip_ids.include?(county_id)}
-    # rating_area.exchange_provided_code.present? ? rating_area.exchange_provided_code : __getobj__.premium_tables.first.rating_area.exchange_provided_code
-    if rating_area
-      rating_area.exchange_provided_code
-    else
+    geographic_rating_area_model = EnrollRegistry[:enroll_app].setting(:geographic_rating_area_model).item
+    if geographic_rating_area_model == 'single'
       __getobj__.premium_tables.first.rating_area.exchange_provided_code
+    else
+      hbx_enrollment.rating_area.exchange_provided_code
     end
   end
 
   #TODO: FIX me to refactor hard coded rating area
   def premium_for(member)
-    (::BenefitMarkets::Products::ProductRateCache.lookup_rate(__getobj__, schedule_date, age_of(member), rating_area) * large_family_factor(member)).round(2)
+    (::BenefitMarkets::Products::ProductRateCache.lookup_rate(__getobj__, schedule_date, age_of(member), rating_area, tobacco_use_for(member)) * large_family_factor(member)).round(2)
     # FIXME
   rescue StandardError => e
     warn e.inspect
@@ -64,6 +61,10 @@ class UnassistedPlanCostDecorator < SimpleDelegator
 
   def employer_contribution_for(_member)
     0.00
+  end
+
+  def tobacco_use_for(member)
+    member.tobacco_use
   end
 
   def all_members_aptc_for_saved_enrs


### PR DESCRIPTION
Add a place to 'freeze' tobacco ratings into the enrollment at time of product selection.

Update the calculator to use the tobacco value.

Provide defaults that require no migration of DC data.

Fix calculations to use 'frozen' IVL rating area selected at time of product selection.