### PR TITLE
safely handle carriers with no Pay Now embed_xml setting

### DIFF
--- a/app/models/one_login/ruby_saml/saml_generator.rb
+++ b/app/models/one_login/ruby_saml/saml_generator.rb
@@ -198,7 +198,7 @@ module OneLogin
       def embed_custom_xml?
         carrier_name = @hbx_enrollment&.product&.issuer_profile&.legal_name
         carrier_key = fetch_carrier_key(carrier_name)
-        EnrollRegistry[carrier_key].setting(:embed_xml).item
+        EnrollRegistry[carrier_key].setting(:embed_xml)&.item
       end
 
       def build_additional_info

--- a/spec/models/one_login/ruby_saml/saml_generator_spec.rb
+++ b/spec/models/one_login/ruby_saml/saml_generator_spec.rb
@@ -22,9 +22,9 @@ module OneLogin
       saml_generator.instance_variable_set(:@cert, test_x509_cert)
       hbx_enrollment.update_attributes(kind: 'individual')
       allow(EnrollRegistry).to receive(:[]).and_call_original
-      allow(EnrollRegistry).to receive(:[]).with(:kaiser_pay_now).and_return(pay_now_double)
-      allow(pay_now_double).to receive(:setting).with(embed_xml_key).and_return(xml_settings_double)
-      allow(xml_settings_double).to receive(:item).and_return(false)
+      # allow(EnrollRegistry).to receive(:[]).with(:kaiser_pay_now).and_return(pay_now_double)
+      # allow(pay_now_double).to receive(:setting).with(embed_xml_key).and_return(xml_settings_double)
+      # allow(xml_settings_double).to receive(:item).and_return(false)
       @saml_response = saml_generator.build_saml_response
       @noko = Nokogiri.parse(@saml_response.to_s) do
         XMLSecurity::BaseDocument::NOKOGIRI_OPTIONS
@@ -133,6 +133,8 @@ module OneLogin
 
         before do
           allow(EnrollRegistry).to receive(:[]).with(carrier_key).and_return(pay_now_double)
+          allow(pay_now_double).to receive(:setting).with(embed_xml_key).and_return(xml_settings_double)
+          allow(xml_settings_double).to receive(:item).and_return(false)
           allow(xml_settings_double).to receive(:item).and_return(true)
           allow(Operations::PayNow::CareFirst::EmbeddedXml).to receive(:new).and_return(operation)
           allow(operation).to receive(:call).and_return(::Dry::Monads::Result::Success.new("sample xml"))
@@ -150,6 +152,12 @@ module OneLogin
       it 'should return encoded value with String class' do
         encoded_response = saml_generator.encode_saml_response(@saml_response)
         expect(encoded_response.class). to eq String
+      end
+    end
+
+    context '#embed_custom_xml?' do
+      it 'should retun nil if the carrier does not have the custom xml setting' do
+        expect(saml_generator.send(:embed_custom_xml?)).to eq nil
       end
     end
   end

--- a/spec/models/one_login/ruby_saml/saml_generator_spec.rb
+++ b/spec/models/one_login/ruby_saml/saml_generator_spec.rb
@@ -22,9 +22,6 @@ module OneLogin
       saml_generator.instance_variable_set(:@cert, test_x509_cert)
       hbx_enrollment.update_attributes(kind: 'individual')
       allow(EnrollRegistry).to receive(:[]).and_call_original
-      # allow(EnrollRegistry).to receive(:[]).with(:kaiser_pay_now).and_return(pay_now_double)
-      # allow(pay_now_double).to receive(:setting).with(embed_xml_key).and_return(xml_settings_double)
-      # allow(xml_settings_double).to receive(:item).and_return(false)
       @saml_response = saml_generator.build_saml_response
       @noko = Nokogiri.parse(@saml_response.to_s) do
         XMLSecurity::BaseDocument::NOKOGIRI_OPTIONS


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184695277

# A brief description of the changes

Current behavior: The SamlGenerator breaks when  a Pay Now carrier is missing the :embed_xml setting

New behavior: The method that checks the :embed_xml setting safely returns nil if the setting is not present for carrier.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
