### PR TITLE
clean whitespace around xml tags in CareFirst Pay Now payload

### DIFF
--- a/app/domain/operations/pay_now/care_first/embedded_xml.rb
+++ b/app/domain/operations/pay_now/care_first/embedded_xml.rb
@@ -16,7 +16,8 @@ module Operations
           cv3_members = yield transform_member_array(enrollment)
           payload = yield construct_payload(cv3_enrollment, cv3_members)
           xml_response = yield transform_xml(payload)
-          Success(xml_response)
+          cleaned_xml = yield clean_xml(xml_response)
+          Success(cleaned_xml)
         end
 
         private
@@ -50,6 +51,14 @@ module Operations
         def transform_xml(payload)
           xml_response = ::AcaEntities::PayNow::CareFirst::Operations::GenerateXml.new.call(payload)
           xml_response.success? ? xml_response : Failure("unable to create xml due to #{xml_response.failure}.")
+        end
+
+        def clean_xml(xml)
+          # clean xml of whitespace around tags
+          cleaned_xml = xml.gsub(/>\s+</, '><').strip
+          Success(cleaned_xml)
+        rescue StandardError => e
+          Failure("::Operations::PayNow::CareFirst::EmbeddedXml.clean_xml -> #{e}")
         end
       end
     end

--- a/spec/domain/operations/generate_saml_response_spec.rb
+++ b/spec/domain/operations/generate_saml_response_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Operations::GenerateSamlResponse do
     allow_any_instance_of(OneLogin::RubySaml::SamlGenerator).to receive(:encode_saml_response).and_return encode_saml_response
     allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
     allow(EnrollRegistry).to receive(:feature_enabled?).with(:validate_saml).and_return(false)
-    # allow(saml_validator).to receive_message_chain("new.call").and_return(Dry::Monads::Result::Success.new(:ok))
   end
 
   subject do

--- a/spec/domain/operations/pay_now/care_first/embedded_xml_spec.rb
+++ b/spec/domain/operations/pay_now/care_first/embedded_xml_spec.rb
@@ -29,10 +29,20 @@ RSpec.describe Operations::PayNow::CareFirst::EmbeddedXml do
                       consumer_role_id: family.primary_person.consumer_role.id,
                       enrollment_members: family.family_members)
   end
+  let(:custom_xml) do
+    "\n  <coverage_kind>urn:openhbx:terms:v1:qhp_benefit_coverage#health</coverage_kind>\n  <primary>\n    <exchange_assigned_member_id>50001279</exchange_assigned_member_id>"\
+    "\n    <member_name>\n      <person_surname>Smith</person_surname>\n      <person_given_name>Michelle</person_given_name>\n      <person_full_name>Michelle Smith"\
+    "</person_full_name>\n    </member_name>\n  </primary>\n  <members>\n    <member>\n      <exchange_assigned_member_id>50001279</exchange_assigned_member_id>\n      "\
+    "<member_name>\n        <person_surname>Smith</person_surname>\n        <person_given_name>Michelle</person_given_name>\n        <person_full_name>Michelle Smith"\
+    "</person_full_name>\n      </member_name>\n      <birth_date>19860401</birth_date>\n      <sex>F</sex>\n      <ssn>123456789</ssn>\n      <relationship>18</relationship>\n"\
+    "      <is_subscriber>false</is_subscriber>\n    </member>\n  </members>\n"
+  end
+
   context "valid payload is created" do
     before do
       allow(::AcaEntities::PayNow::CareFirst::Operations::GenerateXml).to receive_message_chain("new.call").and_return(Dry::Monads::Result::Success.new("sample xml"))
     end
+
     it "should return successful xml" do
       expect(described_class.new.call(enrollment)).to be_success
     end
@@ -42,8 +52,25 @@ RSpec.describe Operations::PayNow::CareFirst::EmbeddedXml do
     before do
       allow(::AcaEntities::PayNow::CareFirst::Operations::GenerateXml).to receive_message_chain("new.call").and_return(Dry::Monads::Result::Failure.new("unable to create xml"))
     end
+
     it "should return failure" do
       expect(described_class.new.call(enrollment)).to be_a(Dry::Monads::Result::Failure)
+    end
+  end
+
+  context "#clean_xml" do
+    subject { described_class.new.send(:clean_xml, custom_xml)  }
+
+    let(:cleaned_xml) do
+      "<coverage_kind>urn:openhbx:terms:v1:qhp_benefit_coverage#health</coverage_kind><primary><exchange_assigned_member_id>50001279</exchange_assigned_member_id><member_name>"\
+      "<person_surname>Smith</person_surname><person_given_name>Michelle</person_given_name><person_full_name>Michelle Smith</person_full_name></member_name></primary><members>"\
+      "<member><exchange_assigned_member_id>50001279</exchange_assigned_member_id><member_name><person_surname>Smith</person_surname><person_given_name>Michelle"\
+      "</person_given_name><person_full_name>Michelle Smith</person_full_name></member_name><birth_date>19860401</birth_date><sex>F</sex><ssn>123456789</ssn><relationship>18"\
+      "</relationship><is_subscriber>false</is_subscriber></member></members>"
+    end
+
+    it "should remove whitespace around the tags" do
+      expect(subject.value!).to eq cleaned_xml
     end
   end
 end

