### PR TITLE
revert splitting out medicaid fields when adding determinations

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination.rb
@@ -86,8 +86,7 @@ module FinancialAssistance
                                              is_without_assistance: ped_entity.is_uqhp_eligible,
                                              csr_percent_as_integer: get_csr_value(ped_entity),
                                              is_ia_eligible: ped_entity.is_ia_eligible,
-                                             is_medicaid_chip_eligible: ped_entity.is_medicaid_chip_eligible,
-                                             is_magi_medicaid: ped_entity.is_magi_medicaid,
+                                             is_medicaid_chip_eligible: ped_entity.is_medicaid_chip_eligible || ped_entity.is_magi_medicaid,
                                              is_totally_ineligible: ped_entity.is_totally_ineligible,
                                              is_eligible_for_non_magi_reasons: ped_entity.is_eligible_for_non_magi_reasons,
                                              is_non_magi_medicaid_eligible: ped_entity.is_non_magi_medicaid_eligible })

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination_spec.rb
@@ -108,10 +108,6 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::MedicaidGateway:
           expect(@applicant.is_medicaid_chip_eligible).to eq(false)
         end
 
-        it 'should update is_magi_medicaid' do
-          expect(@applicant.is_magi_medicaid).to eq(false)
-        end
-
         it 'should update is_non_magi_medicaid_eligible' do
           expect(@applicant.is_non_magi_medicaid_eligible).to eq(false)
         end

--- a/script/daily_faa_submission_report.rb
+++ b/script/daily_faa_submission_report.rb
@@ -44,7 +44,7 @@ CSV.open(logger_file_name, 'w', force_quotes: true) do |logger_csv|
         max_aptc_str = format('%.2f', applicant.eligibility_determination.max_aptc.to_f) if applicant.eligibility_determination&.max_aptc.present?
         max_aptc = max_aptc_str if applicant.is_ia_eligible
         csr_percent = applicant.csr_percent_as_integer.to_s
-        medicaid_eligible = applicant.is_magi_medicaid
+        medicaid_eligible = applicant.is_medicaid_chip_eligible # is_medicaid_chip_eligible stores both magi medicaid and CHIP eligibility determinations
         non_magi_medicaid_eligible = applicant.is_non_magi_medicaid_eligible
         is_totally_ineligible = applicant.is_totally_ineligible.present?
         is_blind = applicant.is_self_attested_blind

--- a/spec/script/daily_faa_submission_report_spec.rb
+++ b/spec/script/daily_faa_submission_report_spec.rb
@@ -47,6 +47,7 @@ describe 'daily_faa_submission_report' do
       is_primary_applicant: true,
       citizen_status: 'us_citizen',
       is_ia_eligible: true,
+      is_medicaid_chip_eligible: false,
       csr_percent_as_integer: 73,
       first_name: person.first_name,
       last_name: person.last_name,
@@ -65,6 +66,7 @@ describe 'daily_faa_submission_report' do
       family_member_id: family_member2.id,
       citizen_status: 'alien_lawfully_present',
       is_ia_eligible: false,
+      is_medicaid_chip_eligible: true,
       csr_percent_as_integer: 87,
       first_name: person2.first_name,
       last_name: person2.last_name,
@@ -144,7 +146,7 @@ describe 'daily_faa_submission_report' do
     end
 
     it 'should match with the applicant medicaid determination' do
-      expect(@file_content[1][7]).to eq(primary_applicant.is_magi_medicaid.to_s)
+      expect(@file_content[1][7]).to eq(primary_applicant.is_medicaid_chip_eligible.to_s)
     end
 
     it 'should match with the applicant non magi medicaid determination' do
@@ -212,7 +214,7 @@ describe 'daily_faa_submission_report' do
     end
 
     it 'should match with the applicant medicaid determination' do
-      expect(@file_content[2][7]).to eq(spouse_applicant.is_magi_medicaid.to_s)
+      expect(@file_content[2][7]).to eq(spouse_applicant.is_medicaid_chip_eligible.to_s)
     end
 
     it 'should match with the applicant non magi medicaid determination' do


### PR DESCRIPTION
Potential downstream effects of the change to how EA stores eligibility determination results for magi medicaid and chip have been deemed too risky at this point without comprehensive testing in place.  This PR reverts those changes and updates the daily determinations report accordingly.