### PR TITLE
Don't require NPN when allow_alphanumeric_npn on

### DIFF
--- a/app/views/ui-components/v1/forms/broker_registration/_personal_information.html.slim
+++ b/app/views/ui-components/v1/forms/broker_registration/_personal_information.html.slim
@@ -33,7 +33,7 @@ fieldset
     .col-md-4.mb-2
         label for="inputNPN"  NPN *
 
-        = f.text_field :npn, placeholder:'NPN', required:'true', id:'inputNPN', class:'form-control', maxlength:'10', onkeypress: EnrollRegistry.feature_enabled?(:allow_alphanumeric_npn) ? 'return isAlphaNumeric(event);' : 'return isNumberKey(event);'
+        = f.text_field :npn, placeholder:'NPN', required: !EnrollRegistry.feature_enabled?(:allow_alphanumeric_npn), id:'inputNPN', class:'form-control', maxlength:'10', onkeypress: EnrollRegistry.feature_enabled?(:allow_alphanumeric_npn) ? 'return isAlphaNumeric(event);' : 'return isNumberKey(event);'
         .invalid-feedback
           |
             Please provide a NPN.


### PR DESCRIPTION
ME-180598928

We had imported broker agencies without NPNs but the field was still required in the edit broker form. This should fix it.