### PR TITLE
reconfigure enrollment details view for only admin

### DIFF
--- a/app/helpers/config/aca_helper.rb
+++ b/app/helpers/config/aca_helper.rb
@@ -380,8 +380,10 @@ module Config::AcaHelper
   def display_enr_summary_is_enabled(enrollment)
     if EnrollRegistry.feature_enabled?(:display_enr_summary)
       return true if enrollment.hbx_enrollment_members.all? { |member| member.person != current_user.person }
+    elsif current_user.has_hbx_staff_role?
+      true
     else
-      return true if current_user.has_hbx_staff_role?
+      false
     end
   end
 end

--- a/app/helpers/config/aca_helper.rb
+++ b/app/helpers/config/aca_helper.rb
@@ -378,6 +378,10 @@ module Config::AcaHelper
   end
 
   def display_enr_summary_is_enabled(enrollment)
-    EnrollRegistry.feature_enabled?(:display_enr_summary) && enrollment.hbx_enrollment_members.all? { |member| member.person != current_user.person }
+    if EnrollRegistry.feature_enabled?(:display_enr_summary)
+      return true if enrollment.hbx_enrollment_members.all? { |member| member.person != current_user.person }
+    else
+      return true if current_user.has_hbx_staff_role?
+    end
   end
 end

--- a/spec/views/ui-components/v1/cards/_summary.html.slim_spec.rb
+++ b/spec/views/ui-components/v1/cards/_summary.html.slim_spec.rb
@@ -264,6 +264,35 @@ RSpec.describe "_summary.html.slim.rb", :type => :view, dbclean: :after_each  do
       expect(rendered).to_not have_content(hbx_enrollment_member.person.full_name.titleize)
     end
   end
+
+  context 'for display of enrollment additional summary with consumer with feature disabled' do
+    before do
+      allow(view).to receive(:display_carrier_logo).and_return('logo/carrier/uhic.jpg')
+      sign_in user
+      render 'ui-components/v1/cards/summary', :qhp => mock_qhp_cost_share_variance
+    end
+
+    it 'should not include enrollment effective_on text' do
+      expect(rendered).to_not have_content(l10n('enrollment.effective_on'))
+    end
+
+    it 'should not include latest transition text' do
+      expect(rendered).to_not have_content(l10n('enrollment.latest_transition'))
+    end
+
+    it 'should not include Product HIOS ID text' do
+      expect(rendered).to_not have_content(l10n('product_hios_id'))
+    end
+
+    it 'should not include RatingArea text' do
+      expect(rendered).to_not have_content(l10n('rating_area.exchange_provided_code'))
+    end
+
+    it 'should not include full name of person' do
+      expect(rendered).to_not have_content(hbx_enrollment_member.person.full_name.titleize)
+    end
+  end
+
   context 'for display of enrollment additional summary with broker' do
     let(:broker_user) { FactoryBot.create(:user, person: broker_person) }
     let(:broker_person) {FactoryBot.create(:person, :with_broker_role)}
@@ -280,24 +309,54 @@ RSpec.describe "_summary.html.slim.rb", :type => :view, dbclean: :after_each  do
       render 'ui-components/v1/cards/summary', :qhp => mock_qhp_cost_share_variance
     end
 
-    it 'should not include enrollment effective_on text' do
+    it 'should include enrollment effective_on text' do
       expect(rendered).to have_content(l10n('enrollment.effective_on'))
     end
 
-    it 'should not include latest transition text' do
+    it 'should include latest transition text' do
       expect(rendered).to have_content(l10n('enrollment.latest_transition'))
     end
 
-    it 'should not include Product HIOS ID text' do
+    it 'should include Product HIOS ID text' do
       expect(rendered).to have_content(l10n('product_hios_id'))
     end
 
-    it 'should not include RatingArea text' do
+    it 'should include RatingArea text' do
       expect(rendered).to have_content(l10n('rating_area.exchange_provided_code'))
     end
 
-    it 'should not include full name of person' do
+    it 'should include full name of person' do
       expect(rendered).to have_content(hbx_enrollment_member.person.full_name.titleize)
+    end
+  end
+
+  context 'for display of enrollment additional summary with broker and feature flag is disabled' do
+    let(:broker_user) { FactoryBot.create(:user, person: broker_person) }
+    let(:broker_person) {FactoryBot.create(:person, :with_broker_role)}
+    before do
+      allow(view).to receive(:display_carrier_logo).and_return('logo/carrier/uhic.jpg')
+      sign_in broker_user
+      render 'ui-components/v1/cards/summary', :qhp => mock_qhp_cost_share_variance
+    end
+
+    it 'should not include enrollment effective_on text' do
+      expect(rendered).to_not have_content(l10n('enrollment.effective_on'))
+    end
+
+    it 'should not include latest transition text' do
+      expect(rendered).to_not have_content(l10n('enrollment.latest_transition'))
+    end
+
+    it 'should not include Product HIOS ID text' do
+      expect(rendered).to_not have_content(l10n('product_hios_id'))
+    end
+
+    it 'should not include RatingArea text' do
+      expect(rendered).to_not have_content(l10n('rating_area.exchange_provided_code'))
+    end
+
+    it 'should not include full name of person' do
+      expect(rendered).to_not have_content(hbx_enrollment_member.person.full_name.titleize)
     end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/101306

# A brief description of the changes

Current behavior: In the DC context, brokers are able to see enrollment details

New behavior: Brokers will not be able to see enrollment details when they select 'more details'

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
