### PR TITLE
ignore brakeman dependency warning

### DIFF
--- a/components/benefit_markets/config/brakeman.ignore
+++ b/components/benefit_markets/config/brakeman.ignore
@@ -2,6 +2,22 @@
   "ignored_warnings": [
     {
       "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 5.2.4.4 ends on 2022-06-01",
+      "file": "Gemfile.lock",
+      "line": 321,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
       "warning_code": 121,
       "fingerprint": "9a3951031616a07c8e02c86652f537e92c08685da97f5ec2b12d5d3602b55bb8",
       "check_name": "EOLRuby",
@@ -16,5 +32,7 @@
       "confidence": "High",
       "note": ""
     }
-  ]
+  ],
+  "updated": "2022-04-04 12:42:43 -0400",
+  "brakeman_version": "5.2.1"
 }

--- a/components/benefit_sponsors/3
+++ b/components/benefit_sponsors/3
@@ -7,7 +7,7 @@
       "check_name": "EOLRails",
       "message": "Support for Rails 5.2.4.4 ends on 2022-06-01",
       "file": "Gemfile.lock",
-      "line": 248,
+      "line": 472,
       "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
       "code": null,
       "render_path": null,
@@ -31,28 +31,8 @@
       "user_input": null,
       "confidence": "High",
       "note": ""
-    },
-    {
-      "warning_type": "File Access",
-      "warning_code": 16,
-      "fingerprint": "c5d79e8b8236b7a3e6f5720164e275def81f455a17426bbbff41350158a865b7",
-      "check_name": "SendFile",
-      "message": "Model attribute used in file name",
-      "file": "app/controllers/notifier/notice_kinds_controller.rb",
-      "line": 59,
-      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(\"#{Rails.root}/tmp/#{Notifier::NoticeKind.find(params[:id]).notice_recipient.hbx_id}_#{Notifier::NoticeKind.find(params[:id]).title.titleize.gsub(/\\s+/, \"_\")}.pdf\", :type => \"application/pdf\", :disposition => \"inline\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Notifier::NoticeKindsController",
-        "method": "preview"
-      },
-      "user_input": "Notifier::NoticeKind.find(params[:id]).notice_recipient.hbx_id",
-      "confidence": "Medium",
-      "note": ""
     }
   ],
-  "updated": "2022-04-04 12:51:47 -0400",
+  "updated": "2022-04-04 12:48:59 -0400",
   "brakeman_version": "5.2.1"
 }

--- a/components/benefit_sponsors/config/brakeman.ignore
+++ b/components/benefit_sponsors/config/brakeman.ignore
@@ -2,6 +2,22 @@
   "ignored_warnings": [
     {
       "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 5.2.4.4 ends on 2022-06-01",
+      "file": "Gemfile.lock",
+      "line": 472,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
       "warning_code": 121,
       "fingerprint": "9a3951031616a07c8e02c86652f537e92c08685da97f5ec2b12d5d3602b55bb8",
       "check_name": "EOLRuby",
@@ -16,5 +32,7 @@
       "confidence": "High",
       "note": ""
     }
-  ]
+  ],
+  "updated": "2022-04-04 12:57:52 -0400",
+  "brakeman_version": "5.2.1"
 }

--- a/components/financial_assistance/config/brakeman.ignore
+++ b/components/financial_assistance/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "Send",
       "message": "User controlled method execution",
       "file": "app/controllers/financial_assistance/evidences_controller.rb",
-      "line": 83,
+      "line": 77,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
       "code": "@docs_owner.send(params[:evidence_kind])",
       "render_path": null,
@@ -21,13 +21,29 @@
       "note": ""
     },
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 5.2.4.3 ends on 2022-06-01",
+      "file": "Gemfile.lock",
+      "line": 380,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Dangerous Send",
       "warning_code": 23,
       "fingerprint": "798c30611f576466c5a8654afa3eb735fb7768a4c0d4f8269f240e80c24948d5",
       "check_name": "Send",
       "message": "User controlled method execution",
       "file": "app/controllers/financial_assistance/verification_documents_controller.rb",
-      "line": 113,
+      "line": 115,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
       "code": "@docs_owner.send(params[:evidence_kind])",
       "render_path": null,
@@ -57,6 +73,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-12-27 18:13:56 -0500",
-  "brakeman_version": "5.1.1"
+  "updated": "2022-04-04 12:51:09 -0400",
+  "brakeman_version": "5.2.1"
 }

--- a/components/sponsored_benefits/config/brakeman.ignore
+++ b/components/sponsored_benefits/config/brakeman.ignore
@@ -2,6 +2,22 @@
   "ignored_warnings": [
     {
       "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 5.2.4.4 ends on 2022-06-01",
+      "file": "Gemfile.lock",
+      "line": 365,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
       "warning_code": 121,
       "fingerprint": "9a3951031616a07c8e02c86652f537e92c08685da97f5ec2b12d5d3602b55bb8",
       "check_name": "EOLRuby",
@@ -16,5 +32,7 @@
       "confidence": "High",
       "note": ""
     }
-  ]
+  ],
+  "updated": "2022-04-04 12:52:16 -0400",
+  "brakeman_version": "5.2.1"
 }

