### PR TITLE
Allow SLCSP identification for non-active family members

### DIFF
--- a/app/data_migrations/migrate_household_thhs_to_thh_group_thhs.rb
+++ b/app/data_migrations/migrate_household_thhs_to_thh_group_thhs.rb
@@ -310,7 +310,8 @@ class MigrateHouseholdThhsToThhGroupThhs < MongoidMigrationTask
 
         if family.save!
           logger.info "----- Successfully created TaxHouseholdGroups for family with family_hbx_assigned_id: #{family.hbx_assigned_id}"
-          determination = ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: family.reload, effective_date: TimeKeeper.date_of_record)
+          is_migrating = family.enrollments.present?
+          determination = ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: family.reload, effective_date: TimeKeeper.date_of_record, is_migrating: is_migrating)
           if determination.success?
             logger.info "----- Successfully created FamilyDetermination: #{determination.success} for family with family_hbx_assigned_id: #{family.hbx_assigned_id}"
 

--- a/app/domain/operations/benchmark_products/identify_rating_and_service_areas.rb
+++ b/app/domain/operations/benchmark_products/identify_rating_and_service_areas.rb
@@ -19,14 +19,14 @@ module Operations
       private
 
       def find_rating_address(params)
-        family = params[:family]
+        @family = params[:family]
         bpm_params = params[:benchmark_product_model].to_h
-        rating_address = family.primary_person&.rating_address
+        rating_address = @family.primary_person&.rating_address
         if rating_address.present?
           bpm_params[:primary_rating_address_id] = rating_address.id
           Success([bpm_params, rating_address])
         else
-          Failure("Unable to find Rating Address for Primary Person with hbx_id: #{family.primary_person.hbx_id} of Family with id: #{family.id}")
+          Failure("Unable to find Rating Address for PrimaryPerson with hbx_id: #{@family.primary_person.hbx_id} of Family with id: #{@family.id}")
         end
       end
 
@@ -39,7 +39,9 @@ module Operations
           bpm_params[:exchange_provided_code] = rating_area.exchange_provided_code
           Success(bpm_params)
         else
-          Failure("Rating Area not found for effective_date: #{effective_date}, county: #{address.county}, zip: #{address.zip}")
+          Failure(
+            "Rating Area not found for PrimaryPerson hbx_id: #{@family.primary_person.hbx_id}, effective_date: #{effective_date}, county: #{address.county}, zip: #{address.zip}, state: #{address.state}"
+          )
         end
       end
 

