### PR TITLE
Use person hbx_id as family member reference for tax households in cv3 family transformer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 4e6d8dbe1818b7ce639f890b876257ca45859d34
+  revision: 25deb1694202cbbbd29576e0d66d69c265871449
   branch: trunk
   specs:
     aca_entities (0.9.0)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/transformers/family_to/cv3_family.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transformers/family_to/cv3_family.rb
@@ -238,7 +238,7 @@ module FinancialAssistance
           def transform_tax_household_members(members)
             members.collect do |member|
               {
-                family_member_reference: member.family_member_id,
+                family_member_reference: member.family_member.hbx_id,
                 # product_eligibility_determination: member.product_eligibility_determination,
                 is_subscriber: member.is_subscriber,
                 reason: member.reason


### PR DESCRIPTION
Description:
The FA component transformer for a cv3 family now uses the person hbx_id as a family member reference for members of a tax household.

Requested by: 
ACES team

Impact on the system:
Changes the described data in outbound Account Transfer payloads only.

QA process:
Will be QA'd as part of Account Transfer testing.