--- a/components/transport_gateway/config/brakeman.ignore
+++ b/components/transport_gateway/config/brakeman.ignore
@@ -2,6 +2,22 @@
   "ignored_warnings": [
     {
       "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 5.2.4.4 ends on 2022-06-01",
+      "file": "Gemfile.lock",
+      "line": 101,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
       "warning_code": 121,
       "fingerprint": "9a3951031616a07c8e02c86652f537e92c08685da97f5ec2b12d5d3602b55bb8",
       "check_name": "EOLRuby",
@@ -16,5 +32,7 @@
       "confidence": "High",
       "note": ""
     }
-  ]
+  ],
+  "updated": "2022-04-04 12:52:46 -0400",
+  "brakeman_version": "5.2.1"
 }

--- a/components/transport_profiles/config/brakeman.ignore
+++ b/components/transport_profiles/config/brakeman.ignore
@@ -2,6 +2,22 @@
   "ignored_warnings": [
     {
       "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 5.2.4.4 ends on 2022-06-01",
+      "file": "Gemfile.lock",
+      "line": 134,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
       "warning_code": 121,
       "fingerprint": "9a3951031616a07c8e02c86652f537e92c08685da97f5ec2b12d5d3602b55bb8",
       "check_name": "EOLRuby",
@@ -16,5 +32,7 @@
       "confidence": "High",
       "note": ""
     }
-  ]
+  ],
+  "updated": "2022-04-04 12:53:14 -0400",
+  "brakeman_version": "5.2.1"
 }

--- a/components/ui_helpers/config/brakeman.ignore
+++ b/components/ui_helpers/config/brakeman.ignore
@@ -2,12 +2,28 @@
   "ignored_warnings": [
     {
       "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 5.2.4.3 ends on 2022-06-01",
+      "file": "Gemfile.lock",
+      "line": 241,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
       "warning_code": 121,
       "fingerprint": "9a3951031616a07c8e02c86652f537e92c08685da97f5ec2b12d5d3602b55bb8",
       "check_name": "EOLRuby",
       "message": "Support for Ruby 2.5.1 ended on 2021-03-31",
       "file": "Gemfile.lock",
-      "line": 770,
+      "line": 241,
       "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
       "code": null,
       "render_path": null,
@@ -16,5 +32,7 @@
       "confidence": "High",
       "note": ""
     }
-  ]
+  ],
+  "updated": "2022-04-04 13:07:33 -0400",
+  "brakeman_version": "5.2.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -137,6 +137,22 @@
       "note": ""
     },
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 5.2.4.4 ends on 2022-06-01",
+      "file": "Gemfile.lock",
+      "line": 770,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Command Injection",
       "warning_code": 14,
       "fingerprint": "22d65d891690c434f7fb0e1b2a23f969f41a4e466fce79e60e75f6d6ccc0dce6",
@@ -290,7 +306,7 @@
           "type": "controller",
           "class": "Insured::GroupSelectionController",
           "method": "edit_plan",
-          "line": 190,
+          "line": 191,
           "file": "app/controllers/insured/group_selection_controller.rb",
           "rendered": {
             "name": "insured/group_selection/edit_plan",
@@ -482,7 +498,7 @@
           "type": "controller",
           "class": "Insured::GroupSelectionController",
           "method": "edit_plan",
-          "line": 190,
+          "line": 191,
           "file": "app/controllers/insured/group_selection_controller.rb",
           "rendered": {
             "name": "insured/group_selection/edit_plan",
@@ -553,7 +569,7 @@
           "type": "controller",
           "class": "Exchanges::HbxProfilesController",
           "method": "view_enrollment_to_update_end_date",
-          "line": 489,
+          "line": 509,
           "file": "app/controllers/exchanges/hbx_profiles_controller.rb",
           "rendered": {
             "name": "exchanges/hbx_profiles/view_enrollment_to_update_end_date",
@@ -784,7 +800,7 @@
       "check_name": "Send",
       "message": "User controlled method execution",
       "file": "components/financial_assistance/app/controllers/financial_assistance/verification_documents_controller.rb",
-      "line": 113,
+      "line": 115,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
       "code": "@docs_owner.send(params[:evidence_kind])",
       "render_path": null,
@@ -904,7 +920,7 @@
       "check_name": "Send",
       "message": "User controlled method execution",
       "file": "components/financial_assistance/app/controllers/financial_assistance/evidences_controller.rb",
-      "line": 83,
+      "line": 77,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
       "code": "@docs_owner.send(params[:evidence_kind])",
       "render_path": null,
@@ -918,6 +934,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-12-27 17:20:42 -0500",
-  "brakeman_version": "5.1.1"
+  "updated": "2022-04-04 12:28:35 -0400",
+  "brakeman_version": "5.2.1"
 }


### PR DESCRIPTION

### How to Ignore Brakeman Warning if it Comes Up Again:

**Step 1.** Make sure the Brakeman version you have locally is the same as on GH. (Currently 5.2.1)

**Step 2.** Run `brakeman -I`

**Step 3.** When prompted, select option 2 to view new errors

**Step 4.** Click 'I' to ignore the warning

**Step 5** Click '1' to save

**Step 6** Repeat in each Engine