### PR TITLE
fix oe warning to display before oe

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/applications/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/index.html.erb
@@ -12,7 +12,7 @@
           <% current_year = oe_year - 1 %>
           <h4><b><%= l10n('faa.coverage_update_reminder', year: current_year, year2: oe_year) %></b></h4>
         <% end %>
-        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && !HbxProfile.current_hbx.under_open_enrollment? %>
+        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && !HbxProfile.current_hbx.under_open_enrollment? && (HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on > Date.today) %>
           <h4 data-cuke='oe_application_warning_display'><%= l10n('faa.cost_savings_applications_oe_desc', next_year: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_end_on.year, oe_start: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on&.strftime("%B %d, %Y")) %></h4>
         <% end %>
         <div class="pull-right" style="display:flex; justify-content: space-between; padding: 10px 0px;">

--- a/components/financial_assistance/app/views/financial_assistance/applications/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/index.html.erb
@@ -12,7 +12,7 @@
           <% current_year = oe_year - 1 %>
           <h4><b><%= l10n('faa.coverage_update_reminder', year: current_year, year2: oe_year) %></b></h4>
         <% end %>
-        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && !HbxProfile.current_hbx.under_open_enrollment? && (HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on > Date.today) %>
+        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && !HbxProfile.current_hbx.under_open_enrollment? && (HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on > TimeKeeper.date_of_record) %>
           <h4 data-cuke='oe_application_warning_display'><%= l10n('faa.cost_savings_applications_oe_desc', next_year: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_end_on.year, oe_start: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on&.strftime("%B %d, %Y")) %></h4>
         <% end %>
         <div class="pull-right" style="display:flex; justify-content: space-between; padding: 10px 0px;">

--- a/components/financial_assistance/app/views/financial_assistance/applications/index_with_filter.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/index_with_filter.html.erb
@@ -13,7 +13,7 @@
           <% current_year = oe_year - 1 %>
           <h4><b><%= l10n('faa.coverage_update_reminder', year: current_year, year2: oe_year) %></b></h4>
         <% end %>
-        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && !HbxProfile.current_hbx.under_open_enrollment? && (HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on > Date.today) %>
+        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && !HbxProfile.current_hbx.under_open_enrollment? && (HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on > TimeKeeper.date_of_record) %>
           <h4 data-cuke='oe_application_warning_display'><%= l10n('faa.cost_savings_applications_oe_desc', next_year: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_end_on.year, oe_start: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on&.strftime("%B %d, %Y")) %></h4>
         <% end %>
         <div style="display:flex; justify-content: space-between; padding: 10px 0px;">

--- a/components/financial_assistance/app/views/financial_assistance/applications/index_with_filter.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/index_with_filter.html.erb
@@ -13,7 +13,7 @@
           <% current_year = oe_year - 1 %>
           <h4><b><%= l10n('faa.coverage_update_reminder', year: current_year, year2: oe_year) %></b></h4>
         <% end %>
-        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && !HbxProfile.current_hbx.under_open_enrollment? %>
+        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && !HbxProfile.current_hbx.under_open_enrollment? && (HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on > Date.today) %>
           <h4 data-cuke='oe_application_warning_display'><%= l10n('faa.cost_savings_applications_oe_desc', next_year: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_end_on.year, oe_start: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on&.strftime("%B %d, %Y")) %></h4>
         <% end %>
         <div style="display:flex; justify-content: space-between; padding: 10px 0px;">

--- a/features/financial_assistance/cost_savings.feature
+++ b/features/financial_assistance/cost_savings.feature
@@ -50,6 +50,7 @@ Feature: Cost Savings
   Scenario: FAA Feature Is Enabled - Consumer will see message if oe_application_warning_display feature is enabled
     Given the oe application warning display feature is enabled
     Given current hbx is not under open enrollment
+    Given it is before open enrollment
     Given consumer visits home page
     And the Cost Savings link is visible
     When the consumer clicks the Cost Savings link
@@ -60,11 +61,22 @@ Feature: Cost Savings
     Given the oe application warning display feature is enabled
     Given the filtered_application_list feature is enabled
     Given current hbx is not under open enrollment
+    Given it is before open enrollment
     Given consumer visits home page
     And the Cost Savings link is visible
     When the consumer clicks the Cost Savings link
     Then the consumer will navigate to the Cost Savings page
     Then the oe application warning will display
+
+  Scenario: Consumer will not see message if after open enrollment
+    Given the oe application warning display feature is enabled
+    Given current hbx is not under open enrollment
+    Given it is after open enrollment
+    Given consumer visits home page
+    And the Cost Savings link is visible
+    When the consumer clicks the Cost Savings link
+    Then the consumer will navigate to the Cost Savings page
+    Then the oe application warning will not display
 
   Scenario: FAA Feature Is Enabled - Consumer has nil fields for Incarcerated status
     Given the FAA feature configuration is enabled

--- a/features/financial_assistance/step_definitions/work_flow_steps.rb
+++ b/features/financial_assistance/step_definitions/work_flow_steps.rb
@@ -132,12 +132,12 @@ end
 
 And(/^it is before open enrollment$/) do
   oe_start_on = HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.detect {|bcp| bcp.start_on.year == Date.today.year}.open_enrollment_start_on
-  allow(Date).to receive(:today).and_return Date.new(oe_start_on.year,10,27)
+  allow(TimeKeeper).to receive(:date_of_record).and_return Date.new(oe_start_on.year,10,27)
 end
 
 And(/^it is after open enrollment$/) do
   oe_end_on = HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_end_on
-  allow(Date).to receive(:today).and_return Date.new(oe_end_on.year,2,15)
+  allow(TimeKeeper).to receive(:date_of_record).and_return Date.new(oe_end_on.year,2,15)
 end
 
 And(/^current hbx is not under open enrollment$/) do

--- a/features/financial_assistance/step_definitions/work_flow_steps.rb
+++ b/features/financial_assistance/step_definitions/work_flow_steps.rb
@@ -130,12 +130,26 @@ And(/^current hbx is under open enrollment$/) do
   HbxProfile.any_instance.stub(:under_open_enrollment?).and_return(true)
 end
 
+And(/^it is before open enrollment$/) do
+  oe_start_on = HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.detect {|bcp| bcp.start_on.year == Date.today.year}.open_enrollment_start_on
+  allow(Date).to receive(:today).and_return Date.new(oe_start_on.year,10,27)
+end
+
+And(/^it is after open enrollment$/) do
+  oe_end_on = HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_end_on
+  allow(Date).to receive(:today).and_return Date.new(oe_end_on.year,2,15)
+end
+
 And(/^current hbx is not under open enrollment$/) do
   HbxProfile.any_instance.stub(:under_open_enrollment?).and_return(false)
 end
 
 Then(/^the oe application warning will display$/) do
   expect(page.has_css?(CostSavingsApplicationPage.oe_application_warning_display)).to eq true
+end
+
+Then(/^the oe application warning will not display$/) do
+  expect(page.has_css?(CostSavingsApplicationPage.oe_application_warning_display)).to eq false
 end
 
 Then(/^the index filter will display$/) do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184232379

# A brief description of the changes

Current behavior: Warning message displays after OE ends

New behavior: Warning message displays only before the start of OE

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