--- a/app/domain/operations/benchmark_products/identify_rating_and_service_areas_for_migration.rb
+++ b/app/domain/operations/benchmark_products/identify_rating_and_service_areas_for_migration.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Operations
+  module BenchmarkProducts
+    # This Operation is used to identify rating area and service areas for rating_address of Primary Person of Family
+    class IdentifyRatingAndServiceAreasForMigration
+      include Dry::Monads[:result, :do]
+
+      def call(params)
+        # params = { family: family, benchmark_product_model: benchmark_product_model }
+        bpm_params, rating_address = yield find_rating_address(params)
+        bpm_params                 = yield find_rating_area(rating_address, bpm_params)
+        bpm_params                 = yield find_service_areas(rating_address, bpm_params)
+        benchmark_product_model    = yield initialize_benchmark_product_model(bpm_params)
+
+        Success(benchmark_product_model)
+      end
+
+      private
+
+      def find_rating_address(params)
+        @family = params[:family]
+        @is_migrating = params[:is_migrating]
+        @hbx_enrollment = params[:hbx_enrollment]
+        @primary_person = @family.primary_person
+        bpm_params = params[:benchmark_product_model].to_h
+        rating_address = @primary_person&.rating_address
+        if rating_address.present?
+          bpm_params[:primary_rating_address_id] = rating_address.id
+          Success([bpm_params, rating_address])
+        else
+          Failure("Unable to find Rating Address for PrimaryPerson with hbx_id: #{@primary_person.hbx_id} of Family with id: #{@family.id}")
+        end
+      end
+
+      def find_rating_area(address, bpm_params)
+        effective_date = bpm_params[:effective_date]
+
+        params = { 'county' => address.county, 'state' => address.state, 'zip' => address.zip }
+        eligible_history_tracks = address.history_tracks.where(:created_at.lte => @hbx_enrollment.created_at).reverse
+        rating_area = eligible_history_tracks.each do |history_obj|
+          params = params.merge(history_obj.modified)
+          add_struct = OpenStruct.new(params)
+          rating_area = ::BenefitMarkets::Locations::RatingArea.rating_area_for(add_struct, during: effective_date)
+
+          break rating_area if rating_area.present?
+        end
+
+        if rating_area.present?
+          bpm_params[:rating_area_id] = rating_area.id
+          bpm_params[:exchange_provided_code] = rating_area.exchange_provided_code
+          Success(bpm_params)
+        else
+          Failure(
+            "Rating Area not found for PrimaryPerson hbx_id: #{@primary_person.hbx_id}, effective_date: #{effective_date}, county: #{address.county}, zip: #{address.zip}, state: #{address.state}"
+          )
+        end
+      end
+
+      def find_service_areas(address, bpm_params)
+        effective_date = bpm_params[:effective_date]
+
+        params = { 'county' => address.county, 'state' => address.state, 'zip' => address.zip }
+        eligible_history_tracks = address.history_tracks.where(:created_at.lte => @hbx_enrollment.created_at).reverse
+        service_areas = eligible_history_tracks.each do |history_obj|
+          params = params.merge(history_obj.modified)
+          add_struct = OpenStruct.new(params)
+          service_areas = ::BenefitMarkets::Locations::ServiceArea.service_areas_for(add_struct, during: effective_date)
+
+          break service_areas if service_areas.present?
+        end
+
+        if service_areas.present?
+          bpm_params[:service_area_ids] = service_areas.map(&:id)
+          Success(bpm_params)
+        else
+          Failure("Service Areas not found for effective_date: #{effective_date}, county: #{address.county}, zip: #{address.zip}")
+        end
+      end
+
+      def initialize_benchmark_product_model(bpm_params)
+        ::Operations::BenchmarkProducts::Initialize.new.call(bpm_params)
+      end
+    end
+  end
+end

--- a/app/domain/operations/benchmark_products/identify_slcsp_with_pediatric_dental_costs.rb
+++ b/app/domain/operations/benchmark_products/identify_slcsp_with_pediatric_dental_costs.rb
@@ -28,6 +28,8 @@ module Operations
 
       def validate(params)
         @application_hbx_id = params[:application_hbx_id] if params[:application_hbx_id].present?
+        @is_migrating = params[:is_migrating]
+        @hbx_enrollment = params[:hbx_enrollment]
         ::Operations::BenchmarkProducts::Initialize.new.call(params)
       end
 
@@ -37,7 +39,18 @@ module Operations
       end
 
       def identify_rating_and_service_areas(family, benchmark_product_model)
-        ::Operations::BenchmarkProducts::IdentifyRatingAndServiceAreas.new.call({ family: family, benchmark_product_model: benchmark_product_model })
+        if @is_migrating
+          ::Operations::BenchmarkProducts::IdentifyRatingAndServiceAreasForMigration.new.call(
+            { family: family,
+              benchmark_product_model: benchmark_product_model,
+              is_migrating: @is_migrating,
+              hbx_enrollment: @hbx_enrollment }
+          )
+        else
+          ::Operations::BenchmarkProducts::IdentifyRatingAndServiceAreas.new.call(
+            { family: family, benchmark_product_model: benchmark_product_model }
+          )
+        end
       end
 
       def identify_slcsapd(family, benchmark_product_model)

--- a/app/domain/operations/benchmark_products/identify_type_of_household.rb
+++ b/app/domain/operations/benchmark_products/identify_type_of_household.rb
@@ -36,7 +36,7 @@ module Operations
         @family ||= Family.where(id: family_id).first
         return Failure("Unable to find Family with family_id: #{family_id}") if @family.blank?
 
