### PR TITLE
skip saving household if primary member has employee role

### DIFF
--- a/app/models/household.rb
+++ b/app/models/household.rb
@@ -55,14 +55,18 @@ class Household
   end
 
   def add_household_coverage_member(family_member)
-    if Family::IMMEDIATE_FAMILY.include?(family_member.primary_relationship)
+    primary_relationship = family_member.primary_relationship
+    primary_person = family_member.family.primary_applicant_person
+
+    if Family::IMMEDIATE_FAMILY.include?(primary_relationship)
       immediate_family_coverage_household.add_coverage_household_member(family_member)
       extended_family_coverage_household.remove_family_member(family_member)
     else
       immediate_family_coverage_household.remove_family_member(family_member)
       extended_family_coverage_household.add_coverage_household_member(family_member)
     end
-    self.save
+
+    self.save unless primary_person&.employee_roles.present? # prevent mongo conflict when dependent is added in SHOP context
   end
 
   def immediate_family_coverage_household

--- a/spec/models/household_spec.rb
+++ b/spec/models/household_spec.rb
@@ -32,6 +32,21 @@ describe Household, "given a coverage household with a dependent", :dbclean => :
     end
   end
 
+  context "new household member not matching existing person record" do
+    let(:new_family_member) {FactoryBot.create(:family_member, family: family, person: person)}
+    let(:primary) {family.family_members.first.person}
+
+    context "primary family member has employee role" do
+      it "should not persist the new coverage household member" do
+        allow(new_family_member).to receive(:primary_relationship).and_return("child")
+        allow(primary).to receive(:employee_roles).and_return(double)
+        active_household = family.active_household
+        active_household.add_household_coverage_member(new_family_member)
+        expect(active_household.coverage_households.first.coverage_household_members.last.persisted?).to eq false
+      end
+    end
+  end
+
   context "new_hbx_enrollment_from" do
     let(:consumer_role) {FactoryBot.create(:consumer_role)}
     let(:address) { FactoryBot.build(:address) }


### PR DESCRIPTION
RM-98476

- prevents Mongo::Error::OperationFailure (Update created a conflict at 'households.0.coverage_households' (40)) when dependent is added by an employee