### PR TITLE
Fix claimed_by_dropdown for FAA

### DIFF
--- a/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
+++ b/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
@@ -103,7 +103,7 @@ module FinancialAssistance
 
     def claim_eligible_tax_dependents
       return if @application.blank? || @applicant.blank?
-      eligible_applicants = @application.active_applicants.map! do |applicant|
+      eligible_applicants = @application.active_applicants.where(is_claimed_as_tax_dependent: false).map! do |applicant|
         [applicant.full_name, applicant.id.to_s] if applicant != @applicant && applicant.is_required_to_file_taxes? && applicant.claimed_as_tax_dependent_by != @applicant.id
       end
       eligible_applicants

--- a/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
+++ b/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
@@ -103,10 +103,9 @@ module FinancialAssistance
 
     def claim_eligible_tax_dependents
       return if @application.blank? || @applicant.blank?
-      eligible_applicants = @application.active_applicants.where(is_claimed_as_tax_dependent: false).map! do |applicant|
+      @application.active_applicants.where(is_claimed_as_tax_dependent: false).map! do |applicant|
         [applicant.full_name, applicant.id.to_s] if applicant != @applicant && applicant.is_required_to_file_taxes? && applicant.claimed_as_tax_dependent_by != @applicant.id
       end
-      eligible_applicants
     end
 
     def frequency_kind_options

--- a/components/financial_assistance/spec/helpers/financial_assistance/application_helper_spec.rb
+++ b/components/financial_assistance/spec/helpers/financial_assistance/application_helper_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe ::FinancialAssistance::ApplicationHelper, :type => :helper, dbcle
                       application: application,
                       eligibility_determination_id: ed.id,
                       is_ia_eligible: true,
+                      is_claimed_as_tax_dependent: false,
+                      is_required_to_file_taxes: true,
                       first_name: 'Test',
                       last_name: 'Test10')
   end
@@ -18,8 +20,27 @@ RSpec.describe ::FinancialAssistance::ApplicationHelper, :type => :helper, dbcle
                       application: application,
                       eligibility_determination_id: ed.id,
                       is_ia_eligible: true,
+                      is_claimed_as_tax_dependent: true,
                       first_name: 'TEst2',
                       last_name: 'Test10')
+  end
+
+  describe 'claim_eligible_tax_dependents' do
+    let!(:applicant3) do
+      FactoryBot.create(:financial_assistance_applicant,
+                        application: application,
+                        eligibility_determination_id: ed.id,
+                        is_ia_eligible: true,
+                        is_claimed_as_tax_dependent: true,
+                        first_name: 'TEst3',
+                        last_name: 'Test10')
+    end
+
+    it "doesn't include is_claimed_as_tax_dependent true applicants (applicant 2)" do
+      assign(:application, application)
+      assign(:applicant, applicant3)
+      expect(helper.claim_eligible_tax_dependents.map(&:first).flatten).to_not include("TEst2 Test10")
+    end
   end
 
   describe 'total_aptc_across_eligibility_determinations' do


### PR DESCRIPTION
ME-180062798

After fixing a lot of 500s along the way we finally determined this person couldn't submit their FAA application because they were trying to nest their tax dependents. This PR will remove that possibility from the dropdown by only showing valid tax fliers who are themselves not dependents.