### PR TITLE
restrict benefit selection for hc4cc quote

### DIFF
--- a/app/models/eligibilities/osse/benefit_sponsorship_osse_policy.rb
+++ b/app/models/eligibilities/osse/benefit_sponsorship_osse_policy.rb
@@ -17,6 +17,10 @@ module Eligibilities
         :benefit_application_fte_count
       ].freeze
 
+      METAL_LEVEL_PRODUCTS_RESTRICTED = [
+        :employer_metal_level_products
+      ].freeze
+
       embedded_in :grant, class_name: "::Eligibilities::Osse::Grant"
 
       field :value, type: String
@@ -24,7 +28,7 @@ module Eligibilities
       validates_presence_of :value
 
       def run
-        RELAXED_RULES.include?(key)
+        RELAXED_RULES.include?(key) || METAL_LEVEL_PRODUCTS_RESTRICTED.include?(key)
       end
     end
   end

--- a/app/models/eligibilities/osse/eligibility.rb
+++ b/app/models/eligibilities/osse/eligibility.rb
@@ -82,7 +82,7 @@ module Eligibilities
       # TODO: returns other classes in the future
       #
       def grant_value_klass
-        if subject[:klass] == 'BenefitSponsors::BenefitSponsorships::BenefitSponsorship'
+        if subject[:klass].match(/BenefitSponsorships::BenefitSponsorship/).present?
           'Eligibilities::Osse::BenefitSponsorshipOssePolicy'
         else
           'Eligibilities::Osse::Value'

--- a/app/models/eligibilities/osse/grant.rb
+++ b/app/models/eligibilities/osse/grant.rb
@@ -21,9 +21,6 @@ module Eligibilities
       field :key, type: Symbol
       field :start_on, type: Date
       field :end_on, type: Date
-      field :value, type: String
-      # field :updated_by, type: String
-      # field :update_reason, type: String
 
       embeds_one :value, class_name: "::Eligibilities::Osse::Value", cascade_callbacks: true
 

--- a/components/benefit_sponsors/spec/dummy/app/models/eligibilities/osse/benefit_sponsorship_osse_policy.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/eligibilities/osse/benefit_sponsorship_osse_policy.rb
@@ -12,9 +12,13 @@ module Eligibilities
       # include Eligibilities::Eventable
 
       RELAXED_RULES = [
-        :minimum_participation_rule_relaxed,
-        :all_contribution_levels_min_met_relaxed,
-        :benefit_application_fte_count_relaxed
+        :minimum_participation_rule,
+        :all_contribution_levels_min_met,
+        :benefit_application_fte_count
+      ].freeze
+
+      METAL_LEVEL_PRODUCTS_RESTRICTED = [
+        :employer_metal_level_products
       ].freeze
 
       embedded_in :grant, class_name: "::Eligibilities::Osse::Grant"
@@ -23,9 +27,8 @@ module Eligibilities
 
       validates_presence_of :value
 
-      def run(_model_instance)
-        return true if RELAXED_RULES.include?(key)
-        false
+      def run
+        RELAXED_RULES.include?(key) || METAL_LEVEL_PRODUCTS_RESTRICTED.include?(key)
       end
     end
   end

--- a/components/benefit_sponsors/spec/dummy/app/models/eligibilities/osse/grant.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/eligibilities/osse/grant.rb
@@ -21,9 +21,6 @@ module Eligibilities
       field :key, type: Symbol
       field :start_on, type: Date
       field :end_on, type: Date
-      field :value, type: String
-      # field :updated_by, type: String
-      # field :update_reason, type: String
 
       embeds_one :value, class_name: "::Eligibilities::Osse::Value", cascade_callbacks: true
 

