### PR TITLE
fix payment amount in carefirst payment redirect saml request

### DIFF
--- a/app/models/one_login/ruby_saml/saml_generator.rb
+++ b/app/models/one_login/ruby_saml/saml_generator.rb
@@ -13,6 +13,8 @@ require 'xml_security/document'
 module OneLogin
   module RubySaml
     class SamlGenerator < SamlMessage
+      include FloatHelper
+
       REQUIRED_ATTRIBUTES = ['Payment Transaction ID', 'Market Indicator', 'Assigned QHP Identifier', 'Total Amount Owed', 'Premium Amount Total', 'APTC Amount',
                              'Proposed Coverage Effective Date', 'First Name', 'Last Name', 'Street Name 1', 'Street Name 2', 'City Name', 'State', 'Zip Code',
                              'Contact Email Address', 'Subscriber Identifier', 'Additional Information'].freeze
@@ -128,7 +130,7 @@ module OneLogin
         when 'Assigned QHP Identifier'
           hbx_enrollment.product.hios_id.gsub('-', '')
         when 'Total Amount Owed'
-          hbx_enrollment.total_premium - hbx_enrollment.applied_aptc_amount.to_f
+          round_down_float_two_decimals(hbx_enrollment.total_premium - hbx_enrollment.applied_aptc_amount.to_f)
         when 'Premium Amount Total'
           hbx_enrollment.total_premium
         when 'APTC Amount'

--- a/app/models/one_login/ruby_saml/saml_generator.rb
+++ b/app/models/one_login/ruby_saml/saml_generator.rb
@@ -130,7 +130,7 @@ module OneLogin
         when 'Assigned QHP Identifier'
           hbx_enrollment.product.hios_id.gsub('-', '')
         when 'Total Amount Owed'
-          round_down_float_two_decimals(hbx_enrollment.total_premium - hbx_enrollment.applied_aptc_amount.to_f)
+          float_fix(hbx_enrollment.total_premium - hbx_enrollment.applied_aptc_amount.to_f)
         when 'Premium Amount Total'
           hbx_enrollment.total_premium
         when 'APTC Amount'

--- a/spec/models/one_login/ruby_saml/saml_generator_spec.rb
+++ b/spec/models/one_login/ruby_saml/saml_generator_spec.rb
@@ -176,5 +176,20 @@ module OneLogin
         expect(saml_generator.send(:embed_custom_xml?)).to eq nil
       end
     end
+
+    context '#set_attribute_values' do
+      let(:premium_amount) { 454.80999999999995 }
+      let(:applied_aptc_amount) { 0.00 }
+      let(:expected_total_amount_owed) { 454.81 } # premium_amount - applied_aptc_amount
+
+      before :each do
+        allow(hbx_enrollment).to receive(:total_premium).and_return(premium_amount)
+        allow(hbx_enrollment).to receive(:applied_aptc_amount).and_return(applied_aptc_amount)
+      end
+
+      it 'should retun rounded total amount owed' do
+        expect(saml_generator.set_attribute_values('Total Amount Owed', hbx_enrollment)).to eq expected_total_amount_owed
+      end
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket:  https://redmine.priv.dchbx.org/issues/101556

# A brief description of the changes

Current behavior: Currently payment amount value not rounded in CareFirst payment redirect SAML request resulting into formatted error.

New behavior: Fixing payment amount in SAML request (i,e "Total Amount Owed") by fixing float issue and round to 2 decimal points

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

NO Feature flag required for this change, Since we are fixing float issue on payment amount in SAML request.

Variable name:

- [x] DC
