### PR TITLE
display non oe multi year selection form 

### DIFF
--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -336,7 +336,10 @@ class Insured::ConsumerRolesController < ApplicationController
   end
 
   def help_paying_coverage_redirect_path(result)
-    return financial_assistance.application_year_selection_application_path(id: result.success) if EnrollRegistry.feature_enabled?(:iap_year_selection) && HbxProfile.current_hbx.under_open_enrollment?
+    if EnrollRegistry.feature_enabled?(:iap_year_selection) && (HbxProfile.current_hbx.under_open_enrollment? || EnrollRegistry.feature_enabled?(:iap_year_selection_form))
+      return financial_assistance.application_year_selection_application_path(id: result.success)
+    end
+
     financial_assistance.application_checklist_application_path(id: result.success)
   end
 

--- a/components/financial_assistance/app/controllers/financial_assistance/applications_controller.rb
+++ b/components/financial_assistance/app/controllers/financial_assistance/applications_controller.rb
@@ -107,7 +107,7 @@ module FinancialAssistance
       if copy_result.success?
         @application = copy_result.success
         @application.set_assistance_year
-        assistance_year_page = HbxProfile.current_hbx.under_open_enrollment? && EnrollRegistry.feature_enabled?(:iap_year_selection)
+        assistance_year_page = EnrollRegistry.feature_enabled?(:iap_year_selection) && (HbxProfile.current_hbx.under_open_enrollment? || EnrollRegistry.feature_enabled?(:iap_year_selection_form))
         redirect_path = assistance_year_page ? application_year_selection_application_path(@application) : edit_application_path(@application)
 
         redirect_to redirect_path

--- a/components/financial_assistance/app/views/financial_assistance/applications/_non_oe_year_selection_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/_non_oe_year_selection_form.html.erb
@@ -1,0 +1,33 @@
+<div class="container">
+  <div id="new_person_wrapper">
+    <%= form_for @application, url: {action: "update_application_year", params: {id: @application.id}} do |f| %>
+    <div class="row">
+      <div class="col-lg-2 col-md-2 col-sm-2 col-xs-12">
+        <%= render :partial => '/financial_assistance/shared/fa_left_nav' %>
+      </div>
+      <div class="col-lg-10 col-md-10 col-sm-10 col-xs-12 row">
+        <div class="col-lg-9 col-md-9 col-sm-9 col-xs-9 bottom-pd">
+          <% calendar_year = Family.application_applicable_year %>
+          <% previous_year = calendar_year - 1 %>
+          <h2 class="darkblue"><%= l10n("faa.year_selection_header") %></h2>
+          <p><%= l10n("faa.year_selection_subheader") %></p>
+          <p><b><%= calendar_year %></b><br> <%= l10n("faa.non_oe_see_if_you_qualify_1") %>.<br><%= link_to l10n("Learn_more_about_life_changes").humanize, FinancialAssistanceRegistry[:iap_year_selection_form].setting(:iap_year_sep_link).item %>.</p>
+          <p><b><%= previous_year %></b><br> <%= l10n("faa.non_oe_see_if_you_qualify_2", calendar_year: calendar_year, previous_year: previous_year) %>.</p>
+          <h3><%= l10n("Choose_a_plan_year") %></h3>
+          <label><%= f.radio_button :assistance_year, calendar_year %> <%= calendar_year %></label><br>
+          <label><%= f.radio_button :assistance_year, previous_year %> <%= previous_year %></label>
+        </div>
+        <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12">
+          <% content_for :submit_button do %>
+            <%= f.submit 'Continue', class: 'btn btn-lg btn-primary btn-block', id: 'btn-continue', disabled: (local_assigns[:disabled].nil? ? false : disabled) %>
+          <% end %>
+          <%= render partial: 'financial_assistance/shared/right_nav', locals: {
+            previous_url: main_app.help_paying_coverage_insured_consumer_role_index_path,
+            next_url: financial_assistance.application_checklist_application_path(@application)
+          } %>
+        </div>
+      </div>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/components/financial_assistance/app/views/financial_assistance/applications/application_year_selection.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/application_year_selection.html.erb
@@ -1,5 +1,9 @@
 <% if FinancialAssistanceRegistry.feature_enabled?(:iap_year_selection_form) %>
-  <%= render 'year_selection_form' %>
+  <% if HbxProfile.current_hbx.under_open_enrollment? %>
+    <%= render 'year_selection_form' %>
+  <% else %>
+    <%= render 'non_oe_year_selection_form' %>
+  <% end %>
 <% else %>
   <div class="container">
     <div id="new_person_wrapper">

