### PR TITLE
deprecate subdomain key from settings.yml

### DIFF
--- a/components/benefit_markets/config/settings.yml
+++ b/components/benefit_markets/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :dc
-  subdomain: "dchbx"
   domain_name: "dchealthlink.com"
   site_title: "DC's Online Health Insurance Marketplace"
   home_url: "https://www.dchealthlink.com/"

--- a/components/benefit_markets/spec/dummy/config/settings.yml
+++ b/components/benefit_markets/spec/dummy/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :me
-  subdomain: "cme"
   domain_name: "cme.enroll.openhbx.org"
   site_title: "Maine Cover ME"
   home_url: "https://cme.enroll.openhbx.org/"
@@ -93,7 +92,7 @@ contact_center:
   non_discrimination_email: "info@coverme.gov"
 
   appeals: "info@coverme.gov"
-  
+
   # Voting Info for FA Engine Steps
   # TOOD: This needs to be updated. These are pulled of Maine government website.
   # # https://www.maine.gov/sos/cec/elec/voter-info/index.html

--- a/components/benefit_sponsors/config/settings.yml
+++ b/components/benefit_sponsors/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :dc
-  subdomain: "dchbx"
   domain_name: "dchealthlink.com"
   site_title: "DC's Online Health Insurance Marketplace"
   home_url: "https://www.dchealthlink.com/"

--- a/components/benefit_sponsors/spec/dummy/config/settings.yml
+++ b/components/benefit_sponsors/spec/dummy/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :me
-  subdomain: "cme"
   domain_name: "cme.enroll.openhbx.org"
   site_title: "Maine Cover ME"
   home_url: "https://cme.enroll.openhbx.org/"
@@ -93,7 +92,7 @@ contact_center:
   non_discrimination_email: "info@coverme.gov"
 
   appeals: "info@coverme.gov"
-  
+
   # Voting Info for FA Engine Steps
   # TOOD: This needs to be updated. These are pulled of Maine government website.
   # # https://www.maine.gov/sos/cec/elec/voter-info/index.html

--- a/components/financial_assistance/config/settings.yml
+++ b/components/financial_assistance/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :dc
-  subdomain: "dchbx"
   domain_name: "dchealthlink.com"
   site_title: "DC's Online Health Insurance Marketplace"
   home_url: "https://www.dchealthlink.com/"

--- a/components/financial_assistance/spec/dummy/config/settings.yml
+++ b/components/financial_assistance/spec/dummy/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :me
-  subdomain: "cme"
   domain_name: "cme.enroll.openhbx.org"
   site_title: "Maine Cover ME"
   home_url: "https://cme.enroll.openhbx.org/"
@@ -93,7 +92,7 @@ contact_center:
   non_discrimination_email: "info@coverme.gov"
 
   appeals: "info@coverme.gov"
-  
+
   # Voting Info for FA Engine Steps
   # TOOD: This needs to be updated. These are pulled of Maine government website.
   # # https://www.maine.gov/sos/cec/elec/voter-info/index.html

--- a/components/notifier/config/settings.yml
+++ b/components/notifier/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :dc
-  subdomain: "dchbx"
   domain_name: "dchealthlink.com"
   site_title: "DC's Online Health Insurance Marketplace"
   home_url: "https://www.dchealthlink.com/"

--- a/components/notifier/spec/dummy/config/settings.yml
+++ b/components/notifier/spec/dummy/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :me
-  subdomain: "cme"
   domain_name: "cme.enroll.openhbx.org"
   site_title: "Maine Cover ME"
   home_url: "https://cme.enroll.openhbx.org/"
@@ -93,7 +92,7 @@ contact_center:
   non_discrimination_email: "info@coverme.gov"
 
   appeals: "info@coverme.gov"
-  
+
   # Voting Info for FA Engine Steps
   # TOOD: This needs to be updated. These are pulled of Maine government website.
   # # https://www.maine.gov/sos/cec/elec/voter-info/index.html

