### PR TITLE
add pdf export for quote employee costs

### DIFF
--- a/components/sponsored_benefits/app/assets/stylesheets/plan_review_pdf.scss
+++ b/components/sponsored_benefits/app/assets/stylesheets/plan_review_pdf.scss
@@ -76,3 +76,9 @@
     display:none;
   }
 }
+
+.panel-heading {
+  h3 {
+    color:$primary-green;
+  }
+}

--- a/components/sponsored_benefits/app/helpers/sponsored_benefits/application_helper.rb
+++ b/components/sponsored_benefits/app/helpers/sponsored_benefits/application_helper.rb
@@ -16,5 +16,9 @@ module SponsoredBenefits
     def eligibility_criteria(employer)
       # toDo - See why do we have this dependency in DC.
     end
+
+    def disable_employee_costs_download?
+      %w[plan_exports plan_reviews].include?(controller_name)
+    end
   end
 end

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_employee_costs.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_employee_costs.html.erb
@@ -1,0 +1,47 @@
+<%= stylesheet_link_tag wicked_pdf_asset_base64("plan_review_pdf") %>
+
+<div class="container plan-details-export">
+  <div class="row">
+    <div class="col-md-12 no-pd">
+        <div class="panel panel-default">
+          <div class="panel-body">
+            <h1 class="main-title">Quote Name: <%= plan_design_proposal.title %></h1>
+            <h5>Claim Code: <% plan_design_proposal.claim_code %></h5>
+            <h5>Effective Date: <%= plan_design_proposal.effective_date.strftime('%d %B %Y') %></h5>
+          </div>
+        </div>
+    </div>
+  </div>
+
+  <%= render 'reference_plan', sponsorship: sponsorship %>
+  <% unless @benefit_group.sole_source? %>
+    <%= render 'employee_premiums_table', benefit_group: @benefit_group %>
+  <% end %>
+
+  <br/>
+  <% if @dental_plan = @benefit_group.dental_reference_plan %>
+  <div class="row">
+    <div class="panel col-xs-12">
+      <table class="table table-striped">
+        <tr>
+          <th>Reference Plan</th>
+          <th>Carrier</th>
+          <th>Type</th>
+          <th>Metal Level</th>
+          <th>Offering By</th>
+        </tr>
+        <tbody>
+          <tr>
+            <td><%= @dental_plan.name %></td>
+            <td><%= @dental_plan.carrier_profile.legal_name %></td>
+            <td><%= @dental_plan.plan_type.upcase %></td>
+            <td><%= @dental_plan.metal_level.capitalize %></td>
+            <td><%= Settings.plan_option_titles.send(@benefit_group.dental_plan_option_kind.to_sym) %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <%= render 'employee_premiums_table' %>
+  <% end %>
+</div>

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_employee_costs.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_employee_costs.html.erb
@@ -3,11 +3,13 @@
 <div class="container plan-details-export">
   <div class="row">
     <div class="col-md-12 no-pd">
-        <div class="panel panel-default">
+        <div class="panel">
           <div class="panel-body">
             <h1 class="main-title">Quote Name: <%= plan_design_proposal.title %></h1>
             <h5>Claim Code: <% plan_design_proposal.claim_code %></h5>
             <h5>Effective Date: <%= plan_design_proposal.effective_date.strftime('%d %B %Y') %></h5>
+
+            <p>Costs are based on the roster associated with this quote: <%= plan_design_proposal.active_census_employees.count %> employee(s) and <%= plan_design_proposal.active_census_familes.count %> families</p>
           </div>
         </div>
     </div>
@@ -18,30 +20,45 @@
     <%= render 'employee_premiums_table', benefit_group: @benefit_group %>
   <% end %>
 
-  <br/>
   <% if @dental_plan = @benefit_group.dental_reference_plan %>
   <div class="row">
