### PR TITLE
fix plan display based on the variants -  178867373

### DIFF
--- a/components/benefit_markets/app/models/benefit_markets/products/product.rb
+++ b/components/benefit_markets/app/models/benefit_markets/products/product.rb
@@ -129,6 +129,7 @@ module BenefitMarkets
     # ex: application_period --> [2018-02-01 00:00:00 UTC..2019-01-31 00:00:00 UTC]
     #     BenefitProduct avilable for both 2018 and 2019
     # output: might pull multiple records
+<<<<<<< HEAD
       scope :by_application_period,       lambda { |application_period|
         where(
           "$or" => [
@@ -153,9 +154,10 @@ module BenefitMarkets
                         {:metal_level_kind => :silver, :csr_variant_id => CSR_KIND_TO_PRODUCT_VARIANT_MAP[csr_kind]}])
       }
 
-      scope :by_csr_kind_with_02_03_variant, lambda {|csr_kind = 'csr_0'|
-        where('$or' => [{:metal_level_kind.in => [:platinum, :gold, :bronze, :catastrophic], :csr_variant_id => '01'},
-                        {:metal_level_kind.in => [:silver, :platinum, :gold, :bronze, :catastrophic], :csr_variant_id => CSR_KIND_TO_PRODUCT_VARIANT_MAP[csr_kind]}])
+      #If the shopping household is eligible for -02 or -03,
+      #then -02 or -03 variants should display for all metal levels.
+      scope :by_csr_kind, lambda {|csr_kind|
+        where(:metal_level_kind.in => [:silver, :platinum, :gold, :bronze, :catastrophic], :csr_variant_id => CSR_KIND_TO_PRODUCT_VARIANT_MAP[csr_kind])
       }
 
     #Products retrieval by type

--- a/components/benefit_markets/app/models/benefit_markets/products/product.rb
+++ b/components/benefit_markets/app/models/benefit_markets/products/product.rb
@@ -129,7 +129,6 @@ module BenefitMarkets
     # ex: application_period --> [2018-02-01 00:00:00 UTC..2019-01-31 00:00:00 UTC]
     #     BenefitProduct avilable for both 2018 and 2019
     # output: might pull multiple records
-<<<<<<< HEAD
       scope :by_application_period,       lambda { |application_period|
         where(
           "$or" => [

--- a/components/benefit_markets/app/models/benefit_markets/products/product_factory.rb
+++ b/components/benefit_markets/app/models/benefit_markets/products/product_factory.rb
@@ -49,7 +49,7 @@ module BenefitMarkets
       csr_list = ['csr_100','csr_limited']
       products_with_premium_tables = by_coverage_kind_and_year(coverage_kind, active_year).with_premium_tables
       return products_with_premium_tables if coverage_kind != 'health'
-      return products_with_premium_tables.by_csr_kind_with_02_03_variant(csr_kind) if csr_list.include?(csr_kind)
+      return products_with_premium_tables.by_csr_kind(csr_kind) if csr_list.include?(csr_kind)
       products_with_premium_tables.by_csr_kind_with_catastrophic(csr_kind)
     end
 

--- a/components/benefit_markets/spec/models/benefit_markets/products/product_factory_spec.rb
+++ b/components/benefit_markets/spec/models/benefit_markets/products/product_factory_spec.rb
@@ -74,23 +74,23 @@ module BenefitMarkets
 
       context 'by_coverage_kind_year_and_csr' do
         it 'should return all default csr products' do
-          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: nil).count).to eq 3
+          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: nil)).to eq [product1,product2,product3]
         end
 
         it 'should return all product along with product having csr 87' do
-          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_87").count).to eq 4
+          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_87")).to eq [product1,product2,product3,product4]
         end
 
-        it 'should return all product along with product having csr 73' do
-          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_94").count).to eq 4
+        it 'should return all product along with product having csr 94' do
+          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_94")).to eq [product1,product2,product3,product15]
         end
 
         it 'should return all product along with product having csr 100' do
-          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_100").count).to eq 4
+          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_100")).to eq [product5,product6,product7,product8]
         end
 
         it 'should return all product along with product having csr limited' do
-          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_limited").count).to eq 4
+          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_limited")).to eq [product9,product10,product11,product12]
         end
       end
 

--- a/components/benefit_markets/spec/models/benefit_markets/products/product_factory_spec.rb
+++ b/components/benefit_markets/spec/models/benefit_markets/products/product_factory_spec.rb
@@ -62,6 +62,12 @@ module BenefitMarkets
       let!(:product11) {FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health, metal_level_kind: :bronze, csr_variant_id: '03')}
       let!(:product12) {FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health, metal_level_kind: :platinum, csr_variant_id: '03')}
 
+      let!(:product13) {FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health, metal_level_kind: :silver, csr_variant_id: '04')}
+      let!(:product14) {FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health, metal_level_kind: :platinum, csr_variant_id: '04')}
+
+      let!(:product15) {FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health, metal_level_kind: :silver, csr_variant_id: '06')}
+      let!(:product16) {FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health, metal_level_kind: :platinum, csr_variant_id: '06')}
+
       before do
         @products = product_factory.new({market_kind: "individual"})
       end
@@ -75,18 +81,22 @@ module BenefitMarkets
           expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_87").count).to eq 4
         end
 
+        it 'should return all product along with product having csr 73' do
+          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_94").count).to eq 4
+        end
+
         it 'should return all product along with product having csr 100' do
-          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_100").count).to eq 7
+          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_100").count).to eq 4
         end
 
         it 'should return all product along with product having csr limited' do
-          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_limited").count).to eq 7
+          expect(@products.by_coverage_kind_year_and_csr('health', TimeKeeper.date_of_record.year, csr_kind: "csr_limited").count).to eq 4
         end
       end
 
       context 'by_coverage_kind_and_year' do
         it 'should return health products' do
-          expect(@products.by_coverage_kind_and_year('health', TimeKeeper.date_of_record.year).count).to eq 12
+          expect(@products.by_coverage_kind_and_year('health', TimeKeeper.date_of_record.year).count).to eq 16
         end
 
         it 'should return deltal products' do


### PR DESCRIPTION
If the shopping household is eligible for -02 or -03, then -02 or -03 variants should display for all metal levels. AI/AN CSR operates different from the other types
If the shopping household is eligible for -04, -05, or -06, this only applies to silver plans. Silver plans should be the CSR variant, all other metal levels should be -01.
