### PR TITLE
Fix `SelfTermOrCancelForm` spec

### DIFF
--- a/spec/models/insured/forms/self_term_or_cancel_form_spec.rb
+++ b/spec/models/insured/forms/self_term_or_cancel_form_spec.rb
@@ -219,7 +219,7 @@ module Insured
       end
 
       it "should terminate an enrollment if it is already effective" do
-        attrs = {enrollment_id: enrollment_to_term.id, term_date: (TimeKeeper.date_of_record + 1.month).to_s}
+        attrs = {enrollment_id: enrollment_to_term.id, term_date: (TimeKeeper.date_of_record + 1.month + 16.days).to_s}
         Insured::Forms::SelfTermOrCancelForm.for_post(attrs)
         enrollment_to_term.reload
         expect(enrollment_to_term.aasm_state).to eq 'coverage_terminated'


### PR DESCRIPTION
This pull request will fix the date based failure for the `SelfTermOrCancelForm` form. It doesn't have a Pivotal Tracker ticket.