### PR TITLE
remove relationship dependency to identify slcsapd

### DIFF
--- a/app/domain/operations/benchmark_products/identify_slcsapd.rb
+++ b/app/domain/operations/benchmark_products/identify_slcsapd.rb
@@ -43,7 +43,7 @@ module Operations
         service_area_ids = params[:benchmark_product_model].service_area_ids
         @effective_date = params[:benchmark_product_model].effective_date
         members = params[:household_params][:members]
-        @child_members = members.select { |member| member[:relationship_with_primary] == 'child' && member[:age_on_effective_date] < 21 }
+        @child_members = members.select { |member| member[:age_on_effective_date] < 21 }
 
         query = {
           :service_area_id.in => service_area_ids,

--- a/spec/domain/operations/benchmark_products/identify_slcsapd_spec.rb
+++ b/spec/domain/operations/benchmark_products/identify_slcsapd_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Operations::BenchmarkProducts::IdentifySlcsapd do
       end
     end
 
-    context 'Adult with 4 children - one 19yo, the rest under 19' do
+    context 'Adult with 4 members - one 19yo, the rest under 19' do
       let(:person1_age) { 30 }
       let(:person2_age) { 19 }
       let(:person3_age) { 2 }
@@ -246,9 +246,9 @@ RSpec.describe Operations::BenchmarkProducts::IdentifySlcsapd do
         household_params.merge!({ type_of_household: 'child_only' })
         household_params[:members][0][:relationship_with_primary] = 'self'
         household_params[:members][1][:relationship_with_primary] = 'child'
-        household_params[:members][2][:relationship_with_primary] = 'child'
+        household_params[:members][2][:relationship_with_primary] = 'other_relationship'
         household_params[:members][3][:relationship_with_primary] = 'child'
-        household_params[:members][4][:relationship_with_primary] = 'child'
+        household_params[:members][4][:relationship_with_primary] = 'other_relationship'
 
         @result = ::Operations::BenchmarkProducts::IdentifySlcsapd.new.call(
           { family: family, benchmark_product_model: @benchmark_product_model, household_params: household_params }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184344121

# A brief description of the changes

Current behavior: For identifying the second lowest cost standalone dental plan, child members are identified based on a combination of both relationship to primary and age.

New behavior: For identifying the second lowest cost standalone dental plan, child members are identified only based on age and do not depend on the relationship to the primary.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
