### PR TITLE
fixing pay now modal bullet point text display logic

### DIFF
--- a/app/views/shared/_pay_now_modal.html.erb
+++ b/app/views/shared/_pay_now_modal.html.erb
@@ -17,13 +17,13 @@
         <p>
           <%= l10n("plans.issuer.pay_now.redirection_message", site_short_name: EnrollRegistry[:enroll_app].setting(:short_name).item, carrier_name: carrier_long_name) %><br/>
           <ul>
-            <% if past_effective_on?(hbx_enrollment) && carrier_key == 'kaiser' %>
+            <% if past_effective_on?(hbx_enrollment) && carrier_key != 'other' %>
               <li><%= l10n("plans.issuer.pay_now.link_info")%></li>
             <% end %>
-            <% if !past_effective_on?(hbx_enrollment) && carrier_key != 'kaiser' %>
+            <% if !past_effective_on?(hbx_enrollment) && carrier_key == 'other' %>
               <li><%= l10n('plans.issuer.pay_now.please_note') %></li>
             <% end %>
-            <% if !past_effective_on?(hbx_enrollment) && carrier_key == 'kaiser' %>
+            <% if !past_effective_on?(hbx_enrollment) && carrier_key != 'other' %>
               <li><%= l10n("plans.issuer.pay_now.processing", carrier_name: carrier_long_name)%></li>
             <% end %>
             <li><%= l10n("plans.issuer.pay_now.collecting_info", carrier_name: carrier_long_name, site_short_name: EnrollRegistry[:enroll_app].setting(:short_name).item)%></li>

--- a/app/views/shared/_pay_now_modal.html.erb
+++ b/app/views/shared/_pay_now_modal.html.erb
@@ -20,10 +20,7 @@
             <% if past_effective_on?(hbx_enrollment) && carrier_key != 'other' %>
               <li><%= l10n("plans.issuer.pay_now.link_info")%></li>
             <% end %>
-            <% if !past_effective_on?(hbx_enrollment) && carrier_key == 'other' %>
-              <li><%= l10n('plans.issuer.pay_now.please_note') %></li>
-            <% end %>
-            <% if !past_effective_on?(hbx_enrollment) && carrier_key != 'other' %>
+            <% if !past_effective_on?(hbx_enrollment) %>
               <li><%= l10n("plans.issuer.pay_now.processing", carrier_name: carrier_long_name)%></li>
             <% end %>
             <li><%= l10n("plans.issuer.pay_now.collecting_info", carrier_name: carrier_long_name, site_short_name: EnrollRegistry[:enroll_app].setting(:short_name).item)%></li>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)
No test coverage needed to check for specific verbage

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [IVL 235579278](https://www.pivotaltracker.com/n/projects/2481183/stories/184276287/comments/235579278)

# A brief description of the changes

Current behavior: Bullet points on pay now redirect popup had the wrong display logic (non pay now carriers had the wrong wording for paying before or on effective date
Logic checked only for KP plans when looking for pay now integrated plans

New behavior: Bullet points now have the correct verbage, pay now specific bullet points will now display for all pay now carriers and not just KP

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
