### PR TITLE
Fix Cv3TaxHouseholdEnrollment Transform

### DIFF
--- a/app/domain/operations/transformers/tax_household_enrollment_to/cv3_tax_household_enrollment.rb
+++ b/app/domain/operations/transformers/tax_household_enrollment_to/cv3_tax_household_enrollment.rb
@@ -19,53 +19,103 @@ module Operations
         private
 
         def tax_household_reference_hash(th_enr)
-          tax_household = th_enr.tax_household
+          @tax_household = th_enr.tax_household
           {
-            hbx_id: tax_household.hbx_id,
-            max_aptc: tax_household.max_aptc,
-            yearly_expected_contribution: tax_household.yearly_expected_contribution
+            hbx_id: @tax_household.hbx_assigned_id.to_s,
+            max_aptc: @tax_household.max_aptc&.to_hash,
+            yearly_expected_contribution: @tax_household.yearly_expected_contribution&.to_hash
           }
         end
 
         def hbx_enrollment_reference_hash(th_enr)
-          enrollment = th_enr.enrollment
+          @enrollment = th_enr.enrollment
           {
-            hbx_id: enrollment.hbx_id,
-            effective_on: enrollment.effective_on,
-            aasm_state: enrollment.aasm_state,
-            is_active: enrollment.is_active,
-            market_place_kind: enrollment.market_place_kind,
-            enrollment_period_kind: enrollment.enrollment_period_kind,
-            product_kind: enrollment.product_kind
+            hbx_id: @enrollment.hbx_id,
+            effective_on: @enrollment.effective_on,
+            aasm_state: @enrollment.aasm_state,
+            is_active: @enrollment.is_active,
+            market_place_kind: @enrollment.kind,
+            enrollment_period_kind: @enrollment.enrollment_kind,
+            product_kind: @enrollment.coverage_kind
           }
         end
 
         def tax_household_members_enrollment_members_hash(th_enr)
           th_enr.tax_household_members_enrollment_members.collect do |member|
+            hbx_enr_member = @enrollment.hbx_enrollment_members.where(id: member.hbx_enrollment_member_id).first
+            fm_reference = fetch_family_member_reference(hbx_enr_member)
             {
-              hbx_enrollment_member_id: member.hbx_enrollment_member_id,
-              tax_household_member_id: member.tax_household_member_id,
+              hbx_enrollment_member: fetch_hbx_enrollment_member(fm_reference, hbx_enr_member),
+              tax_household_member: fetch_tax_household_member(fm_reference, member),
               age_on_effective_date: member.age_on_effective_date,
-              family_member_id: member.family_member_id,
+              family_member_reference: fm_reference,
               relationship_with_primary: member.relationship_with_primary,
               date_of_birth: member.date_of_birth
             }
           end
         end
 
-        def construct_payload(th_enr)
+        def fetch_tax_household_member(fm_reference, member)
+          thh_member = @tax_household.tax_household_members.where(id: member.tax_household_member_id).first
+          return {} if thh_member.blank?
+
           {
-            tax_household_reference: tax_household_reference_hash(th_enr),
-            hbx_enrollment_reference: hbx_enrollment_reference_hash(th_enr),
-            health_product_hios_id: th_enr.health_product_hios_id,
-            dental_product_hios_id: th_enr.dental_product_hios_id,
-            household_benchmark_ehb_premium: th_enr.household_benchmark_ehb_premium,
-            household_health_benchmark_ehb_premium: th_enr.household_health_benchmark_ehb_premium,
-            household_dental_benchmark_ehb_premium: th_enr.household_dental_benchmark_ehb_premium,
-            applied_aptc: th_enr.applied_aptc,
-            available_max_aptc: th_enr.available_max_aptc,
-            tax_household_members_enrollment_members: tax_household_members_enrollment_members_hash(th_enr)
+            family_member_reference: fm_reference,
+            product_eligibility_determination: fetch_product_eligibility_determination(thh_member),
+            is_subscriber: thh_member.is_subscriber
           }
