### PR TITLE
use client variable for translations seed

### DIFF
--- a/db/seedfiles/english_translations_seed.rb
+++ b/db/seedfiles/english_translations_seed.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-site_key = EnrollRegistry[:enroll_app].settings(:site_key).item
+site_key = ENV['CLIENT'] || 'dc'
 
 translations_to_seed = []
 # All filenames should be in a pattern such as


### PR DESCRIPTION
another step towards moving away from the client toggler script

this change allows translations to be run for a client based on the `CLIENT` variable rather than having done a resource registry toggling first and then running the translations seed