### PR TITLE
require CLIENT variable to run rails

### DIFF
--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,0 +1,1 @@
+Dotenv.require_keys("CLIENT")

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
-if ['development', 'test'].include? ENV['RAILS_ENV']
-  Dotenv.require_keys("CLIENT")
-end
+Dotenv.require_keys("CLIENT") if ['development', 'test'].include? ENV['RAILS_ENV']

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-Dotenv.require_keys("CLIENT")
+if ['development', 'test'].include? ENV['RAILS_ENV']
+  Dotenv.require_keys("CLIENT")
+end

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 Dotenv.require_keys("CLIENT")


### PR DESCRIPTION
With the `CLIENT` environment variable set, Rails will start normally. If the variable is not set, Rails will throw:
``` bash
         1: from /workspaces/enroll/config/initializers/dotenv.rb:1:in `<top (required)>'
/usr/local/bundle/gems/dotenv-2.8.1/lib/dotenv.rb:79:in `require_keys': Missing required configuration key: ["CLIENT"] (Dotenv::MissingKeys)
```