--- a/components/sponsored_benefits/config/settings.yml
+++ b/components/sponsored_benefits/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :dc
-  subdomain: "dchbx"
   domain_name: "dchealthlink.com"
   site_title: "DC's Online Health Insurance Marketplace"
   home_url: "https://www.dchealthlink.com/"

--- a/components/sponsored_benefits/spec/dummy/config/settings.yml
+++ b/components/sponsored_benefits/spec/dummy/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :me
-  subdomain: "cme"
   domain_name: "cme.enroll.openhbx.org"
   site_title: "Maine Cover ME"
   home_url: "https://cme.enroll.openhbx.org/"
@@ -93,7 +92,7 @@ contact_center:
   non_discrimination_email: "info@coverme.gov"
 
   appeals: "info@coverme.gov"
-  
+
   # Voting Info for FA Engine Steps
   # TOOD: This needs to be updated. These are pulled of Maine government website.
   # # https://www.maine.gov/sos/cec/elec/voter-info/index.html

--- a/components/transport_gateway/config/settings.yml
+++ b/components/transport_gateway/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :dc
-  subdomain: "dchbx"
   domain_name: "dchealthlink.com"
   site_title: "DC's Online Health Insurance Marketplace"
   home_url: "https://www.dchealthlink.com/"

--- a/components/transport_gateway/spec/dummy/config/settings.yml
+++ b/components/transport_gateway/spec/dummy/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :me
-  subdomain: "cme"
   domain_name: "cme.enroll.openhbx.org"
   site_title: "Maine Cover ME"
   home_url: "https://cme.enroll.openhbx.org/"
@@ -93,7 +92,7 @@ contact_center:
   non_discrimination_email: "info@coverme.gov"
 
   appeals: "info@coverme.gov"
-  
+
   # Voting Info for FA Engine Steps
   # TOOD: This needs to be updated. These are pulled of Maine government website.
   # # https://www.maine.gov/sos/cec/elec/voter-info/index.html

--- a/components/transport_profiles/config/settings.yml
+++ b/components/transport_profiles/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :dc
-  subdomain: "dchbx"
   domain_name: "dchealthlink.com"
   site_title: "DC's Online Health Insurance Marketplace"
   home_url: "https://www.dchealthlink.com/"

--- a/components/transport_profiles/spec/dummy/config/settings.yml
+++ b/components/transport_profiles/spec/dummy/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :me
-  subdomain: "cme"
   domain_name: "cme.enroll.openhbx.org"
   site_title: "Maine Cover ME"
   home_url: "https://cme.enroll.openhbx.org/"
@@ -93,7 +92,7 @@ contact_center:
   non_discrimination_email: "info@coverme.gov"
 
   appeals: "info@coverme.gov"
-  
+
   # Voting Info for FA Engine Steps
   # TOOD: This needs to be updated. These are pulled of Maine government website.
   # # https://www.maine.gov/sos/cec/elec/voter-info/index.html

--- a/components/ui_helpers/config/settings.yml
+++ b/components/ui_helpers/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :dc
-  subdomain: "dchbx"
   domain_name: "dchealthlink.com"
   site_title: "DC's Online Health Insurance Marketplace"
   home_url: "https://www.dchealthlink.com/"

--- a/components/ui_helpers/spec/dummy/config/settings.yml
+++ b/components/ui_helpers/spec/dummy/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :me
-  subdomain: "cme"
   domain_name: "cme.enroll.openhbx.org"
   site_title: "Maine Cover ME"
   home_url: "https://cme.enroll.openhbx.org/"
@@ -93,7 +92,7 @@ contact_center:
   non_discrimination_email: "info@coverme.gov"
 
   appeals: "info@coverme.gov"
-  
+
   # Voting Info for FA Engine Steps
   # TOOD: This needs to be updated. These are pulled of Maine government website.
   # # https://www.maine.gov/sos/cec/elec/voter-info/index.html

--- a/config/client_config/dc/config/settings.yml
+++ b/config/client_config/dc/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :dc
-  subdomain: "dchbx"
   domain_name: "dchealthlink.com"
   site_title: "DC's Online Health Insurance Marketplace"
   home_url: "https://www.dchealthlink.com/"

