### PR TITLE
store magi medicaid response on appropriate applicant field

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination.rb
@@ -86,7 +86,8 @@ module FinancialAssistance
                                              is_without_assistance: ped_entity.is_uqhp_eligible,
                                              csr_percent_as_integer: get_csr_value(ped_entity),
                                              is_ia_eligible: ped_entity.is_ia_eligible,
-                                             is_medicaid_chip_eligible: ped_entity.is_medicaid_chip_eligible || ped_entity.is_magi_medicaid,
+                                             is_medicaid_chip_eligible: ped_entity.is_medicaid_chip_eligible,
+                                             is_magi_medicaid: ped_entity.is_magi_medicaid,
                                              is_totally_ineligible: ped_entity.is_totally_ineligible,
                                              is_eligible_for_non_magi_reasons: ped_entity.is_eligible_for_non_magi_reasons,
                                              is_non_magi_medicaid_eligible: ped_entity.is_non_magi_medicaid_eligible })

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -189,7 +189,6 @@ module FinancialAssistance
     field :magi_medicaid_category, type: String
     field :medicaid_household_size, type: Integer
 
-    # We may not need the following two fields
     field :is_magi_medicaid, type: Boolean, default: false
     field :is_medicare_eligible, type: Boolean, default: false
 

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination_spec.rb
@@ -108,6 +108,10 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::MedicaidGateway:
           expect(@applicant.is_medicaid_chip_eligible).to eq(false)
         end
 
+        it 'should update is_magi_medicaid' do
+          expect(@applicant.is_magi_medicaid).to eq(false)
+        end
+
         it 'should update is_non_magi_medicaid_eligible' do
           expect(@applicant.is_non_magi_medicaid_eligible).to eq(false)
         end


### PR DESCRIPTION
IVL-181961327
- Magi medicaid eligibility and medicaid chip eligibility were both being used to populate the same applicant field (is_medicaid_chip_eligible) in EA.  This was leading to incorrect values appearing for magi medicaid eligibility on the daily determinations report.  The already existing is_magi_medicaid field on the applicant model is now being used to store the magi medicaid eligibility response.