### PR TITLE
pin rubygems version to 3.3.26 in GH workflows

### DIFF
--- a/.docker/production/Dockerfile.gha
+++ b/.docker/production/Dockerfile.gha
@@ -62,7 +62,7 @@ ENV LANG=C.UTF-8
 
 ENV PATH=$HOME/bin:$BUNDLE_BIN:$GEM_HOME/gems/bin:$PATH
 
-RUN gem update --system
+RUN gem update --system 3.3.26
 RUN rm -f /usr/local/bin/ruby/gems/*/specifications/default/bundler-*.gemspec
 RUN gem install bundler -v $BUNDLER_VERSION
 

--- a/.github/workflows/client-swap-suite.yml
+++ b/.github/workflows/client-swap-suite.yml
@@ -44,7 +44,7 @@ jobs:
             v2-${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}-${{ hashFiles('**/Gemfile' ) }}
       - name: Install project gems
         run: |
-          gem update --system
+          gem update --system 3.3.26
           bundle config path vendor/bundle
           bundle install
       - name: Run Client Swap Suite
@@ -106,7 +106,7 @@ jobs:
             v5-${{ matrix.engine-name }}-
       - name: bundle install
         run: |
-          gem update --system --quiet --silent
+          gem update --system 3.3.26 --quiet --silent
           bundle config path vendor/bundle
           bundle install
           bundle exec rake configuration:client_configuration_toggler client='${{ matrix.client-name }}'
@@ -173,7 +173,7 @@ jobs:
             benefit_sponsors-
       - name: bundle install
         run: |
-          gem update --system --quiet --silent
+          gem update --system 3.3.26 --quiet --silent
           bundle config path vendor/bundle
           bundle install
           bundle exec rake configuration:client_configuration_toggler client='${{ matrix.client-name }}'
@@ -237,7 +237,7 @@ jobs:
             v2-${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}-${{ hashFiles('**/Gemfile' ) }}
       - name: Install project gems
         run: |
-          gem update --system
+          gem update --system 3.3.26
           bundle config path vendor/bundle
           bundle install
           gem install treye-semaphore_test_boosters --version '2.5.2'
@@ -292,7 +292,7 @@ jobs:
             v2-${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}-${{ hashFiles('**/Gemfile' ) }}
       - name: Install project gems
         run: |
-          gem update --system
+          gem update --system 3.3.26
           bundle config path vendor/bundle
           bundle install
           gem install treye-semaphore_test_boosters --version '2.5.2'

--- a/.github/workflows/client-swap-suite.yml
+++ b/.github/workflows/client-swap-suite.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
+        with:
+          rubygems: 3.3.26
       - uses: actions/setup-node@v1
         with:
           node-version: '10'
@@ -80,6 +82,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
+        with:
+          rubygems: 3.3.26
       - uses: actions/setup-node@v1
         with:
           node-version: '10'
@@ -145,6 +149,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
+        with:
+          rubygems: 3.3.26
       - uses: actions/setup-node@v1
         with:
           node-version: '10'
@@ -207,6 +213,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
+        with:
+          rubygems: 3.3.26
       - uses: actions/setup-node@v1
         with:
           node-version: '10'
@@ -260,6 +268,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
+        with:
+          rubygems: 3.3.26
       - uses: actions/setup-node@v1
         with:
           node-version: '10'

--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          rubygems: latest
+          rubygems: 3.3.26
       - name: Run View Linter
         run: |
           git fetch --no-tags --depth=1 origin trunk
@@ -33,7 +33,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          rubygems: latest
+          rubygems: 3.3.26
       - run: gem install brakeman
       - run: brakeman -i config/brakeman.ignore
       - name: Run Brakeman In Components
@@ -287,7 +287,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          rubygems: latest
+          rubygems: 3.3.26
       - uses: actions/setup-node@v3
         with:
           node-version: '14'
@@ -398,7 +398,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          rubygems: latest
+          rubygems: 3.3.26
       - uses: actions/setup-node@v3
         with:
           node-version: '14'

--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -92,6 +92,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
+        with:
+          rubygems: 3.3.26
       - uses: actions/setup-node@v3
         with:
           node-version: '14'
@@ -178,6 +180,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
+        with:
+          rubygems: 3.3.26
       - uses: actions/setup-node@v3
         with:
           node-version: '14'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          rubygems: latest
+          rubygems: 3.3.26
       - run: |
           git config diff.renameLimit 800
           git fetch --no-tags --depth=1 origin trunk


### PR DESCRIPTION
Fixes this bug that caused all GHA jobs to start failing two days ago:
```
Error: Error: The process '/opt/hostedtoolcache/Ruby/2.5.9/x64/bin/gem' failed with exit code 1
    at ExecState._setResult (/home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:5371:25)
    at ExecState.CheckComplete (/home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:5354:18)
    at ChildProcess.<anonymous> (/home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:5248:27)
    at ChildProcess.emit (node:events:[39](https://github.com/ideacrew/enroll/actions/runs/3791825204/jobs/6447540490#step:3:45)0:28)
    at maybeClose (node:internal/child_process:1064:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:301:5)
```
Note: not sure if this is the best long-term solution but can be used as a temporary fix, at least.