### PR TITLE
get fpl from applicant on latest determined application for member report

### DIFF
--- a/script/member_outreach_report.rb
+++ b/script/member_outreach_report.rb
@@ -122,8 +122,8 @@ CSV.open(file_name, "w", force_quotes: true) do |csv|
             latest_determined_application&.hbx_id,
             latest_determined_application&.submitted_at,
             program_eligible_for(applicant),
-            # fpl depends on enrollment; assumption: use most recent active health plan enrollment
-            fpl_percentage(mra_health_enrollment, enrollment_member, mra_health_enrollment&.effective_on&.year),
+            # Expected outcome is that FPL value populates for all FAA applicants based on most recent determined application
+            applicant&.magi_as_percentage_of_fpl,
             applicant&.has_eligible_health_coverage.present?,
             applicant&.benefits&.eligible&.map(&:insurance_kind)&.join(", "),
             latest_application&.aasm_state,

--- a/script/member_outreach_report.rb
+++ b/script/member_outreach_report.rb
@@ -28,7 +28,7 @@ field_names = %w[
     latest_application_aasm_state
     latest_application_aasm_state_date
     latest_transfer_id
-    inbound_transfer_date
+    latest_inbound_transfer_date
   ]
 curr_year = TimeKeeper.date_of_record.year
 next_year = TimeKeeper.date_of_record.year + 1

--- a/script/member_outreach_report.rb
+++ b/script/member_outreach_report.rb
@@ -58,19 +58,6 @@ def program_eligible_for(applicant)
   eligible_programs.join(",")
 end
 
-def fpl_percentage(enr, enr_member, effective_year)
-  return unless enr && enr_member
-  tax_households = if EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
-                     enr.family.tax_household_groups.active.by_year(effective_year).first&.tax_households
-                   else
-                     enr.household.latest_tax_households_with_year(effective_year).active_tax_household
-                   end
-  return "N/A" if tax_households.blank?
-
-  tax_household_member = tax_households.map(&:tax_household_members).flatten.detect{|mem| mem.applicant_id == enr_member.applicant_id}
-  tax_household_member&.magi_as_percentage_of_fpl
-end
-
 puts "Generating member outreach report...."
 CSV.open(file_name, "w", force_quotes: true) do |csv|
   csv << field_names

--- a/spec/script/member_outreach_report_spec.rb
+++ b/spec/script/member_outreach_report_spec.rb
@@ -220,6 +220,10 @@ describe 'member_outreach_report' do
     end
 
     context 'primary applicant' do
+      it 'should match with the applicant FPL percentage' do
+        expect(@file_content[1][19]).to eq(primary_applicant.magi_as_percentage_of_fpl.to_s)
+      end
+
       it 'should match with the applicant access to health coverage response' do
         expect(@file_content[1][20]).to eq(primary_applicant.has_eligible_health_coverage.present?.to_s)
       end
@@ -281,6 +285,10 @@ describe 'member_outreach_report' do
     end
 
     context 'spouse applicant' do
+      it 'should match with the applicant FPL percentage' do
+        expect(@file_content[2][19]).to eq(primary_applicant.magi_as_percentage_of_fpl.to_s)
+      end
+
       it 'should match with the applicant access to health coverage response' do
         expect(@file_content[2][20]).to eq(spouse_applicant.has_eligible_health_coverage.present?.to_s)
       end

--- a/spec/script/member_outreach_report_spec.rb
+++ b/spec/script/member_outreach_report_spec.rb
@@ -130,7 +130,7 @@ describe 'member_outreach_report' do
         latest_application_aasm_state
         latest_application_aasm_state_date
         latest_transfer_id
-        inbound_transfer_date
+        latest_inbound_transfer_date
       ]
     headers << "#{curr_year}_most_recent_health_plan_id"
     headers << "#{curr_year}_most_recent_health_status"


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)*
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

*note: this feature is for a report that is manually run, so falls into the category of inert code, no impact until run.  No feature flag is required.
# What is the ticket # detailing the issue?

Ticket: IVL-184639817

# A brief description of the changes

Current behavior:
FPL percent is pulled from the tax household on the enrollment.

New behavior:
FPL percent is pulled from the applicant on the latest determined application.  (Also includes an update to latest_inbound_transfer_date header name, which was missed on previous PR.)

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME
