### PR TITLE
set back button on edit plan page based on previous page

### DIFF
--- a/app/views/insured/families/_enrollment_actions.html.erb
+++ b/app/views/insured/families/_enrollment_actions.html.erb
@@ -26,7 +26,7 @@
                 <!-- This potentially allows certain shop users to view Make Changes -->
                 <% elsif can_make_changes_for_enrollment %>
                     <%= pundit_span Family, :updateable? %>
-                    <a href="<%= edit_plan_insured_group_selections_path(hbx_enrollment_id: hbx_enrollment.id, family_id: @family.id) %>" class='btn-link btn-block dropdown-item ivl-make-changes' id='make-changes-btn' style='padding: 6px 12px; margin: 4px 0;'>
+                    <a href="<%= edit_plan_insured_group_selections_path(hbx_enrollment_id: hbx_enrollment.id, family_id: @family.id) %>" class='btn-link btn-block dropdown-item ivl-make-changes' id='make-changes-btn' style='padding: 6px 12px; margin: 4px 0;' data-turbolinks="false">
                         <%= render partial:"shared/glossary_hover", locals: {key: "make_changes_to_coverage", title: "Make changes to my plan", term: sanitize(l10n('make_changes')) } %>
                     </a>
                 <% end %>

--- a/app/views/insured/group_selection/edit_plan.html.erb
+++ b/app/views/insured/group_selection/edit_plan.html.erb
@@ -2,7 +2,8 @@
   <div class="row">
     <div class="col-md-2">
       <br class="clear"/>
-      <%= link_to l10n("back_to_my_account"),  family_account_path, class: 'btn btn-default btn-default' %>
+      <% back_btn_text = request.referrer&.include?('enrollment_history') ? l10n("back_to_enrollments") : l10n("back_to_my_account") %>
+      <%= link_to back_btn_text, request.referrer, class: 'btn btn-default btn-default' %>
       <br class="clear"/>
       <br class="clear"/>
     </div>

--- a/app/views/insured/group_selection/edit_plan.html.erb
+++ b/app/views/insured/group_selection/edit_plan.html.erb
@@ -3,7 +3,8 @@
     <div class="col-md-2">
       <br class="clear"/>
       <% back_btn_text = request.referrer&.include?('enrollment_history') ? l10n("back_to_enrollments") : l10n("back_to_my_account") %>
-      <%= link_to back_btn_text, request.referrer, class: 'btn btn-default btn-default' %>
+      <% back_btn_path = request.referrer&.include?('enrollment_history') ? enrollment_history_insured_families_path : family_account_path %>
+      <%= link_to back_btn_text, back_btn_path, class: 'btn btn-default btn-default' %>
       <br class="clear"/>
       <br class="clear"/>
     </div>


### PR DESCRIPTION
IVL-183420120

No explicit feature flag reference is required here.  The behavior introduced in this PR is only relevant if the user is navigating to the edit plan page from the Enrollments history page

The presence of that page is controlled by this flag: 
```
ENROLLMENT_HISTORY_PAGE_IS_ENABLED
```