### PR TITLE
update oe instructions to display only during oe

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/applications/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/index.html.erb
@@ -7,10 +7,10 @@
       <div class="col-md-10">
         <h1 class="darkblue no-buffer"><%= l10n('faa.cost_savings_applications') %></h1>
         <h4><%= l10n('faa.cost_savings_applications_desc') %></h4>
-        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) %>
+        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && HbxProfile.current_hbx.under_open_enrollment? %>
           <% oe_year = Family.application_applicable_year %>
           <% current_year = oe_year - 1 %>
-          <h4><b><%= l10n('faa.coverage_update_reminder', year: current_year, year2: oe_year) %></b></h4>
+          <h4 data-cuke='coverage_update_reminder_display'><b><%= l10n('faa.coverage_update_reminder', year: current_year, year2: oe_year) %></b></h4>
         <% end %>
         <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && !HbxProfile.current_hbx.under_open_enrollment? && (HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on > TimeKeeper.date_of_record) %>
           <h4 data-cuke='oe_application_warning_display'><%= l10n('faa.cost_savings_applications_oe_desc', next_year: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_end_on.year, oe_start: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on&.strftime("%B %d, %Y")) %></h4>

--- a/components/financial_assistance/app/views/financial_assistance/applications/index_with_filter.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/index_with_filter.html.erb
@@ -8,10 +8,10 @@
       <div class="col-md-10">
         <h1 class="no-buffer"><%= l10n('faa.cost_savings_applications') %></h1>
         <h4><%= l10n('faa.cost_savings_applications_desc') %></h4>
-        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) %>
+        <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && HbxProfile.current_hbx.under_open_enrollment? %>
           <% oe_year = Family.application_applicable_year %>
           <% current_year = oe_year - 1 %>
-          <h4><b><%= l10n('faa.coverage_update_reminder', year: current_year, year2: oe_year) %></b></h4>
+          <h4 data-cuke='coverage_update_reminder_display'><b><%= l10n('faa.coverage_update_reminder', year: current_year, year2: oe_year) %></b></h4>
         <% end %>
         <% if FinancialAssistanceRegistry.feature_enabled?(:oe_application_warning_display) && !HbxProfile.current_hbx.under_open_enrollment? && (HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on > TimeKeeper.date_of_record) %>
           <h4 data-cuke='oe_application_warning_display'><%= l10n('faa.cost_savings_applications_oe_desc', next_year: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_end_on.year, oe_start: HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on&.strftime("%B %d, %Y")) %></h4>

--- a/features/financial_assistance/cost_savings.feature
+++ b/features/financial_assistance/cost_savings.feature
@@ -105,7 +105,7 @@ Feature: Cost Savings
     Then the consumer will navigate to the Cost Savings page
     Then the coverage update reminder warning will display
 
-  Scenario: Under Open Enrollment - Consumer should see OE Application warning message
+  Scenario: Not under Open Enrollment - Consumer should not see OE Application warning message
     Given the oe application warning display feature is enabled
     Given current hbx is not under open enrollment
     Given consumer visits home page

--- a/features/financial_assistance/cost_savings.feature
+++ b/features/financial_assistance/cost_savings.feature
@@ -95,3 +95,21 @@ Feature: Cost Savings
     When DOB is nil for the consumer
     When consumer click 'Start New Application' button
     Then the consumer should see a message with dob error
+
+  Scenario: Under Open Enrollment - Consumer should see OE Application warning message
+    Given the oe application warning display feature is enabled
+    Given current hbx is under open enrollment
+    Given consumer visits home page
+    And the Cost Savings link is visible
+    When the consumer clicks the Cost Savings link
+    Then the consumer will navigate to the Cost Savings page
+    Then the coverage update reminder warning will display
+
+  Scenario: Under Open Enrollment - Consumer should see OE Application warning message
+    Given the oe application warning display feature is enabled
+    Given current hbx is not under open enrollment
+    Given consumer visits home page
+    And the Cost Savings link is visible
+    When the consumer clicks the Cost Savings link
+    Then the consumer will navigate to the Cost Savings page
+    Then the coverage update reminder warning will not display

--- a/features/financial_assistance/step_definitions/work_flow_steps.rb
+++ b/features/financial_assistance/step_definitions/work_flow_steps.rb
@@ -150,6 +150,12 @@ end
 
 Then(/^the oe application warning will not display$/) do
   expect(page.has_css?(CostSavingsApplicationPage.oe_application_warning_display)).to eq false
+Then(/^the coverage update reminder warning will display$/) do
+  expect(page.has_css?(CostSavingsApplicationPage.coverage_update_reminder_display)).to eq true
+end
+
+Then(/^the coverage update reminder warning will not display$/) do
+  expect(page.has_css?(CostSavingsApplicationPage.coverage_update_reminder_display)).to eq false
 end
 
 Then(/^the index filter will display$/) do

--- a/features/financial_assistance/step_definitions/work_flow_steps.rb
+++ b/features/financial_assistance/step_definitions/work_flow_steps.rb
@@ -150,6 +150,8 @@ end
 
 Then(/^the oe application warning will not display$/) do
   expect(page.has_css?(CostSavingsApplicationPage.oe_application_warning_display)).to eq false
+end
+
 Then(/^the coverage update reminder warning will display$/) do
   expect(page.has_css?(CostSavingsApplicationPage.coverage_update_reminder_display)).to eq true
 end

--- a/features/support/object_model_pages/financial_assistance/cost_savings_application_page.rb
+++ b/features/support/object_model_pages/financial_assistance/cost_savings_application_page.rb
@@ -11,6 +11,10 @@ class CostSavingsApplicationPage
     "[data-cuke='oe_application_warning_display']"
   end
 
+  def self.coverage_update_reminder_display
+    "[data-cuke='coverage_update_reminder_display']"
+  end
+
   def self.index_with_filter
     "[data-cuke='index_with_filter']"
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184230806

# A brief description of the changes

Current behavior: OE instructions display outside OE

New behavior: OE instructions display only during OE

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
