### PR TITLE
restore medicaid review transfer if requested unless non-magi

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -603,6 +603,7 @@ module FinancialAssistance
       unless FinancialAssistanceRegistry.feature_enabled?(:non_magi_transfer)
         # block transfer if any applicant is eligible for non-MAGI reasons
         return false if has_non_magi_referrals?
+        return true if full_medicaid_determination
       end
       active_applicants.any? do |applicant|
         applicant.is_medicaid_chip_eligible || applicant.is_magi_medicaid || applicant.is_non_magi_medicaid_eligible || applicant.is_medicare_eligible || applicant.is_eligible_for_non_magi_reasons

--- a/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
@@ -2074,6 +2074,16 @@ RSpec.describe ::FinancialAssistance::Application, type: :model, dbclean: :after
           expect(application.is_transferrable?).to eq(false)
         end
       end
+
+      context 'user requested referral when not non-MAGI' do
+        before do
+          application.update(full_medicaid_determination: true)
+        end
+
+        it 'should be transferrable' do
+          expect(application.is_transferrable?).to eq(true)
+        end
+      end
     end
 
     context 'block_renewal_application_transfers feature enabled' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184119691

# A brief description of the changes

Current behavior: Requesting a full medicaid review is not guaranteeing that a transfer occurs (except in the expected case where non-MAGI transfers are blocked).

New behavior: Requesting a full medicaid review always transfers, unless any applicant is eligible for non-MAGI reasons.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

NON_MAGI_TRANSFER_IS_ENABLED

- [ ] DC
- [x] ME
