### PR TITLE
Edit SAML idle logout

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1289,7 +1289,7 @@ class Person
 
   def create_inbox
     welcome_subject = "Welcome to #{site_short_name}"
-    welcome_body_translation_key = if broker_role || broker_agency_staff_roles.present? 
+    welcome_body_translation_key = if broker_role || broker_agency_staff_roles.present?
                                      "inbox.create_inbox_broker_message"
                                    else
                                      "inbox.create_inbox_normal_user_message"

--- a/app/views/devise/sessions/sign_out_user.js.erb
+++ b/app/views/devise/sessions/sign_out_user.js.erb
@@ -1,1 +1,1 @@
-window.location.reload();
+window.location.replace("<%= SamlInformation.saml_logout_url %>");


### PR DESCRIPTION
This change has been requested by @matt--williams for having users directed to `SamlInformation.saml_logout_url` after being logged out due to being idle the same as a regular logout currently is. The `saml_logout_url` method has the correct `redirect_uri`s parameters for both DC and ME so we can use the same solution for all clients!