-        family_member = @family.active_family_members.where(id: family_member_id).first
+        family_member = @family.family_members.where(id: family_member_id).first
         return Failure("Unable to find FamilyMember for family_id: #{family_id}, with family_member_id: #{family_member_id}") if family_member.blank?
 
         Success(family_member)

--- a/app/domain/operations/eligibilities/build_family_determination.rb
+++ b/app/domain/operations/eligibilities/build_family_determination.rb
@@ -43,7 +43,7 @@ module Operations
         family = values[:family]
         primary_person = family&.primary_applicant&.person
         is_any_member_applying_for_coverage = family.family_members.any?(&:is_applying_coverage)
-        if is_any_member_applying_for_coverage && primary_person.consumer_role.present?
+        if (is_any_member_applying_for_coverage && primary_person.consumer_role.present?) || values[:is_migrating]
           BuildDetermination.new.call(subjects: subjects, effective_date: values[:effective_date], family: family)
         else
           Failure("Person don't have consumer role or is not applying for coverage")

--- a/app/domain/operations/premium_credits/find_aptc_with_tax_households.rb
+++ b/app/domain/operations/premium_credits/find_aptc_with_tax_households.rb
@@ -225,7 +225,9 @@ module Operations
         payload = {
           family_id: @family.id,
           effective_date: @effective_on,
-          households: households_hash
+          households: households_hash,
+          is_migrating: @is_migrating,
+          enrollment: @hbx_enrollment
         }
 
         result = ::Operations::BenchmarkProducts::IdentifySlcspWithPediatricDentalCosts.new.call(payload)

--- a/app/domain/operations/premium_credits/find_aptc_with_tax_households.rb
+++ b/app/domain/operations/premium_credits/find_aptc_with_tax_households.rb
@@ -227,7 +227,7 @@ module Operations
           effective_date: @effective_on,
           households: households_hash,
           is_migrating: @is_migrating,
-          enrollment: @hbx_enrollment
+          hbx_enrollment: @hbx_enrollment
         }
 
         result = ::Operations::BenchmarkProducts::IdentifySlcspWithPediatricDentalCosts.new.call(payload)

--- a/spec/domain/operations/benchmark_products/identify_rating_and_service_areas_spec.rb
+++ b/spec/domain/operations/benchmark_products/identify_rating_and_service_areas_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Operations::BenchmarkProducts::IdentifyRatingAndServiceAreas do
       end
 
       it 'return failure with message' do
-        expect(@result.failure).to eq("Unable to find Rating Address for Primary Person with hbx_id: #{family.primary_person.hbx_id} of Family with id: #{family.id}")
+        expect(@result.failure).to eq("Unable to find Rating Address for PrimaryPerson with hbx_id: #{family.primary_person.hbx_id} of Family with id: #{family.id}")
       end
     end
   end

--- a/spec/domain/operations/benchmark_products/identify_type_of_household_spec.rb
+++ b/spec/domain/operations/benchmark_products/identify_type_of_household_spec.rb
@@ -56,8 +56,12 @@ RSpec.describe Operations::BenchmarkProducts::IdentifyTypeOfHousehold do
         per
       end
       let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person1) }
-      let(:family_member1) { family.primary_applicant }
-      let(:family_member2) { FactoryBot.create(:family_member, family: family, person: person2) }
+      let(:family_member1) do
+        fm = family.primary_applicant
+        fm.update_attributes!(is_active: false)
+        fm
+      end
+      let(:family_member2) { FactoryBot.create(:family_member, family: family, person: person2, is_active: false) }
       let(:family_id) { family.id }
 
       context 'adult_only' do


### PR DESCRIPTION
IVL-183915202

This PR fixes the below issues and each bug fix listed below maps to each commit respectively.
- Fixes the issue with SLCSP identification for non-active family members.
- Fixes the issue with FamilyDetermination creation by looking at the history to see if members are applying for coverage during enrollment creation.
- Fixes the issue with finding RatingArea by looking at the RatingAddress history during enrollment creation.