### PR TITLE
fix mitc income calculation for prior year

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
@@ -890,24 +890,25 @@ module FinancialAssistance
             end
 
             # Eligible month for selecting matching incomes
-            def month_date_range(assistance_year)
+            def month_date_range(assistance_year, income_start_on)
               system_date = TimeKeeper.date_of_record
               if assistance_year > system_date.year
                 start_of_year = Date.new(assistance_year).beginning_of_year
                 start_of_year..start_of_year.end_of_month
-              else
+              elsif assistance_year == system_date.year
                 system_date.beginning_of_month..system_date.end_of_month
+              else
+                income_start_on..income_start_on.end_of_month
               end
             end
 
-            # Incomes will be selected matching Mitc needs.
             def eligible_incomes_for_mitc(applicant)
               assistance_year = applicant.application.assistance_year
               applicant.incomes.select do |inc|
                 next inc unless assistance_year
                 end_on = inc.end_on || Date.new(assistance_year).end_of_year
                 income_date_range = (inc.start_on)..end_on
-                date_ranges_overlap?(income_date_range, month_date_range(assistance_year))
+                date_ranges_overlap?(income_date_range, month_date_range(assistance_year, inc.start_on))
               end
             end
 

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
@@ -902,6 +902,7 @@ module FinancialAssistance
               end
             end
 
+            # Incomes will be selected matching Mitc needs.
             def eligible_incomes_for_mitc(applicant)
               assistance_year = applicant.application.assistance_year
               applicant.incomes.select do |inc|


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184330272

# A brief description of the changes

Current behavior: For applications with a prior assistance year, we are not accurately including applicant incomes in the mitc calculation

New behavior: We will include applicant incomes in applications with prior assistance years

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
