### PR TITLE
set default value for incarcerated field in cv3 person transform

### DIFF
--- a/app/domain/operations/transformers/person_to/cv3_person.rb
+++ b/app/domain/operations/transformers/person_to/cv3_person.rb
@@ -308,6 +308,8 @@ module Operations
         end
 
         def construct_person_demographics(person)
+          # is_incarcerated field is nil when person is NOT applying for coverage but is required in cv3 contract
+          is_incarcerated = person.is_incarcerated || false
           {
             encrypted_ssn: encrypt(person.ssn),
             no_ssn: person.no_ssn == "0" || person.ssn.present? ? false : true,
@@ -315,7 +317,7 @@ module Operations
             dob: person.dob,
             date_of_death: person.date_of_death,
             dob_check: person.dob_check,
-            is_incarcerated: person.is_incarcerated,
+            is_incarcerated: is_incarcerated,
             ethnicity: person.ethnicity,
             race: person.race,
             tribal_id: person.tribal_id,

--- a/spec/domain/operations/transformers/person_to/cv3_person_spec.rb
+++ b/spec/domain/operations/transformers/person_to/cv3_person_spec.rb
@@ -54,17 +54,5 @@ RSpec.describe ::Operations::Transformers::PersonTo::Cv3Person, dbclean: :after_
         expect(subject[:is_incarcerated]).to eq false
       end
     end
-    # it 'should have contact method' do
-    #   expect(subject[:contact_method]).to eq('Paper and Electronic communications')
-    # end
-
-    # context 'when verification_type_history_elements are present' do
-    #   let!(:verification_type_history_element) { create(:verification_type_history_element, consumer_role: person.consumer_role) }
-    #   subject { ::Operations::Transformers::PersonTo::Cv3Person.new.construct_consumer_role(person.consumer_role.reload) }
-
-    #   it 'should construct verification_type_history_elements' do
-    #     expect(subject[:verification_type_history_elements][0][:verification_type]).to eq(verification_type_history_element.verification_type)
-    #   end
-    # end
   end
 end

--- a/spec/domain/operations/transformers/person_to/cv3_person_spec.rb
+++ b/spec/domain/operations/transformers/person_to/cv3_person_spec.rb
@@ -40,4 +40,31 @@ RSpec.describe ::Operations::Transformers::PersonTo::Cv3Person, dbclean: :after_
       end
     end
   end
+
+  describe '#construct_person_demographics' do
+
+    subject { ::Operations::Transformers::PersonTo::Cv3Person.new.construct_person_demographics(person) }
+
+    context 'when is_incarcerated is nil' do
+      before do
+        person.update(is_incarcerated: nil)
+      end
+
+      it 'should set the value of the field to false' do
+        expect(subject[:is_incarcerated]).to eq false
+      end
+    end
+    # it 'should have contact method' do
+    #   expect(subject[:contact_method]).to eq('Paper and Electronic communications')
+    # end
+
+    # context 'when verification_type_history_elements are present' do
+    #   let!(:verification_type_history_element) { create(:verification_type_history_element, consumer_role: person.consumer_role) }
+    #   subject { ::Operations::Transformers::PersonTo::Cv3Person.new.construct_consumer_role(person.consumer_role.reload) }
+
+    #   it 'should construct verification_type_history_elements' do
+    #     expect(subject[:verification_type_history_elements][0][:verification_type]).to eq(verification_type_history_element.verification_type)
+    #   end
+    # end
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184331037

# A brief description of the changes

Current behavior:
The is_incarcerated field is nil when person is NOT applying for coverage but is required in cv3 contract, so payloads with such applicants are breaking on the contracts.

New behavior:
A default value of false is set in the cv3 person transform so contract validation will pass for these non-applicants.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