-    <div class="panel col-xs-12">
-      <table class="table table-striped">
-        <tr>
-          <th>Reference Plan</th>
-          <th>Carrier</th>
-          <th>Type</th>
-          <th>Metal Level</th>
-          <th>Offering By</th>
-        </tr>
-        <tbody>
-          <tr>
-            <td><%= @dental_plan.name %></td>
-            <td><%= @dental_plan.carrier_profile.legal_name %></td>
-            <td><%= @dental_plan.plan_type.upcase %></td>
-            <td><%= @dental_plan.metal_level.capitalize %></td>
-            <td><%= Settings.plan_option_titles.send(@benefit_group.dental_plan_option_kind.to_sym) %></td>
-          </tr>
-        </tbody>
-      </table>
+    <div class="col-md-12 no-pd">
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <table class="table table-striped">
+            <tr>
+              <th>Reference Plan</th>
+              <th>Carrier</th>
+              <th>Type</th>
+              <th>Metal Level</th>
+              <th>Offering By</th>
+            </tr>
+            <tbody>
+              <tr>
+                <td><%= @dental_plan.name %></td>
+                <td><%= @dental_plan.carrier_profile.legal_name %></td>
+                <td><%= @dental_plan.plan_type.upcase %></td>
+                <td><%= @dental_plan.metal_level.capitalize %></td>
+                <td><%= Settings.plan_option_titles.send(@benefit_group.dental_plan_option_kind.to_sym) %></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
-  <%= render 'employee_premiums_table' %>
+
+  <div class="row">
+    <div class="col-md-12 no-pd">
+      <div class="panel panel-default">
+        <div class="panel-heading custom-heading">
+          <h3 class="panel-title">Employee Costs - Dental Benefits</h3>
+        </div>
+        <div class="panel-body">
+          <%= render 'sponsored_benefits/organizations/plan_design_proposals/shared/dental_benefit_group_cost_summary', benefit_group: @benefit_group,  benefit_group_dental_costs: @benefit_group_dental_costs %>
+        </div>
+      </div>
+    </div>
+  </div>
   <% end %>
 </div>

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_employee_premiums_table.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_employee_premiums_table.html.erb
@@ -1,0 +1,13 @@
+<div class="row">
+  <div class="col-md-12 no-pd">
+    <div class="panel panel-default">
+      <div class="panel-heading custom-heading">
+        <h3 class="panel-title">Employee Costs</h3>
+      </div>
+      <div class="panel-body">
+        <%= render 'sponsored_benefits/organizations/plan_design_proposals/shared/benefit_group_cost_summary', benefit_group: benefit_group %>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_employees_list.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_employees_list.html.erb
@@ -1,0 +1,25 @@
+<div class="row">
+  <div class="panel col-xs-12 no-pd">
+    <table class="table table-striped">
+      <tr>
+        <th>First Name</th>
+        <th>Last Name</th>
+        <th>Relationship Name</th>
+      </tr>
+      <% plan_design_proposal.active_census_employees.each do |employee| %>
+          <tr class="employee">
+            <td><%= employee.first_name %></td>
+            <td><%= employee.last_name %></td>
+            <td><%= employee.employee_relationship %></td>
+          </tr>
+          <% employee.census_dependents.each do |dependent| %>
+            <tr class="dependent">
+              <td><%= dependent.first_name %></td>
+              <td><%= dependent.last_name %></td>
+              <td><%= dependent.employee_relationship %></td>
+            </tr>
+          <% end %>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_plan_details.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_plan_details.html.erb
@@ -10,57 +10,10 @@
       <p>Costs are based on the roster associated with this quote: <%= plan_design_proposal.active_census_employees.count %> employee(s) and <%= plan_design_proposal.active_census_familes.count %> families</p>
     </div>
   </div>
