### PR TITLE
add requested fields to member outreach report

### DIFF
--- a/script/member_outreach_report.rb
+++ b/script/member_outreach_report.rb
@@ -19,14 +19,16 @@ field_names = %w[
     external_id
     user_account
     last_page_visited
-    program_eligible_for
-    application_aasm_state
-    application_aasm_state_date
-    transfer_id
+    latest_determined_application_id
+    determined_date
+    determined_program_eligible_for
+    determined_medicaid_fpl
+    determined_has_access_to_coverage
+    determined_has_access_to_coverage_kinds
+    latest_application_aasm_state
+    latest_application_aasm_state_date
+    latest_transfer_id
     inbound_transfer_date
-    FPL
-    has_access_to_health_coverage
-    has_access_to_health_coverage_kinds
   ]
 curr_year = TimeKeeper.date_of_record.year
 next_year = TimeKeeper.date_of_record.year + 1
@@ -74,11 +76,12 @@ CSV.open(file_name, "w", force_quotes: true) do |csv|
   csv << field_names
   while offset < families_count
     all_families.offset(offset).limit(batch_size).no_timeout.each do |family|
-      application = FinancialAssistance::Application.where(family_id: family._id).order_by(:created_at.desc).first
+      latest_determined_application = FinancialAssistance::Application.where(family_id: family._id).determined.order_by(:created_at.desc).first
+      latest_application = FinancialAssistance::Application.where(family_id: family._id).order_by(:created_at.desc).first
       primary_person = family.primary_person
       family.family_members.each do |family_member|
         person = family_member&.person
-        applicant = application&.applicants&.detect {|a| a.person_hbx_id == person.hbx_id}
+        applicant = latest_determined_application&.applicants&.detect {|a| a.person_hbx_id == person.hbx_id}
         # what is considered primary phone?  assumption: use home phone
         home_phone = person.phones.detect { |phone| phone.kind == 'home' }
         work_phone = person.phones.detect { |phone| phone.kind == 'work' }
@@ -95,7 +98,7 @@ CSV.open(file_name, "w", force_quotes: true) do |csv|
         next_mr_health_enrollment = enrollments.enrolled_and_renewal.select {|enr| enr.coverage_kind == 'health' && enr.effective_on&.year == next_year}.sort_by(&:submitted_at).reverse.first
         curr_mr_dental_enrollment = enrollments.enrolled_and_renewal.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on&.year == curr_year}.sort_by(&:submitted_at).reverse.first
         next_mr_dental_enrollment = enrollments.enrolled_and_renewal.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on&.year == next_year}.sort_by(&:submitted_at).reverse.first
