### PR TITLE
Remove evidences when copying an existing application to a new one

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/factories/application_factory.rb
+++ b/components/financial_assistance/app/models/financial_assistance/factories/application_factory.rb
@@ -199,6 +199,7 @@ module FinancialAssistance
       def reject_applicant_params
         %w[_id created_at updated_at workflow_state_transitions incomes benefits deductions verification_types
            evidences verification_status verification_history eligibility_results
+           income_evidence esi_evidence non_esi_evidence local_mec_evidence
            medicaid_household_size magi_medicaid_category magi_as_percentage_of_fpl magi_medicaid_monthly_income_limit
            magi_medicaid_monthly_household_income is_without_assistance is_ia_eligible is_medicaid_chip_eligible
            is_totally_ineligible is_eligible_for_non_magi_reasons is_non_magi_medicaid_eligible

--- a/components/financial_assistance/spec/models/financial_assistance/factories/application_factory_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/factories/application_factory_spec.rb
@@ -507,6 +507,7 @@ RSpec.describe FinancialAssistance::Factories::ApplicationFactory, type: :model,
       allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:esi_mec_determination).and_return(true)
       allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:non_esi_mec_determination).and_return(true)
       allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:ifsv_determination).and_return(true)
+      allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:real_time_transfer).and_return(true)
       application.send(:create_evidences)
       @new_application = described_class.new(application).create_application
       @new_applicant = @new_application.applicants.first


### PR DESCRIPTION
[ME-180956217](https://www.pivotaltracker.com/story/show/180956217)

Notes - Remove evidences from applicants when copying an existing application to a new one, and create new evidences once the application is determined so that hub calls are made