### PR TITLE
add check for autorenewing enrollment when displaying paynow button

### DIFF
--- a/app/helpers/insured/plan_shopping/pay_now_helper.rb
+++ b/app/helpers/insured/plan_shopping/pay_now_helper.rb
@@ -36,8 +36,8 @@ module Insured
       end
 
       def enrollment_can_pay_now?(hbx_enrollment)
-        if hbx_enrollment.aasm_state != "auto_renewing"
-          has_break_in_coverage_enrollments?(hbx_enrollment) || !has_any_previous_enrollments?(hbx_enrollment)
+        return if hbx_enrollment.aasm_state == "auto_renewing"
+        has_break_in_coverage_enrollments?(hbx_enrollment) || !has_any_previous_enrollments?(hbx_enrollment)
       end
 
       def carrier_url(legal_name)

--- a/app/helpers/insured/plan_shopping/pay_now_helper.rb
+++ b/app/helpers/insured/plan_shopping/pay_now_helper.rb
@@ -36,7 +36,8 @@ module Insured
       end
 
       def enrollment_can_pay_now?(hbx_enrollment)
-        has_break_in_coverage_enrollments?(hbx_enrollment) || !has_any_previous_enrollments?(hbx_enrollment)
+        if hbx_enrollment.aasm_state != "auto_renewing"
+          has_break_in_coverage_enrollments?(hbx_enrollment) || !has_any_previous_enrollments?(hbx_enrollment)
       end
 
       def carrier_url(legal_name)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184276286

# A brief description of the changes

Current behavior: Paynow button on enrollment tile actions drop down shows payment button even if enrollment it auto-renewing.

New behavior: Paynow button on enrollment tile actions drop down does not show payment button if enrollment it auto-renewing.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