-  <div class="row">
-    <div class="panel col-xs-12">
-      <table class="table table-striped">
-        <tr>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>Relationship Name</th>
-        </tr>
-        <% plan_design_proposal.active_census_employees.each do |employee| %>
-          <tr class="employee">
-            <td><%= employee.first_name %></td>
-            <td><%= employee.last_name %></td>
-            <td><%= employee.employee_relationship %></td>
-          </tr>
-          <% employee.census_dependents.each do |dependent| %>
-            <tr class="dependent">
-              <td><%= dependent.first_name %></td>
-              <td><%= dependent.last_name %></td>
-              <td><%= dependent.employee_relationship %></td>
-            </tr>
-          <% end %>
-        <% end %>
-      </table>
-    </div>
-  </div>
 
-  <div class="row">
-    <div class="panel col-xs-12">
-      <h5>Coverage Year: <%= sponsorship.initial_enrollment_period_to_s %></h5>
-      <table class="table table-striped">
-        <tr>
-          <th>Reference Plan</th>
-          <th>Carrier</th>
-          <th>Type</th>
-          <th>Metal Level</th>
-          <th><%= l10n('standard_plan') %></th>
-          <th>Offering By</th>
-        </tr>
-        <tbody>
-          <tr>
-            <td><%= @plan.name %></td>
-            <td><%= @plan.carrier_profile.legal_name %></td>
-            <td><%= @plan.plan_type.upcase %></td>
-            <td><%= @plan.metal_level.capitalize %></td>
-            <td><%= display_standard_plan(@plan) %></td>
-            <td><%= Settings.plan_option_titles.send(@benefit_group.plan_option_kind.to_sym) %></td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
+  <%= render 'employees_list', plan_design_proposal: plan_design_proposal %>
+  <%= render 'reference_plan', sponsorship: sponsorship %>
+
   <div class="row">
     <div class="panel col-xs-12">
       <% if @benefit_group.plan_option_kind != 'sole_source' %>
@@ -98,6 +51,7 @@
       </div>
     </div>
   </div>
+
   <% if sbc_included %>
     <%= render 'sponsored_benefits/organizations/plan_design_proposals/plan_comparisons/export', qhps: @qhps, single_plan_displayed: true %>
   <% end %>
@@ -125,7 +79,6 @@
       </table>
     </div>
   </div>
-
   <div class="row">
     <div class="panel col-xs-12">
       <%= render 'sponsored_benefits/organizations/plan_design_proposals/shared/employee_traditional_costs', relationship_benefits: @benefit_group.dental_relationship_benefits, coverage_kind: :dental %>

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_reference_plan.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_exports/_reference_plan.html.erb
@@ -1,0 +1,29 @@
+<div class="row">
+  <div class="col-md-12 no-pd">
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <h5>Coverage Year: <%= sponsorship.initial_enrollment_period_to_s %></h5>
+        <table class="table table-striped">
+          <tr>
+            <th>Reference Plan</th>
+            <th>Carrier</th>
+            <th>Type</th>
+            <th>Metal Level</th>
+            <th><%= l10n('standard_plan') %></th>
+            <th>Offering By</th>
+          </tr>
+          <tbody>
+            <tr>
+            <td><%= @plan.name %></td>
+            <td><%= @plan.carrier_profile.legal_name %></td>
+            <td><%= @plan.plan_type.upcase %></td>
+            <td><%= @plan.metal_level.capitalize %></td>
+            <td><%= display_standard_plan(@plan) %></td>
+            <td><%= Settings.plan_option_titles.send(@benefit_group.plan_option_kind.to_sym) %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_reviews/_new.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_reviews/_new.html.erb
@@ -97,116 +97,88 @@
         <%= render 'sponsored_benefits/organizations/plan_design_proposals/plan_comparisons/comparison_table', qhps: @qhps, single_plan_displayed: true %>
       </div>
     </div>
+  </div>
     <br />
 		<% if @benefit_group.dental_reference_plan.present? %>
