### PR TITLE
fix CV3 family reference missing issue

### DIFF
--- a/app/domain/operations/premium_credits/find_aptc.rb
+++ b/app/domain/operations/premium_credits/find_aptc.rb
@@ -68,7 +68,6 @@ module Operations
             th_member_enr_member = th_enrollment.tax_household_members_enrollment_members.find_or_create_by(
               family_member_id: family_member_id
             )
-
             th_member_enr_member.update!(
               hbx_enrollment_member_id: hbx_enrollment_member&.id,
               tax_household_member_id: tax_household_member_id,

--- a/app/models/plan_selection.rb
+++ b/app/models/plan_selection.rb
@@ -68,25 +68,7 @@ class PlanSelection
     @same_plan_enrollment.hbx_enrollment_members = build_hbx_enrollment_members
     @same_plan_enrollment = set_enrollment_member_coverage_start_dates(@same_plan_enrollment)
 
-    update_tax_household_enrollments
     @same_plan_enrollment
-  end
-
-  # Update only if TaxHouseholdMemberEnrollmentMember exists and the bson_id is different.
-  def update_tax_household_enrollments
-    member_applicant_ids = @same_plan_enrollment.hbx_enrollment_members.map(&:applicant_id)
-    return if member_applicant_ids.blank?
-
-    th_enrollments = TaxHouseholdEnrollment.where(enrollment_id: hbx_enrollment.id)
-    th_enrollments.each do |th_enr|
-      th_enr.tax_household_members_enrollment_members.each do |thh_enr_member|
-        enr_member_id = @same_plan_enrollment.hbx_enrollment_members.where(applicant_id: thh_enr_member.family_member_id).first.id
-        thh_enr_member.hbx_enrollment_member_id = enr_member_id if enr_member_id.present? && thh_enr_member.hbx_enrollment_member_id != enr_member_id
-      end
-      th_enr.save!
-    end
-  rescue StandardError => e
-    Rails.logger.error "Error raised while update_tax_household_enrollments message: #{e}, backtrace: #{e.backtrace.join('\n')}"
   end
 
   def build_hbx_enrollment_members

--- a/spec/models/plan_selection_spec.rb
+++ b/spec/models/plan_selection_spec.rb
@@ -164,35 +164,6 @@ describe PlanSelection, dbclean: :after_each, :if => ExchangeTestingConfiguratio
         expect(subject.same_plan_enrollment.hbx_enrollment_members.first.tobacco_use).to eq hbx_enrollment.hbx_enrollment_members.first.tobacco_use
       end
     end
-
-    context 'for update_tax_household_enrollments' do
-      let!(:setup_thh_enr) do
-        thh_enr = TaxHouseholdEnrollment.create(
-          enrollment_id: hbx_enrollment.id,
-          tax_household_id: BSON::ObjectId.new,
-          household_benchmark_ehb_premium: 320.00,
-          available_max_aptc: 0.0
-        )
-        enr_mbr = hbx_enrollment.hbx_enrollment_members.first
-        thh_enr.tax_household_members_enrollment_members.create(
-          family_member_id: enr_mbr.applicant_id,
-          hbx_enrollment_member_id: enr_mbr.id.to_s,
-          tax_household_member_id: BSON::ObjectId.new,
-          age_on_effective_date: 20,
-          relationship_with_primary: 'self',
-          date_of_birth: TimeKeeper.date_of_record - 20.years
-        )
-      end
-
-      it 'updates tax_household_members_enrollment_members if the ID is different' do
-        new_enr = subject.same_plan_enrollment
-        expect(
-          TaxHouseholdEnrollment.where(
-            enrollment_id: hbx_enrollment.id
-          ).first.tax_household_members_enrollment_members.first.hbx_enrollment_member_id
-        ).to eq(new_enr.hbx_enrollment_members.first.id)
-      end
-    end
   end
 
   describe '.set_enrollment_member_coverage_start_dates' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2502930/stories/184779340

# A brief description of the changes

Current behavior:
A Family reference missing CV3 error occurs when transforming a family due to a mismatch between hbx_enrollment_member_id on enrollment and hbx_enrollment_member_id on tax_household_member_enrollment_member record. And the reason being whenever a consumer tries to purchase the same plan for continuous coverage enrollment, we replace existing enrollment_members on enrollment with new enrollment members, which in turn causes a mismatch.

New behavior: Update the existing hbx enrollment member's coverage_start_on date instead of recreating the members with new information for continuous coverage enrollments. Also, removes the patch that is done to update for Tax Household Enrollments and Tax Household Members Enrollment Members in some scenarios as it is not needed anymore.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
