### PR TITLE
switch csr to be set with csr_eligibility_kind for cv3 transform

### DIFF
--- a/app/domain/operations/transformers/family_to/cv3_family.rb
+++ b/app/domain/operations/transformers/family_to/cv3_family.rb
@@ -344,7 +344,7 @@ module Operations
             magi_medicaid_monthly_income_limit: member.magi_medicaid_monthly_income_limit&.to_hash,
             magi_as_percentage_of_fpl: member.magi_as_percentage_of_fpl,
             magi_medicaid_category: member.magi_medicaid_category,
-            csr: member.csr_percent_as_integer
+            csr: member.csr_eligibility_kind.split('_').last
           }
         end
 
@@ -383,3 +383,23 @@ module Operations
     end
   end
 end
+
+hbxs = [1002778,1006113,1008426,1009637,1009945,1011200,1011623,1011747,1017151,1022244,1022400,1022854,1023864,1025017,1025217,1028082]
+
+
+hbxs.each do |hbx|
+  family = Person.where(hbx_id: hbx).first.primary_family
+  family.households.each do |household|
+    household.tax_households.each do |th|
+      th.tax_household_members.each do |thm|
+       puts thm.csr_eligibility_kind.gsub('csr_', '')
+      end
+    end
+  end
+end
+
+
+
+
+
+#foo[:households].map { |h| h[:tax_households].map{ |th| th[:tax_household_members].map{ |thm| thm[:product_eligibility_determination][:csr] } } }

--- a/app/domain/operations/transformers/family_to/cv3_family.rb
+++ b/app/domain/operations/transformers/family_to/cv3_family.rb
@@ -383,23 +383,3 @@ module Operations
     end
   end
 end
-
-hbxs = [1002778,1006113,1008426,1009637,1009945,1011200,1011623,1011747,1017151,1022244,1022400,1022854,1023864,1025017,1025217,1028082]
-
-
-hbxs.each do |hbx|
-  family = Person.where(hbx_id: hbx).first.primary_family
-  family.households.each do |household|
-    household.tax_households.each do |th|
-      th.tax_household_members.each do |thm|
-       puts thm.csr_eligibility_kind.gsub('csr_', '')
-      end
-    end
-  end
-end
-
-
-
-
-
-#foo[:households].map { |h| h[:tax_households].map{ |th| th[:tax_household_members].map{ |thm| thm[:product_eligibility_determination][:csr] } } }

--- a/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
+++ b/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
@@ -189,11 +189,16 @@ RSpec.describe ::Operations::Transformers::FamilyTo::Cv3Family, dbclean: :around
     context 'member has csr kind value of csr_limited' do
       before do
         member = family.tax_household_groups.first.tax_households.first.tax_household_members.first
-        member.update(csr_eligibility_kind: 'csr_limited')
+        member.update(csr_percent_as_integer: -1)
       end
 
       it 'should remove csr prefix in the hash' do
+        expect(family.tax_household_groups.first.tax_households.first.tax_household_members.first.csr_eligibility_kind).to eq 'csr_limited'
         expect(subject.first[:tax_households].first[:tax_household_members].first[:product_eligibility_determination][:csr]).to eq 'limited'
+      end
+
+      it 'should validate the contract successfully' do
+        expect(AcaEntities::Contracts::Households::TaxHouseholdGroupContract.new.call(subject.first).success?).to be_truthy
       end
     end
   end

--- a/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
+++ b/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
@@ -185,6 +185,17 @@ RSpec.describe ::Operations::Transformers::FamilyTo::Cv3Family, dbclean: :around
       result = AcaEntities::Households::TaxHouseholdGroup.new(contract_result.to_h)
       expect(result).to be_a AcaEntities::Households::TaxHouseholdGroup
     end
+
+    context 'member has csr kind value of csr_limited' do
+      before do
+        member = family.tax_household_groups.first.tax_households.first.tax_household_members.first
+        member.update(csr_eligibility_kind: 'csr_limited')
+      end
+
+      it 'should remove csr prefix in the hash' do
+        expect(subject.first[:tax_households].first[:tax_household_members].first[:product_eligibility_determination][:csr]).to eq 'limited'
+      end
+    end
   end
 
   describe '#fetch_slcsp_benchmark_premium_for_member' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: 
ME-184364889

# A brief description of the changes

Current behavior:
csr is being set off of csr_percent_as_integer which is incorrectly transforming, leaving behind '-1' csr values that fail in the contract

New behavior:
set csr from csr_eligibility_kind to correctly transform the values

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