-    <div class="panel panel-default">
-      <div class="panel-body">
-        <div class="col-md-2">
-          <i class="fa fa-star fa-5x pr-star" aria-hidden="true"></i>
+    <div class="col-md-12 no-pd">
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <div class="col-md-2">
+            <i class="fa fa-star fa-5x pr-star" aria-hidden="true"></i>
+          </div>
+          <div class="col-md-10">
+            <h3><%= @benefit_group.dental_reference_plan.name %></h3>
+            <a class="pull-right toggle-text" data-toggle="collapse" href="#collapseDental" aria-expanded="true">Hide Details</a>
+            <div class="collapse in" id="collapseDental">
+              <table class="table borderless">
+                <tbody>
+                  <tr class="borderless">
+                    <th style="width:150px" class="th-gray">Coverage Year</th>
+                      <td><%#= @benefit_group.benefit_application.benefit_sponsorship.initial_enrollment_period_to_s %></td>
+                  </tr>
+                  <tr class="borderless">
+                    <th style="width:150px" class="th-gray">Eligibility</th>
+                    <td><%#= @benefit_group.dental_reference_plan.effective_title_by_offset %></td>
+                  </tr>
+                </tbody>
+              </table>
+              <table class="table borderless">
+                <tbody>
+                  <tr class="borderless">
+                    <th class="th-gray">Reference Plan</th>
+                    <th class="th-gray">Carrier</th>
+                    <th class="th-gray">Type</th>
+                    <th class="th-gray">Metal Level</th>
+                    <th class="th-gray">Plans By</th>
+                  </tr>
+                  <tr class="borderless">
+                    <td><%= @benefit_group.dental_reference_plan.name %></td>
+                    <td><%= @benefit_group.dental_reference_plan.carrier_profile.legal_name %></td>
+                    <td><%= @benefit_group.dental_reference_plan.plan_type.upcase %></td>
+                    <td><%= @benefit_group.dental_reference_plan.metal_level.capitalize %></td>
+                    <td><%#= @benefit_group.dental_reference_plan.plan_option_kind.humanize %></td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="col-md-12 no-pd">
+                <%= render 'sponsored_benefits/organizations/plan_design_proposals/shared/employee_traditional_costs', relationship_benefits: @benefit_group.dental_relationship_benefits, coverage_kind: :dental %>
+              </div>
+              <br />
+              <div class="col-md-4 no-pd">
+                <p class="th-gray">Employer Estimated Maximum Monthly Cost</p>
+                <h3 class="text-center"><%= number_to_currency(@employer_dental_contribution_amount) %></h3>
+              </div>
+              <div class="col-md-8">
+                <table class="table borderless">
+                  <tbody>
+                    <tr class="border-bottom">
+                      <th style="width:490px"></th>
+                      <th class="th-gray" style="width:200px">Min</th>
+                      <th class="th-gray" style="width:200px">Max</th>
+                    </tr>
+                    <tr>
+                      <td style="width:490px">Total Estimated Monthly Cost for Plan Participants</td>
+                      <td style="width:200px"><%= number_to_currency(@benefit_group_dental_costs[:lowest_plan_employer_cost]) %></td>
+                      <td style="width:200px"><%= number_to_currency(@benefit_group_dental_costs[:highest_plan_employer_cost]) %></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+      </div>
+    </div>
+
+    <div class="col-md-12 no-pd">
+      <div class="panel panel-default">
+        <div class="panel-heading custom-heading">
+          <h3 class="panel-title">Employee Costs - Dental Benefits</h3>
         </div>
