### PR TITLE
L10n helper spec add

### DIFF
--- a/app/helpers/l10n_helper.rb
+++ b/app/helpers/l10n_helper.rb
@@ -1,5 +1,7 @@
 module L10nHelper
   def l10n(translation_key, interpolated_keys={})
+    Rails.logger.error {"#L10nHelper passed non string key: #{translation_key.inspect}"} unless translation_key.is_a?(String)
+    return "Translation Missing" unless translation_key.is_a?(String)
     t(translation_key, interpolated_keys.merge(default: translation_key.gsub(/\W+/, '').titleize)).html_safe
   end
 end

--- a/app/helpers/l10n_helper.rb
+++ b/app/helpers/l10n_helper.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module L10nHelper
-  def l10n(translation_key, interpolated_keys={})
+  def l10n(translation_key, interpolated_keys = {})
     Rails.logger.error {"#L10nHelper passed non string key: #{translation_key.inspect}"} unless translation_key.is_a?(String)
     return "Translation Missing" unless translation_key.is_a?(String)
     t(translation_key, interpolated_keys.merge(default: translation_key.gsub(/\W+/, '').titleize)).html_safe

--- a/spec/helpers/l10n_helper_spec.rb
+++ b/spec/helpers/l10n_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe L10nHelper, :type => :helper do
+  # All translations are configured to load before every rspec
+  it "should translate existing translations" do
+    expect(helper.l10n('date')).to eq("Date")
+  end
+
+  it "should handle non existent translations gracefully" do
+    expect(helper.l10n('pizza')).to eq("Pizza")
+  end
+
+  it "should handle non string translation keys gracefully" do
+    expect(helper.l10n({:formats=>{:default=>"%m/%d/%Y"}})).to eq("")
+
+  end
+end

--- a/spec/helpers/l10n_helper_spec.rb
+++ b/spec/helpers/l10n_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe L10nHelper, :type => :helper do
   end
 
   it "should handle non string translation keys gracefully" do
-    expect(helper.l10n({:formats=>{:default=>"%m/%d/%Y"}})).to eq('Translation Missing')
+    expect(helper.l10n({:formats => {:default => "%m/%d/%Y"}})).to eq('Translation Missing')
 
   end
 end

--- a/spec/helpers/l10n_helper_spec.rb
+++ b/spec/helpers/l10n_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe L10nHelper, :type => :helper do
   end
 
   it "should handle non string translation keys gracefully" do
-    expect(helper.l10n({:formats=>{:default=>"%m/%d/%Y"}})).to eq("")
+    expect(helper.l10n({:formats=>{:default=>"%m/%d/%Y"}})).to eq('Translation Missing')
 
   end
 end

--- a/spec/helpers/l10n_helper_spec.rb
+++ b/spec/helpers/l10n_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe L10nHelper, :type => :helper do


### PR DESCRIPTION
This should help fix l10n helper when it encounters the weird situation where a hash has been returned or at least log it better for troubleshooting. This pull request is just moving @ZASMan's old one from [dchbx](https://github.com/dchbx/enroll/pull/4285).