--- a/spec/domain/operations/pay_now/care_first/embedded_xml_spec.rb
+++ b/spec/domain/operations/pay_now/care_first/embedded_xml_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe Operations::PayNow::CareFirst::EmbeddedXml do
                       enrollment_members: family.family_members)
   end
   let(:custom_xml) do
-    "\n  <coverage_kind>urn:openhbx:terms:v1:qhp_benefit_coverage#health</coverage_kind>\n  <primary>\n    <exchange_assigned_member_id>50001279</exchange_assigned_member_id>"\
-    "\n    <member_name>\n      <person_surname>Smith</person_surname>\n      <person_given_name>Michelle</person_given_name>\n      <person_full_name>Michelle Smith"\
-    "</person_full_name>\n    </member_name>\n  </primary>\n  <members>\n    <member>\n      <exchange_assigned_member_id>50001279</exchange_assigned_member_id>\n      "\
-    "<member_name>\n        <person_surname>Smith</person_surname>\n        <person_given_name>Michelle</person_given_name>\n        <person_full_name>Michelle Smith"\
+    "\n  <coverage_kind>urn:openhbx:terms:v1:qhp_benefit_coverage#health</coverage_kind>\n  <primary>\n    <exchange_assigned_member_id>1234567</exchange_assigned_member_id>"\
+    "\n    <member_name>\n      <person_surname>Smith</person_surname>\n      <person_given_name>Test</person_given_name>\n      <person_full_name>Test Smith"\
+    "</person_full_name>\n    </member_name>\n  </primary>\n  <members>\n    <member>\n      <exchange_assigned_member_id>1234567</exchange_assigned_member_id>\n      "\
+    "<member_name>\n        <person_surname>Smith</person_surname>\n        <person_given_name>Test</person_given_name>\n        <person_full_name>Test Smith"\
     "</person_full_name>\n      </member_name>\n      <birth_date>19860401</birth_date>\n      <sex>F</sex>\n      <ssn>123456789</ssn>\n      <relationship>18</relationship>\n"\
     "      <is_subscriber>false</is_subscriber>\n    </member>\n  </members>\n"
   end
@@ -62,10 +62,10 @@ RSpec.describe Operations::PayNow::CareFirst::EmbeddedXml do
     subject { described_class.new.send(:clean_xml, custom_xml)  }
 
     let(:cleaned_xml) do
-      "<coverage_kind>urn:openhbx:terms:v1:qhp_benefit_coverage#health</coverage_kind><primary><exchange_assigned_member_id>50001279</exchange_assigned_member_id><member_name>"\
-      "<person_surname>Smith</person_surname><person_given_name>Michelle</person_given_name><person_full_name>Michelle Smith</person_full_name></member_name></primary><members>"\
-      "<member><exchange_assigned_member_id>50001279</exchange_assigned_member_id><member_name><person_surname>Smith</person_surname><person_given_name>Michelle"\
-      "</person_given_name><person_full_name>Michelle Smith</person_full_name></member_name><birth_date>19860401</birth_date><sex>F</sex><ssn>123456789</ssn><relationship>18"\
+      "<coverage_kind>urn:openhbx:terms:v1:qhp_benefit_coverage#health</coverage_kind><primary><exchange_assigned_member_id>1234567</exchange_assigned_member_id><member_name>"\
+      "<person_surname>Smith</person_surname><person_given_name>Test</person_given_name><person_full_name>Test Smith</person_full_name></member_name></primary><members>"\
+      "<member><exchange_assigned_member_id>1234567</exchange_assigned_member_id><member_name><person_surname>Smith</person_surname><person_given_name>Test"\
+      "</person_given_name><person_full_name>Test Smith</person_full_name></member_name><birth_date>19860401</birth_date><sex>F</sex><ssn>123456789</ssn><relationship>18"\
       "</relationship><is_subscriber>false</is_subscriber></member></members>"
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184640239

# A brief description of the changes

Current behavior:
The custom XML string generated for CareFirst Pay Now SAML assertions includes new line and space characters around the tags.

New behavior:
The custom XML string generated for CareFirst Pay Now SAML assertions does not have any whitespace characters around the tags.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: CAREFIRST_PAY_NOW_EMBED_XML_IS_ENABLED

- [x] DC
- [ ] ME
