### PR TITLE
Incorrect text in left nav for DC

### DIFF
--- a/app/views/ui-components/v1/navs/_families_navigation.html.slim
+++ b/app/views/ui-components/v1/navs/_families_navigation.html.slim
@@ -14,7 +14,7 @@ nav
     - if @person.has_consumer_role? && EnrollRegistry.feature_enabled?(:financial_assistance)
       li
         = link_to financial_assistance.applications_path(tab: 'cost_savings') do
-          = l10n("faa.cost_savings_applications")
+          = l10n("faa.cost_savings_nav")
     - if current_user.has_hbx_staff_role? && has_active_resident_members?(@family_members)
       li
         = link_to main_app.upload_application_insured_families_path(tab: 'verification') do

--- a/components/financial_assistance/db/seedfiles/translations/en/dc/financial_assistance.rb
+++ b/components/financial_assistance/db/seedfiles/translations/en/dc/financial_assistance.rb
@@ -171,6 +171,7 @@ FINANCIAL_ASSISTANCE_TRANSLATIONS = {
   "en.faa.evidence_type_non_esi" => "Coverage from another program",
   "en.faa.evidence_type_income" => "Income",
   # FAA start new application page
+  "en.faa.cost_savings_nav" => "Cost Savings",
   "en.faa.cost_savings_applications" => "Cost Savings Applications",
   "en.faa.cost_savings_applications_desc" => "If you started or completed an application for premium reductions, it will be listed below. If the status says it’s a draft, that means you haven’t completed the application. Select ‘Actions’ to view or update an application.",
   "en.faa.start_new_application" => "Start New Application",

--- a/components/financial_assistance/db/seedfiles/translations/en/ic/financial_assistance.rb
+++ b/components/financial_assistance/db/seedfiles/translations/en/ic/financial_assistance.rb
@@ -171,6 +171,7 @@ FINANCIAL_ASSISTANCE_TRANSLATIONS = {
   "en.faa.evidence_type_non_esi" => "Coverage from another program",
   "en.faa.evidence_type_income" => "Income",
   # FAA start new application page
+  "en.faa.cost_savings_nav" => "Cost Savings",
   "en.faa.cost_savings_applications" => "Cost Savings Applications",
   "en.faa.cost_savings_applications_desc" => "If you started or completed an application for premium reductions, it will be listed below. If the status says it’s a draft, that means you haven’t completed the application. Select ‘Actions’ to view or update an application.",
   "en.faa.start_new_application" => "Start New Application",

--- a/components/financial_assistance/db/seedfiles/translations/en/me/financial_assistance.rb
+++ b/components/financial_assistance/db/seedfiles/translations/en/me/financial_assistance.rb
@@ -176,6 +176,7 @@ FINANCIAL_ASSISTANCE_TRANSLATIONS = {
   "en.faa.evidence_type_non_esi" => "Coverage from another program",
   "en.faa.evidence_type_income" => "Income",
   # FAA start new application page
+  "en.faa.cost_savings_nav" => "Applications",
   "en.faa.cost_savings_applications" => "Applications",
   "en.faa.cost_savings_applications_desc" => "If you started or completed an application for financial assistance, it will be listed below. To update an application, find your current application and select 'Copy to new application'. If the status says it's a draft, that means you haven't submitted that application yet.",
   "en.faa.start_new_application" => "Start New Application",


### PR DESCRIPTION
IVL-183293244

changed 'cost savings applications' to 'cost savings' in DC context. ME remains the same.