### PR TITLE
include primary_enrollee_two_dependents for family rated premiums for cv3 enrollment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 439c477fb83a05062256acca955d978dabc943d4
+  revision: 655968480f807cfe9dcbb00de0f4c3eb7afd5476
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment.rb
+++ b/app/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment.rb
@@ -148,6 +148,7 @@ module Operations
             exchange_provided_code: exchange_provided_code,
             primary_enrollee: qhp_table.primary_enrollee,
             primary_enrollee_one_dependent: qhp_table.primary_enrollee_one_dependent,
+            primary_enrollee_two_dependents: qhp_table.primary_enrollee_two_dependent,
             primary_enrollee_many_dependent: qhp_table.primary_enrollee_many_dependent
           }
         end

--- a/spec/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment_spec.rb
+++ b/spec/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment_spec.rb
@@ -42,12 +42,17 @@ RSpec.describe ::Operations::Transformers::HbxEnrollmentTo::Cv3HbxEnrollment, db
       @validated_payload = AcaEntities::Contracts::Enrollments::HbxEnrollmentContract.new.call(transformed_payload).to_h
     end
 
+    let(:family_rated_premiums_result) do
+      @validated_payload[:product_reference][:family_rated_premiums]
+    end
+
     it 'returns with :slcsp_member_premium, :family_rated_premiums & :pediatric_dental_ehb' do
       expect(@validated_payload[:hbx_id]).to eq(enrollment.hbx_id.to_s)
       expect(@validated_payload[:terminated_on]).to eq(enrollment.terminated_on)
       expect(@validated_payload[:hbx_enrollment_members].first[:slcsp_member_premium]).not_to be_empty
       expect(@validated_payload[:hbx_enrollment_members].first[:coverage_end_on]).to eq enrollment_member.coverage_end_on
-      expect(@validated_payload[:product_reference][:family_rated_premiums]).not_to be_empty
+      expect(family_rated_premiums_result).not_to be_empty
+      expect(family_rated_premiums_result[:primary_enrollee_two_dependents]).not_to be_nil
       expect(@validated_payload[:product_reference][:pediatric_dental_ehb]).not_to be_nil
       expect(@validated_payload[:product_reference][:metal_level]).to eq(enr_product.metal_level_kind.to_s)
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket:  ME-184696679

# A brief description of the changes

Current behavior:

New behavior: We are adding the premium value 'primary_enrollee_two_dependents' to the Cv for the downstream systems to use it as needed.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
