### PR TITLE
Remove Mongoid::Attributes::Dynamic

### DIFF
--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -6,7 +6,6 @@ class ConsumerRole
   include Mongoid::Timestamps
   include Acapi::Notifiers
   include AASM
-  include Mongoid::Attributes::Dynamic
   include StateTransitionPublisher
   include Mongoid::History::Trackable
   include DocumentsVerificationStatus

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,7 +1,6 @@
 class Document
   include Mongoid::Document
   include Mongoid::Timestamps
-  include Mongoid::Attributes::Dynamic
   include ModelEvents::Document
   include Config::AcaModelConcern
   include Concerns::Observable

--- a/app/models/lawful_presence_determination.rb
+++ b/app/models/lawful_presence_determination.rb
@@ -6,7 +6,6 @@ class LawfulPresenceDetermination
   include Mongoid::Timestamps
   include AASM
   include Acapi::Notifiers
-  include Mongoid::Attributes::Dynamic
   include Mongoid::History::Trackable
   include EventSource::Command
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -7,7 +7,6 @@ class Person
   include Mongoid::Timestamps
   # include Mongoid::Versioning
   include Ssn
-  include Mongoid::Attributes::Dynamic
   # include SponsoredBenefits::Concerns::Ssn
   # include SponsoredBenefits::Concerns::Dob
 

--- a/app/models/resident_role.rb
+++ b/app/models/resident_role.rb
@@ -4,7 +4,6 @@ class ResidentRole
   include AASM
   include Acapi::Notifiers
   include SetCurrentUser
-  include Mongoid::Attributes::Dynamic
   include Mongoid::History::Trackable
 
   RESIDENCY_VERIFICATION_REQUEST_EVENT_NAME = "local.enroll.residency.verification_request"

--- a/components/benefit_sponsors/app/models/benefit_sponsors/sponsored_benefits/sponsor_contribution.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/sponsored_benefits/sponsor_contribution.rb
@@ -3,7 +3,6 @@ module BenefitSponsors
 
     include Mongoid::Document
     include Mongoid::Timestamps
-    include Mongoid::Attributes::Dynamic
 
     embedded_in :sponsored_benefit,
       class_name: "BenefitSponsors::SponsoredBenefits::SponsoredBenefit"

--- a/components/benefit_sponsors/spec/dummy/app/models/consumer_role.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/consumer_role.rb
@@ -6,7 +6,6 @@ class ConsumerRole
   include Mongoid::Timestamps
   include Acapi::Notifiers
   include AASM
-  include Mongoid::Attributes::Dynamic
 
   embedded_in :person
   # Just added here to simplify engine

--- a/components/benefit_sponsors/spec/dummy/app/models/document.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/document.rb
@@ -1,7 +1,6 @@
 class Document
   include Mongoid::Document
   include Mongoid::Timestamps
-  include Mongoid::Attributes::Dynamic
 
   embedded_in :documentable, polymorphic: true
 end

--- a/components/benefit_sponsors/spec/dummy/app/models/lawful_presence_determination.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/lawful_presence_determination.rb
@@ -6,7 +6,6 @@ class LawfulPresenceDetermination
   include Mongoid::Timestamps
   include AASM
   include Acapi::Notifiers
-  include Mongoid::Attributes::Dynamic
 
   embedded_in :ivl_role, polymorphic: true
   # embeds_many :ssa_responses, class_name:"EventResponse"

--- a/components/benefit_sponsors/spec/dummy/app/models/person.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/person.rb
@@ -10,7 +10,6 @@ class Person
   include SetCurrentUser
   include Mongoid::Timestamps
   include Ssn
-  include Mongoid::Attributes::Dynamic
   include BenefitSponsors::Concerns::UnsetableSparseFields
   include CrmGateway::PersonConcern
   GENDER_KINDS = %w[male female].freeze

--- a/components/financial_assistance/app/models/financial_assistance/document.rb
+++ b/components/financial_assistance/app/models/financial_assistance/document.rb
@@ -5,7 +5,6 @@ module FinancialAssistance
   class Document
     include Mongoid::Document
     include Mongoid::Timestamps
-    include Mongoid::Attributes::Dynamic
 
 
     ACCESS_RIGHTS = %w[public pii_restricted].freeze

--- a/components/financial_assistance/spec/dummy/app/models/consumer_role.rb
+++ b/components/financial_assistance/spec/dummy/app/models/consumer_role.rb
@@ -6,7 +6,6 @@ class ConsumerRole
   include Mongoid::Timestamps
   include Acapi::Notifiers
   include AASM
-  include Mongoid::Attributes::Dynamic
 
   embedded_in :person
   # Just added here to simplify engine

--- a/components/financial_assistance/spec/dummy/app/models/document.rb
+++ b/components/financial_assistance/spec/dummy/app/models/document.rb
@@ -3,7 +3,6 @@
 class Document
   include Mongoid::Document
   include Mongoid::Timestamps
-  include Mongoid::Attributes::Dynamic
 
   embedded_in :documentable, polymorphic: true
 end

--- a/components/financial_assistance/spec/dummy/app/models/lawful_presence_determination.rb
+++ b/components/financial_assistance/spec/dummy/app/models/lawful_presence_determination.rb
@@ -10,7 +10,6 @@ class LawfulPresenceDetermination
   include Mongoid::Timestamps
   include AASM
   include Acapi::Notifiers
-  include Mongoid::Attributes::Dynamic
 
   embedded_in :ivl_role, polymorphic: true
   # embeds_many :ssa_responses, class_name:"EventResponse"

--- a/components/financial_assistance/spec/dummy/app/models/person.rb
+++ b/components/financial_assistance/spec/dummy/app/models/person.rb
@@ -11,7 +11,6 @@ class Person
   include Mongoid::Timestamps
   # include Mongoid::Versioning
   include Ssn
-  include Mongoid::Attributes::Dynamic
   # include SponsoredBenefits::Concerns::Ssn
   # include SponsoredBenefits::Concerns::Dob
 


### PR DESCRIPTION
**'Mongoid::Attributes::Dynamic'** will allow attributes to get set and persisted on the document even if a field was not defined for them.