-        inbound_transfer_date = application.transferred_at if application&.transferred_at.present? && application&.transfer_id.present? && !application&.account_transferred
+        inbound_transfer_date = latest_application.transferred_at if latest_application&.transferred_at.present? && latest_application&.transfer_id.present? && !latest_application&.account_transferred
 
         csv << [
             family.primary_applicant.hbx_id,
@@ -114,15 +117,17 @@ CSV.open(file_name, "w", force_quotes: true) do |csv|
             family.external_app_id,
             primary_person.user&.email, # only primary person has a User account
             primary_person.user&.last_portal_visited,
+            latest_determined_application&.hbx_id,
+            latest_determined_application&.submitted_at,
             program_eligible_for(applicant),
-            application&.aasm_state,
-            application&.workflow_state_transitions&.first&.transition_at,
-            application&.transfer_id,
-            inbound_transfer_date,
             # fpl depends on enrollment; assumption: use most recent active health plan enrollment
             fpl_percentage(mra_health_enrollment, enrollment_member, mra_health_enrollment&.effective_on&.year),
             applicant&.has_eligible_health_coverage.present?,
             applicant&.benefits&.eligible&.map(&:insurance_kind)&.join(", "),
+            latest_application&.aasm_state,
+            latest_application&.workflow_state_transitions&.first&.transition_at,
+            latest_application&.transfer_id,
+            inbound_transfer_date,
             curr_mr_health_enrollment&.product&.hios_id,
             curr_mr_health_enrollment&.aasm_state,
             next_mr_health_enrollment&.product&.hios_id,

--- a/script/member_outreach_report.rb
+++ b/script/member_outreach_report.rb
@@ -86,18 +86,20 @@ CSV.open(file_name, "w", force_quotes: true) do |csv|
         home_phone = person.phones.detect { |phone| phone.kind == 'home' }
         work_phone = person.phones.detect { |phone| phone.kind == 'work' }
         mobile_phone = person.phones.detect { |phone| phone.kind == 'mobile' }
-        enrollments = family.active_household.hbx_enrollments
-        mra_health_enrollment = enrollments.enrolled_and_renewal.effective_desc.detect {|enr| enr.coverage_kind == 'health'}
-        mra_dental_enrollment = enrollments.enrolled_and_renewal.effective_desc.detect {|enr| enr.coverage_kind == 'dental'}
+        enrolled_and_renewal = family.active_household.hbx_enrollments.enrolled_and_renewal
+        canceled_and_terminated = family.active_household.hbx_enrollments.canceled_and_terminated
+        enrollments = enrolled_and_renewal + canceled_and_terminated
+        mra_health_enrollment = enrolled_and_renewal.effective_desc.detect {|enr| enr.coverage_kind == 'health'}
+        mra_dental_enrollment = enrolled_and_renewal.effective_desc.detect {|enr| enr.coverage_kind == 'dental'}
         enrollment_member = if mra_health_enrollment
                               mra_health_enrollment&.hbx_enrollment_members&.detect {|member| member.applicant_id == family_member.id}
                             else
                               mra_dental_enrollment&.hbx_enrollment_members&.detect {|member| member.applicant_id == family_member.id}
                             end
-        curr_mr_health_enrollment = enrollments.enrolled_and_renewal.select {|enr| enr.coverage_kind == 'health' && enr.effective_on&.year == curr_year}.sort_by(&:submitted_at).reverse.first
-        next_mr_health_enrollment = enrollments.enrolled_and_renewal.select {|enr| enr.coverage_kind == 'health' && enr.effective_on&.year == next_year}.sort_by(&:submitted_at).reverse.first
-        curr_mr_dental_enrollment = enrollments.enrolled_and_renewal.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on&.year == curr_year}.sort_by(&:submitted_at).reverse.first
-        next_mr_dental_enrollment = enrollments.enrolled_and_renewal.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on&.year == next_year}.sort_by(&:submitted_at).reverse.first
+        curr_mr_health_enrollment = enrollments.select {|enr| enr.coverage_kind == 'health' && enr.effective_on&.year == curr_year}.sort_by(&:submitted_at).reverse.first
+        next_mr_health_enrollment = enrollments.select {|enr| enr.coverage_kind == 'health' && enr.effective_on&.year == next_year}.sort_by(&:submitted_at).reverse.first
+        curr_mr_dental_enrollment = enrollments.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on&.year == curr_year}.sort_by(&:submitted_at).reverse.first
+        next_mr_dental_enrollment = enrollments.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on&.year == next_year}.sort_by(&:submitted_at).reverse.first
         inbound_transfer_date = latest_application.transferred_at if latest_application&.transferred_at.present? && latest_application&.transfer_id.present? && !latest_application&.account_transferred
 
         csv << [

--- a/spec/script/member_outreach_report_spec.rb
+++ b/spec/script/member_outreach_report_spec.rb
@@ -220,11 +220,6 @@ describe 'member_outreach_report' do
     end
 
     context 'primary applicant' do
-      # it 'should match with the programs that the applicant is eligible for' do
-      #   eligible_programs = "QHP without financial assistance"
-      #   expect(@file_content[1][16]).to eq(eligible_programs)
-      # end
-
       it 'should match with the applicant access to health coverage response' do
         expect(@file_content[1][20]).to eq(primary_applicant.has_eligible_health_coverage.present?.to_s)
       end
@@ -286,11 +281,6 @@ describe 'member_outreach_report' do
     end
 
     context 'spouse applicant' do
-      # it 'should match with the programs that the applicant is eligible for' do
-      #   eligible_programs = "MaineCare and Cub Care(Medicaid)"
-      #   expect(@file_content[2][16]).to eq(eligible_programs)
-      # end
-
       it 'should match with the applicant access to health coverage response' do
         expect(@file_content[2][20]).to eq(spouse_applicant.has_eligible_health_coverage.present?.to_s)
       end
@@ -318,22 +308,6 @@ describe 'member_outreach_report' do
         expect(@file_content[1][18]).to eq(primary_eligible_programs)
         expect(@file_content[2][18]).to eq(spouse_eligible_programs)
       end
-
-      # it 'should match with the date of the most recent aasm_state transition' do
-      #   expect(@file_content[1][18]).to eq(application.workflow_state_transitions.first.transition_at.to_s)
-      #   expect(@file_content[2][18]).to eq(application.workflow_state_transitions.first.transition_at.to_s)
-      # end
-
-      # it 'should match with the transfer id' do
-      #   expect(@file_content[1][19]).to eq(application.transfer_id)
-      #   expect(@file_content[2][19]).to eq(application.transfer_id)
-      # end
-
-      # it 'should match with the inbound transfer timestamp' do
-      #   transfer_timestamp = application.transferred_at
-      #   expect(@file_content[1][20]).to eq(transfer_timestamp.to_s)
-      #   expect(@file_content[2][20]).to eq(transfer_timestamp.to_s)
-      # end
     end
 
     context 'latest application (in any submission state)' do
@@ -443,10 +417,6 @@ describe 'member_outreach_report' do
         expect(@file_content[2][2]).to eq("false")
       end
     end
-  end
-
-  context 'family with no FAA application' do
-    # TODO
   end
 
   after :each do

--- a/spec/script/member_outreach_report_spec.rb
+++ b/spec/script/member_outreach_report_spec.rb
@@ -37,9 +37,22 @@ describe 'member_outreach_report' do
     end
   end
   let(:yesterday) { Time.now.getlocal.prev_day }
-  let!(:application) do
+  let!(:latest_determined_application) do
     FactoryBot.create(
       :financial_assistance_application,
+      applicants: applicants,
+      submitted_at: yesterday,
+      family_id: family.id,
+      aasm_state: 'determined',
+      transfer_id: 'tr12345',
+      assistance_year: FinancialAssistance::Operations::EnrollmentDates::ApplicationYear.new.call.value!,
+      transferred_at: DateTime.now
+    )
+  end
+  let!(:latest_application) do
+    FactoryBot.create(
+      :financial_assistance_application,
+      applicants: applicants,
       submitted_at: yesterday,
       family_id: family.id,
       aasm_state: 'draft',
@@ -48,11 +61,11 @@ describe 'member_outreach_report' do
       transferred_at: DateTime.now
     )
   end
-  let!(:primary_applicant) do
+  let(:primary_applicant) do
     FactoryBot.create(
       :financial_assistance_applicant,
       benefits: [benefit],
-      application: application,
+      # application: application,
       family_member_id: primary_fm.id,
       person_hbx_id: primary_person.hbx_id,
       is_primary_applicant: true,
@@ -67,11 +80,11 @@ describe 'member_outreach_report' do
       has_eligible_health_coverage: true
     )
   end
-  let!(:spouse_applicant) do
+  let(:spouse_applicant) do
     FactoryBot.create(
       :financial_assistance_applicant,
       :spouse,
-      application: application,
+      # application: application,
       family_member_id: spouse_fm.id,
       person_hbx_id: spouse_person.hbx_id,
       citizen_status: 'alien_lawfully_present',
@@ -108,14 +121,16 @@ describe 'member_outreach_report' do
         external_id
         user_account
         last_page_visited
-        program_eligible_for
-        application_aasm_state
-        application_aasm_state_date
-        transfer_id
+        latest_determined_application_id
+        determined_date
+        determined_program_eligible_for
+        determined_medicaid_fpl
+        determined_has_access_to_coverage
+        determined_has_access_to_coverage_kinds
+        latest_application_aasm_state
+        latest_application_aasm_state_date
+        latest_transfer_id
         inbound_transfer_date
-        FPL
-        has_access_to_health_coverage
-        has_access_to_health_coverage_kinds
       ]
     headers << "#{curr_year}_most_recent_health_plan_id"
     headers << "#{curr_year}_most_recent_health_status"
@@ -129,8 +144,10 @@ describe 'member_outreach_report' do
 
   context 'family with application in current enrollment year' do
     before do
-      application.non_primary_applicants.each{|applicant| application.ensure_relationship_with_primary(applicant, applicant.relationship) }
-      application.update(workflow_state_transitions: [workflow_state_transition])
+      latest_application.non_primary_applicants.each{|applicant| latest_application.ensure_relationship_with_primary(applicant, applicant.relationship) }
+      latest_determined_application.non_primary_applicants.each{|applicant| latest_determined_application.ensure_relationship_with_primary(applicant, applicant.relationship) }
+      latest_application.update(workflow_state_transitions: [workflow_state_transition])
+      latest_determined_application.update(workflow_state_transitions: [workflow_state_transition])
       health_enrollment.update(hbx_enrollment_members: enrollment_members)
       invoke_member_outreach_report
       @file_content = CSV.read("#{Rails.root}/member_outreach_report.csv")
@@ -203,18 +220,18 @@ describe 'member_outreach_report' do
     end
 
     context 'primary applicant' do
-      it 'should match with the programs that the applicant is eligible for' do
-        eligible_programs = "QHP without financial assistance"
-        expect(@file_content[1][16]).to eq(eligible_programs)
-      end
+      # it 'should match with the programs that the applicant is eligible for' do
+      #   eligible_programs = "QHP without financial assistance"
+      #   expect(@file_content[1][16]).to eq(eligible_programs)
+      # end
 
       it 'should match with the applicant access to health coverage response' do
-        expect(@file_content[1][22]).to eq(primary_applicant.has_eligible_health_coverage.present?.to_s)
+        expect(@file_content[1][20]).to eq(primary_applicant.has_eligible_health_coverage.present?.to_s)
       end
 
       it 'should match with the health coverage kinds applicant has access to' do
         insurance_kinds = primary_applicant.benefits.eligible.map(&:insurance_kind).join(", ")
-        expect(@file_content[1][23]).to eq(insurance_kinds)
+        expect(@file_content[1][21]).to eq(insurance_kinds)
       end
     end
 
@@ -269,41 +286,76 @@ describe 'member_outreach_report' do
     end
 
     context 'spouse applicant' do
-      it 'should match with the programs that the applicant is eligible for' do
-        eligible_programs = "MaineCare and Cub Care(Medicaid)"
-        expect(@file_content[2][16]).to eq(eligible_programs)
-      end
+      # it 'should match with the programs that the applicant is eligible for' do
+      #   eligible_programs = "MaineCare and Cub Care(Medicaid)"
+      #   expect(@file_content[2][16]).to eq(eligible_programs)
+      # end
 
       it 'should match with the applicant access to health coverage response' do
-        expect(@file_content[2][22]).to eq(spouse_applicant.has_eligible_health_coverage.present?.to_s)
+        expect(@file_content[2][20]).to eq(spouse_applicant.has_eligible_health_coverage.present?.to_s)
       end
 
       it 'should match with the health coverage kinds applicant has access to' do
         insurance_kinds = spouse_applicant.benefits.eligible.map(&:insurance_kind).join(", ")
-        expect(@file_content[2][23]).to eq(insurance_kinds)
+        expect(@file_content[2][21]).to eq(insurance_kinds)
       end
     end
 
-    context 'application' do
+    context 'latest determined application' do
+      it 'should match with application id' do
+        expect(@file_content[1][16]).to eq(latest_determined_application.hbx_id)
+        expect(@file_content[2][16]).to eq(latest_determined_application.hbx_id)
+      end
+
+      it 'should match with the determination date' do
+        expect(@file_content[1][17]).to eq(latest_determined_application.submitted_at.to_s)
+        expect(@file_content[2][17]).to eq(latest_determined_application.submitted_at.to_s)
+      end
+
+      it 'should match with the programs that the applicants are eligible for' do
+        primary_eligible_programs = "QHP without financial assistance"
+        spouse_eligible_programs = "MaineCare and Cub Care(Medicaid)"
+        expect(@file_content[1][18]).to eq(primary_eligible_programs)
+        expect(@file_content[2][18]).to eq(spouse_eligible_programs)
+      end
+
+      # it 'should match with the date of the most recent aasm_state transition' do
+      #   expect(@file_content[1][18]).to eq(application.workflow_state_transitions.first.transition_at.to_s)
+      #   expect(@file_content[2][18]).to eq(application.workflow_state_transitions.first.transition_at.to_s)
+      # end
+
+      # it 'should match with the transfer id' do
+      #   expect(@file_content[1][19]).to eq(application.transfer_id)
+      #   expect(@file_content[2][19]).to eq(application.transfer_id)
+      # end
+
+      # it 'should match with the inbound transfer timestamp' do
+      #   transfer_timestamp = application.transferred_at
+      #   expect(@file_content[1][20]).to eq(transfer_timestamp.to_s)
+      #   expect(@file_content[2][20]).to eq(transfer_timestamp.to_s)
+      # end
+    end
+
+    context 'latest application (in any submission state)' do
       it 'should match with the application aasm_state' do
-        expect(@file_content[1][17]).to eq(application.aasm_state)
-        expect(@file_content[2][17]).to eq(application.aasm_state)
+        expect(@file_content[1][22]).to eq(latest_application.aasm_state)
+        expect(@file_content[2][22]).to eq(latest_application.aasm_state)
       end
 
       it 'should match with the date of the most recent aasm_state transition' do
-        expect(@file_content[1][18]).to eq(application.workflow_state_transitions.first.transition_at.to_s)
-        expect(@file_content[2][18]).to eq(application.workflow_state_transitions.first.transition_at.to_s)
+        expect(@file_content[1][23]).to eq(latest_application.workflow_state_transitions.first.transition_at.to_s)
+        expect(@file_content[2][23]).to eq(latest_application.workflow_state_transitions.first.transition_at.to_s)
       end
 
       it 'should match with the transfer id' do
-        expect(@file_content[1][19]).to eq(application.transfer_id)
-        expect(@file_content[2][19]).to eq(application.transfer_id)
+        expect(@file_content[1][24]).to eq(latest_application.transfer_id)
+        expect(@file_content[2][24]).to eq(latest_application.transfer_id)
       end
 
       it 'should match with the inbound transfer timestamp' do
-        transfer_timestamp = application.transferred_at
-        expect(@file_content[1][20]).to eq(transfer_timestamp.to_s)
-        expect(@file_content[2][20]).to eq(transfer_timestamp.to_s)
+        transfer_timestamp = latest_application.transferred_at
+        expect(@file_content[1][25]).to eq(transfer_timestamp.to_s)
+        expect(@file_content[2][25]).to eq(transfer_timestamp.to_s)
       end
     end
 
@@ -325,50 +377,50 @@ describe 'member_outreach_report' do
 
         it 'should match with the current year most recent health plan hios id' do
           health_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'health' && enr.effective_on.year == curr_year}.sort_by(&:submitted_at).reverse.first
