### PR TITLE
render pay now modal in refactored enrollment tile

### DIFF
--- a/app/views/insured/families/_enrollment.html.erb
+++ b/app/views/insured/families/_enrollment.html.erb
@@ -255,6 +255,3 @@
   </div>
   </div>
 <% end %>
-<% if hbx_enrollment.product.present? %>
-  <%= render "shared/pay_now_modal", hbx_enrollment: hbx_enrollment, source: "enrollment_tile" %>
-<% end %>

--- a/app/views/insured/families/_enrollment_actions.html.erb
+++ b/app/views/insured/families/_enrollment_actions.html.erb
@@ -55,3 +55,6 @@
         </div>
     <% end %>
 </div>
+<% if hbx_enrollment.product.present? %>
+  <%= render "shared/pay_now_modal", hbx_enrollment: hbx_enrollment, source: "enrollment_tile" %>
+<% end %>

--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -161,3 +161,6 @@
         </div>
     </div>
 <% end %>
+<% if hbx_enrollment.product.present? %>
+  <%= render "shared/pay_now_modal", hbx_enrollment: hbx_enrollment, source: "enrollment_tile" %>
+<% end %>

--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -161,6 +161,3 @@
         </div>
     </div>
 <% end %>
-<% if hbx_enrollment.product.present? %>
-  <%= render "shared/pay_now_modal", hbx_enrollment: hbx_enrollment, source: "enrollment_tile" %>
-<% end %>


### PR DESCRIPTION
IVL-183235259

This change is in the new enrollment tile partial that was requested in CR-74.

The env variable that controls whether or not this tile is displayed in the UI is:
``` 
ENROLLMENT_PLAN_TILE_UPDATE_IS_ENABLED
```