### PR TITLE
ensure boolean values appear for uqhp and totally ineligible fields

### DIFF
--- a/script/daily_faa_submission_report.rb
+++ b/script/daily_faa_submission_report.rb
@@ -38,7 +38,7 @@ CSV.open(logger_file_name, 'w', force_quotes: true) do |logger_csv|
     applications.each do |application|
       application.applicants.each do |applicant|
         age = applicant.age_on(end_time)
-        uqhp_eligble = applicant.is_without_assistance
+        uqhp_eligble = applicant.is_without_assistance.present?
         aptc = applicant.is_ia_eligible
         family = Family.find(application.family_id)
         max_aptc_str = format('%.2f', applicant.eligibility_determination.max_aptc.to_f) if applicant.eligibility_determination&.max_aptc.present?
@@ -46,7 +46,7 @@ CSV.open(logger_file_name, 'w', force_quotes: true) do |logger_csv|
         csr_percent = applicant.csr_percent_as_integer.to_s
         medicaid_eligible = applicant.is_magi_medicaid
         non_magi_medicaid_eligible = applicant.is_non_magi_medicaid_eligible
-        is_totally_ineligible = applicant.is_totally_ineligible
+        is_totally_ineligible = applicant.is_totally_ineligible.present?
         is_blind = applicant.is_self_attested_blind
         is_disabled = applicant.is_physically_disabled
         need_help_with_daily_living = applicant.has_daily_living_help

--- a/spec/script/daily_faa_submission_report_spec.rb
+++ b/spec/script/daily_faa_submission_report_spec.rb
@@ -127,7 +127,7 @@ describe 'daily_faa_submission_report' do
     end
 
     it 'should match with the applicant uqhp determination' do
-      expect(@file_content[1][3]).to eq(primary_applicant.is_without_assistance.to_s)
+      expect(@file_content[1][3]).to eq(primary_applicant.is_without_assistance.present?.to_s)
     end
 
     it 'should match with the applicant aptc/csr determination' do
@@ -152,7 +152,7 @@ describe 'daily_faa_submission_report' do
     end
 
     it 'should match with the applicant totally ineligible determination' do
-      expect(@file_content[1][9]).to eq(primary_applicant.is_totally_ineligible.to_s)
+      expect(@file_content[1][9]).to eq(primary_applicant.is_totally_ineligible.present?.to_s)
     end
 
     it 'should match with the application submission date' do
@@ -195,7 +195,7 @@ describe 'daily_faa_submission_report' do
     end
 
     it 'should match with the applicant uqhp determination' do
-      expect(@file_content[2][3]).to eq(spouse_applicant.is_without_assistance.to_s)
+      expect(@file_content[2][3]).to eq(spouse_applicant.is_without_assistance.present?.to_s)
     end
 
     it 'should match with the applicant aptc/csr determination' do
@@ -220,7 +220,7 @@ describe 'daily_faa_submission_report' do
     end
 
     it 'should match with the applicant totally ineligible determination' do
-      expect(@file_content[2][9]).to eq(spouse_applicant.is_totally_ineligible.to_s)
+      expect(@file_content[2][9]).to eq(spouse_applicant.is_totally_ineligible.present?.to_s)
     end
 
     it 'should match with the application submission date' do


### PR DESCRIPTION
IVL-181961327
- Client has requested that blank cells not appear in the .csv report for the 'UQHP' and 'Is Totally Ineligible' columns.