-          expect(@file_content[1][24]).to eq(health_enrollment.product.hios_id)
-          expect(@file_content[2][24]).to eq(health_enrollment.product.hios_id)
-        end
-
-        it 'should match with the current year most recent health plan status' do
-          health_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'health' && enr.effective_on.year == curr_year}.sort_by(&:submitted_at).reverse.first
-          expect(@file_content[1][25]).to eq(health_enrollment.aasm_state)
-          expect(@file_content[2][25]).to eq(health_enrollment.aasm_state)
-        end
-
-        it 'should match with the prospective year most recent health plan hios id' do
-          health_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'health' && enr.effective_on.year == next_year}.sort_by(&:submitted_at).reverse.first
           expect(@file_content[1][26]).to eq(health_enrollment.product.hios_id)
           expect(@file_content[2][26]).to eq(health_enrollment.product.hios_id)
         end
 
-        it 'should match with the prospective year most recent health plan status' do
-          health_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'health' && enr.effective_on.year == next_year}.sort_by(&:submitted_at).reverse.first
+        it 'should match with the current year most recent health plan status' do
+          health_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'health' && enr.effective_on.year == curr_year}.sort_by(&:submitted_at).reverse.first
           expect(@file_content[1][27]).to eq(health_enrollment.aasm_state)
           expect(@file_content[2][27]).to eq(health_enrollment.aasm_state)
         end
 
