### PR TITLE
set beginning and end of day explicitly in  FAA report date range

### DIFF
--- a/script/monthly_faa_submission_report.rb
+++ b/script/monthly_faa_submission_report.rb
@@ -28,8 +28,8 @@ report_file_name = "#{Rails.root}/monthly_faa_submission_report_#{date.strftime(
 logger_file_name = "#{Rails.root}/monthly_faa_submission_report_logger_#{date.strftime('%m_%d_%Y')}.csv"
 start_on = ENV['start_on']
 end_on = ENV['end_on']
-start_time = start_on ? Time.parse(start_on).beginning_of_month : date.prev_month.beginning_of_month
-end_time = end_on ? Time.parse(end_on).end_of_month : date.prev_month.end_of_month
+start_time = start_on ? Time.parse(start_on).beginning_of_month.beginning_of_day : date.prev_month.beginning_of_month.beginning_of_day
+end_time = end_on ? Time.parse(end_on).end_of_month.end_of_day : date.prev_month.end_of_month.end_of_day
 
 CSV.open(logger_file_name, 'w', force_quotes: true) do |logger_csv|
   logger_csv << logger_field_names

--- a/spec/domain/operations/hbx_enrollments/drop_enrollment_members_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/drop_enrollment_members_spec.rb
@@ -135,29 +135,36 @@ RSpec.describe Operations::HbxEnrollments::DropEnrollmentMembers, :type => :mode
           expect(result.failure).to eq "Not an ivl enrollment."
         end
 
-        it 'should return a failure when hbx_enrollment is not an ivl' do
+        it 'should return a failure when members have not been selected for termination' do
           result = subject.call({hbx_enrollment: enrollment,
                                  options: {"termination_date_#{enrollment.id}" => (TimeKeeper.date_of_record + 1.day).to_s}})
 
           expect(result.failure).to eq "Member(s) have not been selected for termination."
         end
 
-        it 'should return a failure when hbx_enrollment is not an ivl' do
+        it 'should return a failure when termination date has not been selected' do
           result = subject.call({hbx_enrollment: enrollment,
                                  options: {"terminate_member_#{hbx_enrollment_member3.id}" => hbx_enrollment_member3.id.to_s}})
 
           expect(result.failure).to eq "Termination date has not been selected."
         end
 
-        it 'should return a failure when hbx_enrollment is not an ivl' do
-          result = subject.call({hbx_enrollment: enrollment,
-                                 options: {"termination_date_#{enrollment.id}" => enrollment.effective_on.end_of_year.to_s,
-                                           "terminate_member_#{hbx_enrollment_member3.id}" => hbx_enrollment_member3.id.to_s}})
+        context 'when termination date is before effective on' do
+          before do
+            new_effective_on = Date.today.next_year.beginning_of_year
+            enrollment.update(effective_on: new_effective_on)
+          end
 
-          expect(result.failure).to eq "Termination date must be in current calendar year."
+          it 'should return a failure when termination date is not in current calendar year' do
+            termination_date = enrollment.effective_on - 1
+            result = subject.call({hbx_enrollment: enrollment,
+                                  options: {"termination_date_#{enrollment.id}" => termination_date.to_s,
+                                            "terminate_member_#{hbx_enrollment_member3.id}" => hbx_enrollment_member3.id.to_s}})
+            expect(result.failure).to eq "Termination date must be in current calendar year."
+          end
         end
 
-        it 'should return a failure when hbx_enrollment is not an ivl' do
+        it 'should return a failure when termination date is not in current calendar year' do
           result = subject.call({hbx_enrollment: enrollment,
                                  options: {"termination_date_#{enrollment.id}" => enrollment.effective_on.next_year.to_s,
                                            "terminate_member_#{hbx_enrollment_member3.id}" => hbx_enrollment_member3.id.to_s}})

--- a/spec/domain/operations/hbx_enrollments/drop_enrollment_members_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/drop_enrollment_members_spec.rb
@@ -158,8 +158,8 @@ RSpec.describe Operations::HbxEnrollments::DropEnrollmentMembers, :type => :mode
           it 'should return a failure when termination date is not in current calendar year' do
             termination_date = enrollment.effective_on - 1
             result = subject.call({hbx_enrollment: enrollment,
-                                  options: {"termination_date_#{enrollment.id}" => termination_date.to_s,
-                                            "terminate_member_#{hbx_enrollment_member3.id}" => hbx_enrollment_member3.id.to_s}})
+                                   options: {"termination_date_#{enrollment.id}" => termination_date.to_s,
+                                             "terminate_member_#{hbx_enrollment_member3.id}" => hbx_enrollment_member3.id.to_s}})
             expect(result.failure).to eq "Termination date must be in current calendar year."
           end
         end


### PR DESCRIPTION
This spec is failing due to a sneaky issue with the date range values. 

Using date.prev_month.end_of_month in the query was returning the beginning of the last day of the previous month, e.g., Wed, 30 Nov 2022 00:00:00 UTC +00:00.  But the spec was setting the submission date of the test application with Time.now.getlocal.prev_month, e.g., 2022-11-30 16:53:32 +0000.  So, no applications were being returned by the query in the report.

This PR resolves the issue by explicitly setting the date range values with beginning_of_day, eg., Tue, 01 Nov 2022 00:00:00 UTC +00:00, and end_of_day, e.g.,  Wed, 30 Nov 2022 23:59:59 UTC +00:00.