--- a/config/client_config/me/config/settings.yml
+++ b/config/client_config/me/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :me
-  subdomain: "cme"
   domain_name: "cme.enroll.openhbx.org"
   site_title: "CoverME.gov"
   home_url: "https://cme.enroll.openhbx.org/"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,5 @@
 site:
   key: :dc
-  subdomain: "dchbx"
   domain_name: "dchealthlink.com"
   site_title: "DC's Online Health Insurance Marketplace"
   home_url: "https://www.dchealthlink.com/"
@@ -64,11 +63,9 @@ site:
   statewide_area: "DC Metro"
   assistance_estimate_url: "https://dc.checkbookhealth.org/hie/dc/2021/index.cfm?page"
   elligibile_immigration_statuses_url: "https://dchealthlink.com/sites/default/files/v2/forms/Eligible%20Immigration%20Status%20List_0.pdf"
-
   exchange_name: "Washington DC Health Benefit Exchange"
   social_media:
     facebook_url: ""
-
 contact_center:
   state_and_city: "Washington, DC"
   name: "DC Health Link's Customer Care Center"
@@ -91,14 +88,11 @@ contact_center:
   zip_code: "20090"
   small_business_email: "info@dchealthlink.com"
   non_discrimination_email: "info@dchealthlink.com"
-
   appeals: "info@dchealthlink.com"
-
   board_of_elections_entity: "DC Board of Elections"
   board_of_elections_address: "1015 Half Street, SE<br>Suite 750<br>Washington, DC 20003<br>"
   board_of_elections_email: ""
   board_of_elections_phone_number: "(202) 727-2525"
-
   mailing_address:
     name: "DC Health Link"
     address_1: "PO Box 97022"
@@ -106,7 +100,6 @@ contact_center:
     city: "Washington"
     state: "DC"
     zip_code: "20090"
-
   appeal_center:
     name: "DC Health Link"
     address_1: "PO Box 97022"
@@ -114,14 +107,12 @@ contact_center:
     city: "Washington"
     state: "DC"
     zip_code: "20090"
-
   non_discrimination:
     email: "info@dchealthlink.com"
     phone_1: "1-855-532-5465"
     phone_2: "1-855-532-5465"
     phone_3: "1-855-532-5465"
     complaint_url: "https://www.hhs.gov/civil-rights/filing-a-complaint"
-
 plan_option_titles:
   sole_source: 'One Plan'
   metal_level: 'By Metal Level'
@@ -130,7 +121,6 @@ plan_option_titles:
   plan_year_tooltip: "Employer premium contribution for Employee Only Health Plans must be at least"
   multi_product: 'Custom'
   single_issuer: 'By Carrier'
-
 plan_option_descriptions:
   sole_source: "Choose one plan and your contribution amount. All employees can enroll in that plan."
   metal_level: "Select your preferred metal level. Your plan participants will be able to choose any plan by any carrier within the metal level you select. Your costs will be fixed to a specific plan you’ll choose in a minute. Bronze means the plan is expected to pay 60% of expenses for an average population of consumers, Silver 70%, Gold 80% and Platinum 90%."
@@ -140,17 +130,14 @@ plan_option_descriptions:
     single_plan: "For Dental coverage, you will choose one dental plan from one carrier as the option that all of your employees can enroll in."
     single_issuer: "Select your preferred insurance company carrier. Your plan participants will be able to choose any plan offered by the carrier you select. Your costs will be fixed to a specific plan you’ll choose in a minute."
     multi_product: "Select your preferred insurance company carrier. Your plan participants will be able to choose any plan offered by the carrier you select. Your costs will be fixed to a specific plan you’ll choose in a minute."
-
 invoices:
   addendum: 'ma_non_discrimination_and_language_tags.pdf'
   minimum_invoice_display_year: 2015
-
 aca:
   state_key : "dc"
   state_name: "District of Columbia"
   state_abbreviation: "DC"
   market_kinds: ["shop", "individual", "fehb"]
