### PR TITLE
enabling kp pay now phase 2 for dc

### DIFF
--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -419,7 +419,7 @@ registry:
           - key: :plan_shopping
             item: true
           - key: :enrollment_tile
-            item: false
+            item: true
           - key: :carriers_long_name
             item: 'Kaiser Permanente'
           - key: :connect_test

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -419,7 +419,7 @@ registry:
           - key: :plan_shopping
             item: true
           - key: :enrollment_tile
-            item: true
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TITLE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Kaiser Permanente'
           - key: :connect_test

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -419,7 +419,7 @@ registry:
           - key: :plan_shopping
             item: true
           - key: :enrollment_tile
-            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TITLE_IS_ENABLED'] || false %>
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Kaiser Permanente'
           - key: :connect_test

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -426,7 +426,7 @@ registry:
           - key: :plan_shopping
             item: false
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TITLE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Kaiser Permanente'
           - key: :connect_test

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -426,7 +426,7 @@ registry:
           - key: :plan_shopping
             item: false
           - key: :enrollment_tile
-            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TITLE_IS_ENABLED'] || false %>
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Kaiser Permanente'
           - key: :connect_test

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -419,7 +419,7 @@ registry:
           - key: :plan_shopping
             item: true
           - key: :enrollment_tile
-            item: false
+            item: true
           - key: :carriers_long_name
             item: 'Kaiser Permanente'
           - key: :connect_test

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -419,7 +419,7 @@ registry:
           - key: :plan_shopping
             item: true
           - key: :enrollment_tile
-            item: true
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TITLE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Kaiser Permanente'
           - key: :connect_test

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -419,7 +419,7 @@ registry:
           - key: :plan_shopping
             item: true
           - key: :enrollment_tile
-            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TITLE_IS_ENABLED'] || false %>
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Kaiser Permanente'
           - key: :connect_test


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2481183/stories/184276282
# A brief description of the changes

Current behavior:
KP pay now phase 2 is disabled in dc

New behavior:
KP pay now phase 2 is now enabled - enrollment tile details will appear

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED

- [x] DC
- [ ] ME
