### PR TITLE
adding no_timeout when expiring enrollments in advance day job

### DIFF
--- a/app/models/services/ivl_enrollment_service.rb
+++ b/app/models/services/ivl_enrollment_service.rb
@@ -23,7 +23,7 @@ module Services
         :kind.in => ['individual', 'coverall'],
         :aasm_state.in => HbxEnrollment::ENROLLED_STATUSES - ['coverage_termination_pending']
       )
-      individual_market_enrollments.each do |enrollment|
+      individual_market_enrollments.no_timeout.each do |enrollment|
         enrollment.expire_coverage! if enrollment.may_expire_coverage?
         @logger.info "Processed enrollment: #{enrollment.hbx_id}"
       rescue Exception => e


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)
Bugfix change is to add no_timeout, unsure how to address in spec

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2502930/stories/184193318

# A brief description of the changes

Current behavior: During advance day job on January 1-4, a no cursor found error was thrown due to cursor timeout when expiring enrollments (lots of enrollments to expire for the new year so it timed out).  This caused the begin_ivl_enrollment advance day job to also not run so enrollments are stuck in auto_renewing state.

New behavior: Added no timeout to prevent this from happening and ensure advance_day jobs complete everyday

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