-
   hbx_abbreviation: "DC Health Benefit Exchange"
   nationwide_markets: true
   general_agency_enabled: true
@@ -173,12 +160,10 @@ aca:
   carrier_hios_logo_variant:
     '': ""
   ## acceptable options are ["platinum", "gold", "silver", "dental"]
-
   plan_option_years:
     single_carriers_available: ['2018', '2019']
     sole_source_carriers_available: ['2017','2018', '2019']
     metal_level_carriers_available: ['2018', '2019']
-
   qle:
     with_in_sixty_days: 60
   #
@@ -188,7 +173,6 @@ aca:
       days: 0
     verification_due:
       days: 95
-
     open_enrollment:
       start_on: <%= Date.new(2020,11,1) %>
       end_on: <%= Date.new(2022,2,4) %>
@@ -199,7 +183,6 @@ aca:
     upcoming_open_enrollment:
       start_on: <%= Date.new(2021,11,1) %>
       end_on: <%= Date.new(2022,01,31) %>
-
   shop_market:
     valid_employer_attestation_documents_url: 'https://www.mahealthconnector.org/business/business-resource-center/employer-verification-checklist'
     small_market_employee_count_maximum: 50
@@ -214,10 +197,8 @@ aca:
     census_employees_template_file: 'DCHL Employee Census'
     coverage_start_period: "2 months"
     auto_cancel_ineligible: false
-
     employee:
       default_contact_method: 'Only Electronic communications'
-
     binder_payment_dates: [
       {"2019-01-01": '2018,12,12'},
       {"2019-02-01": '2019,1,14'},
@@ -244,17 +225,14 @@ aca:
       {"2020-11-01": '2020,10,14'},
       {"2020-12-01": '2020,11,13'},
     ]
-
     earliest_enroll_prior_to_effective_on:
       days: -30
     latest_enroll_after_effective_on:
       days: 30
     latest_enroll_after_employee_roster_correction_on:
       days: 30
-
     retroactive_coverage_termination_maximum:
       days: -60
-
     initial_application:
       publish_due_day_of_month: 5
       advertised_deadline_of_month: 1
@@ -271,7 +249,6 @@ aca:
       quiet_period:
         month_offset: -1
         mday: 28
-
     renewal_application:
       earliest_start_prior_to_effective_on:
         months: -3
@@ -287,70 +264,56 @@ aca:
       quiet_period:
         month_offset: -1
         mday: 15
-
     benefit_period:
       length_minimum:
         year: 1
       length_maximum:
         year: 1
-
     open_enrollment:
       monthly_start_on: 1
       monthly_end_on: 10
-
       minimum_length:
         days: 5
         adv_days: 10
       maximum_length:
         months: 2
-
     cobra_enrollment_period:
       months: 6
-
     group_file:
       new_enrollment_transmit_on: 16
       update_transmit_day_of_week: "friday"
-
     broker_agency_profile:
       minimum_commission_statement_year: 2017
-
     transmit_scheduled_employers: true
     employer_transmission_day_of_month: 16
     transmit_carrier_drop_events: true
-
     mid_month_benefit_application_terminations:
       voluntary: false
       non_payment: true
       show_termination_reasons: false
-
   transmit_employers_immediately: false
   employer_has_sic_field: false
   employer_registration_has_referred_by_field: false
   validate_county: false
-
   use_simple_employer_calculation_model: true
   carrier_special_plan_identifier_namespace: "urn:MA:terms:v1:plan:super_group_id#"
   offerings_constrained_to_service_areas: false
   employer_attestation: false
   enforce_employer_attestation: false
   plan_match_tool: true
-
   rating_areas:
     - R-DC001
-
 notices:
   individual_market:
     mail_address:
       address_1: "PO Box 44018"
       city: "Washington"
       zip_code: "20026"
-
   shop_market:
     mail_address:
       address_1: "1225 I Street, NW"
       address_2: "Suite 400"
       zip_code: "20005"
