### PR TITLE
pass in exclusion list as an argument for 1095a generation

### DIFF
--- a/spec/domain/operations/edi_gateway/trigger_bulk_tax1095a_notices_spec.rb
+++ b/spec/domain/operations/edi_gateway/trigger_bulk_tax1095a_notices_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ::Operations::EdiGateway::TriggerBulkTax1095aNotices do
 
   describe 'with invalid params' do
     it "should fail to publish" do
-      result = described_class.new.call({tax_year: Date.today.year,tax_form_type: ""})
+      result = described_class.new.call({tax_year: Date.today.year,tax_form_type: "", exclusion_list: []})
       expect(result.success?).to be_falsey
       expect(result.failure).to eq("Valid tax form type is not present")
     end
@@ -14,7 +14,7 @@ RSpec.describe ::Operations::EdiGateway::TriggerBulkTax1095aNotices do
 
   describe 'with valid params' do
     it "return success" do
-      result = described_class.new.call({tax_year: Date.today.year,tax_form_type: "IVL_TAX"})
+      result = described_class.new.call({tax_year: Date.today.year,tax_form_type: "IVL_TAX", exclusion_list: []})
       expect(result.success?).to be_truthy
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-84304706

# A brief description of the changes

Current behavior:  1095A generation event does not accept exclusion list.

New behavior: Provide a way to exclude generation of 1095's for the list provided by Business.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
