### PR TITLE
Update path helper for external person link

### DIFF
--- a/app/domain/operations/transformers/person_to/cv3_person.rb
+++ b/app/domain/operations/transformers/person_to/cv3_person.rb
@@ -27,7 +27,7 @@ module Operations
         def construct_payload(person)
           payload = {
             person_id: person.id.to_s,
-            external_person_link: resume_enrollment_exchanges_agents_url(person_id: person.id.to_s),
+            external_person_link: "https://#{ENV['ENROLL_FQDN']}#{resume_enrollment_exchanges_agents_path(person_id: person.id.to_s)}",
             hbx_id: person.hbx_id.to_s,
             person_name: construct_person_name(person),
             person_demographics: construct_person_demographics(person),


### PR DESCRIPTION
This fixes the external person link for person CV3 transforms. The hostname wasn't be set as expected in the deployed Rails app.