### PR TITLE
check change in variant for renewal enr products

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -210,6 +210,8 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
       elsif eligible_csr_variant == '01'
         fetch_product("01")&.id || @enrollment.product.renewal_product_id
       else
+        product = fetch_product(eligible_csr_variant) || fetch_product('01')
+        return product.id if product
         @enrollment.product.renewal_product_id
       end
     else

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -1035,7 +1035,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
 
         before :each do
           ::BenefitMarkets::Products::HealthProducts::HealthProduct.silver_plans.update_all(metal_level_kind: :bronze)
-           enrollment.product.update_attributes!(renewal_product_id: renewal_product.id)
+          enrollment.product.update_attributes!(renewal_product_id: renewal_product.id)
         end
         it "should default to 01 variant if no other plan found" do
           expect(subject.assisted_renewal_product).to eq csr_01_product.id

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -1022,6 +1022,25 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
           expect(subject.assisted_renewal_product).to eq renewal_product.id
         end
       end
+
+      context "when individual has CSR change" do
+
+        let!(:renewal_product) { FactoryBot.create(:renewal_ivl_silver_health_product,  hios_id: "11111111122302-04", hios_base_id: "11111111122302", csr_variant_id: "04") }
+        let!(:current_product) { FactoryBot.create(:active_ivl_silver_health_product, hios_id: "11111111122302-04", hios_base_id: "11111111122302", csr_variant_id: "04", renewal_product_id: renewal_product.id) }
+        let!(:csr_product) { FactoryBot.create(:renewal_ivl_silver_health_product, hios_id: "11111111122302-05", hios_base_id: "11111111122302", csr_variant_id: "05") }
+        let!(:csr_01_product) { FactoryBot.create(:active_ivl_silver_health_product, hios_id: "11111111122302-01", hios_base_id: "11111111122302", csr_variant_id: "01") }
+        let!(:csr_02_product) { FactoryBot.create(:active_ivl_silver_health_product, hios_id: "11111111122302-02", hios_base_id: "11111111122302", csr_variant_id: "02") }
+        let!(:csr_03_product) { FactoryBot.create(:active_ivl_silver_health_product, hios_id: "11111111122302-03", hios_base_id: "11111111122302", csr_variant_id: "03") }
+        let(:aptc_values) {{ csr_amt: "94" }}
+
+        before :each do
+          ::BenefitMarkets::Products::HealthProducts::HealthProduct.silver_plans.update_all(metal_level_kind: :bronze)
+           enrollment.product.update_attributes!(renewal_product_id: renewal_product.id)
+        end
+        it "should default to 01 variant if no other plan found" do
+          expect(subject.assisted_renewal_product).to eq csr_01_product.id
+        end
+      end
     end
 
     describe ".clone_enrollment" do

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -1024,7 +1024,6 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
       end
 
       context "when individual has CSR change" do
-
         let!(:renewal_product) { FactoryBot.create(:renewal_ivl_silver_health_product,  hios_id: "11111111122302-04", hios_base_id: "11111111122302", csr_variant_id: "04") }
         let!(:current_product) { FactoryBot.create(:active_ivl_silver_health_product, hios_id: "11111111122302-04", hios_base_id: "11111111122302", csr_variant_id: "04", renewal_product_id: renewal_product.id) }
         let!(:csr_product) { FactoryBot.create(:renewal_ivl_silver_health_product, hios_id: "11111111122302-05", hios_base_id: "11111111122302", csr_variant_id: "05") }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: ME-183912951

# A brief description of the changes

Current behavior: When renewing enrollments, we are attaching the renewal product id regardless of if there was a change in variants.

New behavior: We will look at if there is a change in variants and attach a product correctly.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
