### PR TITLE
turn off filing_as_head_of_household feature

### DIFF
--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -204,7 +204,7 @@ registry:
     - key: :native_american_csr
       is_enabled: true
     - key: :filing_as_head_of_household
-      is_enabled: true
+      is_enabled: false
     - key: :no_coverage_tribe_details
       is_enabled: false
     - key: :display_medicaid_question

--- a/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -204,7 +204,7 @@ registry:
     - key: :native_american_csr
       is_enabled: true
     - key: :filing_as_head_of_household
-      is_enabled: true
+      is_enabled: false
     - key: :no_coverage_tribe_details
       is_enabled: false
     - key: :display_medicaid_question


### PR DESCRIPTION
IVL-181590019

- This feature was enabled as part of the development work for implementing the DC Eligibility Engine.  Client has requested this feature be disabled moving forward.