### PR TITLE
validate joint filing response when primary is married and filing taxes

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -802,6 +802,8 @@ module FinancialAssistance
     end
 
     def tax_info_complete?
+      # is_joint_tax_filing can't be nil for primary or spouse of primary if married and filing taxes
+      return false if is_required_to_file_taxes && is_joint_tax_filing.nil? && (is_spouse_of_primary || (is_primary_applicant && has_spouse))
       filing_as_head = (FinancialAssistanceRegistry.feature_enabled?(:filing_as_head_of_household) && is_required_to_file_taxes && is_joint_tax_filing == false && !is_claimed_as_tax_dependent.nil?) ? !is_filing_as_head_of_household.nil? : true
       !is_required_to_file_taxes.nil? &&
         !is_claimed_as_tax_dependent.nil? &&
@@ -1312,7 +1314,7 @@ module FinancialAssistance
     end
 
     def presence_of_attr_step_1
-      errors.add(:is_joint_tax_filing, "' Will this person be filling jointly?' can't be blank") if is_required_to_file_taxes && is_joint_tax_filing.nil? && is_spouse_of_primary
+      errors.add(:is_joint_tax_filing, "#{full_name} must answer 'Will this person be filing jointly?'") if is_required_to_file_taxes && is_joint_tax_filing.nil? && (is_spouse_of_primary || (is_primary_applicant && has_spouse))
 
       errors.add(:claimed_as_tax_dependent_by, "' This person will be claimed as a dependent by' can't be blank") if is_claimed_as_tax_dependent && claimed_as_tax_dependent_by.nil?
 

--- a/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
@@ -405,6 +405,26 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
         expect(applicant.tax_info_complete?).to eq true
       end
     end
+
+    context 'primary is married and filing taxes' do
+      let(:application) { FactoryBot.create(:financial_assistance_application, :with_applicants) }
+      let(:primary) { application.primary_applicant }
+      let(:spouse) { application.applicants.at(1) }
+
+      before do
+        spouse.relationship = ('spouse')
+      end
+
+      context 'when is_joint_tax_filing is missing for primary and spouse' do
+        it 'should return false for primary' do
+          expect(primary.tax_info_complete?).to eq false
+        end
+
+        it 'should return false for spouse' do
+          expect(spouse.tax_info_complete?).to eq false
+        end
+      end
+    end
   end
 
   context 'is filing application with parents in household' do

--- a/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
@@ -1120,6 +1120,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
     context 'living_outside_state feature enabled' do
       before do
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:living_outside_state).and_return(true)
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:display_county).and_return(false)
       end
 
       context 'valid addresses' do
@@ -1159,6 +1160,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
     context 'living_outside_state feature disabled' do
       before do
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:living_outside_state).and_return(false)
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:display_county).and_return(false)
       end
 
       context 'valid addresses' do


### PR DESCRIPTION
IVL-181590019

-  Addresses the issue identified in this ticket: https://redmine.dchbx.org/issues/98249
-  Tax info is no longer considered complete for the primary if primary is married and required to file taxes, but joint filing question is unanswered