### PR TITLE
optimize faa outstanding verification query

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -192,7 +192,7 @@ class Family
   scope :outstanding_verifications_including_faa_datatable, lambda {
     where(
       :_id.in => (HbxEnrollment.individual_market.enrolled_and_renewing.by_unverified.distinct(:family_id) +
-                     FinancialAssistance::Application.families_with_latest_determined_outstanding_verification.map {|record| record["_id"]})
+                     FinancialAssistance::Application.families_with_latest_determined_outstanding_verification.pluck(:family_id))
     )
   }
 

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -364,7 +364,12 @@ module FinancialAssistance
 
     def self.families_with_latest_determined_outstanding_verification
       FinancialAssistance::Application.collection.aggregate([
-        {"$match" => {"aasm_state" => "determined" } },
+        {
+          "$match" => {
+            "aasm_state" => "determined",
+            "applicants.evidences.eligibility_status" => {"$in" => ["outstanding", "in_review"]}
+          }
+        },
         {"$sort" => {"family_id" => 1, "created_at" => 1}},
         {
           "$group" => {
@@ -372,14 +377,6 @@ module FinancialAssistance
             "applicants" => {"$last" => "$applicants"},
             "application_id" => {"$last" => "$_id"},
             "hbx_id" => {"$last" => "$hbx_id"}
-          }
-        },
-        { "$unwind" => "$applicants" },
-        { "$match" => {"applicants.is_active" => true} },
-        { "$unwind" => "$applicants.evidences" },
-        {
-          "$match" => {
-            "applicants.evidences.eligibility_status" => {"$in" => ["outstanding", "in_review"]}
           }
         },
         {


### PR DESCRIPTION
It's a part of optimization asked by Dan/sarah.

Testing: 
1. Page should load fast
2. Check Outstanding verifications page performance, it should sho the families with both vlp or faa documents in outstanding/in_review. 