### PR TITLE
share docker image builds to dc slack

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -246,3 +246,27 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.YELLR_BOT_TOKEN }}
+      - name: Post to DC slack
+        # Only run if matrix client is DC
+        if: matrix.client == 'dc'
+        id: slack
+        uses: slackapi/slack-github-action@v1
+        with:
+          channel-id: 'docker-images-${{ needs.prep.outputs.repositoryName }}'
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*${{ format('{0} {1} image*:\n`{2}/{3}-{4}`', env.CLIENT, matrix.registry, matrix.registry, needs.prep.outputs.taggedImage, matrix.client) }}"
+                  }
+                },
+                {
+                  "type": "divider"
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.DC_DEPLOY_SLACK_BOT_TOKEN }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Git Commit Data w/ Message
         uses: jcputney/git-commit-data-action@1.0.2
       - name: Post to a Slack channel
-        id: slack
+        id: ic-slack
         uses: slackapi/slack-github-action@v1
         with:
           channel-id: 'docker-images-${{ needs.prep.outputs.repositoryName }}'
@@ -225,7 +225,7 @@ jobs:
           MATRIX_CLIENT=$(echo ${{ matrix.client }} | tr '[:lower:]' '[:upper:]')
           echo "CLIENT=${MATRIX_CLIENT}" >> ${GITHUB_ENV}
       - name: Post to a Slack channel
-        id: slack
+        id: dc-slack
         uses: slackapi/slack-github-action@v1
         with:
           channel-id: 'docker-images-${{ needs.prep.outputs.repositoryName }}'


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes

# What is the ticket # detailing the issue?

Ticket: request in support of DC development, cc @matt--williams 

# A brief description of the changes

Current behavior:
All image notifications go only to IdeaCrew slack

New behavior:
Images built for DC will also go to DC slack

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
