### PR TITLE
let rating_area_for use default 'during' when enrollment.effective_on is nil

### DIFF
--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -1710,7 +1710,7 @@ class HbxEnrollment
             "You may not enroll unless it’s open enrollment or you’re eligible for a special enrollment period."
           )
         end
-        enrollment.rating_area_id = ::BenefitMarkets::Locations::RatingArea.rating_area_for(consumer_role.rating_address, during: enrollment.effective_on)&.id
+        enrollment.rating_area_id = ::BenefitMarkets::Locations::RatingArea.rating_area_for(consumer_role.rating_address)&.id
       when resident_role.present?
         enrollment.kind = "coverall"
         enrollment.resident_role = resident_role


### PR DESCRIPTION
### Master Redmine ticket
* (Required!)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