+        end
+
+        def fetch_product_eligibility_determination(member)
+          {
+            is_ia_eligible: member.is_ia_eligible,
+            is_medicaid_chip_eligible: member.is_medicaid_chip_eligible,
+            is_non_magi_medicaid_eligible: member.is_non_magi_medicaid_eligible,
+            is_totally_ineligible: member.is_totally_ineligible,
+            is_without_assistance: member.is_without_assistance,
+            magi_medicaid_monthly_household_income: member.magi_medicaid_monthly_household_income&.to_hash,
+            medicaid_household_size: member.medicaid_household_size,
+            magi_medicaid_monthly_income_limit: member.magi_medicaid_monthly_income_limit&.to_hash,
+            magi_as_percentage_of_fpl: member.magi_as_percentage_of_fpl,
+            magi_medicaid_category: member.magi_medicaid_category,
+            csr: member.csr_percent_as_integer
+          }
+        end
+
+        def fetch_hbx_enrollment_member(fm_reference, hbx_enr_member)
+          return {} if hbx_enr_member.blank?
+
+          {
+            family_member_reference: fm_reference,
+            is_subscriber: hbx_enr_member.is_subscriber,
+            eligibility_date: hbx_enr_member.eligibility_date,
+            coverage_start_on: hbx_enr_member.coverage_start_on
+          }
+        end
+
+        def fetch_family_member_reference(hbx_enr_member)
+          return {} if hbx_enr_member.blank?
+
+          {
+            family_member_hbx_id: hbx_enr_member.hbx_id, age: hbx_enr_member.age_on_effective_date,
+            first_name: hbx_enr_member.person.first_name, last_name: hbx_enr_member.person.last_name,
+            person_hbx_id: hbx_enr_member.person.hbx_id, is_primary_family_member: (hbx_enr_member.primary_relationship == 'self')
+          }
+        end
+
+        def construct_payload(th_enr)
+          Success(
+            { tax_household_reference: tax_household_reference_hash(th_enr),
+              hbx_enrollment_reference: hbx_enrollment_reference_hash(th_enr),
+              health_product_hios_id: th_enr.health_product_hios_id,
+              dental_product_hios_id: th_enr.dental_product_hios_id,
+              household_benchmark_ehb_premium: th_enr.household_benchmark_ehb_premium&.to_hash,
+              household_health_benchmark_ehb_premium: th_enr.household_health_benchmark_ehb_premium&.to_hash,
+              household_dental_benchmark_ehb_premium: th_enr.household_dental_benchmark_ehb_premium&.to_hash,
+              applied_aptc: th_enr.applied_aptc&.to_hash,
+              available_max_aptc: th_enr.available_max_aptc&.to_hash,
+              tax_household_members_enrollment_members: tax_household_members_enrollment_members_hash(th_enr) }
+          )
         end
       end
     end

