### PR TITLE
transmit non tobacco rate premiums

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 8e672ad0592983003da2bba7c09b78125eb9c8aa
+  revision: d9472c7c59c60dffaf3b37b23d96b6518ca92ec3
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment.rb
+++ b/app/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment.rb
@@ -179,7 +179,8 @@ module Operations
 
           enrollment.hbx_enrollment_members.collect do |hem|
             person = hem.person
-            {
+
+            member_hash = {
               family_member_reference: {
                 family_member_hbx_id: hem.hbx_id,
                 age: hem.age_on_effective_date,
@@ -192,8 +193,12 @@ module Operations
               eligibility_date: hem.eligibility_date,
               coverage_start_on: hem.coverage_start_on,
               coverage_end_on: hem.coverage_end_on,
+              tobacco_use: hem.tobacco_use,
               slcsp_member_premium: fetch_slcsp_benchmark_premium_for_member(person.hbx_id, slcsp_info)
             }
+
+            member_hash.merge!(non_tobacco_use_premium: enrollment.premium_for_non_tobacco_use(hem).to_money.to_hash) if hem.tobacco_use == "Y"
+            member_hash
           end
         end
       end

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -193,7 +193,7 @@ class HbxEnrollment
   associated_with_one :broker, :writing_agent_id, "BrokerRole"
 
   delegate :total_premium, :total_employer_contribution, :total_employee_cost, :total_ehb_premium, to: :decorated_hbx_enrollment, allow_nil: true
-  delegate :premium_for, to: :decorated_hbx_enrollment, allow_nil: true
+  delegate :premium_for, :premium_for_non_tobacco_use, to: :decorated_hbx_enrollment, allow_nil: true
 
   #indexes
   index({"household_id" => 1})

--- a/app/models/unassisted_plan_cost_decorator.rb
+++ b/app/models/unassisted_plan_cost_decorator.rb
@@ -78,6 +78,14 @@ class UnassistedPlanCostDecorator < SimpleDelegator
     0
   end
 
+  def premium_for_non_tobacco_use(member)
+    (::BenefitMarkets::Products::ProductRateCache.lookup_rate(__getobj__, schedule_date, age_of(member), rating_area) * large_family_factor(member)).round(2)
+  rescue StandardError => e
+    warn e.inspect unless Rails.env.test?
+    warn e.backtrace unless Rails.env.test?
+    0
+  end
+
   def employer_contribution_for(_member)
     0.00
   end

--- a/spec/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment_spec.rb
+++ b/spec/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment_spec.rb
@@ -47,4 +47,45 @@ RSpec.describe ::Operations::Transformers::HbxEnrollmentTo::Cv3HbxEnrollment, db
     expect(@validated_payload[:product_reference][:pediatric_dental_ehb]).not_to be_nil
     expect(@validated_payload[:product_reference][:metal_level]).to eq(enr_product.metal_level_kind.to_s)
   end
+
+  context 'for tobacco use' do
+    let(:enr_product) do
+      BenefitMarkets::Products::HealthProducts::HealthProduct.by_year(TimeKeeper.date_of_record.year).first
+    end
+
+    let!(:enrollment) do
+      FactoryBot.create(:hbx_enrollment,
+                        :individual_unassisted,
+                        effective_on: TimeKeeper.date_of_record.beginning_of_month,
+                        terminated_on: TimeKeeper.date_of_record.end_of_month,
+                        family: family,
+                        product_id: enr_product.id,
+                        rating_area_id: rating_area.id,
+                        coverage_kind: 'health',
+                        consumer_role_id: family.primary_person.consumer_role.id,
+                        enrollment_members: family.family_members)
+    end
+
+    let!(:enrollment_member) do
+      FactoryBot.create(:hbx_enrollment_member, applicant_id: family.primary_applicant.id,
+                                                eligibility_date: (TimeKeeper.date_of_record - 2.months), hbx_enrollment: enrollment,
+                                                coverage_end_on: TimeKeeper.date_of_record.end_of_month, tobacco_use: 'Y')
+    end
+
+    before do
+      transformed_payload = subject.call(enrollment).success
+      @validated_payload = AcaEntities::Contracts::Enrollments::HbxEnrollmentContract.new.call(transformed_payload).to_h
+    end
+
+    it 'should return :tobacoo_use, :non_tobacco_use_premium along with other attributes' do
+      expect(@validated_payload[:hbx_id]).to eq(enrollment.hbx_id.to_s)
+      expect(@validated_payload[:terminated_on]).to eq(enrollment.terminated_on)
+      expect(@validated_payload[:hbx_enrollment_members].first[:tobacco_use]).to eq "Y"
+      expect(@validated_payload[:hbx_enrollment_members].first[:non_tobacco_use_premium]).not_to be_empty
+      expect(@validated_payload[:hbx_enrollment_members].first[:slcsp_member_premium]).not_to be_empty
+      expect(@validated_payload[:hbx_enrollment_members].first[:coverage_end_on]).to eq enrollment_member.coverage_end_on
+      expect(@validated_payload[:product_reference][:metal_level]).to eq(enr_product.metal_level_kind.to_s)
+    end
+  end
 end
+


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

[IVL-184265122](https://www.pivotaltracker.com/n/projects/2481183/stories/184265122)

# A brief description of the changes

Current behavior: We've tobacco_use flag under hbx_enrollment_member, but not being transmitted to edit_gateway in cv3_family payload.

New behavior: Added tobacco_use flag and non_tobacco_use_premium to cv3_family payload

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
