### PR TITLE
change to TRA value for a Osse eligible enrollments on shop enrollment report

### DIFF
--- a/app/reports/hbx_reports/shop_enrollment_report.rb
+++ b/app/reports/hbx_reports/shop_enrollment_report.rb
@@ -94,6 +94,7 @@ class ShopEnrollmentReport < MongoidMigrationTask
             enrollees_hbx_ids = hbx_enrollment.hbx_enrollment_members.map(&:hbx_id).join(', ')
             enrollees_dob = hbx_enrollment.hbx_enrollment_members.map { |member| member.person.dob }.join(', ')
             osse_eligible = (hbx_enrollment.eligible_child_care_subsidy > 0 ? "Yes" : "No")
+            total_responsible_amount = BigDecimal((calculator.total_premium.to_f - calculator.total_employer_contribution.to_f - hbx_enrollment.eligible_child_care_subsidy.to_f).to_s).round(2)
             csv << [
               employer_profile.hbx_id, employer_profile.fein, employer_profile.legal_name,
               plan_year_start, plan_year.aasm_state, plan_year.benefit_sponsorship.aasm_state,
@@ -101,7 +102,7 @@ class ShopEnrollmentReport < MongoidMigrationTask
               hbx_enrollment.terminated_on, hbx_enrollment.coverage_kind, hbx_enrollment.aasm_state,
               subscriber_hbx_id,first_name,last_name,
               product.hios_id,
-              calculator.total_premium, calculator.total_employer_contribution, hbx_enrollment.applied_aptc_amount, calculator.total_employee_cost,
+              calculator.total_premium, calculator.total_employer_contribution, hbx_enrollment.applied_aptc_amount, total_responsible_amount,
               hbx_enrollment.hbx_enrollment_members.size,
               enrollment_reason,
               in_glue, hbx_enrollment.product.title, enrollees_hbx_ids, enrollees_dob,


### PR DESCRIPTION


# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [bug-101016](https://redmine.dchbx.org/issues/101016)

# A brief description of the changes

Current behavior: On the shop enrollment report the TRA value is not populating correctly and it's not considering OSSE value

New behavior: Change to TRA value to display correctly on the shop enrollment report which considers OSSE eligible enrollments

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [x] DC
- [ ] ME
