### PR TITLE
drop invalid applicant phones on ATP import

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -296,6 +296,7 @@ module FinancialAssistance
               citizen_status_info = applicant_hash['citizenship_immigration_status_information']
               foster_info = applicant_hash['foster_care']
               address_result = same_address_with_primary(family_member, primary)
+              phones = valid_applicant_phones(applicant_hash['phones'])
               return address_result unless address_result.success?
               sanitize_params << {
                 family_member_id: family_member.id,
@@ -383,7 +384,7 @@ module FinancialAssistance
 
                 addresses: applicant_hash['addresses'],
                 emails: applicant_hash['emails'],
-                phones: applicant_hash['phones'],
+                phones: phones,
                 incomes: applicant_hash['incomes'],
                 benefits: applicant_hash['benefits'],
                 deductions: applicant_hash['deductions'],
@@ -404,6 +405,15 @@ module FinancialAssistance
             Success(sanitize_params)
           rescue StandardError => e
             Failure("sanitize_applicant_params: #{e}")
+          end
+
+          def valid_applicant_phones(phones)
+            phones.map do |phone|
+              valid_phone_params = phone.slice("kind", "country_code", "area_code", "number", "extension", "primary", "full_phone_number")
+              invalid_phone = FinancialAssistance::Locations::Phone.new(valid_phone_params).invalid? || phone['full_phone_number']&.first == '0' || phone['area_code']&.first == '0'
+              next if invalid_phone
+              valid_phone_params
+            end.compact
           end
 
           def sanitize_person_params(family_member_hash)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: ME-184360725

# A brief description of the changes

Current behavior:
Inbound ATP process does not run validations on applicant data that is used to populate a new draft application, so it is possible to import a bad phone number, e.g., 000-000-0000

New behavior:
Phones that do not pass validations on the model or that start with '0' are dropped during the import process and not saved to the database.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
