### PR TITLE
Create relationships before adding family members in ATP

### DIFF
--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
           @immediate_family_coverage_household_members = family.active_household.immediate_family_coverage_household.valid_coverage_household_members
         end
 
-        it 'should add all immediate family members as valid coverage household members' do          
+        it 'should add all immediate family members as valid coverage household members' do
           expect(@immediate_family_coverage_household_members.map(&:family_member_id)).to eq @immediate_family_members.map(&:id)
         end
       end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -60,6 +60,19 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
           expect(@application_rels.map(&:persisted?)).not_to include(false)
         end
       end
+
+      context 'immediate family coverage household' do
+        before do
+          family = Family.first
+          @immediate_family_members = family.family_members.select { |member| Family::IMMEDIATE_FAMILY.include?(member.primary_relationship) }
+          @immediate_family_coverage_household = family.active_household.immediate_family_coverage_household
+        end
+
+        it 'should add all immediate family members as valid coverage household members' do
+          valid_coverage_household_members = @immediate_family_coverage_household.valid_coverage_household_members
+          expect(valid_coverage_household_members.map(&:family_member_id)).to eq @immediate_family_members.map(&:id)
+        end
+      end
     end
   end
 

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -65,12 +65,11 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
         before do
           family = Family.first
           @immediate_family_members = family.family_members.select { |member| Family::IMMEDIATE_FAMILY.include?(member.primary_relationship) }
-          @immediate_family_coverage_household = family.active_household.immediate_family_coverage_household
+          @immediate_family_coverage_household_members = family.active_household.immediate_family_coverage_household.valid_coverage_household_members
         end
 
-        it 'should add all immediate family members as valid coverage household members' do
-          valid_coverage_household_members = @immediate_family_coverage_household.valid_coverage_household_members
-          expect(valid_coverage_household_members.map(&:family_member_id)).to eq @immediate_family_members.map(&:id)
+        it 'should add all immediate family members as valid coverage household members' do          
+          expect(@immediate_family_coverage_household_members.map(&:family_member_id)).to eq @immediate_family_members.map(&:id)
         end
       end
     end

--- a/components/financial_assistance/spec/dummy/app/models/coverage_household.rb
+++ b/components/financial_assistance/spec/dummy/app/models/coverage_household.rb
@@ -179,6 +179,13 @@ class CoverageHousehold
     end
   end
 
+  def valid_coverage_household_members
+    family_member_ids = family.family_members.select(&:persisted?).map {|fm| fm.id.to_s }
+    coverage_household_members.select do |chm|
+      chm.family_member_id.present? && chm.family_member.is_active && family_member_ids.include?(chm.family_member_id.to_s)
+    end
+  end
+
   def notify_verification_outstanding; end
 
   def notify_verification_success; end


### PR DESCRIPTION
ME-180444706
- Inbound account transfers to enroll were creating person relationships after family members had been added, but adding family members requires checking the person relationship to determine if they belong in the immediate family coverage household. Relationships are now created before the addition of family members, which ensures that immediate family members are in the proper coverage household and therefore appear on the plan shopping page.