+        it 'should match with the prospective year most recent health plan hios id' do
+          health_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'health' && enr.effective_on.year == next_year}.sort_by(&:submitted_at).reverse.first
+          expect(@file_content[1][28]).to eq(health_enrollment.product.hios_id)
+          expect(@file_content[2][28]).to eq(health_enrollment.product.hios_id)
+        end
+
+        it 'should match with the prospective year most recent health plan status' do
+          health_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'health' && enr.effective_on.year == next_year}.sort_by(&:submitted_at).reverse.first
+          expect(@file_content[1][29]).to eq(health_enrollment.aasm_state)
+          expect(@file_content[2][29]).to eq(health_enrollment.aasm_state)
+        end
+
         it 'should match with the current year most recent dental plan hios id' do
           dental_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on.year == curr_year}.sort_by(&:submitted_at).reverse.first
-          expect(@file_content[1][28]).to eq(dental_enrollment.product.hios_id)
-          expect(@file_content[2][28]).to eq(dental_enrollment.product.hios_id)
-        end
-
-        it 'should match with the current year most recent dental plan status' do
-          dental_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on.year == curr_year}.sort_by(&:submitted_at).reverse.first
-          expect(@file_content[1][29]).to eq(dental_enrollment.aasm_state)
-          expect(@file_content[2][29]).to eq(dental_enrollment.aasm_state)
-        end
-
-        it 'should match with the prospective year most recent dental plan hios id' do
-          dental_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on.year == next_year}.sort_by(&:submitted_at).reverse.first
           expect(@file_content[1][30]).to eq(dental_enrollment.product.hios_id)
           expect(@file_content[2][30]).to eq(dental_enrollment.product.hios_id)
         end
 
