### PR TITLE
ATP transfer rake use current year rather than flag

### DIFF
--- a/components/financial_assistance/lib/transfer_accounts.rb
+++ b/components/financial_assistance/lib/transfer_accounts.rb
@@ -9,7 +9,7 @@ module FinancialAssistance
       start_on = ENV['start_on'].present? ? Date.strptime(ENV['start_on'].to_s, "%m/%d/%Y") : Date.yesterday
       end_on = ENV['end_on'].present? ? Date.strptime(ENV['end_on'].to_s, "%m/%d/%Y") : Date.yesterday
       range = start_on.beginning_of_day..end_on.end_of_day
-      assistance_year = FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!
+      assistance_year = TimeKeeper.date_of_record.year
       eligible_family_ids = ::FinancialAssistance::Application.determined.where(submitted_at: range, :assistance_year.gte => assistance_year).distinct(:family_id)
       transferred_apps = []
       eligible_family_ids.each do |family_id|

--- a/components/financial_assistance/spec/lib/transfer_accounts_spec.rb
+++ b/components/financial_assistance/spec/lib/transfer_accounts_spec.rb
@@ -157,6 +157,13 @@ RSpec.describe ::FinancialAssistance::TransferAccounts, dbclean: :after_each do
   end
 
   context 'only current or future assistance year applications' do
+    it 'should send for current years even after 11/1' do
+      year = TimeKeeper.date_of_record.year
+      allow(TimeKeeper).to receive(:date_of_record).and_return(Date.new(year, 12, 31))
+      result = ::FinancialAssistance::TransferAccounts.run
+      expect(application.reload.account_transferred).to eq true
+      expect(result).to include(application.hbx_id)
+    end
     it 'should transfer an application from a future year' do
       application.assistance_year = TimeKeeper.date_of_record.year + 1
       application.save!


### PR DESCRIPTION
IVL-183585220

Current year applications after 11/1 would not be set due to override in default year