### PR TITLE
run docs job only manually

### DIFF
--- a/.github/workflows/yard-doc.yml
+++ b/.github/workflows/yard-doc.yml
@@ -1,10 +1,6 @@
 name: yard doc generation
 on:
-  push:
-    paths:
-      - "hugo/**"
-    branches:
-      - trunk
+  workflow_dispatch:
 
 jobs:
   docs_deployment:


### PR DESCRIPTION
stops yard doc job from running while we fix the workflow file