-        it 'should match with the prospective year most recent dental plan status' do
-          dental_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on.year == next_year}.sort_by(&:submitted_at).reverse.first
+        it 'should match with the current year most recent dental plan status' do
+          dental_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on.year == curr_year}.sort_by(&:submitted_at).reverse.first
           expect(@file_content[1][31]).to eq(dental_enrollment.aasm_state)
           expect(@file_content[2][31]).to eq(dental_enrollment.aasm_state)
+        end
+
+        it 'should match with the prospective year most recent dental plan hios id' do
+          dental_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on.year == next_year}.sort_by(&:submitted_at).reverse.first
+          expect(@file_content[1][32]).to eq(dental_enrollment.product.hios_id)
+          expect(@file_content[2][32]).to eq(dental_enrollment.product.hios_id)
+        end
+
+        it 'should match with the prospective year most recent dental plan status' do
+          dental_enrollment = @enrollments.select {|enr| enr.coverage_kind == 'dental' && enr.effective_on.year == next_year}.sort_by(&:submitted_at).reverse.first
+          expect(@file_content[1][33]).to eq(dental_enrollment.aasm_state)
+          expect(@file_content[2][33]).to eq(dental_enrollment.aasm_state)
         end
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184639817

# A brief description of the changes

Current behavior:
Member outreach report does not report on most recent determined application specifically.  Cancelled and terminated enrollments are not used to populate fields for most recent enrollments.  

New behavior:
Member outreach report has requested fields for most recent determined application.  Cancelled and terminated enrollments are used to populate fields for most recent enrollments.  

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME
