### PR TITLE
Atp response

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 49564ce58862936062bb3b6ecb3d98b8adcf2904
+  revision: 2745a058201236201e04b69a5b1d2b269a2ceca6
   branch: release_0.9.0
   specs:
     aca_entities (0.9.0)

--- a/app/event_source/subscribers/atp_subscriber.rb
+++ b/app/event_source/subscribers/atp_subscriber.rb
@@ -16,7 +16,7 @@ module Subscribers
       details = payload["family"]["magi_medicaid_applications"][0]["transfer_id"]
       transfer_details[:transfer_id] = details || payload
       if result.success?
-        transfer_response = FinancialAssistance::Operations::Transfers::MedicaidGateway::AccountTransferResponse.new.call(transfer_details[:transfer_id])
+        transfer_response = FinancialAssistance::Operations::Transfers::MedicaidGateway::AccountTransferResponse.new.call(result.value!)
         transfer_failure = {}
         transfer_failure[:result] = "Failed"
         transfer_failure[:failure] = "Unsucessfully ingested by Enroll - #{transfer_response.failure}"

--- a/components/financial_assistance/Gemfile.lock
+++ b/components/financial_assistance/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 91d993ac24740e48536db9056782f78b08e33969
+  revision: 2745a058201236201e04b69a5b1d2b269a2ceca6
   branch: release_0.9.0
   specs:
     aca_entities (0.9.0)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -26,7 +26,7 @@ module FinancialAssistance
             family = yield build_family(payload["family"])
             application = yield build_application(payload, family)
             applicants = yield fill_applicants_form(payload["family"]['magi_medicaid_applications'].first, application)
-            Success(applicants)
+            Success(application)
           end
 
           private

--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_response.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_response.rb
@@ -16,19 +16,19 @@ module FinancialAssistance
 
           # Pass the payload from the subscriber
           # Return the result of publishing the identifiers back to MG
-          def call(transfer_id)
-            application         = yield find_application(transfer_id)
+          def call(app_id)
+            application         = yield find_application(app_id)
             family              = yield find_family(application)
             construct_payload(application, family)
           end
 
           private
 
-          def find_application(transfer_id)
-            application = FinancialAssistance::Application.find_by(transfer_id: transfer_id)
+          def find_application(app_id)
+            application = FinancialAssistance::Application.find(app_id)
             Success(application)
           rescue Mongoid::Errors::DocumentNotFound
-            Failure("Unable to find Application by Transfer ID.")
+            Failure("Unable to find Application by ID.")
           end
 
           def find_family(application)

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -14,17 +14,13 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
   let(:transformed) { ::AcaEntities::Atp::Transformers::Cv::Family.transform(record.to_hash(identifier: true)) }
 
   context 'success' do
-    context 'with valid application' do
+    context 'with valid payload' do
       before do
         @result = subject.call(transformed)
       end
 
       it 'should return success' do
         expect(@result).to be_success
-      end
-
-      it 'should return success with message' do
-        expect(@result.success).to eq('Successfully transferred in account')
       end
     end
   end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_response_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_response_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
   let(:transfer_id) { "tr123" }
 
   context 'success' do
-    context 'with valid transfer id' do
+    context 'with valid application id' do
       before do
         family = FactoryBot.create(:family, :with_primary_family_member)
         family.primary_person.emails.create(kind: "home", address: "fakeemail@email.com")
@@ -25,7 +25,7 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
             application_identifier: application.hbx_id,
             result: "Success"
           }
-        @result = subject.call(transfer_id)
+        @result = subject.call(application.id)
       end
 
       it 'should return success' do
@@ -49,14 +49,14 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
       end
 
       it 'should return expected error message' do
-        expect(@result.failure).to eq("Unable to find Application by Transfer ID.")
+        expect(@result.failure).to eq("Unable to find Application by ID.")
       end
     end
 
     context 'with missing family' do
       before do
         @application = FactoryBot.create(:financial_assistance_application, transfer_id: transfer_id, family_id: "missing")
-        @result = subject.call(transfer_id)
+        @result = subject.call(@application.id)
       end
 
       it 'should return failure' do


### PR DESCRIPTION
Move the atp response from needing the transfer id as currently that is not always saving as expected to using the application id of the newly created application