### PR TITLE
allow FAA submission when primary applicant lives out of state

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1233,10 +1233,10 @@ module FinancialAssistance
     end
 
     # Case1: Missing address - No address objects at all
-    # Case2: Invalid Address - No addresses matching the state (skip if living_outside_state feature is enabled and applicant plans to return)
+    # Case2: Invalid Address - No addresses matching the state (unless out_of_state_primary feature is enabled)
     # Case3: Unable to get rating area(home_address || mailing_address)
     def has_valid_address?
-      if EnrollRegistry.feature_enabled?(:living_outside_state) && is_temporarily_out_of_state
+      if FinancialAssistanceRegistry[:out_of_state_primary].enabled?
         addresses.where(
           :kind.in => ['home', 'mailing']
         ).present?

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1236,7 +1236,7 @@ module FinancialAssistance
     # Case2: Invalid Address - No addresses matching the state (unless out_of_state_primary feature is enabled)
     # Case3: Unable to get rating area(home_address || mailing_address)
     def has_valid_address?
-      if FinancialAssistanceRegistry[:out_of_state_primary].enabled?
+      if FinancialAssistanceRegistry.feature_enabled?(:out_of_state_primary)
         addresses.where(
           :kind.in => ['home', 'mailing']
         ).present?

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/haven/request_magi_medicaid_eligibility_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/haven/request_magi_medicaid_eligibility_determination_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Haven::RequestMa
     allow(obj2.class).to receive(:new).and_return(obj2)
     allow(obj2).to receive(:build_event).and_return(event)
     allow(event.success).to receive(:publish).and_return(true)
+    allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:out_of_state_primary)
   end
 
   context 'success' do

--- a/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
@@ -1135,7 +1135,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
 
     context 'out_of_state_primary feature enabled' do
       before do
-        allow(EnrollRegistry).to receive(:feature_enabled?).with(:out_of_state_primary).and_return(true)
+        allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:out_of_state_primary).and_return(true)
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:display_county).and_return(false)
       end
 
@@ -1171,7 +1171,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
 
     context 'out_of_state_primary feature disabled' do
       before do
-        allow(EnrollRegistry).to receive(:feature_enabled?).with(:out_of_state_primary).and_return(false)
+        allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:out_of_state_primary).and_return(false)
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:display_county).and_return(false)
       end
 

--- a/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
@@ -1133,9 +1133,9 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
       end
     end
 
-    context 'living_outside_state feature enabled' do
+    context 'out_of_state_primary feature enabled' do
       before do
-        allow(EnrollRegistry).to receive(:feature_enabled?).with(:living_outside_state).and_return(true)
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:out_of_state_primary).and_return(true)
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:display_county).and_return(false)
       end
 
@@ -1152,11 +1152,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
           end
         end
 
-        context 'applicant lives out-of-state but plans to return' do
-          before do
-            applicant.update(is_temporarily_out_of_state: true)
-          end
-
+        context 'applicant lives out-of-state' do
           it 'should consider out-of-state home address valid' do
             applicant.addresses.first.state = "OS"
             applicant.save
@@ -1173,9 +1169,9 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
       end
     end
 
-    context 'living_outside_state feature disabled' do
+    context 'out_of_state_primary feature disabled' do
       before do
-        allow(EnrollRegistry).to receive(:feature_enabled?).with(:living_outside_state).and_return(false)
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:out_of_state_primary).and_return(false)
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:display_county).and_return(false)
       end
 

--- a/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
@@ -1608,6 +1608,7 @@ RSpec.describe ::FinancialAssistance::Application, type: :model, dbclean: :after
       allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:haven_determination).and_return(haven_determination)
       allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:medicaid_gateway_determination).and_return(medicaid_gateway_determination)
       allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:verification_type_income_verification).and_return(false)
+      allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:out_of_state_primary)
       create_instate_addresses
       create_relationships
       application.update_attributes!(aasm_state: app_state)

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -82,6 +82,8 @@ registry:
         is_enabled: true
       - key: :non_applicant_citizen_status
         is_enabled: false
+      - key: :out_of_state_primary
+        is_enabled: true
   - namespace:
     - :request_determination
     features:

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -82,6 +82,8 @@ registry:
         is_enabled: false
       - key: :non_applicant_citizen_status
         is_enabled: true
+      - key: :out_of_state_primary
+        is_enabled: false
   - namespace:
     - :request_determination
     features:

--- a/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -82,6 +82,8 @@ registry:
         is_enabled: true
       - key: :non_applicant_citizen_status
         is_enabled: false
+      - key: :out_of_state_primary
+        is_enabled: true
   - namespace:
     - :request_determination
     features:


### PR DESCRIPTION
https://redmine.dchbx.org/issues/98145

- adds new feature flag : out_of_state_primary
- skips in-state adderess validation on primary applicant if feature is enabled
- updates specs