-
   shop:
     store_paper_notice: false
     attachments:
@@ -362,7 +325,6 @@ notices:
       header: "notices/shared/shop_header.html.erb"
       footer: "notices/shared/shop_footer.html.erb"
       layout: "notifier/pdf_layout.html.erb"
-
   individual:
     store_paper_notice: true
     attachments:
@@ -375,7 +337,6 @@ notices:
       header: "notices/shared/header_ivl.html.erb"
       footer: "notices/shared/footer_ivl.html.erb"
       layout: "notifier/ivl_pdf_layout.html.erb"
-
 paper_notice: 'paper-notices'
 # Note: Remote Aceess keys ad URL's Provided by DC checkbook
 checkbook_services:
@@ -388,7 +349,6 @@ checkbook_services:
     plan_match: "DC"
     current_year: 2019
     previous_year: 2018
-
 aptc_errors:
   effective_date_overflow: "Updates not allowed at this time. Effective Date happens to be after the Policy's life (next year) when following the 15th day rule."
   enrollment_max_smaller_than_applied: "Max Applied APTC for any Enrollment cannot be smaller than the Applied APTC."
@@ -397,10 +357,8 @@ aptc_errors:
   max_aptc_too_small: "Max APTC should be greater than or equal to the sum of APTC Applied for all enrollments."
   max_aptc_too_big: "Max APTC should be less than 9999.99"
   cat_plan_error: 'APTC cannot be applied to a catastrophic plan.'
-
 #   ShopOpenEnrollmentBeginDueDayOfMonth = ShopOpenEnrollmentEndDueDayOfMonth - ShopOpenEnrollmentPeriodMinimum
 #   ShopPlanYearPublishedDueDayOfMonth = ShopOpenEnrollmentBeginDueDayOfMonth
-
 style:
   primary_orange: '#333333'
   brand_primary: '#007bc4'
@@ -415,7 +373,6 @@ style:
   primary_icon_color: '#333333'
   qle_header_color: '#333333'
   primary_header_font: "'Open Sans', serif"
-
 external_applications:
   admin:
     url: <%= ENV['ANGULAR_ADMIN_APPLICATION_URL'] %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,7 +82,6 @@ contact_center:
   ivl_number: "1-877-623-6765"
   ivl_phone_number: "1-877-623-6765"
   email_address: "info@dchealthlink.com"
-  po_box: "PO Box 97022"
   city: "Washington"
   state: "DC"
   zip_code: "20090"

--- a/db/seedfiles/dental_benefit_market_catalog_seed.rb
+++ b/db/seedfiles/dental_benefit_market_catalog_seed.rb
@@ -1,6 +1,6 @@
 Mongoid::Migration.say_with_time("Updating MA Benefit Market Catalogs with Dental packages") do
 
-  site = BenefitSponsors::Site.where(site_key: "#{Settings.site.subdomain}").first
+  site = BenefitSponsors::Site.where(site_key: "#{EnrollRegistry[:enroll_app].setting(:subdomain).item}").first
 
   benefit_market = BenefitMarkets::BenefitMarket.where(:site_urn => Settings.site.key, kind: :aca_shop).first
 

--- a/db/seedfiles/ma_benefit_market_catalogs_product_packages.rb
+++ b/db/seedfiles/ma_benefit_market_catalogs_product_packages.rb
@@ -1,6 +1,6 @@
 Mongoid::Migration.say_with_time("Load MA Benefit Market Catalogs") do
 
-  site = BenefitSponsors::Site.where(site_key: "#{Settings.site.subdomain}").first
+  site = BenefitSponsors::Site.where(site_key: "#{EnrollRegistry[:enroll_app].setting(:subdomain).item}").first
 
   benefit_market = BenefitMarkets::BenefitMarket.where(:site_urn => Settings.site.key, kind: :aca_shop).first
 


### PR DESCRIPTION
removes the `subdomain` key in favor of the `:subdomain` item in the `EnrollRegistry`

also removes a bunch of whitespace in the `settings.yml` file