### PR TITLE
 fix active benefit group assignment method to compare app

### DIFF
--- a/app/models/benefit_group_assignment.rb
+++ b/app/models/benefit_group_assignment.rb
@@ -155,6 +155,10 @@ class BenefitGroupAssignment
     benefit_package.benefit_application if benefit_package.present?
   end
 
+  def is_application_active?
+    benefit_application&.active?
+  end
+
   def belongs_to_offexchange_planyear?
     employer_profile = plan_year.employer_profile
     employer_profile.is_conversion? && plan_year.is_conversion

--- a/app/models/census_employee.rb
+++ b/app/models/census_employee.rb
@@ -616,7 +616,9 @@ class CensusEmployee < CensusMember
   end
 
   def active_benefit_group_assignment(coverage_date = TimeKeeper.date_of_record)
-    benefit_package_assignment_on(coverage_date) || benefit_group_assignments.detect(&:is_active)
+    assignment = benefit_package_assignment_on(coverage_date)
+    assignment ||= benefit_group_assignments.detect(&:is_application_active?)
+    assignment || benefit_group_assignments.detect(&:is_active)
   end
 
   # Pass in active coverage_date to get the renewal benefit group assignment


### PR DESCRIPTION
[DC-98480](https://redmine.dchbx.org/issues/98480)

Fixed following issues:

- Incorrect benefit group assignment getting created with wrong start_on date.
- Cobra coverage not getting created when employee reinstated as Cobra.

Fix Added:

Issue happening when benefit_group_assignment is_active flag set to true on very old assignment. Due to this active_benefit_group_assignment method return old application assignment, there by returning zero cobra eligible enrollments.

To resolve this, fixed active benefit group assignment method to consider application status when it can't find one with the date passed.




