### PR TITLE
ref: 179439034 Adds check to determine csr variant on product for hou…

### DIFF
--- a/app/models/enrollments/replicator/reinstatement.rb
+++ b/app/models/enrollments/replicator/reinstatement.rb
@@ -141,11 +141,22 @@ module Enrollments
       def form_ivl_params
         # TODO: Query is too long
         # TODO: undefined local variable or method `year' for #<Enrollments::Replicator::Reinstatement:0x00007fca4bcb2970>
+        new_product_id = base_enrollment.is_ivl_by_kind? ? product_id_csr_variant(base_enrollment) : base_enrollment.product_id
         {
-          product_id: base_enrollment.product_id,
+          product_id: new_product_id,
           consumer_role_id: base_enrollment.consumer_role_id,
           rating_area_id: ::BenefitMarkets::Locations::RatingArea.rating_area_for(base_enrollment.consumer_role.rating_address, during: new_effective_date)&.id
         }
+      end
+
+      def product_id_csr_variant(base_enrollment)
+        tax_household = base_enrollment.family.active_household.latest_active_thh_with_year(@year)
+        base_enrollment_product_id = base_enrollment.product_id
+        return base_enrollment_product_id unless tax_household.present?
+        eligible_csr = tax_household.eligibile_csr_kind(base_enrollment.hbx_enrollment_members.map(&:applicant_id))
+        csr_variant = EligibilityDetermination::CSR_KIND_TO_PLAN_VARIANT_MAP[eligible_csr]
+        products = ::BenefitMarkets::Products::HealthProducts::HealthProduct.by_year(@year).where({:hios_id => "#{base_enrollment.product.hios_base_id}-#{csr_variant}"})
+        products.count >= 1 ? products.last.id : base_enrollment_product_id
       end
 
       def common_params

--- a/spec/models/insured/forms/self_term_or_cancel_form_spec.rb
+++ b/spec/models/insured/forms/self_term_or_cancel_form_spec.rb
@@ -10,6 +10,62 @@ module Insured
       EnrollRegistry[:apply_aggregate_to_enrollment].feature.stub(:is_enabled).and_return(false)
     end
 
+    let!(:rating_area) do
+      ::BenefitMarkets::Locations::RatingArea.rating_area_for(address, during: start_on) || FactoryBot.create_default(:benefit_markets_locations_rating_area)
+    end
+    let!(:service_area) do
+      ::BenefitMarkets::Locations::ServiceArea.service_areas_for(address, during: start_on).first || FactoryBot.create_default(:benefit_markets_locations_service_area)
+    end
+
+    let(:start_on) { TimeKeeper.date_of_record }
+    let(:address) { person.rating_address }
+    let(:application_period) { start_on.beginning_of_year..start_on.end_of_year }
+
+    let!(:product) do
+      prod = FactoryBot.create(:benefit_markets_products_health_products_health_product,
+                               :with_issuer_profile,
+                               benefit_market_kind: :aca_individual,
+                               kind: :health,
+                               service_area: service_area,
+                               csr_variant_id: '01',
+                               metal_level_kind: 'silver',
+                               application_period: application_period)
+      prod.premium_tables = [premium_table]
+      prod.save
+      prod
+    end
+
+    let!(:product1) do
+      prod = FactoryBot.create(:benefit_markets_products_health_products_health_product,
+                               :with_issuer_profile,
+                               benefit_market_kind: :aca_individual,
+                               kind: :health,
+                               service_area: service_area,
+                               csr_variant_id: '05',
+                               metal_level_kind: 'silver',
+                               application_period: application_period)
+      prod.premium_tables = [premium_table]
+      prod.save
+      prod
+    end
+
+    let(:premium_table)        { build(:benefit_markets_products_premium_table, effective_period: application_period, rating_area: rating_area) }
+
+    let!(:person) {FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role)}
+    let!(:family) {FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person)}
+    let(:sep) {FactoryBot.create(:special_enrollment_period, family: family)}
+    let!(:enrollment) {FactoryBot.create(:hbx_enrollment, :individual_unassisted, family: family, product: product, consumer_role_id: person.consumer_role.id, rating_area_id: rating_area.id)}
+    let!(:hbx_enrollment_member1) {FactoryBot.create(:hbx_enrollment_member, applicant_id: family.primary_applicant.id, is_subscriber: true, eligibility_date: (TimeKeeper.date_of_record - 1.day), hbx_enrollment: enrollment)}
+    let!(:hbx_enrollment_member2) {FactoryBot.create(:hbx_enrollment_member, applicant_id: family.family_members[1].id, eligibility_date: (TimeKeeper.date_of_record - 1.day), hbx_enrollment: enrollment)}
+    let!(:hbx_profile) {FactoryBot.create(:hbx_profile, :open_enrollment_coverage_period)}
+    let!(:tax_household10) {FactoryBot.create(:tax_household, household: family.active_household, effective_ending_on: nil)}
+    let!(:eligibility_determination) {FactoryBot.create(:eligibility_determination, tax_household: tax_household10, max_aptc: 2000)}
+    let!(:tax_household_member1) {tax_household10.tax_household_members.create(applicant_id: family.primary_applicant.id, is_subscriber: true, is_ia_eligible: true)}
+    let!(:tax_household_member2) {tax_household10.tax_household_members.create(applicant_id: family.family_members[1].id, is_ia_eligible: true)}
+    let(:applied_aptc_amount) { 120.78 }
+    let(:primary_person_age) { hbx_enrollment_member1.age_on_effective_date }
+    let(:hbx_enrollment_member_2_age) { hbx_enrollment_member2.age_on_effective_date }
+
     subject { Insured::Forms::SelfTermOrCancelForm.new }
 
     describe "model attributes" do
