### PR TITLE
add report kind to transmission requested event

### DIFF
--- a/app/domain/operations/fdsh/h41_1095as/transmissions/create.rb
+++ b/app/domain/operations/fdsh/h41_1095as/transmissions/create.rb
@@ -6,13 +6,17 @@ module Operations
       module Transmissions
         # Send transmission request to generate h41 and 1095a
         class Create
-          send(:include, Dry::Monads[:result, :do, :try])
+          include Dry::Monads[:result, :do]
           include EventSource::Command
+
           REPORT_TYPES = %w[all original corrected void].freeze
+
+          REPORT_KINDS = %w[h41_and_1095a h41_only].freeze
 
           # @param [String] assistance_year
           # @param [Array] report_types
           # @param [Array] excluded_policies
+          # @param [String] report_kind default value 'h41_and_1095a'
           def call(params)
             values = yield validate(params)
             event = yield build_event(values)
@@ -25,6 +29,7 @@ module Operations
 
           def validate(params)
             params[:report_types]&.map!(&:to_s)
+            params[:report_kind] = 'h41_and_1095a' if params[:report_kind].blank?
 
             errors = []
             errors << 'assistance_year required' unless params[:assistance_year]
@@ -33,6 +38,7 @@ module Operations
                (params[:report_types] - REPORT_TYPES).any?
               errors << 'invalid report_types'
             end
+            errors << 'invalid report_kind' if REPORT_KINDS.exclude?(params[:report_kind])
 
             return Failure(errors) if errors.present?
             Success(params)
@@ -46,7 +52,7 @@ module Operations
                   allow_list: values[:allow_list],
                   deny_list: values[:deny_list]
                 },
-                headers: values.slice(:assistance_year, :report_types)
+                headers: values.slice(:assistance_year, :report_types, :report_kind)
               )
 
             Success(event.success)
@@ -55,7 +61,7 @@ module Operations
           def publish(event)
             event.publish
 
-            Success('Successfully published the payload to fdsh_gateway')
+            Success("Successfully published the payload for event with name: #{event.name}")
           end
         end
       end

--- a/app/domain/operations/fdsh/h41_1095as/transmissions/create.rb
+++ b/app/domain/operations/fdsh/h41_1095as/transmissions/create.rb
@@ -11,12 +11,12 @@ module Operations
 
           REPORT_TYPES = %w[all original corrected void].freeze
 
-          REPORT_KINDS = %w[h41_and_1095a h41_only].freeze
+          REPORT_KINDS = %w[h41_1095a h41].freeze
 
           # @param [String] assistance_year
           # @param [Array] report_types
           # @param [Array] excluded_policies
-          # @param [String] report_kind default value 'h41_and_1095a'
+          # @param [String] report_kind default value 'h41_1095a'
           def call(params)
             values = yield validate(params)
             event = yield build_event(values)
@@ -29,7 +29,7 @@ module Operations
 
           def validate(params)
             params[:report_types]&.map!(&:to_s)
-            params[:report_kind] = 'h41_and_1095a' if params[:report_kind].blank?
+            params[:report_kind] = 'h41_1095a' if params[:report_kind].blank?
 
             errors = []
             errors << 'assistance_year required' unless params[:assistance_year]

--- a/spec/domain/operations/fdsh/h41_1095as/transmissions/create_spec.rb
+++ b/spec/domain/operations/fdsh/h41_1095as/transmissions/create_spec.rb
@@ -51,16 +51,16 @@ RSpec.describe ::Operations::Fdsh::H411095as::Transmissions::Create do
       end
     end
 
-    context 'with h41_and_1095a as report_kind' do
-      let(:report_kind) { 'h41_and_1095a' }
+    context 'with h41_1095a as report_kind' do
+      let(:report_kind) { 'h41_1095a' }
 
       it 'should publish event successfully' do
         expect(result.success).to eq(event_name)
       end
     end
 
-    context 'with h41_only as report_kind' do
-      let(:report_kind) { 'h41_only' }
+    context 'with h41 as report_kind' do
+      let(:report_kind) { 'h41' }
 
       it 'should publish event successfully' do
         expect(result.success).to eq(event_name)

--- a/spec/domain/operations/fdsh/h41_1095as/transmissions/create_spec.rb
+++ b/spec/domain/operations/fdsh/h41_1095as/transmissions/create_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe ::Operations::Fdsh::H411095as::Transmissions::Create do
-  send(:include, Dry::Monads[:result, :do, :try])
   subject { described_class.new }
 
   context 'with invalid params' do
@@ -30,19 +29,42 @@ RSpec.describe ::Operations::Fdsh::H411095as::Transmissions::Create do
   end
 
   context 'when valid params passed' do
+    let(:result) { subject.call(params) }
+
     let(:params) do
       {
         assistance_year: Date.today.year,
         report_types: ['original'],
         allow_list: ['523232'],
-        deny_list: ['523232']
+        deny_list: ['523232'],
+        report_kind: report_kind
       }
     end
 
-    it 'should publish event successfully' do
-      result = subject.call(params)
+    let(:event_name) { 'Successfully published the payload for event with name: events.h411095as.transmission_requested' }
 
-      expect(result.success?).to be_truthy
+    context 'without a report_kind' do
+      let(:report_kind) { nil }
+
+      it 'should publish event successfully' do
+        expect(result.success).to eq(event_name)
+      end
+    end
+
+    context 'with h41_and_1095a as report_kind' do
+      let(:report_kind) { 'h41_and_1095a' }
+
+      it 'should publish event successfully' do
+        expect(result.success).to eq(event_name)
+      end
+    end
+
+    context 'with h41_only as report_kind' do
+      let(:report_kind) { 'h41_only' }
+
+      it 'should publish event successfully' do
+        expect(result.success).to eq(event_name)
+      end
     end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: ME-184811647

# A brief description of the changes

Current behavior: Currently, when we trigger a build transmission event it will generate both H41s and 1095As.

New behavior: report_kind attribute is added to the build transmission event which will allow us to generate H41s only or H41s & 1095As

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