-        <div class="col-md-10">
-          <h3><%= @benefit_group.dental_reference_plan.name %></h3>
-          <a class="pull-right toggle-text" data-toggle="collapse" href="#collapseDental" aria-expanded="true">Hide Details</a>
-          <div class="collapse in" id="collapseDental">
-          <table class="table borderless">
-            <tbody>
-              <tr class="borderless">
-                <th style="width:150px" class="th-gray">Coverage Year</th>
-                  <td><%#= @benefit_group.benefit_application.benefit_sponsorship.initial_enrollment_period_to_s %></td>
-              </tr>
-              <tr class="borderless">
-                <th style="width:150px" class="th-gray">Eligibility</th>
-                <td><%#= @benefit_group.dental_reference_plan.effective_title_by_offset %></td>
-              </tr>
-            </tbody>
-          </table>
-          <table class="table borderless">
-            <tbody>
-              <tr class="borderless">
-                <th class="th-gray">Reference Plan</th>
-                <th class="th-gray">Carrier</th>
-                <th class="th-gray">Type</th>
-                <th class="th-gray">Metal Level</th>
-                <th class="th-gray">Plans By</th>
-              </tr>
-              <tr class="borderless">
-                <td><%= @benefit_group.dental_reference_plan.name %></td>
-                <td><%= @benefit_group.dental_reference_plan.carrier_profile.legal_name %></td>
-                <td><%= @benefit_group.dental_reference_plan.plan_type.upcase %></td>
-                <td><%= @benefit_group.dental_reference_plan.metal_level.capitalize %></td>
-                <td><%#= @benefit_group.dental_reference_plan.plan_option_kind.humanize %></td>
-              </tr>
-            </tbody>
-          </table>
-          <div class="col-md-12 no-pd">
-            <%= render 'sponsored_benefits/organizations/plan_design_proposals/shared/employee_traditional_costs', relationship_benefits: @benefit_group.dental_relationship_benefits, coverage_kind: :dental %>
-          </div>
-          <br />
-          <div class="col-md-4 no-pd">
-            <p class="th-gray">Employer Estimated Maximum Monthly Cost</p>
-            <h3 class="text-center"><%= number_to_currency(@employer_dental_contribution_amount) %></h3>
-          </div>
-          <div class="col-md-8">
-            <table class="table borderless">
-              <tbody>
-                <tr class="border-bottom">
-                  <th style="width:490px"></th>
-                  <th class="th-gray" style="width:200px">Min</th>
-                  <th class="th-gray" style="width:200px">Max</th>
-                </tr>
-                <tr>
-                  <td style="width:490px">Total Estimated Monthly Cost for Plan Participants</td>
-                  <td style="width:200px"><%= number_to_currency(@benefit_group_dental_costs[:lowest_plan_employer_cost]) %></td>
-                  <td style="width:200px"><%= number_to_currency(@benefit_group_dental_costs[:highest_plan_employer_cost]) %></td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+        <div class="panel-body">
+          <%= render 'sponsored_benefits/organizations/plan_design_proposals/shared/dental_benefit_group_cost_summary', benefit_group: @benefit_group,  benefit_group_dental_costs: @benefit_group_dental_costs %>
         </div>
       </div>
     </div>
