### PR TITLE
Update Pay Now selector for continue

### DIFF
--- a/app/assets/javascripts/families.js
+++ b/app/assets/javascripts/families.js
@@ -1,5 +1,5 @@
 
-$(document).on('click', ".interaction-click-control-leave-dc-health-link, .interaction-click-control-continue", function(e) {
+$(document).on('click', "#pay-now", function(e) {
   if ($(this).parent('form').attr('method') == 'post') {
     e.preventDefault();
     let hbx_id = $(this).val();

--- a/app/assets/javascripts/families.js
+++ b/app/assets/javascripts/families.js
@@ -1,5 +1,5 @@
 
-$(document).on('click', ".interaction-click-control-leave-dc-health-link", function(e) {
+$(document).on('click', ".interaction-click-control-leave-dc-health-link, .interaction-click-control-continue", function(e) {
   if ($(this).parent('form').attr('method') == 'post') {
     e.preventDefault();
     let hbx_id = $(this).val();


### PR DESCRIPTION
During SSL troubleshooting with Matt we noticed the Pay Now button wasn't working with the new translation because of the `interaction-click-control-` class name changed because the text of the button changed. We should revisit this and use the translation for the selector but for now this will work.