### PR TITLE
bypass validation of in-state address if applicant plans to return

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1224,13 +1224,19 @@ module FinancialAssistance
     end
 
     # Case1: Missing address - No address objects at all
-    # Case2: Invalid Address - No addresses matching the state
+    # Case2: Invalid Address - No addresses matching the state (skip if living_outside_state feature is enabled and applicant plans to return)
     # Case3: Unable to get rating area(home_address || mailing_address)
     def has_valid_address?
-      addresses.where(
-        state: FinancialAssistanceRegistry[:enroll_app].setting(:state_abbreviation).item,
-        :kind.in => ['home', 'mailing']
-      ).present?
+      if EnrollRegistry.feature_enabled?(:living_outside_state) && is_temporarily_out_of_state
+        addresses.where(
+          :kind.in => ['home', 'mailing']
+        ).present?
+      else
+        addresses.where(
+          state: FinancialAssistanceRegistry[:enroll_app].setting(:state_abbreviation).item,
+          :kind.in => ['home', 'mailing']
+        ).present?
+      end
     end
 
     #use this method to check what evidences needs to be included on notices

--- a/components/financial_assistance/spec/dummy/spec/factories/addresses.rb
+++ b/components/financial_assistance/spec/dummy/spec/factories/addresses.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     sequence(:address_1, 1111) { |n| "#{n} Awesome Street NE" }
     sequence(:address_2, 111) { |n| "##{n}" }
     city { 'Washington' }
-    state { Settings.aca.state_abbreviation }
+    state { EnrollRegistry[:enroll_app].setting(:state_abbreviation).item }
     zip { '01001' }
     county { 'Hampden' }
 

--- a/components/financial_assistance/spec/factories/financial_assistance_addresses.rb
+++ b/components/financial_assistance/spec/factories/financial_assistance_addresses.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     sequence(:address_1, 1111) { |n| "#{n} Awesome Street NE" }
     sequence(:address_2, 111) { |n| "##{n}" }
     city { 'Washington' }
-    state { Settings.aca.state_abbreviation }
+    state { EnrollRegistry[:enroll_app].setting(:state_abbreviation).item }
     zip { '01001' }
     county { 'Hampden' }
 

--- a/components/financial_assistance/spec/factories/financial_assistance_addresses.rb
+++ b/components/financial_assistance/spec/factories/financial_assistance_addresses.rb
@@ -9,5 +9,13 @@ FactoryBot.define do
     state { Settings.aca.state_abbreviation }
     zip { '01001' }
     county { 'Hampden' }
+
+    trait :mailing_address do
+      kind { 'mailing' }
+    end
+
+    trait :work_address do
+      kind { 'work' }
+    end
   end
 end


### PR DESCRIPTION
IVL-181590019
- addresses issue with scenario OC-5 identified in this redmine ticket: https://redmine.dchbx.org/issues/98135 
- method used to validate primary's address in FA submission flow was not checking for living_outside_state feature flag or is_temporarily_out_of_state field on applicant
- method has been updated to bypass validation of in-state address if applicant lives out of state but plans to return