-    </div>
-
-		<div class="panel panel-default">
-			<div class="panel-heading custom-heading">
-				<h3 class="panel-title">Employee Costs - Dental Benefits</h3>
-			</div>
-			<div class="panel-body">
-				<label>Plan Offerings - <%= @benefit_group.dental_reference_plan.name %></label><br />
-        <!-- For dental we allow single_plan choice only. lowest cost plan and highest cost plan are same -->        
-        <label>Employer Lowest/Reference/Highest - <%= number_to_currency(@benefit_group_dental_costs[:lowest_plan_employer_cost]) %>/<%= number_to_currency(@benefit_group_dental_costs[:ref_plan_employer_cost]) %>/<%= number_to_currency(@benefit_group_dental_costs[:highest_plan_employer_cost]) %></label>
-		    <table class="table table-bg-white table-employee-2">
-		      <thead>
-		        <tr>
-		          <th class="text-left">Employee</th>
-		          <th class="text-center">Dependent Count</th>
-              <% if @benefit_group.dental_plan_option_kind != "single_plan" %>
-                <th class="text-right">Lowest Cost Available Plan</th>
-              <% end %>
-		          <th class="text-right">Reference Plan</th>
-              <% if @benefit_group.dental_plan_option_kind != "single_plan" %>
-                <th class="text-right">Highest Cost Available Plan</th>
-              <% end %>
-		        </tr>
-		      </thead>
-		      <tbody id="employee_index_scroll">
-            <% @benefit_group.census_employees.active.each do |census_employee| %>
-              <tr>
-                <td class="text-left"> <%= census_employee.full_name %></td>
-                <td class="text-center"> <%= census_employee.census_dependents.count %></td>
-                <% if @benefit_group.dental_plan_option_kind != "single_plan" %>
-                  <td class="text-right"> <%= number_to_currency(@benefit_group_dental_costs[census_employee.id][:lowest_plan_cost]) %></td>
-                <% end %>
-                <td class="text-right"> <%= number_to_currency(@benefit_group_dental_costs[census_employee.id][:ref_plan_cost]) %></td>
-                <% if @benefit_group.dental_plan_option_kind != "single_plan" %>
-                  <td class="text-right"> <%= number_to_currency(@benefit_group_dental_costs[census_employee.id][:highest_plan_cost]) %></td>
-                <% end %>
-              </tr>
-            <% end %>
-          </tbody>
-		    </table>
-			</div>
-		</div>
 		<% end %>
   </div>
   <div class="col-md-6 col-md-offset-5">

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_selections/_plan_selection_form.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/plan_selections/_plan_selection_form.html.erb
@@ -122,7 +122,7 @@
           <br />
           <a class="text-center employee-details-text" data-toggle="collapse" href="#collapseExample" aria-expanded="true" >Show Details</a>
         </div>
-        <div class="collapse" id="collapseExample">
+        <div class="collapse col-md-12" id="collapseExample">
           <div class="employee-costs"></div>
         </div>
       </div>

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/shared/_benefit_group_cost_summary.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/shared/_benefit_group_cost_summary.html.erb
@@ -1,7 +1,9 @@
+<% plan_export_default_class ||= "plan-not-saved" %>
+<% plan ||= @service.reference_plan %>
 <% kind ||= "health" %>
 <% benefit_group_costs ||= @benefit_group_costs %>
 <div class="row">
-  <div id="scroll_container" class="col-xs-12">
+  <div id="scroll_container" class="col-md-8">
     <div>
       <label class="plan-offerings">Plan Offerings - <%= render_plan_offerings(benefit_group, kind) %></label>
     </div>
@@ -13,7 +15,13 @@
           <div><%= l10n('highest_cost_plan') %> - <%= benefit_group_costs[:highest_plan_name] %> - <%= number_to_currency(benefit_group_costs[:highest_plan_employer_cost]) %></div>            
       <% end %>
     </div>
-    <br />
+  </div>
+  <div id="scroll_container" class="col-md-4">
+    <div class="text-center">
+      <a class="btn btn-default <%= plan_export_default_class %> downloadEmployeeCostsDetailsButton <%= disable_employee_costs_download? ? " hidden" : " enabled" %>" data-kind=<%= plan.coverage_kind %> onclick="downloadPdf(event, this)" href=<%= sponsored_benefits.employee_costs_organizations_plan_design_proposal_plan_exports_path(@plan_design_proposal) %>>Download PDF</a>
+    </div>
+  </div>
+  <div id="scroll_container" class="col-md-12">
     <table class="table table-bg-white table-employee-2">
       <thead>
         <tr>

