### PR TITLE
Refs #IapCopyFeature: do not create eligibility_determination objects…

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/factories/application_factory.rb
+++ b/components/financial_assistance/app/models/financial_assistance/factories/application_factory.rb
@@ -188,7 +188,7 @@ module FinancialAssistance
         %w[_id created_at updated_at submitted_at workflow_state_transitions applicants relationships
            determination_http_status_code has_eligibility_response eligibility_response_payload eligibility_request_payload
            predecessor_id renewal_base_year effective_date has_mec_check_response transfer_requested account_transferred
-           hbx_id aasm_state assistance_year determination_error_message]
+           hbx_id aasm_state assistance_year determination_error_message eligibility_determinations]
       end
 
       # Do not exclude is_claimed_as_tax_dependent. If you want to exclude is_claimed_as_tax_dependent,
@@ -198,7 +198,8 @@ module FinancialAssistance
            medicaid_household_size magi_medicaid_category magi_as_percentage_of_fpl magi_medicaid_monthly_income_limit
            magi_medicaid_monthly_household_income is_without_assistance is_ia_eligible is_medicaid_chip_eligible
            is_totally_ineligible is_eligible_for_non_magi_reasons is_non_magi_medicaid_eligible
-           csr_percent_as_integer csr_eligibility_kind net_annual_income claimed_as_tax_dependent_by]
+           csr_percent_as_integer csr_eligibility_kind net_annual_income claimed_as_tax_dependent_by
+           eligibility_determination_id]
       end
 
       def income_klass

--- a/components/financial_assistance/spec/models/financial_assistance/factories/application_factory_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/factories/application_factory_spec.rb
@@ -508,4 +508,23 @@ RSpec.describe FinancialAssistance::Factories::ApplicationFactory, type: :model 
       expect(@new_applicant.deductions.first.kind).to eq(applicant.deductions.first.kind)
     end
   end
+
+  describe 'with eligibility_determinations' do
+    let!(:eligibility_determination) do
+      ed = FactoryBot.create(:financial_assistance_eligibility_determination, application: application)
+      application.applicants.each { |applicant| applicant.write_attribute(:eligibility_determination_id, ed.id) }
+    end
+
+    before do
+      @new_application = described_class.new(application).create_application
+    end
+
+    it 'should not create eligibility determination objects for newly created application' do
+      expect(@new_application.eligibility_determinations.present?).to be_falsy
+    end
+
+    it 'should not set eligibilitydetermination_id for new applicants' do
+      expect(@new_application.applicants.pluck(:eligibility_determination_id).compact).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
… for application and do not copy eligibility_determination_id for applicants with rspec updates.

### Master Redmine ticket
* (Required!)

### Child Redmine ticket(s)
* ()
* ()

### Local build result

```
bundle exec rake parallel:spec[4]
bundle exec cucumber
```

### Latest rebase/merge tag
*

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* (For code review)

#### Functional Testing
* (For testing locally)

#### Deployment
* (for release manager and/or build manager)
