### PR TITLE
creating tax household enrollments when eligibility determined

### DIFF
--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -579,6 +579,17 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
           end
 
           context 'when renewal grants present' do
+            let!(:tax_household_group) do
+              family.tax_household_groups.create!(
+                assistance_year: TimeKeeper.date_of_record.year + 1,
+                source: 'Admin',
+                start_on: TimeKeeper.date_of_record.beginning_of_year.next_year,
+                tax_households: [
+                  FactoryBot.build(:tax_household, household: family.active_household)
+                ]
+              )
+            end
+
             let!(:eligibility_determination) do
               determination = family.create_eligibility_determination(effective_date: TimeKeeper.date_of_record.beginning_of_year)
               determination.grants.create(


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/184695733

# A brief description of the changes

Current behavior: does not create tax household enrollments when not eligible for aptc.

New behavior: creates tax household enrollments when eligibility determined.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [x] ME
