### PR TITLE
get max aptc from applicant eligibility determination

### DIFF
--- a/script/daily_faa_submission_report.rb
+++ b/script/daily_faa_submission_report.rb
@@ -41,10 +41,7 @@ CSV.open(logger_file_name, 'w', force_quotes: true) do |logger_csv|
         uqhp_eligble = applicant.is_without_assistance
         aptc = applicant.is_ia_eligible
         family = Family.find(application.family_id)
-        tax_households = family.active_household.tax_households
-        applicant_thh = tax_households.detect {|th| th.applicant_ids.include?(applicant.family_member_id)}
-        applicant_thm = applicant_thh.tax_household_members.detect {|thm| thm.applicant_id == applicant.family_member_id}
-        max_aptc_str = format('%.2f', applicant_thh.current_max_aptc.to_f) if applicant_thh&.current_max_aptc.present?
+        max_aptc_str = format('%.2f', applicant.eligibility_determination.max_aptc.to_f) if applicant.eligibility_determination&.max_aptc.present?
         max_aptc = max_aptc_str if applicant.is_ia_eligible
         csr_percent = applicant.csr_percent_as_integer.to_s
         medicaid_eligible = applicant.is_magi_medicaid

--- a/spec/script/daily_faa_submission_report_spec.rb
+++ b/spec/script/daily_faa_submission_report_spec.rb
@@ -52,7 +52,8 @@ describe 'daily_faa_submission_report' do
       last_name: person.last_name,
       gender: person.gender,
       dob: person.dob,
-      encrypted_ssn: person.encrypted_ssn
+      encrypted_ssn: person.encrypted_ssn,
+      eligibility_determination_id: eligibility_determination.id
     )
   end
   let!(:applicant2) do
@@ -69,7 +70,8 @@ describe 'daily_faa_submission_report' do
       last_name: person2.last_name,
       gender: person2.gender,
       dob: person2.dob,
-      encrypted_ssn: person.encrypted_ssn
+      encrypted_ssn: person.encrypted_ssn,
+      eligibility_determination_id: eligibility_determination2.id
     )
   end
   let!(:applicants) { [applicant, applicant2] }


### PR DESCRIPTION
IVL-181961327
- Tax household was previously used for populating max aptc but this was not reflecting the application-specific max aptc value.  The eligibility determination id stored on the applicant model is used to find the eligibility determination (and max aptc value) specific to a given application.  The report is now populating the max aptc based on this eligibility determination referenced on the applicant model.