### PR TITLE
applicant cannot be mitc state resident if temporarily out of state

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
@@ -869,7 +869,7 @@ module FinancialAssistance
               in_state_address = home_address&.state == us_state
               is_temporarily_out_of_state = applicant.is_temporarily_out_of_state
 
-              # Should be considered Mitc state resident if 'temporarily out of state' box is not checked and one of the following:
+              # Should be considered Mitc state resident if 'temporarily out of state' box is NOT checked and either:
               # Case 1 - applicant has in state address
               # Case 2 - applicant does not have in state address but 'is homeless resident' box is checked
               (in_state_address && !is_temporarily_out_of_state) || (!in_state_address && !is_temporarily_out_of_state && is_homeless)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
@@ -867,7 +867,12 @@ module FinancialAssistance
               return false if home_address.blank? && !is_homeless
 
               in_state_address = home_address&.state == us_state
-              in_state_address || is_homeless || applicant.is_temporarily_out_of_state
+              is_temporarily_out_of_state = applicant.is_temporarily_out_of_state
+
+              # Should be considered Mitc state resident if 'temporarily out of state' box is not checked and one of the following:
+              # Case 1 - applicant has in state address
+              # Case 2 - applicant does not have in state address but 'is homeless resident' box is checked
+              (in_state_address && !is_temporarily_out_of_state) || (!in_state_address && !is_temporarily_out_of_state && is_homeless)
             end
           end
         end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
@@ -1766,7 +1766,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Transformers::Ap
       end
     end
 
-    context 'applicant is homeless' do
+    context 'applicant is homeless (and not temporarily out of state)' do
       before do
         applicant.update!(is_homeless: true)
         result = subject.call(application)
@@ -1786,8 +1786,8 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Transformers::Ap
         @applicant = result.success[:applicants].first
       end
 
-      it 'should return true' do
-        expect(@applicant[:mitc_state_resident]).to eq true
+      it 'should return false' do
+        expect(@applicant[:mitc_state_resident]).to eq false
       end
     end
 


### PR DESCRIPTION
https://redmine.dchbx.org/issues/98135

Applicants that are temporarily living outside of state but plan to return should not be considered residents when building the Mitc request payload.  The mitc_state_resident method has been updated so that the payload sent to MG accurately reflects this.