--- a/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
+++ b/components/sponsored_benefits/app/assets/javascripts/sponsored_benefits/plan_design_proposals.js
@@ -94,6 +94,8 @@ function fetchCarriers() {
   var active_year = $("#forms_plan_design_proposal_effective_date").val().substr(0,4);
   var selected_carrier_level = $(this).siblings('input').val();
   var plan_design_organization_id = $('#plan_design_organization_id').val();
+  var plan_design_proposal_id = $('#plan_design_proposal_id').val();
+
   var kind = $("#benefits_kind").val();
   $(this).closest('.plan-design').find('.nav-tabs li').removeClass('active');
   $(this).closest('li').addClass('active');
@@ -103,6 +105,7 @@ function fetchCarriers() {
     data:{
       active_year: active_year,
       selected_carrier_level: selected_carrier_level,
+      plan_design_proposal_id: plan_design_proposal_id,
       kind: kind
     },
     success: function() {

--- a/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_proposals/carriers_controller.rb
+++ b/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_proposals/carriers_controller.rb
@@ -33,6 +33,9 @@ module SponsoredBenefits
 
         def load_broker_agency_profile
           @plan_design_organization = PlanDesignOrganization.find(params[:plan_design_organization_id])
+          @plan_design_proposal = @plan_design_organization.plan_design_proposals.find(
+            params[:plan_design_proposal_id]
+          )
           @broker_agency_profile = @plan_design_organization.broker_agency_profile
           @provider = @broker_agency_profile.primary_broker_role.person
         end

--- a/components/sponsored_benefits/app/models/sponsored_benefits/benefit_sponsorships/benefit_sponsorship.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/benefit_sponsorships/benefit_sponsorship.rb
@@ -85,6 +85,14 @@ module SponsoredBenefits
         # build_inbox if inbox.nil?
       end
 
+      def market_kind
+        if benefit_market.to_s.scan(/aca_shop/).present?
+          'aca_shop'
+        else
+          benefit_market
+        end
+      end
+
       def eligibility_for(evidence_key, start_on)
         eligibilities.by_date(start_on).select do |eligibility|
           el = eligibility.evidences.by_key(evidence_key).max_by(&:created_at)

--- a/components/sponsored_benefits/app/models/sponsored_benefits/forms/plan_design_proposal.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/forms/plan_design_proposal.rb
@@ -82,7 +82,7 @@ module SponsoredBenefits
         @quote_date = @proposal.updated_at.strftime('%m/%d/%Y')
         sponsorship = @proposal.profile.benefit_sponsorships.first
         @osse_eligibility ||= 'true' if sponsorship &&
-                                        proposal_osse_eligibility(sponsorship).present?
+                                        osse_eligibility_with(sponsorship).present?
       end
 
       def ensure_proposal
@@ -231,7 +231,7 @@ module SponsoredBenefits
         service.is_dental_plans_avialable?(self)
       end
 
-      def proposal_osse_eligibility(benefit_sponsorship)
+      def osse_eligibility_with(benefit_sponsorship)
         benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
       end
 
@@ -239,7 +239,7 @@ module SponsoredBenefits
         return unless osse_eligibility.present?
 
         osse_eligibility_present =
-          proposal_osse_eligibility(benefit_sponsorship).present?
+          osse_eligibility_with(benefit_sponsorship).present?
 
         if osse_eligibility_present
           terminate_eligibility(benefit_sponsorship) if osse_eligibility.to_s == 'false'
@@ -284,6 +284,10 @@ module SponsoredBenefits
           evidence_value: osse_eligibility,
           effective_date: effective_date
         }
+      end
+
+      def osse_eligibile?
+        osse_eligibility == 'true'
       end
     end
   end

--- a/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
@@ -31,24 +31,30 @@ module SponsoredBenefits
       scope :expired, -> { any_in(aasm_state: %w(expired renewing_expired)) }
       scope :claimed, -> { any_in(aasm_state: %w(claimed renewing_claimed)) }
 
+      # rubocop:disable Lint/SafeNavigationChain
       def active_benefit_group
-        return nil if profile.nil?
-        return nil if profile.benefit_sponsorships.empty?
-        sponsorship = profile.benefit_sponsorships.first
-        return nil if sponsorship.benefit_applications.empty?
-        application = sponsorship.benefit_applications.first
-        return nil if application.benefit_groups.empty?
-        application.benefit_groups.first
+        benefit_application&.benefit_groups.first
       end
 
+      def benefit_application
+        benefit_sponsorship&.benefit_applications.first
+      end
+
+      def benefit_sponsorship
+        profile&.benefit_sponsorships.first
+      end
+      # rubocop:enable Lint/SafeNavigationChain
+
       def active_census_employees
-        return nil if profile.benefit_sponsorships.empty?
-        sponsorship = profile.benefit_sponsorships.first
-        sponsorship.census_employees
+        benefit_sponsorship&.census_employees
       end
 
       def active_census_familes
         active_census_employees.where({ "census_dependents.0" => { "$exists" => true } })
+      end
+
+      def osse_eligibility
+        benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
       end
 
       # class methods

--- a/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
@@ -57,6 +57,12 @@ module SponsoredBenefits
         benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
       end
 
+      def metal_level_products_restricted?
+        grant = osse_eligibility&.grant_for(:employer_metal_level_products)
+        return false unless grant
+        grant.value.run
+      end
+
       # class methods
       class << self
 

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/carriers/_carriers_list.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/carriers/_carriers_list.html.erb
@@ -85,6 +85,9 @@
   <% if check_plan_options_title %>
       <% metal_levels = enabled_metal_levels_for_single_carrier - ['dental'] %>
   <% end %>
+  <% if plan_design_proposal.osse_eligibility %>
+      <% metal_levels = metal_levels - ['bronze'] %>
+  <% end %>
   <form>
   <% metal_levels.each_with_index do |kind, index| %>
     <div class="col-xs-4 metals">

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/carriers/_carriers_list.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/carriers/_carriers_list.html.erb
@@ -85,7 +85,7 @@
   <% if check_plan_options_title %>
       <% metal_levels = enabled_metal_levels_for_single_carrier - ['dental'] %>
   <% end %>
-  <% if plan_design_proposal.osse_eligibility %>
+  <% if plan_design_proposal.metal_level_products_restricted? %>
       <% metal_levels = metal_levels - ['bronze'] %>
   <% end %>
   <form>

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/carriers/index.js.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/carriers/index.js.erb
@@ -11,7 +11,7 @@ $('.tab-container').hide();
   $('#singleCarrierCarrierList').html("<%= escape_javascript(render partial: 'carriers_list', locals: { carrier_names: @carrier_names, search_level: selected_carrier_level, active_year: active_year, kind: kind }) %>");
 <% when 'metal_level' %>
   $('.metals-tab').show();
-  $('#metalLevelCarrierList').html("<%= escape_javascript(render partial: 'carriers_list', locals: { carrier_names: @carrier_names, search_level: selected_carrier_level, active_year: active_year, kind: kind }) %>");
+  $('#metalLevelCarrierList').html("<%= escape_javascript(render partial: 'carriers_list', locals: { carrier_names: @carrier_names, search_level: selected_carrier_level, active_year: active_year, kind: kind, plan_design_proposal: @plan_design_proposal }) %>");
 <% when 'custom' %>
 $('.carrier-custom-plan-tab').show();
 $('#CustomCarrierList').html("<%= escape_javascript(render partial: 'carriers_list', locals: { carrier_names: @carrier_names, search_level: selected_carrier_level, active_year: active_year, kind: kind }) %>");

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_selections/_health_carrier_options.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_selections/_health_carrier_options.html.erb
@@ -1,6 +1,7 @@
 <%# TODO: Implment using view object because it is doing repetative stuff %>
+<% display_only_metal_level = plan_design_form.proposal.metal_level_products_restricted? %>
 <ul class="nav nav-tabs">
-  <% if offer_sole_source? && check_plan_options_title && !plan_design_form.osse_eligibile? %>
+  <% if offer_sole_source? && check_plan_options_title && !display_only_metal_level %>
     <li role="presentation" class="col-xs-4 sole-source-tab" data-offering-kind="sole_source" data-offering-id="<%= offering_id %>">
       <%=  f.radio_button :plan_option_kind, "sole_source", true %>
       <%= f.label :plan_option_kind_sole_source, class: "elected_plan" do %>
@@ -10,7 +11,7 @@
       <% end %>
     </li>
   <% end %>
-  <% if offers_single_carrier? && !plan_design_form.osse_eligibile? %>
+  <% if offers_single_carrier? && !display_only_metal_level %>
     <li role="presentation" class="col-xs-4 single-carrier-tab" data-offering-id="<%= offering_id %>">
       <%= f.radio_button :plan_option_kind, "single_carrier" %>
       <%= f.label :plan_option_kind_single_carrier, class: "elected_plan" do %>
@@ -38,7 +39,7 @@
       <% end %>
     </li>
   <% end %>
-  <% if offers_single_plan? && !plan_design_form.osse_eligibile? %>
+  <% if offers_single_plan? && !display_only_metal_level %>
     <li role="presentation" class="col-xs-4 single-plan-tab" data-offering-id="<%= offering_id %>">
       <%= f.radio_button :plan_option_kind, "single_plan", selected: f.object.plan_option_kind %>
       <%= f.label :plan_option_kind_single_plan, class: "elected_plan" do %>
@@ -50,7 +51,7 @@
   <% end %>
 </ul>
 <div class="col-xs-12 plan-options" style="display: none;">
-  <% if offer_sole_source? && !plan_design_form.osse_eligibile? %>
+  <% if offer_sole_source? && !display_only_metal_level %>
     <div class="col-xs-12 sole-source-plan-tab tab-container" style="display: none;">
       <br><br>
       <p class="twenty plan_heading_text"><%= fetch_health_product_option_choice_description_for_sole_source %></p>
@@ -61,7 +62,7 @@
       </div>
     </div>
   <% end %>
-  <% if offers_single_carrier? && !plan_design_form.osse_eligibile? %>
+  <% if offers_single_carrier? && !display_only_metal_level %>
     <div class="col-xs-12 carriers-tab tab-container" style="display: none;">
       <br><br>
       <p class="twenty plan_heading_text"><%= fetch_health_product_option_choice_description_for_single_carrier %></p>
@@ -83,7 +84,7 @@
       </div>
     </div>
   <% end %>
-  <% if offers_single_plan? && !plan_design_form.osse_eligibile? %>
+  <% if offers_single_plan? && !display_only_metal_level %>
     <div class="col-xs-12 single-plan-tab tab-container" style="display: none;">
       <br><br>
       <% if plan_design_form.is_dental? %>

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_selections/_health_carrier_options.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_selections/_health_carrier_options.html.erb
@@ -1,6 +1,6 @@
 <%# TODO: Implment using view object because it is doing repetative stuff %>
 <ul class="nav nav-tabs">
-  <% if offer_sole_source? && check_plan_options_title %>
+  <% if offer_sole_source? && check_plan_options_title && !plan_design_form.osse_eligibile? %>
     <li role="presentation" class="col-xs-4 sole-source-tab" data-offering-kind="sole_source" data-offering-id="<%= offering_id %>">
       <%=  f.radio_button :plan_option_kind, "sole_source", true %>
       <%= f.label :plan_option_kind_sole_source, class: "elected_plan" do %>
@@ -10,7 +10,7 @@
       <% end %>
     </li>
   <% end %>
-  <% if offers_single_carrier? %>
+  <% if offers_single_carrier? && !plan_design_form.osse_eligibile? %>
     <li role="presentation" class="col-xs-4 single-carrier-tab" data-offering-id="<%= offering_id %>">
       <%= f.radio_button :plan_option_kind, "single_carrier" %>
       <%= f.label :plan_option_kind_single_carrier, class: "elected_plan" do %>
@@ -38,7 +38,7 @@
       <% end %>
     </li>
   <% end %>
-  <% if offers_single_plan? %>
+  <% if offers_single_plan? && !plan_design_form.osse_eligibile? %>
     <li role="presentation" class="col-xs-4 single-plan-tab" data-offering-id="<%= offering_id %>">
       <%= f.radio_button :plan_option_kind, "single_plan", selected: f.object.plan_option_kind %>
       <%= f.label :plan_option_kind_single_plan, class: "elected_plan" do %>
@@ -50,7 +50,7 @@
   <% end %>
 </ul>
 <div class="col-xs-12 plan-options" style="display: none;">
-  <% if offer_sole_source? %>
+  <% if offer_sole_source? && !plan_design_form.osse_eligibile? %>
     <div class="col-xs-12 sole-source-plan-tab tab-container" style="display: none;">
       <br><br>
       <p class="twenty plan_heading_text"><%= fetch_health_product_option_choice_description_for_sole_source %></p>
@@ -61,7 +61,7 @@
       </div>
     </div>
   <% end %>
-  <% if offers_single_carrier? %>
+  <% if offers_single_carrier? && !plan_design_form.osse_eligibile? %>
     <div class="col-xs-12 carriers-tab tab-container" style="display: none;">
       <br><br>
       <p class="twenty plan_heading_text"><%= fetch_health_product_option_choice_description_for_single_carrier %></p>
@@ -83,7 +83,7 @@
       </div>
     </div>
   <% end %>
-  <% if offers_single_plan? %>
+  <% if offers_single_plan? && !plan_design_form.osse_eligibile? %>
     <div class="col-xs-12 single-plan-tab tab-container" style="display: none;">
       <br><br>
       <% if plan_design_form.is_dental? %>

--- a/components/sponsored_benefits/spec/dummy/app/models/eligibilities/osse/benefit_sponsorship_osse_policy.rb
+++ b/components/sponsored_benefits/spec/dummy/app/models/eligibilities/osse/benefit_sponsorship_osse_policy.rb
@@ -17,6 +17,10 @@ module Eligibilities
         :benefit_application_fte_count
       ].freeze
 
+      METAL_LEVEL_PRODUCTS_RESTRICTED = [
+        :employer_metal_level_products
+      ].freeze
+
       embedded_in :grant, class_name: "::Eligibilities::Osse::Grant"
 
       field :value, type: String
@@ -24,7 +28,7 @@ module Eligibilities
       validates_presence_of :value
 
       def run
-        RELAXED_RULES.include?(key)
+        RELAXED_RULES.include?(key) || METAL_LEVEL_PRODUCTS_RESTRICTED.include?(key)
       end
     end
   end

--- a/components/sponsored_benefits/spec/dummy/app/models/eligibilities/osse/eligibility.rb
+++ b/components/sponsored_benefits/spec/dummy/app/models/eligibilities/osse/eligibility.rb
@@ -82,7 +82,7 @@ module Eligibilities
       # TODO: returns other classes in the future
       #
       def grant_value_klass
-        if subject[:klass] == 'BenefitSponsors::BenefitSponsorships::BenefitSponsorship'
+        if subject[:klass].match(/BenefitSponsorships::BenefitSponsorship/).present?
           'Eligibilities::Osse::BenefitSponsorshipOssePolicy'
         else
           'Eligibilities::Osse::Value'

--- a/components/sponsored_benefits/spec/dummy/app/models/eligibilities/osse/grant.rb
+++ b/components/sponsored_benefits/spec/dummy/app/models/eligibilities/osse/grant.rb
@@ -21,9 +21,6 @@ module Eligibilities
       field :key, type: Symbol
       field :start_on, type: Date
       field :end_on, type: Date
-      # field :value, type: String
-      # field :updated_by, type: String
-      # field :update_reason, type: String
 
       embeds_one :value, class_name: "::Eligibilities::Osse::Value", cascade_callbacks: true
 

--- a/features/brokers/broker_create_hc4cc_quote.feature
+++ b/features/brokers/broker_create_hc4cc_quote.feature
@@ -2,6 +2,7 @@ Feature: Broker HC4CC quote creation
     
   Background: Broker Quoting Tool
     Given the shop market configuration is enabled
+    And Broker HC4CC feature enabled
     And a CCA site exists with a benefit market
     And Health and Dental plans exist
     And there is a Broker Agency exists for District Brokers Inc

--- a/features/brokers/broker_create_hc4cc_quote.feature
+++ b/features/brokers/broker_create_hc4cc_quote.feature
@@ -1,0 +1,24 @@
+Feature: Broker HC4CC quote creation 
+    
+  Background: Broker Quoting Tool
+    Given the shop market configuration is enabled
+    And a CCA site exists with a benefit market
+    And Health and Dental plans exist
+    And there is a Broker Agency exists for District Brokers Inc
+    And the broker Max Planck is primary broker for District Brokers Inc
+    Given Max Planck logs on to the Broker Agency Portal
+    When Primary Broker clicks on the Employers tab
+    And Primary Broker clicks on the Add Prospect Employer button
+    And Primary Broker creates new Prospect Employer with default_office_location
+    Then Primary Broker should see successful message
+
+  Scenario: Broker should be able to create a quote for prospect employer with flexible rules
+    Given prospect employer exist for District Brokers Inc
+    And Primary broker clicks Actions dropdown and clicks Create Quote
+    And Primary Broker enters quote name
+    And Primary Broker should see HC4CC option
+    Then Primary Broker selects quote as HC4CCC quote
+    And Primary broker clicks on Select Health Benefits button
+    And Primary broker should see metal level non bronze options
+    And Primary broker selects plan offerings by metal level and enters 50 for employee and deps
+    And Primary broker publishes the quote and sees successful message of published quote

--- a/features/step_definitions/broker_employee_quote_steps.rb
+++ b/features/step_definitions/broker_employee_quote_steps.rb
@@ -371,6 +371,11 @@ And(/^Primary broker clicks Actions dropdown and clicks Assign General Agency$/)
   find(BrokerEmployersPage.assign_general_agency).click
 end
 
+And(/^Broker HC4CC feature enabled$/) do
+  EnrollRegistry[:broker_quote_hc4cc_subsidy].feature.stub(:is_enabled).and_return(true)
+  EnrollRegistry[:aca_shop_osse_subsidy].feature.stub(:is_enabled).and_return(true)
+end
+
 And(/^Primary Broker should see HC4CC option$/) do
   expect(page).to have_css('.panel', text: 'Healthcare4Childcare (HC4CC) Program')
 end

--- a/features/step_definitions/broker_employee_quote_steps.rb
+++ b/features/step_definitions/broker_employee_quote_steps.rb
@@ -360,6 +360,7 @@ end
 
 And(/^Primary broker clicks Actions dropdown and clicks Create Quote$/) do
   find(BrokerEmployersPage.actions_dropdown).click
+  wait_for_ajax
   expect(page).to have_css('.btn.btn-xs', text: 'Create Quote')
   find(BrokerEmployersPage.create_quote).click
 end
@@ -370,3 +371,16 @@ And(/^Primary broker clicks Actions dropdown and clicks Assign General Agency$/)
   find(BrokerEmployersPage.assign_general_agency).click
 end
 
+And(/^Primary Broker should see HC4CC option$/) do
+  expect(page).to have_css('.panel', text: 'Healthcare4Childcare (HC4CC) Program')
+end
+
+Then(/^Primary Broker selects quote as HC4CCC quote$/) do
+  find('#forms_plan_design_proposal_osse_eligibility_true').click
+  wait_for_ajax
+end
+
+And(/^Primary broker should see metal level non bronze options$/) do
+  expect(find_all('.benefits-setup-tab-bqt ul li').count).to eq 1
+  expect(find_all("input[name='metal_level_for_elected_plan']").collect(&:value)).not_to include('bronze')
+end

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -1034,8 +1034,8 @@ end
 
 When(/^(?:General){0}.+ clicks? on the ((?:General|Staff){0}.+) tab$/) do |tab_name|
   click_link 'HBX Portal' if page.has_link?('HBX Portal')
-  find(:xpath, "//li[contains(., '#{tab_name}')]", :wait => 10).click
-  wait_for_ajax
+  find(:xpath, "//li[contains(., '#{tab_name}')]", :wait => 5).click
+  sleep 5
 end
 
 When(/^(?:General){0}.+ clicks? on the ((?:General|Staff){0}.+) dropdown$/) do |tab_name|


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/184639823

# A brief description of the changes

Current behavior:

     Currently while creating quote we see all plan option choices

New behavior:

    For HC4CC quotes, we display only metal level options except bronze plan choices

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [x] DC
- [ ] ME
