### PR TITLE
update aca_entities gem reference to pull CE terminated event

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 8e2649dfd89776b01ca5efd16766f7edd61f2a02
+  revision: 6c026996fa88124228199db094f3291d674b936c
   branch: trunk
   specs:
     aca_entities (0.10.0)


### PR DESCRIPTION
[RM-99243](https://redmine.dchbx.org/issues/99243)