### PR TITLE
adds new publisher for insurance policies refresh

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 9c6c591e3bb77d07f54511fe295cb4f303e16a29
+  revision: 5b2fd33f41cd2fa0104cf5e43bae0b6b60aa59ea
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/domain/operations/edi_gateway/insurance_policies/request_refresh.rb
+++ b/app/domain/operations/edi_gateway/insurance_policies/request_refresh.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'dry/monads/do'
+
+module Operations
+  module EdiGateway
+    module InsurancePolicies
+      # Operation to publish an event to request refresh of insurance policies within a date range(refresh_period).
+      class RequestRefresh
+        include Dry::Monads[:result, :do]
+        include EventSource::Command
+
+        def call(params)
+          validated_params = yield validate(params)
+          event            = yield build_event(validated_params)
+          publish_result   = yield publish(event)
+
+          Success(publish_result)
+        end
+
+        private
+
+        def build_event(validated_params)
+          event('events.insurance_policies.refresh_requested', attributes: { header: { refresh_period: validated_params[:refresh_period] }, payload: {} })
+        end
+
+        def formatted_params(params)
+          refresh_period_range = params[:refresh_period]
+          refresh_period_range = refresh_period_range.min.utc..refresh_period_range.max.utc
+          params[:refresh_period] = refresh_period_range
+          params
+        end
+
+        def publish(event)
+          event.publish
+          Success("Successfully published event: #{event.name}")
+        end
+
+        def validate(params)
+          if valid_date_range?(params[:refresh_period])
+            Success(formatted_params(params))
+          else
+            Failure('refresh_period must be a range with timestamps and max timestamps must be equal to or less than current time.')
+          end
+        end
+
+        def valid_date_range?(date_range)
+          return false unless date_range.is_a?(Range)
+          return false unless date_range.min.is_a?(Time) && date_range.max.is_a?(Time)
+
+          date_range.min <= date_range.max &&
+            date_range.max.utc <= Time.now.utc
+        end
+      end
+    end
+  end
+end

--- a/app/event_source/events/insurance_policies/refresh_requested.rb
+++ b/app/event_source/events/insurance_policies/refresh_requested.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Events
+  module InsurancePolicies
+    # This class has publisher path to register event
+    class RefreshRequested < EventSource::Event
+      publisher_path 'publishers.insurance_policies.refresh_requested_publisher'
+    end
+  end
+end

--- a/app/event_source/publishers/insurance_policies/refresh_requested_publisher.rb
+++ b/app/event_source/publishers/insurance_policies/refresh_requested_publisher.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Publishers
+  module InsurancePolicies
+    # This class will register event
+    class RefreshRequestedPublisher
+      include ::EventSource::Publisher[amqp: 'enroll.insurance_policies']
+
+      register_event 'refresh_requested'
+    end
+  end
+end

--- a/components/financial_assistance/Gemfile.lock
+++ b/components/financial_assistance/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 9c6c591e3bb77d07f54511fe295cb4f303e16a29
+  revision: 5b2fd33f41cd2fa0104cf5e43bae0b6b60aa59ea
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/spec/domain/operations/edi_gateway/insurance_policies/request_refresh_spec.rb
+++ b/spec/domain/operations/edi_gateway/insurance_policies/request_refresh_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Operations::EdiGateway::InsurancePolicies::RequestRefresh, dbclean: :after_each do
+
+  subject { described_class.new.call(input_params) }
+
+  describe '#call' do
+    context 'with valid refresh_period' do
+      let(:input_params) { { refresh_period: start_timestamp..end_timestamp } }
+
+      context 'timestamps in UTC' do
+        let(:end_timestamp) { (Time.now - 1.hours).utc }
+        let(:start_timestamp) { (Time.now - 10.hours).utc }
+
+        it 'returns success with a message' do
+          expect(subject.success).to eq('Successfully published event: events.insurance_policies.refresh_requested')
+        end
+      end
+
+      context 'timestamps not in UTC' do
+        let(:end_timestamp) { (Time.now - 1.hours) }
+        let(:start_timestamp) { (Time.now - 10.hours) }
+
+        it 'returns success with a message' do
+          expect(subject.success).to eq('Successfully published event: events.insurance_policies.refresh_requested')
+        end
+      end
+    end
+
+    context 'with an invalid refresh_period' do
+      context 'with no refresh_period key value' do
+        let(:input_params) { {} }
+
+        it 'returns failure with a message' do
+          expect(subject.failure).to eq('refresh_period must be a range with timestamps and max timestamps must be equal to or less than current time.')
+        end
+      end
+
+      context 'with bad refresh_period data types' do
+        let(:input_params) { { refresh_period: 2..6 } }
+
+        it 'returns failure with a message' do
+          expect(subject.failure).to eq('refresh_period must be a range with timestamps and max timestamps must be equal to or less than current time.')
+        end
+      end
+
+      context 'with bad refresh_period date range' do
+        let(:input_params) do
+          { refresh_period: TimeKeeper.date_of_record.next_month..TimeKeeper.date_of_record.prev_month }
+        end
+
+        it 'returns failure with a message' do
+          expect(subject.failure).to eq('refresh_period must be a range with timestamps and max timestamps must be equal to or less than current time.')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184384592

# A brief description of the changes

Current behavior:

New behavior: Operation to publish an event to request a refresh of insurance policies within a date range(refresh_period).

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