--- a/spec/domain/operations/transformers/tax_household_enrollment_to/cv3_tax_household_enrollment_spec.rb
+++ b/spec/domain/operations/transformers/tax_household_enrollment_to/cv3_tax_household_enrollment_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Operations::Transformers::TaxHouseholdEnrollmentTo::Cv3TaxHouseholdEnrollment, dbclean: :after_each do
+  let!(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+  let!(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+  let!(:thhg) { FactoryBot.create(:tax_household_group, family: family) }
+  let!(:thh) do
+    thhg.tax_households.create(
+      eligibility_determination_hbx_id: '7821',
+      yearly_expected_contribution: 100.00,
+      effective_starting_on: TimeKeeper.date_of_record,
+      max_aptc: 100.00
+    )
+  end
+  let!(:thhm) { FactoryBot.create(:tax_household_member, applicant_id: family.primary_applicant.id, tax_household: thh) }
+  let!(:hbx_enrollment) do
+    FactoryBot.create(:hbx_enrollment, :with_silver_health_product,
+                      :with_enrollment_members, enrollment_members: family.family_members, family: family)
+  end
+  let!(:hbx_enrollment_member) do
+    FactoryBot.create(:hbx_enrollment_member, hbx_enrollment: hbx_enrollment, applicant_id: family.primary_applicant.id)
+  end
+
+  let!(:thh_enrollment) do
+    TaxHouseholdEnrollment.create(
+      enrollment_id: hbx_enrollment.id,
+      tax_household_id: thh.id,
+      household_benchmark_ehb_premium: 100.00,
+      health_product_hios_id: BSON::ObjectId.new,
+      dental_product_hios_id: nil,
+      household_health_benchmark_ehb_premium: 100.00,
+      household_dental_benchmark_ehb_premium: 0.0,
+      applied_aptc: 100.00,
+      available_max_aptc: 100.00
+    )
+  end
+
+  let!(:thh_enrollment_member) do
+    thh_enrollment.tax_household_members_enrollment_members.create(
+      hbx_enrollment_member_id: hbx_enrollment_member.id,
+      tax_household_member_id: thhm.id,
+      age_on_effective_date: 19,
+      family_member_id: family.primary_applicant.id,
+      relationship_with_primary: 'self',
+      date_of_birth: person.dob
+    )
+  end
+
+  let(:result) { subject.call(thh_enrollment) }
+
+  describe '#call' do
+    it 'should return success' do
+      expect(result.success?).to be_truthy
+      contract_result = AcaEntities::Contracts::PremiumCredits::TaxHouseholdEnrollmentContract.new.call(result.success)
+      expect(contract_result.success?).to be_truthy
+      expect(
+        AcaEntities::PremiumCredits::TaxHouseholdEnrollment.new(contract_result.to_h)
+      ).to be_a(AcaEntities::PremiumCredits::TaxHouseholdEnrollment)
+    end
+  end
+end

--- a/spec/models/sponsored_benefits/employer_profile_builder_spec.rb
+++ b/spec/models/sponsored_benefits/employer_profile_builder_spec.rb
@@ -3,7 +3,7 @@ require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_market.rb"
 
 module SponsoredBenefits
   RSpec.describe BenefitApplications::EmployerProfileBuilder, type: :model do
-    let(:effective_period_start_on) { TimeKeeper.date_of_record.end_of_month + 1.day + 1.month }
+    let(:effective_period_start_on) { TimeKeeper.date_of_record.beginning_of_month }
     let(:effective_period_end_on)   { effective_period_start_on + 1.year - 1.day }
     let(:effective_period)          { effective_period_start_on..effective_period_end_on }
 
@@ -47,8 +47,9 @@ module SponsoredBenefits
       let(:plan_design_proposal)      { SponsoredBenefits::Organizations::PlanDesignProposal.new(title: "New Proposal") }
       let(:profile) {SponsoredBenefits::Organizations::AcaShopCcaEmployerProfile.new}
 
-      let(:product)  { FactoryBot.create :benefit_markets_products_health_products_health_product, issuer_profile: issuer_profile }
-      let(:plan )    { FactoryBot.create(:plan, hios_id: product.hios_id) }
+      let(:application_period)   { Date.new(benefit_application.effective_period.min.year, 1, 1)..Date.new(benefit_application.effective_period.min.year, 12, 31) }
+      let(:product)  { FactoryBot.create :benefit_markets_products_health_products_health_product, issuer_profile: issuer_profile, application_period:  application_period}
+      let(:plan)    { FactoryBot.create(:plan, hios_id: product.hios_id, active_year: benefit_application.effective_period.min.year) }
       let(:benefit_group)             { FactoryBot.create(:benefit_group, reference_plan_id: plan.id, title: 'benefit group') }
 
       before(:each) do


### PR DESCRIPTION
ME-183683992

We have to merge this code to both **trunk** and **release_10_30_2022**. Need to confirm this with @DFos85 and @markgoho about the merge.

PR has
1. Cv3TaxHouseholdEnrollment Transform fix.
2. Cherrypicked(e8f18b40da1ef1e4508a3dccff9cd56fa0c535ba) failing spec fix from Trunk.

TestCase: MTHHs world, Enrollment with APTC, Determination from FAA