--- a/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/shared/_dental_benefit_group_cost_summary.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/organizations/plan_design_proposals/shared/_dental_benefit_group_cost_summary.html.erb
@@ -1,0 +1,33 @@
+<label>Plan Offerings - <%= benefit_group.dental_reference_plan.name %></label><br />
+<!-- For dental we allow single_plan choice only. lowest cost plan and highest cost plan are same -->        
+<label>Employer Lowest/Reference/Highest - <%= number_to_currency(benefit_group_dental_costs[:lowest_plan_employer_cost]) %>/<%= number_to_currency(benefit_group_dental_costs[:ref_plan_employer_cost]) %>/<%= number_to_currency(benefit_group_dental_costs[:highest_plan_employer_cost]) %></label>
+<table class="table table-bg-white table-employee-2">
+    <thead>
+    <tr>
+        <th class="text-left">Employee</th>
+        <th class="text-center">Dependent Count</th>
+    <% if benefit_group.dental_plan_option_kind != "single_plan" %>
+    <th class="text-right">Lowest Cost Available Plan</th>
+    <% end %>
+        <th class="text-right">Reference Plan</th>
+    <% if benefit_group.dental_plan_option_kind != "single_plan" %>
+    <th class="text-right">Highest Cost Available Plan</th>
+    <% end %>
+    </tr>
+    </thead>
+    <tbody id="employee_index_scroll">
+<% benefit_group.census_employees.active.each do |census_employee| %>
+    <tr>
+    <td class="text-left"> <%= census_employee.full_name %></td>
+    <td class="text-center"> <%= census_employee.census_dependents.count %></td>
+    <% if benefit_group.dental_plan_option_kind != "single_plan" %>
+        <td class="text-right"> <%= number_to_currency(benefit_group_dental_costs[census_employee.id][:lowest_plan_cost]) %></td>
+    <% end %>
+    <td class="text-right"> <%= number_to_currency(benefit_group_dental_costs[census_employee.id][:ref_plan_cost]) %></td>
+    <% if benefit_group.dental_plan_option_kind != "single_plan" %>
+        <td class="text-right"> <%= number_to_currency(benefit_group_dental_costs[census_employee.id][:highest_plan_cost]) %></td>
+    <% end %>
+    </tr>
+<% end %>
+</tbody>
+</table>

--- a/components/sponsored_benefits/config/routes.rb
+++ b/components/sponsored_benefits/config/routes.rb
@@ -55,8 +55,10 @@ SponsoredBenefits::Engine.routes.draw do
       post :publish
 
       resources :plan_exports, controller: 'plan_design_proposals/plan_exports', only: [:create] do
+        collection do
+          post :employee_costs
+        end
       end
-
     end
 
     resource :office_locations do

--- a/features/brokers/broker_create_hc4cc_quote.feature
+++ b/features/brokers/broker_create_hc4cc_quote.feature
@@ -25,5 +25,6 @@ Feature: Broker HC4CC quote creation
     And Primary broker selects reference plan
     And Primary broker clicks on show details in employee costs section
     Then Primary broker should see plan names in employee costs
+    Then Primary broker should see employee costs download pdf button
     Then Primary broker should see total HC4CC subcidy applied amount
     And Primary broker publishes the quote and sees successful message of published quote

--- a/features/step_definitions/broker_employee_quote_steps.rb
+++ b/features/step_definitions/broker_employee_quote_steps.rb
@@ -399,6 +399,10 @@ And(/^Primary broker clicks on show details in employee costs section$/) do
   find(BrokerCreateQuotePage.show_employee_details).click
 end
 
+And(/^Primary broker should see employee costs download pdf button$/) do
+  expect(find_all('a.downloadEmployeeCostsDetailsButton').count).to eq 1
+end
+
 And(/^Primary broker selects reference plan$/) do
   find(BrokerCreateQuotePage.reference_plan_radio).click
 end

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -1029,6 +1029,7 @@ end
 
 When(/Primary Broker clicks the Employers tab/) do
   find(BrokerHomePage.employers_tab, wait: 5).click
+  sleep 2
   wait_for_ajax
 end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/184416827

# A brief description of the changes

Current behavior:
 
    Right now we don't export employee costs into plan_details_export.pdf

New behavior:

   Added new PDF download option to download employee costs. Its named employee_cost_details_export.pdf

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [x] DC
- [ ] ME
