### PR TITLE
populate applied aptc for tax household enrollments during renewals

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -28,6 +28,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
       if is_dependent_dropped?
         renewal_enrollment.aasm_state = 'coverage_selected'
         renewal_enrollment.workflow_state_transitions.build(from_state: 'shopping', to_state: 'coverage_selected')
+        renewal_enrollment.update_tax_household_enrollment
       else
         renewal_enrollment.renew_enrollment
       end

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -1073,7 +1073,7 @@ class HbxEnrollment
     thh_enr_premiums = thh_enr_group_ehb_premium_of_aptc_members(aptc_tax_household_enrollments)
     populate_applied_aptc_for_thh_enrs(aptc_tax_household_enrollments, thh_enr_premiums)
   rescue StandardError => e
-    Rails.logger.error { "Couldn't generate enrollment save event due to #{e.backtrace}" }
+    Rails.logger.error { "Unable to update tax_household_enrollments due to #{e.backtrace}" }
   end
 
   def handle_coverage_selection
@@ -2146,7 +2146,7 @@ class HbxEnrollment
 
     # after_all_transitions :perform_employer_plan_year_count
 
-    event :renew_enrollment, :after => [:record_transition, :trigger_enrollment_notice] do
+    event :renew_enrollment, :after => [:record_transition, :update_tax_household_enrollment, :trigger_enrollment_notice] do
       transitions from: :shopping, to: :auto_renewing
     end
 
@@ -2154,7 +2154,7 @@ class HbxEnrollment
       transitions from: :shopping, to: :renewing_waived
     end
 
-    event :select_coverage, :after => [:record_transition, :propagate_selection, :update_reinstate_coverage, :generate_prior_py_shop_renewals, :publish_select_coverage_events, :update_tax_household_enrollment] do
+    event :select_coverage, :after => [:record_transition, :update_tax_household_enrollment, :propagate_selection, :update_reinstate_coverage, :generate_prior_py_shop_renewals, :publish_select_coverage_events] do
       transitions from: :shopping,
                   to: :coverage_selected, :guard => :can_select_coverage?
       transitions from: [:auto_renewing, :actively_renewing],

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -14,23 +14,19 @@ RSpec.describe HbxEnrollment, type: :model do
   let(:family) { create(:family, :with_primary_family_member, person: person) }
   let(:aasm_state) { 'coverage_selected' }
   let(:hbx_enrollment) do
-    create(:hbx_enrollment,
-            :individual_aptc,
-            :with_silver_health_product,
-            aasm_state: aasm_state,
-            applied_aptc_amount: applied_aptc_amount,
-            elected_aptc_pct: elected_aptc_pct,
-            family: family,
-            consumer_role_id: person.consumer_role.id,
-            ehb_premium: enrollment_ehb_premium)
+    create(:hbx_enrollment, :individual_aptc, :with_silver_health_product, aasm_state: aasm_state,
+                                                                           applied_aptc_amount: applied_aptc_amount,
+                                                                           elected_aptc_pct: elected_aptc_pct,
+                                                                           family: family,
+                                                                           consumer_role_id: person.consumer_role.id,
+                                                                           ehb_premium: enrollment_ehb_premium)
   end
 
   let(:hbx_enrollment_member) do
-    create(:hbx_enrollment_member,
-            hbx_enrollment: hbx_enrollment,
-            applicant_id: family.primary_applicant.id,
-            coverage_start_on: start_of_month,
-            eligibility_date: start_of_month)
+    create(:hbx_enrollment_member, hbx_enrollment: hbx_enrollment,
+                                   applicant_id: family.primary_applicant.id,
+                                   coverage_start_on: start_of_month,
+                                   eligibility_date: start_of_month)
   end
 
   let(:tax_household_group) do
@@ -67,12 +63,11 @@ RSpec.describe HbxEnrollment, type: :model do
   let(:family_member) { create(:family_member, person: person2, family: family) }
 
   let(:hbx_enrollment_member2) do
