### PR TITLE
only include residency_determined_at key if value is present

### DIFF
--- a/app/domain/operations/transformers/person_to/cv3_person.rb
+++ b/app/domain/operations/transformers/person_to/cv3_person.rb
@@ -203,7 +203,7 @@ module Operations
             local_residency_responses: resident_role.local_residency_responses,
             lawful_presence_determination: construct_lawful_presence_determination(resident_role.lawful_presence_determination)
           }
-          # only include residency_determined_at key if value is present in order to pass ResidentRoleContract validations
+          # only include residency_determined_at key if value is present in order to pass ResidentRoleContract fvalidations
           result.merge!(residency_determined_at: residency_determined_at) if residency_determined_at.present?
           result
         end

--- a/app/domain/operations/transformers/person_to/cv3_person.rb
+++ b/app/domain/operations/transformers/person_to/cv3_person.rb
@@ -193,16 +193,19 @@ module Operations
 
         def construct_resident_role(resident_role)
           return if resident_role.nil?
-          {
+          residency_determined_at = resident_role.residency_determined_at
+          result = {
             is_applicant: resident_role.is_applicant,
             is_active: resident_role.is_active,
             is_state_resident: resident_role.is_state_resident,
-            residency_determined_at: resident_role.residency_determined_at,
             contact_method: resident_role.contact_method,
             language_preference: resident_role.language_preference,
             local_residency_responses: resident_role.local_residency_responses,
             lawful_presence_determination: construct_lawful_presence_determination(resident_role.lawful_presence_determination)
           }
+          # only include residency_determined_at key if value is present in order to pass ResidentRoleContract validations
+          result.merge!(residency_determined_at: residency_determined_at) if residency_determined_at.present?
+          result
         end
 
         def construct_consumer_role(consumer_role)

--- a/spec/domain/operations/transformers/person_to/cv3_person_spec.rb
+++ b/spec/domain/operations/transformers/person_to/cv3_person_spec.rb
@@ -66,6 +66,11 @@ RSpec.describe ::Operations::Transformers::PersonTo::Cv3Person, dbclean: :after_
       it 'should not include the field in the output hash' do
         expect(subject.key?(:residency_determined_at)).to eq false
       end
+
+      it 'should be valid according to the ResdientRole contract' do
+        contract_result = ::AcaEntities::Contracts::People::ResidentRoleContract.new.call(subject)
+        expect(contract_result.errors).to be_empty
+      end
     end
 
     context 'when residency_determined_at field is not nil' do
@@ -78,6 +83,11 @@ RSpec.describe ::Operations::Transformers::PersonTo::Cv3Person, dbclean: :after_
       it 'should include the field and value in the output hash' do
         expect(subject.key?(:residency_determined_at)).to eq true
         expect(subject[:residency_determined_at]).to eq timestamp
+      end
+
+      it 'should be valid according to the ResdientRole contract' do
+        contract_result = ::AcaEntities::Contracts::People::ResidentRoleContract.new.call(subject)
+        expect(contract_result.errors).to be_empty
       end
     end
   end

--- a/spec/domain/operations/transformers/person_to/cv3_person_spec.rb
+++ b/spec/domain/operations/transformers/person_to/cv3_person_spec.rb
@@ -55,4 +55,30 @@ RSpec.describe ::Operations::Transformers::PersonTo::Cv3Person, dbclean: :after_
       end
     end
   end
+
+  describe '#construct_resident_role' do
+
+    let(:person) { create(:person, :with_resident_role) }
+
+    subject { ::Operations::Transformers::PersonTo::Cv3Person.new.construct_resident_role(person.resident_role) }
+
+    context 'when residency_determined_at field is nil' do
+      it 'should not include the field in the output hash' do
+        expect(subject.has_key?(:residency_determined_at)).to eq false
+      end
+    end
+
+    context 'when residency_determined_at field is not nil' do
+      let!(:timestamp) { Time.now }
+
+      before do
+        person.resident_role.update(residency_determined_at: timestamp)
+      end
+
+      it 'should include the field and value in the output hash' do
+        expect(subject.has_key?(:residency_determined_at)).to eq true
+        expect(subject[:residency_determined_at]).to eq timestamp
+      end
+    end
+  end
 end

--- a/spec/domain/operations/transformers/person_to/cv3_person_spec.rb
+++ b/spec/domain/operations/transformers/person_to/cv3_person_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ::Operations::Transformers::PersonTo::Cv3Person, dbclean: :after_
 
     context 'when residency_determined_at field is nil' do
       it 'should not include the field in the output hash' do
-        expect(subject.has_key?(:residency_determined_at)).to eq false
+        expect(subject.key?(:residency_determined_at)).to eq false
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe ::Operations::Transformers::PersonTo::Cv3Person, dbclean: :after_
       end
 
       it 'should include the field and value in the output hash' do
-        expect(subject.has_key?(:residency_determined_at)).to eq true
+        expect(subject.key?(:residency_determined_at)).to eq true
         expect(subject[:residency_determined_at]).to eq timestamp
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184780268

# A brief description of the changes

Current behavior:
The CV3 Person transform will add the key for the residency_determined_at field and set it to nil even if the document in the database does not have the field present.  This breaks validating the payload against the Person contract defined in aca_entities.

New behavior:
The residency_determined_at key is only added to the resident role hash in the CV3 Person transform if there is data stored in that field.  The resulting hash is valid according to the ResidentRole contract in aca_entities.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
