### PR TITLE
fixes an issue on the tiles home for admin and family that can see all enrollments

### DIFF
--- a/app/controllers/insured/families_controller.rb
+++ b/app/controllers/insured/families_controller.rb
@@ -52,7 +52,7 @@ class Insured::FamiliesController < FamiliesController
 
       if EnrollRegistry.feature_enabled?(:home_tiles_current_and_future_only)
         @hbx_enrollments = @hbx_enrollments.select { |d| d["effective_on"] >= TimeKeeper.date_of_record.beginning_of_year }
-        @all_hbx_enrollments_for_admin = @all_hbx_enrollments_for_admin.select { |d| d["effective_on"] > TimeKeeper.date_of_record.beginning_of_year }
+        @all_hbx_enrollments_for_admin = @all_hbx_enrollments_for_admin.select { |d| d["effective_on"] >= TimeKeeper.date_of_record.beginning_of_year }
       end
 
       respond_to do |format|

--- a/spec/controllers/insured/families_controller_spec.rb
+++ b/spec/controllers/insured/families_controller_spec.rb
@@ -1522,6 +1522,9 @@ RSpec.describe Insured::FamiliesController, dbclean: :after_each do
       it "should only return this year enrollment" do
         expect(assigns(:hbx_enrollments)).to eq([ivl_enrollment])
       end
+      it "admin should see all enrollments for this year" do
+        expect(assigns(:all_hbx_enrollments_for_admin)).to eq([this_year_cancelled, ivl_enrollment])
+      end
     end
 
     context "ivl with 'show non pay enrollments' FF " do


### PR DESCRIPTION
IV-183104708 

FF to manage this feature;
TILES_CURRENT_AND_FUTURE_ONLY_IS_ENABLED