### PR TITLE
pass in correlation_id in headers for edi_gateway

### DIFF
--- a/app/domain/operations/families/find_by.rb
+++ b/app/domain/operations/families/find_by.rb
@@ -12,11 +12,11 @@ module Operations
 
       # params = { { person_hbx_id: 10239, year: 2022 } }
       def call(params)
-        person     = yield find_person(params[:person_hbx_id])
+        person     = yield find_person(params[:response][:person_hbx_id])
         family     = yield find_primary_family(person)
         cv3_family = yield transform_family(family)
         payload    = yield validate_payload(cv3_family, person)
-        event      = yield build_event(payload, params[:year])
+        event      = yield build_event(payload, params)
         result     = yield publish(event)
 
         Success(result)
@@ -24,8 +24,11 @@ module Operations
 
       private
 
-      def build_event(payload, year)
-        event('events.families.found_by', attributes: { payload: payload.to_h, year: year })
+      def build_event(payload, params)
+        event('events.families.found_by', attributes: {
+                family: payload.to_h,
+                primary_person_hbx_id: params[:response][:person_hbx_id]
+              }, headers: { correlation_id: params[:correlation_id] })
       end
 
       def find_person(person_hbx_id)

--- a/spec/domain/operations/families/find_by_spec.rb
+++ b/spec/domain/operations/families/find_by_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ::Operations::Families::FindBy, dbclean: :after_each do
   subject { described_class.new.call(input_params) }
 
-  let(:input_params) { { person_hbx_id: person_hbx_id, year: year } }
+  let(:input_params) { { correlation_id: correlation_id, response: { person_hbx_id: person_hbx_id, year: year } } }
 
   describe '#call' do
     let(:person) { FactoryBot.create(:person, :with_consumer_role) }
@@ -14,6 +14,7 @@ RSpec.describe ::Operations::Families::FindBy, dbclean: :after_each do
     context 'with valid input params' do
       let(:person_hbx_id) { family.primary_person.hbx_id }
       let(:year) { TimeKeeper.date_of_record.year }
+      let(:correlation_id) { "12345" }
 
       it 'returns a success with a message' do
         expect(
@@ -26,6 +27,7 @@ RSpec.describe ::Operations::Families::FindBy, dbclean: :after_each do
       context 'invalid person hbx_id' do
         let(:person_hbx_id) { 'sdcb982c2e83' }
         let(:year) { TimeKeeper.date_of_record.year }
+        let(:correlation_id) { "12345" }
 
         it 'returns a failure with a message' do
           expect(
@@ -37,6 +39,7 @@ RSpec.describe ::Operations::Families::FindBy, dbclean: :after_each do
       context 'person without any family' do
         let(:person_hbx_id) { person.hbx_id }
         let(:year) { TimeKeeper.date_of_record.year }
+        let(:correlation_id) { "12345" }
 
         it 'returns a failure with a message' do
           expect(


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184418813

# A brief description of the changes

Current behavior:
Not passing in Correlation  ID in headers

New behavior:
Pass in Correlation  ID in headers to edi gateway

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