-    create(:hbx_enrollment_member,
-            is_subscriber: false,
-            hbx_enrollment: hbx_enrollment,
-            applicant_id: family_member.id,
-            coverage_start_on: start_of_month,
-            eligibility_date: start_of_month)
+    create(:hbx_enrollment_member, is_subscriber: false,
+                                   hbx_enrollment: hbx_enrollment,
+                                   applicant_id: family_member.id,
+                                   coverage_start_on: start_of_month,
+                                   eligibility_date: start_of_month)
   end
 
   let(:tax_household_group2) do

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -9,109 +9,151 @@ RSpec.describe HbxEnrollment, type: :model do
     DatabaseCleaner.clean
   end
 
+  let(:start_of_month) { TimeKeeper.date_of_record.beginning_of_month }
+  let(:person) { create(:person, :with_consumer_role, :with_active_consumer_role) }
+  let(:family) { create(:family, :with_primary_family_member, person: person) }
+  let(:aasm_state) { 'coverage_selected' }
+  let(:hbx_enrollment) do
+    create(:hbx_enrollment,
+            :individual_aptc,
+            :with_silver_health_product,
+            aasm_state: aasm_state,
+            applied_aptc_amount: applied_aptc_amount,
+            elected_aptc_pct: elected_aptc_pct,
+            family: family,
+            consumer_role_id: person.consumer_role.id,
+            ehb_premium: enrollment_ehb_premium)
+  end
+
+  let(:hbx_enrollment_member) do
+    create(:hbx_enrollment_member,
+            hbx_enrollment: hbx_enrollment,
+            applicant_id: family.primary_applicant.id,
+            coverage_start_on: start_of_month,
+            eligibility_date: start_of_month)
+  end
+
+  let(:tax_household_group) do
+    thhg = family.tax_household_groups.create!(
+      assistance_year: start_of_month.year, source: 'Admin', start_on: start_of_month.year,
+      tax_households: [FactoryBot.build(:tax_household, household: family.active_household)]
+    )
+    thhg.tax_households.first.tax_household_members.create!(
+      applicant_id: family.primary_applicant.id, is_ia_eligible: true
+    )
+    thhg
+  end
+
+  let!(:tax_household_enrollment) do
+    thh_enr = TaxHouseholdEnrollment.create(
+      enrollment_id: hbx_enrollment.id, tax_household_id: tax_household_group.tax_households.first.id,
+      household_benchmark_ehb_premium: 500.00, available_max_aptc: available_max_aptc
+    )
+
+    thh_enr.tax_household_members_enrollment_members.create(
+      family_member_id: hbx_enrollment_member.applicant_id, hbx_enrollment_member_id: hbx_enrollment_member.id,
+      tax_household_member_id: tax_household_group.tax_households.first.tax_household_members.first.id,
+      age_on_effective_date: 20, relationship_with_primary: 'self', date_of_birth: start_of_month - 20.years
+    )
+    thh_enr
+  end
+
+  let(:person2) do
+    per = create(:person, :with_consumer_role, :with_active_consumer_role)
+    person.ensure_relationship_with(per, 'spouse')
+    per
+  end
+
+  let(:family_member) { create(:family_member, person: person2, family: family) }
+
+  let(:hbx_enrollment_member2) do
+    create(:hbx_enrollment_member,
+            is_subscriber: false,
+            hbx_enrollment: hbx_enrollment,
+            applicant_id: family_member.id,
+            coverage_start_on: start_of_month,
+            eligibility_date: start_of_month)
+  end
+
+  let(:tax_household_group2) do
+    thhg = family.tax_household_groups.create!(
+      assistance_year: start_of_month.year, source: 'Admin', start_on: start_of_month.year,
+      tax_households: [FactoryBot.build(:tax_household, household: family.active_household)]
+    )
+    thhg.tax_households.first.tax_household_members.create!(
+      applicant_id: family_member.id, is_ia_eligible: true
+    )
+    thhg
+  end
+
+  let!(:tax_household_enrollment2) do
+    thh_enr = TaxHouseholdEnrollment.create(
+      enrollment_id: hbx_enrollment.id, tax_household_id: tax_household_group2.tax_households.first.id,
+      household_benchmark_ehb_premium: 500.00, available_max_aptc: available_max_aptc2
+    )
+
+    thh_enr.tax_household_members_enrollment_members.create(
+      family_member_id: hbx_enrollment_member2.applicant_id, hbx_enrollment_member_id: hbx_enrollment_member2.id,
+      tax_household_member_id: tax_household_group2.tax_households.first.tax_household_members.first.id,
+      age_on_effective_date: 20, relationship_with_primary: 'self', date_of_birth: start_of_month - 20.years
+    )
+    thh_enr
+  end
+
+  before do
+    ::BenefitMarkets::Products::ProductRateCache.initialize_rate_cache!
+    EnrollRegistry[:temporary_configuration_enable_multi_tax_household_feature].feature.stub(:is_enabled).and_return(true)
+
+    allow(
+      hbx_enrollment.ivl_decorated_hbx_enrollment
+    ).to receive(:member_ehb_premium).with(hbx_enrollment_member).and_return(member1_ehb_premium)
+
+    allow(
+      hbx_enrollment.ivl_decorated_hbx_enrollment
+    ).to receive(:member_ehb_premium).with(hbx_enrollment_member2).and_return(member2_ehb_premium)
+  end
+
+  let(:member1_ehb_premium) { 350.00 }
+  let(:member2_ehb_premium) { 375.00 }
+  let(:available_max_aptc) { 250.00 }
+  let(:available_max_aptc2) { 275.00 }
+  let(:applied_aptc_amount) { available_max_aptc + available_max_aptc2 }
+  let(:enrollment_ehb_premium) { member1_ehb_premium + member2_ehb_premium }
+  let(:elected_aptc_pct) { 1.0 }
+
+  describe '#renew_enrollment' do
+    let(:aasm_state) { 'shopping' }
+
+    it 'sets applied_aptc and group_ehb_premium' do
+      expect(tax_household_enrollment.applied_aptc).to be_nil
+      expect(tax_household_enrollment.group_ehb_premium).to be_nil
+      expect(tax_household_enrollment2.applied_aptc).to be_nil
+      expect(tax_household_enrollment2.group_ehb_premium).to be_nil
+      hbx_enrollment.renew_enrollment!
+      expect(tax_household_enrollment.reload.applied_aptc.to_f).to eq(available_max_aptc)
+      expect(tax_household_enrollment.reload.group_ehb_premium.to_f).to eq(member1_ehb_premium)
+      expect(tax_household_enrollment2.reload.applied_aptc.to_f).to eq(available_max_aptc2)
+      expect(tax_household_enrollment2.reload.group_ehb_premium.to_f).to eq(member2_ehb_premium)
+    end
+  end
+
+  describe '#select_coverage' do
+    let(:aasm_state) { 'shopping' }
+
+    it 'sets applied_aptc and group_ehb_premium' do
+      expect(tax_household_enrollment.applied_aptc).to be_nil
+      expect(tax_household_enrollment.group_ehb_premium).to be_nil
+      expect(tax_household_enrollment2.applied_aptc).to be_nil
+      expect(tax_household_enrollment2.group_ehb_premium).to be_nil
+      hbx_enrollment.select_coverage!
+      expect(tax_household_enrollment.reload.applied_aptc.to_f).to eq(available_max_aptc)
+      expect(tax_household_enrollment.reload.group_ehb_premium.to_f).to eq(member1_ehb_premium)
+      expect(tax_household_enrollment2.reload.applied_aptc.to_f).to eq(available_max_aptc2)
+      expect(tax_household_enrollment2.reload.group_ehb_premium.to_f).to eq(member2_ehb_premium)
+    end
+  end
+
   describe '#update_tax_household_enrollment' do