--- a/components/financial_assistance/db/seedfiles/translations/en/me/financial_assistance.rb
+++ b/components/financial_assistance/db/seedfiles/translations/en/me/financial_assistance.rb
@@ -163,6 +163,8 @@ FINANCIAL_ASSISTANCE_TRANSLATIONS = {
   "en.faa.year_selection_oe_year" => " Open Enrollment",
   "en.faa.see_if_you_qualify_1" => "Select to see if you qualify for lower monthly premiums on your %{short_name} insurance plan or %{medicaid_or_chip_program_short_name}.",
   "en.faa.see_if_you_qualify_2" => "Select if you have experienced a life change and need to update your current enrollment or see if you qualify for lower monthly premiums or %{medicaid_or_chip_program_short_name}",
+  "en.faa.non_oe_see_if_you_qualify_1" => "Select if you have experienced a life change or need to enroll for the first time",
+  "en.faa.non_oe_see_if_you_qualify_2" => "Select if you need to make changes for coverage from last year. <b>This is uncommon.</b> You can only sign up for %{previous_year} coverage if CoverMe.gov has approved you for a special enrollment period. Changes you make to your %{previous_year} application do not automatically apply to your %{calendar_year} application. To apply changes, you must copy your application and submit it for %{calendar_year}",
   "en.faa.year_selection_oe_range_from" => "Open enrollment is from ",
   "en.faa.year_selection_oe_range_through" => " through ",
   "en.faa.year_selection_learn_more" => "If you need health insurance, lower premiums, or Medicaid now, you can <a href='#'>submit a webform</a> or call %{short_name} at (855) 532-5465 / TTY: 711. <a target='_blank' href='https://www.dchealthlink.com/individuals/life-changes'>Learn more about Life Changes</a>.", # TODO: Update URL and phones

--- a/components/ui_helpers/lib/ui_helpers/workflow_helper.rb
+++ b/components/ui_helpers/lib/ui_helpers/workflow_helper.rb
@@ -149,7 +149,7 @@ module UIHelpers
     def assistance_year
       return @assistance_year if defined? @assistance_year
 
-      year_selection_enabled = HbxProfile.current_hbx.under_open_enrollment? && FinancialAssistanceRegistry.feature_enabled?(:iap_year_selection) && FinancialAssistanceRegistry.feature_enabled?(:iap_year_selection_form)
+      year_selection_enabled = FinancialAssistanceRegistry.feature_enabled?(:iap_year_selection) && (HbxProfile.current_hbx.under_open_enrollment? || FinancialAssistanceRegistry.feature_enabled?(:iap_year_selection_form))
       @assistance_year = year_selection_enabled ? @application.assistance_year.to_s : FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s
     end
 

--- a/features/financial_assistance/start_new_application.feature
+++ b/features/financial_assistance/start_new_application.feature
@@ -48,3 +48,35 @@ Feature: Cost Savings -  Start New Application
     Then consumer should see 'Start New Application' button
     When consumer click 'Start New Application' button
     Then the consumer is navigated to Application checklist page
+
+  Scenario: FAA is enabled - year selection enabled - OE ended - and consumer has a no existing FAA applications
+    Given the iap year selection feature is enabled
+    And the iap year selection form feature is disabled
+    And current hbx is not under open enrollment
+    Given the date is after open enrollment
+    Given a consumer exists
+    And the consumer is logged in
+    And consumer has successful ridp
+    And the FAA feature configuration is enabled
+    When consumer visits home page
+    And the Cost Savings link is visible
+    And the consumer clicks on Cost Savings link
+    Then consumer should see 'Start New Application' button
+    When consumer click 'Start New Application' button
+    Then the consumer is navigated to Application checklist page
+
+  Scenario: FAA is enabled - year selection enabled - OE ended - year selection form enabled - and consumer has a no existing FAA applications
+    Given the iap year selection feature is enabled
+    And the iap year selection form feature is enabled
+    And current hbx is not under open enrollment
+    Given the date is after open enrollment
+    Given a consumer exists
+    And the consumer is logged in
+    And consumer has successful ridp
+    And the FAA feature configuration is enabled
+    When consumer visits home page
+    And the Cost Savings link is visible
+    And the consumer clicks on Cost Savings link
+    Then consumer should see 'Start New Application' button
+    When consumer click 'Start New Application' button
+    Then the user will navigate to the assistance year selection page

--- a/features/financial_assistance/step_definitions/financial_assistance_steps.rb
+++ b/features/financial_assistance/step_definitions/financial_assistance_steps.rb
@@ -516,6 +516,16 @@ Given(/the iap year selection feature is enabled/) do
   enable_feature :iap_year_selection
 end
 
+Given(/the iap year selection form feature is enabled/) do
+  enable_feature :iap_year_selection_form, {registry_name: FinancialAssistanceRegistry}
+  enable_feature :iap_year_selection_form
+end
+
+Given(/the iap year selection form feature is disabled/) do
+  disable_feature :iap_year_selection_form, {registry_name: FinancialAssistanceRegistry}
+  disable_feature :iap_year_selection_form
+end
+
 Given(/the oe application warning display feature is enabled/) do
   enable_feature :oe_application_warning_display, {registry_name: FinancialAssistanceRegistry}
   enable_feature :oe_application_warning_display

--- a/features/financial_assistance/step_definitions/work_flow_steps.rb
+++ b/features/financial_assistance/step_definitions/work_flow_steps.rb
@@ -126,6 +126,10 @@ And(/^the date is within open enrollment$/) do
   allow(Settings.aca.individual_market.open_enrollment).to receive(:end_on).and_return(TimeKeeper.date_of_record + 1.day)
 end
 
+And(/^the date is after open enrollment$/) do
+  allow(Settings.aca.individual_market.open_enrollment).to receive(:end_on).and_return(TimeKeeper.date_of_record - 1.day)
+end
+
 And(/^current hbx is under open enrollment$/) do
   HbxProfile.any_instance.stub(:under_open_enrollment?).and_return(true)
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket:

[ME-184230807](https://www.pivotaltracker.com/story/show/184230807) 

Added New non oe multi year selection form template to display after OE

Current behavior: Currently we display multi year selection form only during open enrollment

New behavior: Along with current form we'll also display new multi year selection form after the open enrollment as well.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

**IAP_YEAR_SELECTION_IS_ENABLED**
- [x] DC
- [x] ME

**IAP_YEAR_SELECTION_FORM_IS_ENABLED**
- [ ] DC
- [x] ME

