### PR TITLE
update medicaid eligible warning message for choose coverage page

### DIFF
--- a/app/controllers/insured/group_selection_controller.rb
+++ b/app/controllers/insured/group_selection_controller.rb
@@ -240,8 +240,9 @@ class Insured::GroupSelectionController < ApplicationController
     incarcerated = person.is_consumer_role_active? && family_member.is_applying_coverage && person.is_incarcerated.nil? ? "incarcerated_not_answered" : family_member.person.is_incarcerated
 
     if EnrollRegistry.feature_enabled?(:choose_coverage_medicaid_warning)
-      is_eligible_for_mdcr = family_member_eligible_for_medicaid(family_member, @family, @new_effective_on&.year)
-      errors << l10n("insured.group_selection.mdcr_eligible_warning") if is_eligible_for_mdcr
+      is_eligible_for_medicaid = family_member_eligible_for_medicaid(family_member, @family, @new_effective_on&.year)
+      translation_keys = { medicaid_or_chip_program_short_name: FinancialAssistanceRegistry[:medicaid_or_chip_program_short_name].setting(:name).item }
+      errors << l10n("insured.group_selection.medicaid_eligible_warning", translation_keys) if is_eligible_for_medicaid
     end
 
     @fm_hash[family_member.id] = [is_ivl_coverage, rule, errors, incarcerated]

--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -301,7 +301,7 @@ How to find the SEVIS ID: On the DS-2019, the number is on the top right hand si
   :'en.month' => "Month",
   :'en.termination_date' => "Termination date",
   :'en.insured.group_selection.coverage_household_ineligible_coverage' => "This dependent is ineligible for employer-sponsored %{coverage_kind} coverage.",
-  :'en.insured.group_selection.mdcr_eligible_warning' => "Potentially eligible for Medicaid/CHIP",
+  :'en.insured.group_selection.medicaid_eligible_warning' => "Potentially eligible for Medicaid/CHIP",
   :'en.insured.group_selection.new.choose_coverage_for_your_household' => "Choose Coverage for your Household",
   :'en.insured.group_selection.new.select_who_needs_coverage' => "Select who needs coverage and the type of coverage needed. When you’re finished, select CONTINUE.",
   :'en.insured.group_selection.new.effective_date' => "EFFECTIVE DATE",

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -362,7 +362,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.month' => "Month",
   :'en.termination_date' => "Termination date",
   :'en.insured.group_selection.coverage_household_ineligible_coverage' => "Employer sponsored coverage is not available",
-  :'en.insured.group_selection.mdcr_eligible_warning' => "Potentially eligible for Medicaid/CHIP",
+  :'en.insured.group_selection.medicaid_eligible_warning' => "Potentially eligible for Medicaid/CHIP",
   :'en.insured.group_selection.is_tobacco_user' => "Is this person a Tobacco user?",
   :'en.insured.group_selection.new.choose_coverage_for_your_household' => "Choose Coverage for your Household",
   :'en.insured.group_selection.new.select_who_needs_coverage' => "Select who needs coverage and the type of coverage needed. When you’re finished, select CONTINUE.",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -364,7 +364,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.month' => "Month",
   :'en.termination_date' => "Termination date",
   :'en.insured.group_selection.coverage_household_ineligible_coverage' => "Employer sponsored coverage is not available",
-  :'en.insured.group_selection.mdcr_eligible_warning' => "Potentially eligible for MaineCare/CubCare",
+  :'en.insured.group_selection.medicaid_eligible_warning' => "Assessed eligible for MaineCare/CubCare",
   :'en.insured.group_selection.is_tobacco_user' => "Is this person a Tobacco user?",
   :'en.insured.group_selection.new.choose_coverage_for_your_household' => "Choose Coverage for your Household",
   :'en.insured.group_selection.new.select_who_needs_coverage' => "Select who needs coverage and the type of coverage needed. When you’re finished, select CONTINUE.",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -364,7 +364,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.month' => "Month",
   :'en.termination_date' => "Termination date",
   :'en.insured.group_selection.coverage_household_ineligible_coverage' => "Employer sponsored coverage is not available",
-  :'en.insured.group_selection.medicaid_eligible_warning' => "Assessed eligible for MaineCare/CubCare",
+  :'en.insured.group_selection.medicaid_eligible_warning' => "Assessed eligible for %{medicaid_or_chip_program_short_name}",
   :'en.insured.group_selection.is_tobacco_user' => "Is this person a Tobacco user?",
   :'en.insured.group_selection.new.choose_coverage_for_your_household' => "Choose Coverage for your Household",
   :'en.insured.group_selection.new.select_who_needs_coverage' => "Select who needs coverage and the type of coverage needed. When you’re finished, select CONTINUE.",


### PR DESCRIPTION
IVL-182598258

- On CC for HH page, change the word "Potentially" to "Assessed"
- Remove hard coding of program short name from warning
- update variable and translation key to reflect business logic (was incorrectly referencing medicare)