-    let(:start_of_month) { TimeKeeper.date_of_record.beginning_of_month }
-    let(:person) { create(:person, :with_consumer_role, :with_active_consumer_role) }
-    let(:family) { create(:family, :with_primary_family_member, person: person) }
-    let(:hbx_enrollment) do
-      create(:hbx_enrollment,
-             :individual_aptc,
-             :with_silver_health_product,
-             applied_aptc_amount: applied_aptc_amount,
-             elected_aptc_pct: elected_aptc_pct,
-             family: family,
-             consumer_role_id: person.consumer_role.id,
-             ehb_premium: enrollment_ehb_premium)
-    end
-
-    let(:hbx_enrollment_member) do
-      create(:hbx_enrollment_member,
-             hbx_enrollment: hbx_enrollment,
-             applicant_id: family.primary_applicant.id,
-             coverage_start_on: start_of_month,
-             eligibility_date: start_of_month)
-    end
-
-    let(:tax_household_group) do
-      thhg = family.tax_household_groups.create!(
-        assistance_year: start_of_month.year, source: 'Admin', start_on: start_of_month.year,
-        tax_households: [FactoryBot.build(:tax_household, household: family.active_household)]
-      )
-      thhg.tax_households.first.tax_household_members.create!(
-        applicant_id: family.primary_applicant.id, is_ia_eligible: true
-      )
-      thhg
-    end
-
-    let!(:tax_household_enrollment) do
-      thh_enr = TaxHouseholdEnrollment.create(
-        enrollment_id: hbx_enrollment.id, tax_household_id: tax_household_group.tax_households.first.id,
-        household_benchmark_ehb_premium: 500.00, available_max_aptc: available_max_aptc
-      )
-
-      thh_enr.tax_household_members_enrollment_members.create(
-        family_member_id: hbx_enrollment_member.applicant_id, hbx_enrollment_member_id: hbx_enrollment_member.id,
-        tax_household_member_id: tax_household_group.tax_households.first.tax_household_members.first.id,
-        age_on_effective_date: 20, relationship_with_primary: 'self', date_of_birth: start_of_month - 20.years
-      )
-      thh_enr
-    end
-
-    let(:person2) do
-      per = create(:person, :with_consumer_role, :with_active_consumer_role)
-      person.ensure_relationship_with(per, 'spouse')
-      per
-    end
-
-    let(:family_member) { create(:family_member, person: person2, family: family) }
-
-    let(:hbx_enrollment_member2) do
-      create(:hbx_enrollment_member,
-             is_subscriber: false,
-             hbx_enrollment: hbx_enrollment,
-             applicant_id: family_member.id,
-             coverage_start_on: start_of_month,
-             eligibility_date: start_of_month)
-    end
-
-    let(:tax_household_group2) do
-      thhg = family.tax_household_groups.create!(
-        assistance_year: start_of_month.year, source: 'Admin', start_on: start_of_month.year,
-        tax_households: [FactoryBot.build(:tax_household, household: family.active_household)]
-      )
-      thhg.tax_households.first.tax_household_members.create!(
-        applicant_id: family_member.id, is_ia_eligible: true
-      )
-      thhg
-    end
-
-    let!(:tax_household_enrollment2) do
-      thh_enr = TaxHouseholdEnrollment.create(
-        enrollment_id: hbx_enrollment.id, tax_household_id: tax_household_group2.tax_households.first.id,
-        household_benchmark_ehb_premium: 500.00, available_max_aptc: available_max_aptc2
-      )
-
-      thh_enr.tax_household_members_enrollment_members.create(
-        family_member_id: hbx_enrollment_member2.applicant_id, hbx_enrollment_member_id: hbx_enrollment_member2.id,
-        tax_household_member_id: tax_household_group2.tax_households.first.tax_household_members.first.id,
-        age_on_effective_date: 20, relationship_with_primary: 'self', date_of_birth: start_of_month - 20.years
-      )
-      thh_enr
-    end
-
-    before do
-      ::BenefitMarkets::Products::ProductRateCache.initialize_rate_cache!
-      EnrollRegistry[:temporary_configuration_enable_multi_tax_household_feature].feature.stub(:is_enabled).and_return(true)
-
-      allow(
-        hbx_enrollment.ivl_decorated_hbx_enrollment
-      ).to receive(:member_ehb_premium).with(hbx_enrollment_member).and_return(member1_ehb_premium)
-
-      allow(
-        hbx_enrollment.ivl_decorated_hbx_enrollment
-      ).to receive(:member_ehb_premium).with(hbx_enrollment_member2).and_return(member2_ehb_premium)
-    end
-
     subject { hbx_enrollment.update_tax_household_enrollment }
 
     context 'with applied_aptc_amount same as total_ehb_premium' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184890139

# A brief description of the changes

Current behavior: Currently, the applied aptc is not populated for IVL renewal enrollments

New behavior: Applied APTC and Group Ehb Premium will be populated for Tax Household Enrollment that are associated with IVL renewal enrollments

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
