### PR TITLE
add indexes for tax household enrollment

### DIFF
--- a/app/models/tax_household_enrollment.rb
+++ b/app/models/tax_household_enrollment.rb
@@ -31,6 +31,9 @@ class TaxHouseholdEnrollment
 
   embeds_many :tax_household_members_enrollment_members, class_name: "::TaxHouseholdMemberEnrollmentMember", cascade_callbacks: true
 
+  index({"enrollment_id" => 1})
+  index({"tax_household_id" => 1})
+
   def enrollment
     HbxEnrollment.find(enrollment_id)
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2502930/stories/184331004

querying  tax household enrollment documents taking too long. so added missing indexes

# A brief description of the changes

Current behavior: missing indexes on tax household enrollments

New behavior: added indexes for `enrollment_id`, `tax_household_id`

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
