### PR TITLE
fixing generic redirect display for anthem

### DIFF
--- a/app/helpers/insured/plan_shopping/pay_now_helper.rb
+++ b/app/helpers/insured/plan_shopping/pay_now_helper.rb
@@ -30,7 +30,7 @@ module Insured
         end
       end
 
-      def show_generic_redirect?
+      def show_generic_redirect(hbx_enrollment)?
         return unless EnrollRegistry.feature_enabled?(:generic_redirect)
         @carrier_key = fetch_carrier_key_from_legal_name(hbx_enrollment&.product&.issuer_profile&.legal_name)
         EnrollRegistry.feature_enabled?(:strict_generic_redirect) ? EnrollRegistry["#{@carrier_key}_pay_now".to_sym].setting(:enrollment_tile).item : true

--- a/app/helpers/insured/plan_shopping/pay_now_helper.rb
+++ b/app/helpers/insured/plan_shopping/pay_now_helper.rb
@@ -30,8 +30,9 @@ module Insured
         end
       end
 
-      def show_generic_redirect?(enrollment)
+      def show_generic_redirect?
         return unless EnrollRegistry.feature_enabled?(:generic_redirect)
+        @carrier_key = fetch_carrier_key_from_legal_name(hbx_enrollment&.product&.issuer_profile&.legal_name)
         EnrollRegistry.feature_enabled?(:strict_generic_redirect) ? EnrollRegistry["#{@carrier_key}_pay_now".to_sym].setting(:enrollment_tile).item : true
       end
 

--- a/app/helpers/insured/plan_shopping/pay_now_helper.rb
+++ b/app/helpers/insured/plan_shopping/pay_now_helper.rb
@@ -30,6 +30,11 @@ module Insured
         end
       end
 
+      def show_generic_redirect?(enrollment)
+        return unless EnrollRegistry.feature_enabled?(:generic_redirect)
+        EnrollRegistry.feature_enabled?(:strict_generic_redirect) ? EnrollRegistry["#{@carrier_key}_pay_now".to_sym].setting(:enrollment_tile).item : true
+      end
+
       def carrier_key_from_enrollment(enrollment)
         carrier_key = enrollment&.product&.issuer_profile&.legal_name
         fetch_carrier_key_from_legal_name(carrier_key)

--- a/app/helpers/insured/plan_shopping/pay_now_helper.rb
+++ b/app/helpers/insured/plan_shopping/pay_now_helper.rb
@@ -30,7 +30,7 @@ module Insured
         end
       end
 
-      def show_generic_redirect(hbx_enrollment)?
+      def show_generic_redirect?(hbx_enrollment)
         return unless EnrollRegistry.feature_enabled?(:generic_redirect)
         @carrier_key = fetch_carrier_key_from_legal_name(hbx_enrollment&.product&.issuer_profile&.legal_name)
         EnrollRegistry.feature_enabled?(:strict_generic_redirect) ? EnrollRegistry["#{@carrier_key}_pay_now".to_sym].setting(:enrollment_tile).item : true

--- a/app/helpers/insured/plan_shopping/pay_now_helper.rb
+++ b/app/helpers/insured/plan_shopping/pay_now_helper.rb
@@ -31,9 +31,14 @@ module Insured
       end
 
       def show_generic_redirect?(hbx_enrollment)
-        return unless EnrollRegistry.feature_enabled?(:generic_redirect)
+        generic_redirect_enabled = EnrollRegistry.feature_enabled?(:generic_redirect)
+        return unless generic_redirect_enabled
+
         @carrier_key = fetch_carrier_key_from_legal_name(hbx_enrollment&.product&.issuer_profile&.legal_name)
-        EnrollRegistry.feature_enabled?(:strict_generic_redirect) ? EnrollRegistry["#{@carrier_key}_pay_now".to_sym].setting(:enrollment_tile).item : true
+        strict_tile_check_enabled = EnrollRegistry[:generic_redirect].setting(:strict_tile_check).item
+        enrollment_tile_enabled = EnrollRegistry["#{@carrier_key}_pay_now".to_sym].setting(:enrollment_tile).item
+
+        strict_tile_check_enabled ? enrollment_tile_enabled : generic_redirect_enabled
       end
 
       def carrier_key_from_enrollment(enrollment)

