### PR TITLE
populate applied aptc for tax household enrollments

### DIFF
--- a/app/data_migrations/populate_applied_aptc_for_thh_enrs.rb
+++ b/app/data_migrations/populate_applied_aptc_for_thh_enrs.rb
@@ -28,7 +28,7 @@ class PopulateAppliedAptcForThhEnrs < MongoidMigrationTask
     end
   end
 
-  def update_single_thh_enr(family, enrollment, thh_enr)
+  def update_single_thh_enr(enrollment, thh_enr)
     thh_enr.update_attributes!(
       {
         applied_aptc: enrollment.applied_aptc_amount,
@@ -106,7 +106,7 @@ class PopulateAppliedAptcForThhEnrs < MongoidMigrationTask
     thh_enr_premiums
   end
 
-  def update_thh_enrs_ineligible_for_applied_aptc(family, enrollment, tax_hh_enrs)
+  def update_thh_enrs_ineligible_for_applied_aptc(tax_hh_enrs)
     tax_hh_enrs.each do |thh_enr|
       thh_enr.applied_aptc = 0.00
       thh_enr.group_ehb_premium = 0.00
@@ -114,7 +114,7 @@ class PopulateAppliedAptcForThhEnrs < MongoidMigrationTask
     end
   end
 
-  def update_multiple_thh_enrs(family, enrollment, tax_hh_enrs)
+  def update_multiple_thh_enrs(_family, enrollment, tax_hh_enrs)
     thh_enr_premiums = find_premiums_for_thh_enrs(enrollment, tax_hh_enrs)
     non_applied_aptc_thh_enrs = find_non_applied_aptc_thh_enrs(thh_enr_premiums)
     applied_aptc_amount = enrollment.applied_aptc_amount
@@ -140,7 +140,7 @@ class PopulateAppliedAptcForThhEnrs < MongoidMigrationTask
     TaxHouseholdEnrollment.where(enrollment_id: enrollment.id, :'available_max_aptc.cents'.lte => 0.00).each do |thh_enr|
       thh_enr.update_attributes!(
         applied_aptc: 0.00,
-        group_ehb_premium: 0.00,
+        group_ehb_premium: 0.00
       )
     end
   end
@@ -160,7 +160,6 @@ class PopulateAppliedAptcForThhEnrs < MongoidMigrationTask
       enrollment.coverage_kind == 'health' &&
       enrollment.applied_aptc_amount.positive? &&
       enrollment.consumer_role_id.present?
-
   end
 
   def process_hbx_enrollment_hbx_ids
@@ -188,9 +187,9 @@ class PopulateAppliedAptcForThhEnrs < MongoidMigrationTask
         end
 
         if !eligible_to_populate_applied_aptc?(enrollment)
-          update_thh_enrs_ineligible_for_applied_aptc(family, enrollment, tax_hh_enrs)
+          update_thh_enrs_ineligible_for_applied_aptc(tax_hh_enrs)
         elsif tax_hh_enrs.count == 1
-          update_single_thh_enr(family, enrollment, tax_hh_enrs.first)
+          update_single_thh_enr(enrollment, tax_hh_enrs.first)
         else
           update_multiple_thh_enrs(family, enrollment, tax_hh_enrs)
         end

--- a/app/data_migrations/populate_applied_aptc_for_thh_enrs.rb
+++ b/app/data_migrations/populate_applied_aptc_for_thh_enrs.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require File.join(Rails.root, 'lib/mongoid_migration_task')
+require File.join(Rails.root, 'app/helpers/float_helper')
+
+# Rake task is to populate applied_aptc for TaxHouseholdEnrollment objects for Health Enrollments with effective on or after 2022/1/1.
+# This class will not update Enrollment.
+class PopulateAppliedAptcForThhEnrs < MongoidMigrationTask
+  include ::FloatHelper
+
+  def find_enrollment_hbx_ids
+    hbx_ids = ENV['enrollment_hbx_ids'].to_s.split(',').map(&:squish!)
+    return hbx_ids if hbx_ids.present?
+
+    HbxEnrollment.where(
+      :effective_on.gte => Date.new(2022),
+      :aasm_state.ne => ['shopping', 'coverage_canceled'],
+      :product_id.ne => nil,
+      coverage_kind: 'health',
+      :'applied_aptc_amount.cents'.gt => 0,
+      :consumer_role_id.ne => nil
+    ).pluck(:hbx_id)
+  end
+
+  def sum_of_member_ehb_premiums(enrollment, thh_enr)
+    aptc_family_member_ids = thh_enr.tax_household.aptc_members.map(&:applicant_id)
+    enrollment.hbx_enrollment_members.where(:applicant_id.in => aptc_family_member_ids).reduce(0) do |sum, member|
+      sum + enrollment.ivl_decorated_hbx_enrollment.member_ehb_premium(member)
+    end
+  end
+
+  def update_single_thh_enr(family, enrollment, thh_enr)
+    thh_enr.update_attributes!(
+      {
+        applied_aptc: enrollment.applied_aptc_amount,
+        group_ehb_premium: float_fix(sum_of_member_ehb_premiums(enrollment, thh_enr))
+      }
+    )
+
+    populate_info_to_csv(family, enrollment, thh_enr)
+  end
+
+  def populate_info_to_csv(family, enrollment, thh_enr)
+    thh = thh_enr.tax_household
+    [
+      family.primary_person.hbx_id,
+      enrollment.hbx_id,
+      enrollment.aasm_state,
+      enrollment.total_premium.to_f,
+      enrollment.effective_on,
+      enrollment.product.ehb,
+      enrollment.applied_aptc_amount.to_f,
+      thh_enr.applied_aptc.to_f,
+      thh_enr.group_ehb_premium.to_f,
+      thh.monthly_expected_contribution.to_f,
+      thh.hbx_assigned_id,
+      thh_enr.household_benchmark_ehb_premium.to_f,
+      thh_enr.health_product_hios_id,
+      thh_enr.dental_product_hios_id,
+      thh_enr.household_health_benchmark_ehb_premium.to_f,
+      thh_enr.household_dental_benchmark_ehb_premium.to_f,
+      thh_enr.available_max_aptc.to_f
+    ]
+  end
+
+  def find_premiums_for_thh_enrs(enrollment, tax_hh_enrs)
+    ratio = enrollment.applied_aptc_amount / tax_hh_enrs.map(&:available_max_aptc).sum
+
+    tax_hh_enrs.inject({}) do |thh_enr_premiums_hash, thh_enrollment|
+      assumed_applied_aptc = ratio * thh_enrollment.available_max_aptc
+      group_ehb_cost = Money.new(
+        float_fix(sum_of_member_ehb_premiums(enrollment, thh_enrollment)) * 100
+      )
+
+      assumed_applied_aptc_greater_than_group_ehb_premium = assumed_applied_aptc > group_ehb_cost
+      thh_enr_premiums_hash[thh_enrollment] = {
+        assumed_applied_aptc: assumed_applied_aptc,
+        group_ehb_premium: group_ehb_cost,
+        assumed_applied_aptc_greater_than_group_ehb_premium: assumed_applied_aptc_greater_than_group_ehb_premium,
+        applied_aptc: assumed_applied_aptc_greater_than_group_ehb_premium ? group_ehb_cost : 0.00
+      }
+
+      thh_enr_premiums_hash
+    end
+  end
+
+  def find_non_applied_aptc_thh_enrs(thh_enr_premiums)
+    thh_enr_premiums.select do |_thh_enr, premium_hash|
+      premium_hash[:applied_aptc].zero?
+    end
+  end
+
+  def set_applied_aptc_for_remaining_thh_enrs(thh_enr_premiums, non_applied_aptc_thh_enrs, applied_aptc_amount)
+    non_applied_aptc_count = non_applied_aptc_thh_enrs.count
+    remaining_consumed_aptc = applied_aptc_amount - thh_enr_premiums.values.collect { |val| val[:applied_aptc] }.sum
+    ratio = remaining_consumed_aptc / non_applied_aptc_thh_enrs.keys.map(&:available_max_aptc).sum
+
+    non_applied_aptc_thh_enrs.each_with_index do |haash, i|
+      thh_enr = haash.first
+      thh_enr_premiums[thh_enr][:applied_aptc] =
+        if i == non_applied_aptc_count.pred
+          applied_aptc_amount - thh_enr_premiums.values.collect { |val| val[:applied_aptc] }.sum
+        else
+          ratio * thh_enr.available_max_aptc
+        end
+    end
+
+    thh_enr_premiums
+  end
+
+  def update_multiple_thh_enrs(family, enrollment, tax_hh_enrs)
+    thh_enr_premiums = find_premiums_for_thh_enrs(enrollment, tax_hh_enrs)
+    non_applied_aptc_thh_enrs = find_non_applied_aptc_thh_enrs(thh_enr_premiums)
+    applied_aptc_amount = enrollment.applied_aptc_amount
+
+    thh_enr_premiums =
+      if non_applied_aptc_thh_enrs.count == 1
+        thh_enr_premiums[non_applied_aptc_thh_enrs.keys.first][:applied_aptc] =
+          applied_aptc_amount - thh_enr_premiums.values.collect { |val| val[:applied_aptc] }.sum
+
+        thh_enr_premiums
+      else
+        set_applied_aptc_for_remaining_thh_enrs(thh_enr_premiums, non_applied_aptc_thh_enrs, applied_aptc_amount)
+      end
+
+    thh_enrs_info_array = []
+    thh_enr_premiums.each do |thh_enr, premiums_hash|
+      thh_enr.applied_aptc = premiums_hash[:applied_aptc]
+      thh_enr.group_ehb_premium = premiums_hash[:group_ehb_premium]
+      thh_enr.save!
+      thh_enrs_info_array << populate_info_to_csv(family, enrollment, thh_enr)
+    end
+
+    thh_enrs_info_array
+  end
+
+  def aptc_tax_household_enrollments(enrollment)
+    TaxHouseholdEnrollment.where(enrollment_id: enrollment.id).select do |thh_enr|
+      thh_enr.tax_household_members_enrollment_members.where(
+        :family_member_id.in => thh_enr.tax_household.aptc_members.map(&:applicant_id)
+      ).present?
+    end
+  end
+
+  def process_hbx_enrollment_hbx_ids
+    file_name = "#{Rails.root}/populate_applied_aptc_for_thh_enrs_list_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.csv"
+    counter = 0
+
+    field_names = %w[person_hbx_id enrollment_hbx_id enrollment_aasm_state enrollment_total_premium enrollment_effective_on
+                     product_ehb enrollment_applied_aptc_amount thh_enr_applied_aptc group_ehb_premium thh_monthly_expected_contribution
+                     thh_hbx_assigned_id household_benchmark_ehb_premium health_product_hios_id dental_product_hios_id
+                     household_health_benchmark_ehb_premium household_dental_benchmark_ehb_premium available_max_aptc]
+
+    CSV.open(file_name, 'w', force_quotes: true) do |csv|
+      csv << field_names
+      find_enrollment_hbx_ids.each do |hbx_id|
+        counter += 1
+        @logger.info "Processed #{counter} hbx_enrollments" if counter % 100 == 0
+        @logger.info "----- EnrHbxID: #{hbx_id} - Processing Enrollment"
+        enrollment = HbxEnrollment.by_hbx_id(hbx_id).first
+        family = enrollment.family
+        tax_hh_enrs = aptc_tax_household_enrollments(enrollment)
+        if tax_hh_enrs.blank?
+          @logger.info "---------- EnrHbxID: #{hbx_id} - No TaxHouseholdEnrollments for Enrollment"
+          next hbx_id
+        end
+
+        if tax_hh_enrs.count == 1
+          csv << update_single_thh_enr(family, enrollment, tax_hh_enrs.first)
+        else
+          update_multiple_thh_enrs(family, enrollment, tax_hh_enrs).each do |csv_data|
+            csv << csv_data
+          end
+        end
+      rescue StandardError => e
+        @logger.info "---------- EnrHbxID: #{hbx_id} - Error raised processing enrollment, error: #{e}, backtrace: #{e.backtrace}"
+      end
+    end
+  end
+
+  def migrate
+    @logger = Logger.new("#{Rails.root}/populate_applied_aptc_for_thh_enrs_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+    start_time = DateTime.current
+    @logger.info "PopulateAppliedAptcForThhEnrs start_time: #{start_time}"
+    process_hbx_enrollment_hbx_ids
+    end_time = DateTime.current
+    @logger.info "PopulateAppliedAptcForThhEnrs end_time: #{end_time}, total_time_taken_in_minutes: #{((end_time - start_time) * 24 * 60).to_f.ceil}"
+  end
+end

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -17,6 +17,8 @@ class HbxEnrollment
   include EventSource::Command
   include ::Employers::EmployerHelper
 
+  include FloatHelper
+
   belongs_to :household
   # Override attribute accessor as well
   # Migrate all the family ids to that
@@ -1065,12 +1067,11 @@ class HbxEnrollment
   end
 
   def update_tax_household_enrollment
-    return if is_shop?
+    return if is_shop? || dental? || applied_aptc_amount.zero?
     return unless EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
 
-    TaxHouseholdEnrollment.where(enrollment_id: id).each do |th_enrollment|
-      th_enrollment.update_attributes(applied_aptc: (th_enrollment.available_max_aptc * elected_aptc_pct))
-    end
+    thh_enr_premiums = thh_enr_group_ehb_premium_of_aptc_members(aptc_tax_household_enrollments)
+    update_multiple_thh_enrollments(aptc_tax_household_enrollments, thh_enr_premiums)
   rescue StandardError => e
     Rails.logger.error { "Couldn't generate enrollment save event due to #{e.backtrace}" }
   end
@@ -2847,6 +2848,56 @@ class HbxEnrollment
   end
 
   private
+
+  def aptc_tax_household_enrollments
+    @aptc_tax_household_enrollments ||=
+      TaxHouseholdEnrollment.by_enrollment_id(id).select do |thh_enr|
+        thh_enr.tax_household_members_enrollment_members.where(
+          :family_member_id.in => thh_enr.tax_household.aptc_members.map(&:applicant_id)
+        ).present?
+      end
+  end
+
+  # Calculates sum of enrolled aptc member's of TaxHouseholdEnrollment ehb_premiums including Minimum Responsibility.
+  def sum_of_member_ehb_premiums(thh_enr)
+    aptc_family_member_ids = thh_enr.tax_household.aptc_members.map(&:applicant_id)
+    hbx_enrollment_members.where(:applicant_id.in => aptc_family_member_ids).reduce(0) do |sum, member|
+      sum + ivl_decorated_hbx_enrollment.member_ehb_premium(member)
+    end
+  end
+
+  def thh_enr_group_ehb_premium_of_aptc_members(thh_enrs)
+    thh_enrs.inject({}) do |premiums, thh_enr|
+      premiums[thh_enr] = { group_ehb_premium: float_fix(sum_of_member_ehb_premiums(thh_enr)) }
+      premiums
+    end
+  end
+
+  # Incase of MultipleTaxHouseholdEnrollments, applied_aptc is either
+  #   1. group_ehb_premium (or)
+  #   2. thh_enr.available_max_aptc * elected_aptc_pct
+  # To make this inline with plan shopping logic we are considering tax_household_enrollment level ehb_premium.
+  def update_multiple_thh_enrollments(thh_enrs, thh_enr_premiums)
+    if applied_aptc_amount == total_ehb_premium.to_money
+      thh_enrs.each do |thh_enr|
+        thh_enr.update_attributes!(
+          {
+            applied_aptc: thh_enr_premiums[thh_enr][:group_ehb_premium],
+            group_ehb_premium: thh_enr_premiums[thh_enr][:group_ehb_premium]
+          }
+        )
+      end
+    else
+      thh_enrs.each do |thh_enr|
+        thh_enr.update_attributes!(
+          {
+            applied_aptc: thh_enr.available_max_aptc * elected_aptc_pct,
+            group_ehb_premium: thh_enr_premiums[thh_enr][:group_ehb_premium]
+          }
+        )
+      end
+    end
+  end
 
   def set_is_any_enrollment_member_outstanding
     if kind == "individual"

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -1071,7 +1071,7 @@ class HbxEnrollment
     return unless EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
 
     thh_enr_premiums = thh_enr_group_ehb_premium_of_aptc_members(aptc_tax_household_enrollments)
-    update_multiple_thh_enrollments(aptc_tax_household_enrollments, thh_enr_premiums)
+    populate_applied_aptc_for_thh_enrs(aptc_tax_household_enrollments, thh_enr_premiums)
   rescue StandardError => e
     Rails.logger.error { "Couldn't generate enrollment save event due to #{e.backtrace}" }
   end
@@ -2877,7 +2877,7 @@ class HbxEnrollment
   #   1. group_ehb_premium (or)
   #   2. thh_enr.available_max_aptc * elected_aptc_pct
   # To make this inline with plan shopping logic we are considering tax_household_enrollment level ehb_premium.
-  def update_multiple_thh_enrollments(thh_enrs, thh_enr_premiums)
+  def populate_applied_aptc_for_thh_enrs(thh_enrs, thh_enr_premiums)
     if applied_aptc_amount == total_ehb_premium.to_money
       thh_enrs.each do |thh_enr|
         thh_enr.update_attributes!(

--- a/app/models/tax_household_enrollment.rb
+++ b/app/models/tax_household_enrollment.rb
@@ -17,7 +17,7 @@ class TaxHouseholdEnrollment
 
   field :available_max_aptc, type: Money
 
-  # group_ehb_premium is sum of ehb_premiums of TaxHouseholdMembers associated with :tax_household_id who are enrolled in HbxEnrollment(enrollment_id).
+  # group_ehb_premium is sum of ehb_premiums of APTC eligible TaxHouseholdMembers associated with :tax_household_id who are enrolled in HbxEnrollment(enrollment_id).
   #   For Example:
   #     Enrollment1: A, B, C, D
   #     TaxHousehold1: A, C
@@ -25,6 +25,9 @@ class TaxHouseholdEnrollment
   #     For a given TaxHouseholdEnrollment(enrollment_id: Enrollment1.id, tax_household_id: TaxHousehold1.id),
   #       the :group_ehb_premium is sum of ehb_premiums of A and C
   field :group_ehb_premium, type: Money
+
+  # Scopes
+  scope :by_enrollment_id, ->(enrollment_id) { where(enrollment_id: enrollment_id) }
 
   embeds_many :tax_household_members_enrollment_members, class_name: "::TaxHouseholdMemberEnrollmentMember", cascade_callbacks: true
 

--- a/lib/tasks/populate_applied_aptc_for_thh_enrs.rake
+++ b/lib/tasks/populate_applied_aptc_for_thh_enrs.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Rake task is to populate applied_aptc for TaxHouseholdEnrollment objects for Health Enrollments with effective on or after 2022/1/1.
+# To run rake task: bundle exec rake migrations:populate_applied_aptc_for_thh_enrs
+
+# To run this on specific enrollments
+# To run rake task: bundle exec rake migrations:populate_applied_aptc_for_thh_enrs enrollment_hbx_ids=1234, 2345
+
+require File.join(Rails.root, 'app', 'data_migrations', 'populate_applied_aptc_for_thh_enrs')
+
+namespace :migrations do
+  desc 'Populated AppliedAptc and GroupEhbPremiums for TaxHouseholdEnrollments of Enrollments'
+  PopulateAppliedAptcForThhEnrs.define_task :populate_applied_aptc_for_thh_enrs => :environment
+end

--- a/script/list_of_tax_household_enrollments.rb
+++ b/script/list_of_tax_household_enrollments.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # This script generates a CSV report with information about Enrollments with TaxHouseholdEnrollments
-# To run this for all 2022 enrollments
+# To run this for all enrollments effectuated on or after 2022/1/1
 # bundle exec rails runner script/list_of_tax_household_enrollments.rb
 
 # To run this on specific enrollments
@@ -11,10 +11,15 @@ def process_enrollments(enrollments, logger)
   file_name = "#{Rails.root}/list_of_enrollments_with_thh_enr_info.csv"
   field_names = %w[person_hbx_id
                    enrollment_hbx_id
+                   enrollment_effective_on
+                   enrollment_terminated_on
                    enrollment_aasm_state
                    enrollment_total_premium
                    product_ehb
                    enrollment_applied_aptc_amount
+                   thh_applied_aptc
+                   thh_available_max_aptc
+                   thh_enr_group_ehb_premium
                    tax_household_members
                    household_benchmark_ehb_premium
                    health_product_hios_id
@@ -27,22 +32,24 @@ def process_enrollments(enrollments, logger)
     enrollments.no_timeout.each do |enrollment|
       person = enrollment.family.primary_person
       thh_enrs = TaxHouseholdEnrollment.where(enrollment_id: enrollment.id)
-
       logger.info "No TaxHouseholdEnrollment objects for given enrollment with hbx_id: #{enrollment.hbx_id}, PrimaryPersonHbxId: #{person.hbx_id}" if thh_enrs.blank?
 
-      thh = thh_enr.tax_household
-      next enrollment if thh.blank?
-
-      valid_thh_members = thh.tax_household_members.where(:id.in => thh_enr.tax_household_members_enrollment_members.pluck(:tax_household_member_id))
-
       thh_enrs.each do |thh_enr|
+        thh = thh_enr.tax_household
+        valid_thh_members = thh.tax_household_members.where(:id.in => thh_enr.tax_household_members_enrollment_members.pluck(:tax_household_member_id))
+
         csv << [
           person.hbx_id,
           enrollment.hbx_id,
+          enrollment.effective_on,
+          enrollment.terminated_on,
           enrollment.aasm_state,
           enrollment.total_premium.to_f,
           enrollment.product.ehb,
           enrollment.applied_aptc_amount.to_f,
+          thh_enr.applied_aptc,
+          thh_enr.available_max_aptc,
+          thh_enr.group_ehb_premium,
           valid_thh_members.map(&:person).flat_map(&:full_name),
           thh_enr.household_benchmark_ehb_premium,
           thh_enr.health_product_hios_id,
@@ -52,7 +59,7 @@ def process_enrollments(enrollments, logger)
         ]
       end
     rescue StandardError => e
-      logger.info e.message
+      logger.info "Error raised for EnrHbxID: #{enrollment.hbx_id}, message: #{e}"
     end
   end
 end
@@ -65,16 +72,16 @@ def find_enrollments
   hbx_ids = ENV['enr_hbx_ids'].to_s.split(',').map(&:squish!)
 
   if hbx_ids.present?
-    HbxEnrollment.by_year(2022).by_coverage_kind('health').where(:aasm_state.in => show_enrollments_sans_canceled, :hbx_id.in => hbx_ids)
+    HbxEnrollment.by_coverage_kind('health').where(:effective_on.gte => Date.new(2022), :aasm_state.in => show_enrollments_sans_canceled, :hbx_id.in => hbx_ids)
   else
-    HbxEnrollment.by_year(2022).by_coverage_kind('health').where(:aasm_state.in => show_enrollments_sans_canceled)
+    HbxEnrollment.by_coverage_kind('health').where(:effective_on.gte => Date.new(2022), :aasm_state.in => show_enrollments_sans_canceled)
   end
 end
 
 start_time = DateTime.current
-logger = Logger.new("#{Rails.root}/migration_validation_log_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
-logger.info "Migration Report start_time: #{start_time}"
+logger = Logger.new("#{Rails.root}/enrollments_with_thh_enr_info_log_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+logger.info "TaxHousehold Enrollment Report start_time: #{start_time}"
 enrollments = find_enrollments
 process_enrollments(enrollments, logger)
 end_time = DateTime.current
-logger.info "Migration Report end_time: #{end_time}, total_time_taken_in_minutes: #{((end_time - start_time) * 24 * 60).to_i}"
+logger.info "TaxHousehold Enrollment Report end_time: #{end_time}, total_time_taken_in_minutes: #{((end_time - start_time) * 24 * 60).to_i}"

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'pry'
+
+RSpec.describe HbxEnrollment, type: :model do
+
+  before :all do
+    DatabaseCleaner.clean
+  end
+
+  describe '#update_tax_household_enrollment' do
+    let(:start_of_month) { TimeKeeper.date_of_record.beginning_of_month }
+    let(:person) { create(:person, :with_consumer_role, :with_active_consumer_role) }
+    let(:family) { create(:family, :with_primary_family_member, person: person) }
+    let(:hbx_enrollment) do
+      create(:hbx_enrollment,
+             :individual_aptc,
+             :with_silver_health_product,
+             applied_aptc_amount: applied_aptc_amount,
+             elected_aptc_pct: elected_aptc_pct,
+             family: family,
+             consumer_role_id: person.consumer_role.id,
+             ehb_premium: enrollment_ehb_premium)
+    end
+
+    let(:hbx_enrollment_member) do
+      create(:hbx_enrollment_member,
+             hbx_enrollment: hbx_enrollment,
+             applicant_id: family.primary_applicant.id,
+             coverage_start_on: start_of_month,
+             eligibility_date: start_of_month)
+    end
+
+    let(:tax_household_group) do
+      thhg = family.tax_household_groups.create!(
+        assistance_year: start_of_month.year, source: 'Admin', start_on: start_of_month.year,
+        tax_households: [FactoryBot.build(:tax_household, household: family.active_household)]
+      )
+      thhg.tax_households.first.tax_household_members.create!(
+        applicant_id: family.primary_applicant.id, is_ia_eligible: true
+      )
+      thhg
+    end
+
+    let!(:tax_household_enrollment) do
+      thh_enr = TaxHouseholdEnrollment.create(
+        enrollment_id: hbx_enrollment.id, tax_household_id: tax_household_group.tax_households.first.id,
+        household_benchmark_ehb_premium: 500.00, available_max_aptc: available_max_aptc
+      )
+
+      thh_enr.tax_household_members_enrollment_members.create(
+        family_member_id: hbx_enrollment_member.applicant_id, hbx_enrollment_member_id: hbx_enrollment_member.id,
+        tax_household_member_id: tax_household_group.tax_households.first.tax_household_members.first.id,
+        age_on_effective_date: 20, relationship_with_primary: 'self', date_of_birth: start_of_month - 20.years
+      )
+      thh_enr
+    end
+
+    let(:person2) do
+      per = create(:person, :with_consumer_role, :with_active_consumer_role)
+      person.ensure_relationship_with(per, 'spouse')
+      per
+    end
+
+    let(:family_member) { create(:family_member, person: person2, family: family) }
+
+    let(:hbx_enrollment_member2) do
+      create(:hbx_enrollment_member,
+             is_subscriber: false,
+             hbx_enrollment: hbx_enrollment,
+             applicant_id: family_member.id,
+             coverage_start_on: start_of_month,
+             eligibility_date: start_of_month)
+    end
+
+    let(:tax_household_group2) do
+      thhg = family.tax_household_groups.create!(
+        assistance_year: start_of_month.year, source: 'Admin', start_on: start_of_month.year,
+        tax_households: [FactoryBot.build(:tax_household, household: family.active_household)]
+      )
+      thhg.tax_households.first.tax_household_members.create!(
+        applicant_id: family_member.id, is_ia_eligible: true
+      )
+      thhg
+    end
+
+    let!(:tax_household_enrollment2) do
+      thh_enr = TaxHouseholdEnrollment.create(
+        enrollment_id: hbx_enrollment.id, tax_household_id: tax_household_group2.tax_households.first.id,
+        household_benchmark_ehb_premium: 500.00, available_max_aptc: available_max_aptc2
+      )
+
+      thh_enr.tax_household_members_enrollment_members.create(
+        family_member_id: hbx_enrollment_member2.applicant_id, hbx_enrollment_member_id: hbx_enrollment_member2.id,
+        tax_household_member_id: tax_household_group2.tax_households.first.tax_household_members.first.id,
+        age_on_effective_date: 20, relationship_with_primary: 'self', date_of_birth: start_of_month - 20.years
+      )
+      thh_enr
+    end
+
+    before do
+      ::BenefitMarkets::Products::ProductRateCache.initialize_rate_cache!
+      EnrollRegistry[:temporary_configuration_enable_multi_tax_household_feature].feature.stub(:is_enabled).and_return(true)
+
+      allow(
+        hbx_enrollment.ivl_decorated_hbx_enrollment
+      ).to receive(:member_ehb_premium).with(hbx_enrollment_member).and_return(member1_ehb_premium)
+
+      allow(
+        hbx_enrollment.ivl_decorated_hbx_enrollment
+      ).to receive(:member_ehb_premium).with(hbx_enrollment_member2).and_return(member2_ehb_premium)
+    end
+
+    subject { hbx_enrollment.update_tax_household_enrollment }
+
+    context 'with applied_aptc_amount same as total_ehb_premium' do
+      let(:member1_ehb_premium) { 250.00 }
+      let(:member2_ehb_premium) { 275.00 }
+      let(:available_max_aptc) { 250.00 }
+      let(:available_max_aptc2) { 275.00 }
+      let(:applied_aptc_amount) { available_max_aptc + available_max_aptc2 }
+      let(:enrollment_ehb_premium) { member1_ehb_premium + member2_ehb_premium }
+      let(:elected_aptc_pct) { 1.0 }
+
+      it 'sets applied_aptc same as ehb_premium' do
+        subject
+        expect(tax_household_enrollment.reload.applied_aptc.to_f).to eq(member1_ehb_premium)
+        expect(tax_household_enrollment.reload.group_ehb_premium.to_f).to eq(member1_ehb_premium)
+        expect(tax_household_enrollment2.reload.applied_aptc.to_f).to eq(member2_ehb_premium)
+        expect(tax_household_enrollment2.reload.group_ehb_premium.to_f).to eq(member2_ehb_premium)
+      end
+    end
+
+    context 'with applied_aptc_amount not same as total_ehb_premium' do
+      let(:member1_ehb_premium) { 350.00 }
+      let(:member2_ehb_premium) { 375.00 }
+      let(:available_max_aptc) { 250.00 }
+      let(:available_max_aptc2) { 275.00 }
+      let(:applied_aptc_amount) { available_max_aptc + available_max_aptc2 }
+      let(:enrollment_ehb_premium) { member1_ehb_premium + member2_ehb_premium }
+      let(:elected_aptc_pct) { 1.0 }
+
+      it 'sets applied_aptc same as available_max_aptc * elected_aptc_pct' do
+        subject
+        expect(tax_household_enrollment.reload.applied_aptc.to_f).to eq(available_max_aptc)
+        expect(tax_household_enrollment.reload.group_ehb_premium.to_f).to eq(member1_ehb_premium)
+        expect(tax_household_enrollment2.reload.applied_aptc.to_f).to eq(available_max_aptc2)
+        expect(tax_household_enrollment2.reload.group_ehb_premium.to_f).to eq(member2_ehb_premium)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: ME-184163013

# A brief description of the changes

Current behavior: Applied aptc is populated by factoring in pct and available max aptc

New behavior: Populate applied aptc correctly for tax household enrollments based on ehb premiums.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
