### PR TITLE
validate Pay Now SAML payload as string

### DIFF
--- a/app/domain/operations/generate_saml_response.rb
+++ b/app/domain/operations/generate_saml_response.rb
@@ -49,7 +49,7 @@ module Operations
 
     def validate_saml_response(saml_response)
       return Success(:ok) unless EnrollRegistry.feature_enabled?(:validate_saml)
-      AcaEntities::Serializers::Xml::PayNow::CareFirst::Operations::ValidatePayNowTransferPayloadSaml.new.call(saml_response)
+      AcaEntities::Serializers::Xml::PayNow::CareFirst::Operations::ValidatePayNowTransferPayloadSaml.new.call(saml_response.to_s)
     end
 
     def encode_saml_reponse(saml_object, saml_response)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184640239

# A brief description of the changes

Current behavior:
Call to SAML validator operation returns `Failure(#<TypeError: no implicit conversion of XMLSecurity::Document into String>)` for valid payloads.

New behavior:
Call to SAML validator returns `Success(:ok)` for valid payloads.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: VALIDATE_SAML_IS_ENABLED

- [x] DC
- [x] ME