@@ -54,50 +110,6 @@ module Insured
     end
 
     describe "#for_view" do
-      let!(:rating_area) do
-        ::BenefitMarkets::Locations::RatingArea.rating_area_for(address, during: start_on) || FactoryBot.create_default(:benefit_markets_locations_rating_area)
-      end
-      let!(:service_area) do
-        ::BenefitMarkets::Locations::ServiceArea.service_areas_for(address, during: start_on).first || FactoryBot.create_default(:benefit_markets_locations_service_area)
-      end
-
-      let(:start_on) { TimeKeeper.date_of_record }
-      let(:address) { person.rating_address }
-      let(:application_period) { start_on.beginning_of_year..start_on.end_of_year }
-
-      let!(:product) do
-        prod =
-          FactoryBot.create(
-            :benefit_markets_products_health_products_health_product,
-            :with_issuer_profile,
-            benefit_market_kind: :aca_individual,
-            kind: :health,
-            service_area: service_area,
-            csr_variant_id: '01',
-            metal_level_kind: 'silver',
-            application_period: application_period
-          )
-        prod.premium_tables = [premium_table]
-        prod.save
-        prod
-      end
-      let(:premium_table)        { build(:benefit_markets_products_premium_table, effective_period: application_period, rating_area: rating_area) }
-
-      let!(:person) {FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role)}
-      let!(:family) {FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person)}
-      let(:sep) {FactoryBot.create(:special_enrollment_period, family: family)}
-      let!(:enrollment) {FactoryBot.create(:hbx_enrollment, :individual_unassisted, family: family, product: product, consumer_role_id: person.consumer_role.id, rating_area_id: rating_area.id)}
-      let!(:hbx_enrollment_member1) {FactoryBot.create(:hbx_enrollment_member, applicant_id: family.primary_applicant.id, is_subscriber: true, eligibility_date: (TimeKeeper.date_of_record - 1.day), hbx_enrollment: enrollment)}
-      let!(:hbx_enrollment_member2) {FactoryBot.create(:hbx_enrollment_member, applicant_id: family.family_members[1].id, eligibility_date: (TimeKeeper.date_of_record - 1.day), hbx_enrollment: enrollment)}
-      let!(:hbx_profile) {FactoryBot.create(:hbx_profile, :open_enrollment_coverage_period)}
-      let!(:tax_household10) {FactoryBot.create(:tax_household, household: family.active_household, effective_ending_on: nil)}
-      let!(:eligibility_determination) {FactoryBot.create(:eligibility_determination, tax_household: tax_household10, max_aptc: 2000)}
-      let!(:tax_household_member1) {tax_household10.tax_household_members.create(applicant_id: family.primary_applicant.id, is_subscriber: true, is_ia_eligible: true)}
-      let!(:tax_household_member2) {tax_household10.tax_household_members.create(applicant_id: family.family_members[1].id, is_ia_eligible: true)}
-      let(:applied_aptc_amount) { 120.78 }
-      let(:primary_person_age) { hbx_enrollment_member1.age_on_effective_date }
-      let(:hbx_enrollment_member_2_age) { hbx_enrollment_member2.age_on_effective_date }
-
       before(:each) do
         # This effective on mock to compensate for new yaers
         enrollment.update_attributes!(effective_on: TimeKeeper.date_of_record - 1.day) if enrollment.effective_on.year != TimeKeeper.date_of_record.year
