### PR TITLE
adding env variables for kp and cf pay now feature

### DIFF
--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -480,16 +480,16 @@ registry:
           - key: :connect_test
             item: false
       - key: :carefirst_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['CAREFIRST_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['CAREFIRST_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['CAREFIRST_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'CareFirst'
           - key: :connect_test
-            item: false
+            item: <%= ENV['CAREFIRST_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :aetna_pay_now
         is_enabled: false
         settings:

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -414,16 +414,16 @@ registry:
       - :pay_now_feature
     features:
       - key: :kaiser_pay_now
-        is_enabled: true
+        is_enabled: <%= ENV['KAISER_PERMANENTE_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: true
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
             item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Kaiser Permanente'
           - key: :connect_test
-            item: true
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :delta_dental_pay_now
         is_enabled: false
         settings:

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -486,17 +486,17 @@ registry:
             item: 'MetLife'
           - key: :connect_test
             item: false
-      - key: :carefirst_pay_now
-        is_enabled: false
+- key: :carefirst_pay_now
+        is_enabled: <%= ENV['CAREFIRST_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['CAREFIRST_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['CAREFIRST_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'CareFirst'
           - key: :connect_test
-            item: false
+            item: <%= ENV['CAREFIRST_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :aetna_pay_now
         is_enabled: false
         settings:

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -486,7 +486,7 @@ registry:
             item: 'MetLife'
           - key: :connect_test
             item: false
-- key: :carefirst_pay_now
+      - key: :carefirst_pay_now
         is_enabled: <%= ENV['CAREFIRST_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -421,16 +421,16 @@ registry:
       - :pay_now_feature
     features:
       - key: :kaiser_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['KAISER_PERMANENTE_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
             item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Kaiser Permanente'
           - key: :connect_test
-            item: false
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :delta_dental_pay_now
         is_enabled: false
         settings:

--- a/features/financial_assistance/step_definitions/financial_assistance_steps.rb
+++ b/features/financial_assistance/step_definitions/financial_assistance_steps.rb
@@ -448,6 +448,11 @@ Given(/^the kaiser paynow feature configuration is disabled$/) do
   disable_feature :kaiser_pay_now
 end
 
+When(/kaiser pay now feature is enabled/) do
+  EnrollRegistry[:kaiser_pay_now].feature.stub(:is_enabled).and_return(true)
+  EnrollRegistry[:kaiser_pay_now].setting(:plan_shopping).stub(:item).and_return(true)
+end
+
 Given(/^the enrollment tile feature is enabled$/) do
   skip_this_scenario unless EnrollRegistry[:kaiser_pay_now].setting(:enrollment_tile).item || EnrollRegistry[:anthem_blue_cross_and_blue_shield_pay_now].setting(:enrollment_tile).item
 end

--- a/features/permissions/pay_now.feature
+++ b/features/permissions/pay_now.feature
@@ -9,6 +9,7 @@ Feature: Hbx Admin creates a New Consumer Application for ivl users
     And Hbx Admin logs on to the Hbx Portal
     And creates a consumer with SEP
     When the person enrolls in a Kaiser plan
+    When kaiser pay now feature is enabled
     And I click on purchase confirm button for matched person
     Then I should <action> pay now button
 

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -480,16 +480,16 @@ registry:
           - key: :connect_test
             item: false
       - key: :carefirst_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['CAREFIRST_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['CAREFIRST_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['CAREFIRST_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'CareFirst'
           - key: :connect_test
-            item: false
+            item: <%= ENV['CAREFIRST_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :aetna_pay_now
         is_enabled: false
         settings:

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -414,16 +414,16 @@ registry:
       - :pay_now_feature
     features:
       - key: :kaiser_pay_now
-        is_enabled: true
+        is_enabled: <%= ENV['KAISER_PERMANENTE_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: true
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
             item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Kaiser Permanente'
           - key: :connect_test
-            item: true
+            item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :delta_dental_pay_now
         is_enabled: false
         settings:


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2481183/stories/182735939

# A brief description of the changes

Current behavior: config settings do not use an environment variable to handle being enabled

New behavior: environment variables added for kp and cf pay now features

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: 
KAISER_PERMANENTE_PAY_NOW_IS_ENABLED
- [x] DC
- [ ] ME

KAISER_PERMANENTE_PAY_NOW_PLAN_SHOPPING_IS_ENABLED
- [x] DC
- [ ] ME

KAISER_PERMANENTE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED
- [x] DC
- [ ] ME

KAISER_PERMANENTE_PAY_NOW_CONNECT_TEST_IS_ENABLED
- [x] DC
- [ ] ME

CAREFIRST_PAY_NOW_IS_ENABLED
- [x] DC
- [ ] ME

CAREFIRST_PAY_NOW_PLAN_SHOPPING_IS_ENABLED
- [x] DC
- [ ] ME

CAREFIRST_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED
- [x] DC
- [ ] ME

CAREFIRST_PAY_NOW_CONNECT_TEST_IS_ENABLED
- [x] DC
- [ ] ME
