### PR TITLE
only display max aptc if applicant is ia eligible

### DIFF
--- a/script/daily_faa_submission_report.rb
+++ b/script/daily_faa_submission_report.rb
@@ -45,8 +45,8 @@ CSV.open(logger_file_name, 'w', force_quotes: true) do |logger_csv|
         applicant_thh = tax_households.detect {|th| th.applicant_ids.include?(applicant.family_member_id)}
         applicant_thm = applicant_thh.tax_household_members.detect {|thm| thm.applicant_id == applicant.family_member_id}
         max_aptc_str = format('%.2f', applicant_thh.current_max_aptc.to_f) if applicant_thh&.current_max_aptc.present?
-        max_aptc = applicant.is_magi_medicaid ? 'N/A' : max_aptc_str
-        csr_percent = applicant&.csr_percent_as_integer.present? ? applicant.csr_percent_as_integer.to_s : 'N/A'
+        max_aptc = max_aptc_str if applicant.is_ia_eligible
+        csr_percent = applicant.csr_percent_as_integer.to_s
         medicaid_eligible = applicant.is_magi_medicaid
         non_magi_medicaid_eligible = applicant.is_non_magi_medicaid_eligible
         is_totally_ineligible = applicant.is_totally_ineligible

--- a/spec/script/daily_faa_submission_report_spec.rb
+++ b/spec/script/daily_faa_submission_report_spec.rb
@@ -46,6 +46,7 @@ describe 'daily_faa_submission_report' do
       family_member_id: family_member.id,
       is_primary_applicant: true,
       citizen_status: 'us_citizen',
+      is_ia_eligible: true,
       csr_percent_as_integer: 73,
       first_name: person.first_name,
       last_name: person.last_name,
@@ -62,6 +63,7 @@ describe 'daily_faa_submission_report' do
       application: application,
       family_member_id: family_member2.id,
       citizen_status: 'alien_lawfully_present',
+      is_ia_eligible: false,
       csr_percent_as_integer: 87,
       first_name: person2.first_name,
       last_name: person2.last_name,
@@ -131,7 +133,8 @@ describe 'daily_faa_submission_report' do
     end
 
     it 'should match with the max aptc' do
-      expect(@file_content[1][5]).to eq format('%.2f', eligibility_determination.max_aptc.to_f)
+      max_aptc = format('%.2f', eligibility_determination.max_aptc.to_f) if primary_applicant.is_ia_eligible
+      expect(@file_content[1][5]).to eq max_aptc.to_s
     end
 
     it 'should match with the csr percent as integer' do
@@ -198,7 +201,8 @@ describe 'daily_faa_submission_report' do
     end
 
     it 'should match with the max aptc' do
-      expect(@file_content[2][5]).to eq format('%.2f', eligibility_determination2.max_aptc.to_f)
+      max_aptc = format('%.2f', eligibility_determination2.max_aptc.to_f) if spouse_applicant.is_ia_eligible
+      expect(@file_content[2][5]).to eq max_aptc.to_s
     end
 
     it 'should match with the csr percent as integer' do


### PR DESCRIPTION
IVL-181961327
- Daily  determination report was displaying the last available max aptc value, so a value was being populated if an aptc determination was received on any prior application.  A check has been added so max aptc values only appear if the applicant is currently determined to be aptc eligible.