--- a/app/views/insured/families/_enrollment.html.erb
+++ b/app/views/insured/families/_enrollment.html.erb
@@ -246,7 +246,7 @@
                           <%= render partial:"shared/glossary_hover", locals: {key: "make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
                         <% end %>
                       </button>
-                    <% elsif show_generic_redirect? %>
+                    <% elsif show_generic_redirect?(hbx_enrollment) %>
                       <button class="btn-link btn-block" data-toggle="modal" data-target="#payNowModal<%= hbx_enrollment.hbx_id %>" style="padding: 6px 12px; margin: 4px 0; text-align: left;" data-enrollment="<%= hbx_enrollment.hbx_id %>">
                         <%= render partial:"shared/glossary_hover", locals: {key: "generic_make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
                       </button>

--- a/app/views/insured/families/_enrollment.html.erb
+++ b/app/views/insured/families/_enrollment.html.erb
@@ -248,8 +248,8 @@
                       </button>
                     <% elsif show_generic_redirect? %>
                       <button class="btn-link btn-block" data-toggle="modal" data-target="#payNowModal<%= hbx_enrollment.hbx_id %>" style="padding: 6px 12px; margin: 4px 0; text-align: left;" data-enrollment="<%= hbx_enrollment.hbx_id %>">
-                            <%= render partial:"shared/glossary_hover", locals: {key: "generic_make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
-                        </button>
+                          <%= render partial:"shared/glossary_hover", locals: {key: "generic_make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
+                      </button>
                     <% end %>
                   <% end %>
                 </div>

--- a/app/views/insured/families/_enrollment.html.erb
+++ b/app/views/insured/families/_enrollment.html.erb
@@ -248,7 +248,7 @@
                       </button>
                     <% elsif show_generic_redirect? %>
                       <button class="btn-link btn-block" data-toggle="modal" data-target="#payNowModal<%= hbx_enrollment.hbx_id %>" style="padding: 6px 12px; margin: 4px 0; text-align: left;" data-enrollment="<%= hbx_enrollment.hbx_id %>">
-                          <%= render partial:"shared/glossary_hover", locals: {key: "generic_make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
+                        <%= render partial:"shared/glossary_hover", locals: {key: "generic_make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
                       </button>
                     <% end %>
                   <% end %>

--- a/app/views/insured/families/_enrollment.html.erb
+++ b/app/views/insured/families/_enrollment.html.erb
@@ -246,10 +246,10 @@
                           <%= render partial:"shared/glossary_hover", locals: {key: "make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
                         <% end %>
                       </button>
-                    <% elsif EnrollRegistry.feature_enabled?(:generic_redirect) %>
+                    <% elsif show_generic_redirect?(hbx_enrollment) %>
                       <button class="btn-link btn-block" data-toggle="modal" data-target="#payNowModal<%= hbx_enrollment.hbx_id %>" style="padding: 6px 12px; margin: 4px 0; text-align: left;" data-enrollment="<%= hbx_enrollment.hbx_id %>">
-                        <%= render partial:"shared/glossary_hover", locals: {key: "generic_make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
-                      </button>
+                            <%= render partial:"shared/glossary_hover", locals: {key: "generic_make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
+                        </button>
                     <% end %>
                   <% end %>
                 </div>

--- a/app/views/insured/families/_enrollment.html.erb
+++ b/app/views/insured/families/_enrollment.html.erb
@@ -246,7 +246,7 @@
                           <%= render partial:"shared/glossary_hover", locals: {key: "make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
                         <% end %>
                       </button>
-                    <% elsif show_generic_redirect?(hbx_enrollment) %>
+                    <% elsif show_generic_redirect? %>
                       <button class="btn-link btn-block" data-toggle="modal" data-target="#payNowModal<%= hbx_enrollment.hbx_id %>" style="padding: 6px 12px; margin: 4px 0; text-align: left;" data-enrollment="<%= hbx_enrollment.hbx_id %>">
                             <%= render partial:"shared/glossary_hover", locals: {key: "generic_make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
                         </button>

--- a/app/views/insured/families/_enrollment_actions.html.erb
+++ b/app/views/insured/families/_enrollment_actions.html.erb
@@ -42,7 +42,7 @@
                                 <%= render partial:"shared/glossary_hover", locals: {key: "make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
                             <% end %>
                       </button>
-                    <% elsif show_generic_redirect? %>
+                    <% elsif show_generic_redirect?(hbx_enrollment) %>
                         <button class="btn-link btn-block" data-toggle="modal" data-target="#payNowModal<%= hbx_enrollment.hbx_id %>" style="padding: 6px 12px; margin: 4px 0; text-align: left;" data-enrollment="<%= hbx_enrollment.hbx_id %>">
                             <%= render partial:"shared/glossary_hover", locals: {key: "generic_make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
                         </button>

--- a/app/views/insured/families/_enrollment_actions.html.erb
+++ b/app/views/insured/families/_enrollment_actions.html.erb
@@ -42,7 +42,7 @@
                                 <%= render partial:"shared/glossary_hover", locals: {key: "make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
                             <% end %>
                       </button>
-                    <% elsif EnrollRegistry.feature_enabled?(:generic_redirect) %>
+                    <% elsif show_generic_redirect? %>
                         <button class="btn-link btn-block" data-toggle="modal" data-target="#payNowModal<%= hbx_enrollment.hbx_id %>" style="padding: 6px 12px; margin: 4px 0; text-align: left;" data-enrollment="<%= hbx_enrollment.hbx_id %>">
                             <%= render partial:"shared/glossary_hover", locals: {key: "generic_make_payments_hover", title: "Make payments for my plan", term: sanitize(l10n("plans.issuer.pay_now.make_payments")) } %>
                         </button>

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -415,8 +415,9 @@ registry:
     features:
       - key: :generic_redirect
         is_enabled: <%= ENV['GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
-      - key: :strict_generic_redirect
-        is_enabled: <%= ENV['STRICT_GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
+        settings: 
+          - key: :strict_tile_check
+            item: <%= ENV['STRICT_TILE_CHECK_PAY_NOW_IS_ENABLED'] || false %>
       - key: :kaiser_pay_now
         is_enabled: <%= ENV['KAISER_PERMANENTE_PAY_NOW_IS_ENABLED'] || false %>
         settings:

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -415,6 +415,8 @@ registry:
     features:
       - key: :generic_redirect
         is_enabled: <%= ENV['GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
+      - key: :strict_generic_redirect
+        is_enabled: <%= ENV['STRICT_GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
       - key: :kaiser_pay_now
         is_enabled: <%= ENV['KAISER_PERMANENTE_PAY_NOW_IS_ENABLED'] || false %>
         settings:

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -422,6 +422,8 @@ registry:
     features:
       - key: :generic_redirect
         is_enabled: <%= ENV['GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
+      - key: :strict_generic_redirect
+        is_enabled: <%= ENV['STRICT_GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
       - key: :kaiser_pay_now
         is_enabled: <%= ENV['KAISER_PERMANENTE_PAY_NOW_IS_ENABLED'] || false %>
         settings:

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -422,8 +422,9 @@ registry:
     features:
       - key: :generic_redirect
         is_enabled: <%= ENV['GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
-      - key: :strict_generic_redirect
-        is_enabled: <%= ENV['STRICT_GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
+        settings: 
+          - key: :strict_tile_check
+            item: <%= ENV['STRICT_TILE_CHECK_PAY_NOW_IS_ENABLED'] || false %>
       - key: :kaiser_pay_now
         is_enabled: <%= ENV['KAISER_PERMANENTE_PAY_NOW_IS_ENABLED'] || false %>
         settings:

--- a/spec/helpers/insured/plan_shopping/pay_now_helper_spec.rb
+++ b/spec/helpers/insured/plan_shopping/pay_now_helper_spec.rb
@@ -367,5 +367,18 @@ RSpec.describe Insured::PlanShopping::PayNowHelper, :type => :helper do
       allow(hbx_enrollment).to receive(:is_shop?).and_return(true)
       expect(helper.show_pay_now?("Enrollment Tile", hbx_enrollment1)).to be_falsey
     end
+
+    it 'should show if generic redirect is enabled' do
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:generic_redirect).and_return(true)
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:strict_generic_redirect).and_return(false)
+      expect(helper.show_generic_redirect?(hbx_enrollment)).to eq true
+    end
+
+    it 'should return false if strict generic redirect is enabled and enrollment tile is enabled' do
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:generic_redirect).and_return(true)
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:strict_generic_redirect).and_return(true)
+      allow(EnrollRegistry[:kaiser_pay_now].setting(:enrollment_tile)).to receive(:item).and_return(false)
+      expect(helper.show_generic_redirect?(hbx_enrollment)).to be_falsey
+    end
   end
 end

--- a/spec/helpers/insured/plan_shopping/pay_now_helper_spec.rb
+++ b/spec/helpers/insured/plan_shopping/pay_now_helper_spec.rb
@@ -370,13 +370,13 @@ RSpec.describe Insured::PlanShopping::PayNowHelper, :type => :helper do
 
     it 'should show if generic redirect is enabled' do
       allow(EnrollRegistry).to receive(:feature_enabled?).with(:generic_redirect).and_return(true)
-      allow(EnrollRegistry).to receive(:feature_enabled?).with(:strict_generic_redirect).and_return(false)
+      allow(EnrollRegistry[:generic_redirect].setting(:strict_tile_check)).to receive(:item).and_return(false)
       expect(helper.show_generic_redirect?(hbx_enrollment)).to eq true
     end
 
     it 'should return false if strict generic redirect is enabled and enrollment tile is disabled' do
       allow(EnrollRegistry).to receive(:feature_enabled?).with(:generic_redirect).and_return(true)
-      allow(EnrollRegistry).to receive(:feature_enabled?).with(:strict_generic_redirect).and_return(true)
+      allow(EnrollRegistry[:generic_redirect].setting(:strict_tile_check)).to receive(:item).and_return(true)
       allow(EnrollRegistry[:kaiser_pay_now].setting(:enrollment_tile)).to receive(:item).and_return(false)
       expect(helper.show_generic_redirect?(hbx_enrollment)).to be_falsey
     end

--- a/spec/helpers/insured/plan_shopping/pay_now_helper_spec.rb
+++ b/spec/helpers/insured/plan_shopping/pay_now_helper_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe Insured::PlanShopping::PayNowHelper, :type => :helper do
       expect(helper.show_generic_redirect?(hbx_enrollment)).to eq true
     end
 
-    it 'should return false if strict generic redirect is enabled and enrollment tile is enabled' do
+    it 'should return false if strict generic redirect is enabled and enrollment tile is disabled' do
       allow(EnrollRegistry).to receive(:feature_enabled?).with(:generic_redirect).and_return(true)
       allow(EnrollRegistry).to receive(:feature_enabled?).with(:strict_generic_redirect).and_return(true)
       allow(EnrollRegistry[:kaiser_pay_now].setting(:enrollment_tile)).to receive(:item).and_return(false)

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -415,8 +415,9 @@ registry:
     features:
       - key: :generic_redirect
         is_enabled: <%= ENV['GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
-      - key: :strict_generic_redirect
-        is_enabled: <%= ENV['STRICT_GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
+        settings: 
+          - key: :strict_tile_check
+            item: <%= ENV['STRICT_TILE_CHECK_PAY_NOW_IS_ENABLED'] || false %>
       - key: :kaiser_pay_now
         is_enabled: <%= ENV['KAISER_PERMANENTE_PAY_NOW_IS_ENABLED'] || false %>
         settings:

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -415,6 +415,8 @@ registry:
     features:
       - key: :generic_redirect
         is_enabled: <%= ENV['GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
+      - key: :strict_generic_redirect
+        is_enabled: <%= ENV['STRICT_GENERIC_REDIRECT_PAY_NOW_IS_ENABLED'] || false %>
       - key: :kaiser_pay_now
         is_enabled: <%= ENV['KAISER_PERMANENTE_PAY_NOW_IS_ENABLED'] || false %>
         settings:


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2481183/stories/184695277#

# A brief description of the changes

Current behavior: Make Payments button on enrollment tile shows for Anthem plans when it shouldn't

New behavior: Make payments button will not show for plans with enrollment tile disabled 

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: STRICT_TILE_CHECK_PAY_NOW_IS_ENABLED

- [ ] DC
- [x] ME
