### PR TITLE
updated dc dental paynow feature flags to be controlled with env vars

### DIFF
--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -425,16 +425,16 @@ registry:
           - key: :connect_test
             item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :delta_dental_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['DELTA_DENTAL_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['DELTA_DENTAL_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['DELTA_DENTAL_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Delta Dental'
           - key: :connect_test
-            item: false
+            item: <%= ENV['DELTA_DENTAL_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :dentegra_pay_now
         is_enabled: false
         settings:
@@ -447,27 +447,27 @@ registry:
           - key: :connect_test
             item: false
       - key: :dominion_national_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['DOMINION_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['DOMINION_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['DOMINION_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Dominion National'
           - key: :connect_test
-            item: false
+            item: <%= ENV['DOMINION_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :best_life_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['BEST_LIFE_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['BEST_LIFE_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['BEST_LIFE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'BEST Life'
           - key: :connect_test
-            item: false
+            item: <%= ENV['BEST_LIFE_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :metlife_pay_now
         is_enabled: false
         settings:

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -432,16 +432,16 @@ registry:
           - key: :connect_test
             item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :delta_dental_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['DELTA_DENTAL_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['DELTA_DENTAL_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['DELTA_DENTAL_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Delta Dental'
           - key: :connect_test
-            item: false
+            item: <%= ENV['DELTA_DENTAL_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :dentegra_pay_now
         is_enabled: false
         settings:
@@ -454,27 +454,27 @@ registry:
           - key: :connect_test
             item: false
       - key: :dominion_national_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['DOMINION_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['DOMINION_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['DOMINION_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Dominion National'
           - key: :connect_test
-            item: false
+            item: <%= ENV['DOMINION_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :best_life_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['BEST_LIFE_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['BEST_LIFE_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['BEST_LIFE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'BEST Life'
           - key: :connect_test
-            item: false
+            item: <%= ENV['BEST_LIFE_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :metlife_pay_now
         is_enabled: false
         settings:

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -425,16 +425,16 @@ registry:
           - key: :connect_test
             item: <%= ENV['KAISER_PERMANENTE_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :delta_dental_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['DELTA_DENTAL_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['DELTA_DENTAL_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['DELTA_DENTAL_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Delta Dental'
           - key: :connect_test
-            item: false
+            item: <%= ENV['DELTA_DENTAL_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :dentegra_pay_now
         is_enabled: false
         settings:
@@ -447,27 +447,27 @@ registry:
           - key: :connect_test
             item: false
       - key: :dominion_national_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['DOMINION_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['DOMINION_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['DOMINION_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'Dominion National'
           - key: :connect_test
-            item: false
+            item: <%= ENV['DOMINION_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :best_life_pay_now
-        is_enabled: false
+        is_enabled: <%= ENV['BEST_LIFE_PAY_NOW_IS_ENABLED'] || false %>
         settings:
           - key: :plan_shopping
-            item: false
+            item: <%= ENV['BEST_LIFE_PAY_NOW_PLAN_SHOPPING_IS_ENABLED'] || false %>
           - key: :enrollment_tile
-            item: false
+            item: <%= ENV['BEST_LIFE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED'] || false %>
           - key: :carriers_long_name
             item: 'BEST Life'
           - key: :connect_test
-            item: false
+            item: <%= ENV['BEST_LIFE_PAY_NOW_CONNECT_TEST_IS_ENABLED'] || false %>
       - key: :metlife_pay_now
         is_enabled: false
         settings:


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184558317

# A brief description of the changes

Current behavior: Existing pay now enabled dental carriers for DC have hardcoded feature flags

New behavior: Update pay now ff to be controlled with env vars

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: 
`DELTA_DENTAL_PAY_NOW_IS_ENABLED`
- [x] DC
- [ ] ME

`DELTA_DENTAL_PAY_NOW_PLAN_SHOPPING_IS_ENABLED`
- [x] DC
- [ ] ME

`DELTA_DENTAL_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED`
- [x] DC
- [ ] ME

`DELTA_DENTAL_PAY_NOW_CONNECT_TEST_IS_ENABLED`
- [x] DC
- [ ] ME

`DOMINION_PAY_NOW_IS_ENABLED`
- [x] DC
- [ ] ME

`DOMINION_PAY_NOW_PLAN_SHOPPING_IS_ENABLED`
- [x] DC
- [ ] ME

`DOMINION_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED`
- [x] DC
- [ ] ME

`DOMINION_PAY_NOW_CONNECT_TEST_IS_ENABLED`
- [x] DC
- [ ] ME

`BEST_LIFE_PAY_NOW_IS_ENABLED`
- [x] DC
- [ ] ME

`BEST_LIFE_PAY_NOW_PLAN_SHOPPING_IS_ENABLED`
- [x] DC
- [ ] ME

`BEST_LIFE_PAY_NOW_ENROLLMENT_TILE_IS_ENABLED`
- [x] DC
- [ ] ME

`BEST_LIFE_PAY_NOW_CONNECT_TEST_IS_ENABLED`
- [x] DC
- [ ] ME
