### PR TITLE
Update EDI when a broker agency is decertified

### DIFF
--- a/app/domain/operations/families/terminate_broker_agency.rb
+++ b/app/domain/operations/families/terminate_broker_agency.rb
@@ -13,8 +13,9 @@ module Operations
         valid_params = yield validate(params)
         agency_account = yield find_broker_agency_account(valid_params)
         family = yield find_family(valid_params)
+        broker_role = agency_account.writing_agent
         result = yield terminate_broker_agency(agency_account, valid_params)
-        notify_broker_terminated_event_to_edi(valid_params, family)
+        notify_broker_terminated_event_to_edi(valid_params, family, broker_role)
         Success(result)
       end
 
@@ -38,8 +39,8 @@ module Operations
         ::Operations::Families::Find.new.call(id: valid_params[:family_id])
       end
 
-      def notify_broker_terminated_event_to_edi(valid_params, family)
-        return Success("") unless valid_params[:notify_edi]
+      def notify_broker_terminated_event_to_edi(valid_params, family, broker_role)
+        return Success("") if valid_params[:notify_edi].present? && valid_params[:notify_edi] == false
         return Success("") unless broker_role&.npn&.scan(/\D/)&.empty?
 
         family.notify_broker_update_on_impacted_enrollments_to_edi({family_id: family.id.to_s})

--- a/spec/domain/operations/families/terminate_broker_agency_spec.rb
+++ b/spec/domain/operations/families/terminate_broker_agency_spec.rb
@@ -32,6 +32,20 @@ RSpec.describe ::Operations::Families::TerminateBrokerAgency, dbclean: :after_ea
         family.reload
         expect(family.current_broker_agency).to eq nil
       end
+
+      it 'should terminate broker agency account but should not notify EDI if set to false' do
+        expect(family.current_broker_agency.writing_agent).to eq writing_agent
+        terminate_params = { family_id: family.id,
+                             terminate_date: TimeKeeper.date_of_record,
+                             broker_account_id: family.current_broker_agency&.id,
+                             notify_edi: false }
+
+        result = subject.call(terminate_params)
+        expect(result).to be_a(Dry::Monads::Result::Success)
+        expect(result.success).to eq "Not notifying EDI"
+        family.reload
+        expect(family.current_broker_agency).to eq nil
+      end
     end
 
     context 'when invalid params passed' do

--- a/spec/domain/operations/families/terminate_broker_agency_spec.rb
+++ b/spec/domain/operations/families/terminate_broker_agency_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe ::Operations::Families::TerminateBrokerAgency, dbclean: :after_ea
   let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person)}
   let(:broker_agency_profile) { FactoryBot.build(:benefit_sponsors_organizations_broker_agency_profile)}
   let(:writing_agent)         { FactoryBot.create(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id) }
+  let(:assistor)  do
+    assistor = FactoryBot.build(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, npn: "SMECDOA00")
+    assistor.save(validate: false)
+    assistor
+  end
 
   describe 'broker agency account term params for family' do
 
@@ -43,6 +48,26 @@ RSpec.describe ::Operations::Families::TerminateBrokerAgency, dbclean: :after_ea
         result = subject.call(terminate_params)
         expect(result).to be_a(Dry::Monads::Result::Success)
         expect(result.success).to eq "Not notifying EDI"
+        family.reload
+        expect(family.current_broker_agency).to eq nil
+      end
+
+      it 'should terminate broker agency account but not notify EDI if broker is assistor' do
+        family.current_broker_agency.update(is_active: false)
+        family.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id,
+                                                                                            writing_agent_id: assistor.id,
+                                                                                            start_on: Time.now,
+                                                                                            is_active: true)
+        family.reload
+        expect(family.current_broker_agency.writing_agent).to eq assistor
+        terminate_params = { family_id: family.id,
+                             terminate_date: TimeKeeper.date_of_record,
+                             broker_account_id: family.current_broker_agency&.id,
+                             notify_edi: true }
+
+        result = subject.call(terminate_params)
+        expect(result).to be_a(Dry::Monads::Result::Success)
+        expect(result.success).to eq "Not notifying EDI because broker is an assistor"
         family.reload
         expect(family.current_broker_agency).to eq nil
       end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184251541

# A brief description of the changes

Current behavior: When a broker is decertified, broker decertification events for families under that broker were not flowing to EDI

New behavior: When a broker is decertified, broker decertification events for families under that broker will now flow to EDI

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
