### PR TITLE
drop person phones starting with zero on ATP import 

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -412,6 +412,7 @@ module FinancialAssistance
               valid_phone_params = phone.slice("kind", "country_code", "area_code", "number", "extension", "primary", "full_phone_number")
               invalid_phone = FinancialAssistance::Locations::Phone.new(valid_phone_params).invalid? || phone['full_phone_number']&.first == '0' || phone['area_code']&.first == '0'
               next if invalid_phone
+
               valid_phone_params
             end.compact
           end
@@ -465,6 +466,7 @@ module FinancialAssistance
               valid_phone_params = phone.slice("kind", "country_code", "area_code", "number", "extension", "primary", "full_phone_number")
               invalid_phone = Phone.new(valid_phone_params).invalid? || phone['full_phone_number']&.first == '0' || phone['area_code']&.first == '0'
               next if invalid_phone
+
               valid_phone_params
             end.compact
           end

--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -453,11 +453,20 @@ module FinancialAssistance
               verification_types: person_hash['verification_types'],
               addresses: person_hash['addresses'],
               emails: person_hash['emails'],
-              phones: person_hash['phones']
+              phones: valid_person_phones(person_hash['phones'])
             }
             Success(phash)
           rescue StandardError => e
             Failure("build person hash #{e}")
+          end
+
+          def valid_person_phones(phones)
+            phones.map do |phone|
+              valid_phone_params = phone.slice("kind", "country_code", "area_code", "number", "extension", "primary", "full_phone_number")
+              invalid_phone = Phone.new(valid_phone_params).invalid? || phone['full_phone_number']&.first == '0' || phone['area_code']&.first == '0'
+              next if invalid_phone
+              valid_phone_params
+            end.compact
           end
 
           def transform_no_ssn(ssn)

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
         end
       end
 
-      context 'applicant has an invalid phone number' do
+      context 'invalid phone number' do
         context 'where the phone number starts with 0' do
           before do
             zero_phone_xml = Nokogiri::XML(xml)
@@ -130,7 +130,16 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
             @result = subject.call(transformed)
           end
 
-          it 'should drop the invalid phone number' do
+          it 'should drop the invalid phone number for the person' do
+            person = Person.first
+            has_invalid_phone = person.phones.any? do |p|
+              p.area_code == '000' || p.full_phone_number == '0000000000'
+            end
+
+            expect(has_invalid_phone).to eq false
+          end
+
+          it 'should drop the invalid phone number for the applicant' do
             application = FinancialAssistance::Application.last
             has_invalid_phone = application.applicants.any? do |a|
               a.phones.detect { |p| p.area_code == '000' || p.full_phone_number == '0000000000' }

--- a/components/financial_assistance/spec/shared_examples/medicaid_gateway/Simple_Test_Case_E_New.xml
+++ b/components/financial_assistance/spec/shared_examples/medicaid_gateway/Simple_Test_Case_E_New.xml
@@ -217,7 +217,7 @@
                 <ns4:ContactInformation>
                     <ns2:ContactTelephoneNumber>
                         <ns2:FullTelephoneNumber>
-                            <ns2:TelephoneNumberFullID>9991510341</ns2:TelephoneNumberFullID>
+                            <ns2:TelephoneNumberFullID>0000000000</ns2:TelephoneNumberFullID>
                         </ns2:FullTelephoneNumber>
                     </ns2:ContactTelephoneNumber>
                 </ns4:ContactInformation>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: ME-184360725

# A brief description of the changes

Current behavior:
Only applicant phones are dropped if they start with '0' on inbound ATP import.

New behavior:
Person and applicant phones are dropped if they start with '0' on inbound ATP import.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
