### PR TITLE
add dotenv gem to development and test gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,6 +141,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'dotenv-rails'
   gem 'action-cable-testing'
   # gem 'bundler-audit',          '~> 0.6'
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,6 +462,10 @@ GEM
       warden-jwt_auth (~> 0.3.6)
     diff-lcs (1.4.4)
     docile (1.3.2)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     dry-auto_inject (0.6.1)
       dry-container (>= 0.3.4)
     dry-configurable (0.9.0)
@@ -1082,6 +1086,7 @@ DEPENDENCIES
   database_cleaner (~> 1.7)
   devise (~> 4.5)
   devise-jwt (~> 0.5.9)
+  dotenv-rails
   effective_datatables!
   email_spec (~> 2)
   event_source!


### PR DESCRIPTION
this gem will allow us to use `.env` files locally -- giving us the ability to have overrides for variables during local development

this makes it easier to change local config without needing to change anything in enroll code and always needing to remember to unstage the change before committing