@@ -150,9 +162,45 @@ module Insured
       end
     end
 
+    describe "#for_aptc_update_post" do
+      before(:each) do
+        enrollment.update_attributes!(effective_on: TimeKeeper.date_of_record - 1.day) if enrollment.effective_on.year != TimeKeeper.date_of_record.year
+        tax_household_member1.update_attributes(csr_percent_as_integer: 87)
+        tax_household_member2.update_attributes(csr_percent_as_integer: 87)
+        enrollment.update_attributes(product: product, applied_aptc_amount: applied_aptc_amount)
+        hbx_profile.benefit_sponsorship.benefit_coverage_periods.each {|bcp| bcp.update_attributes!(slcsp_id: product.id)}
+      end
+
+      it 'should create a new enrollment with same variant when the hios_id does not match' do
+        family.special_enrollment_periods << sep
+        expect(family.hbx_enrollments.size).to eq 1
+        expect(family.hbx_enrollments.first.product.csr_variant_id).to eq '01'
+        attrs = {enrollment_id: enrollment.id, elected_aptc_pct: 1.0, aptc_applied_total: applied_aptc_amount}
+        Insured::Forms::SelfTermOrCancelForm.for_aptc_update_post(attrs)
+        expect(family.hbx_enrollments.size).to eq 2
+        expect(family.hbx_enrollments.last.product.csr_variant_id).to eq '01'
+      end
+
+      context 'Hios id of the product match for a different variant' do
+        before(:each) do
+          new_hios_id = "#{product.hios_base_id}-#{product1.csr_variant_id}"
+          product1.update_attributes(hios_base_id: product.hios_base_id, hios_id: new_hios_id)
+          product1.save!
+        end
+
+        it 'should create a new enrollment with different variant when the hios_id match' do
+          family.special_enrollment_periods << sep
+          expect(family.hbx_enrollments.size).to eq 1
+          expect(family.hbx_enrollments.first.product.csr_variant_id).to eq '01'
+          attrs = {enrollment_id: enrollment.id, elected_aptc_pct: 1.0, aptc_applied_total: applied_aptc_amount}
+          Insured::Forms::SelfTermOrCancelForm.for_aptc_update_post(attrs)
+          expect(family.hbx_enrollments.size).to eq 2
+          expect(family.hbx_enrollments.to_a.last.product.csr_variant_id).to eq '05'
+        end
+      end
+    end
+
     describe "#for_post" do
-      let(:family) { FactoryBot.create(:family, :with_primary_family_member) }
-      let(:sep) {FactoryBot.create(:special_enrollment_period, family: family) }
       let(:sbc_document) { FactoryBot.build(:document, subject: "SBC", identifier: "urn:openhbx#124") }
       let(:product) { FactoryBot.create(:benefit_markets_products_health_products_health_product, title: "AAA", issuer_profile_id: "ab1233", sbc_document: sbc_document) }
       let(:enrollment_to_cancel) { FactoryBot.create(:hbx_enrollment, :individual_unassisted, family: family, product: product, effective_on: Date.today + 1.month) }


### PR DESCRIPTION
…sehold during enrollment generation using self-serve tool.

### Master Redmine ticket
* (Required!)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
