### PR TITLE
update bigdecimal syntax to remove deprecate warnings

### DIFF
--- a/app/models/benefit_group.rb
+++ b/app/models/benefit_group.rb
@@ -393,7 +393,7 @@ class BenefitGroup
       else
         pcd = PlanCostDecorator.new(plan, ce, self, rp)
       end
-      BigDecimal.new((acc + pcd.total_employer_contribution).to_s).round(2)
+      BigDecimal((acc + pcd.total_employer_contribution).to_s).round(2)
     end
   end
 

--- a/app/models/composite_rating_list_bill_precalculator.rb
+++ b/app/models/composite_rating_list_bill_precalculator.rb
@@ -65,6 +65,6 @@ class CompositeRatingListBillPrecalculator < SimpleDelegator
   def premium_for(member)
       value = (Caches::PlanDetails.lookup_rate_with_area(__getobj__.id, plan_year_start_on, age_of(member), benefit_group.rating_area) * large_family_factor(member))
       adjusted_value = value * benefit_group.sic_factor_for(plan) * benefit_group.group_size_factor_for(plan) * benefit_group.composite_participation_rate_factor_for(plan)
-      BigDecimal.new("#{adjusted_value}").round(2).to_f
+      BigDecimal(adjusted_value.to_s).round(2).to_f
   end
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -412,7 +412,7 @@ class Plan
     bound_age_val = bound_age(age)
     begin
       value = premium_table_for(schedule_date).detect {|pt| pt.age == bound_age_val }.cost
-      BigDecimal.new("#{value}").round(2).to_f
+      BigDecimal(value.to_s).round(2).to_f
     rescue
       raise [self.id, bound_age_val, schedule_date, age].inspect
     end

--- a/app/models/plan_cost_decorator.rb
+++ b/app/models/plan_cost_decorator.rb
@@ -119,7 +119,7 @@ class PlanCostDecorator < SimpleDelegator
     relationship_benefit = relationship_benefit_for(member)
     if relationship_benefit && relationship_benefit.offered? && benefit_group
       value = rate_lookup(__getobj__, plan_year_start_on, age_of(member), member, benefit_group)
-      BigDecimal.new("#{value}").round(2).to_f
+      BigDecimal(value.to_s).round(2).to_f
     else
       0.00
     end

--- a/app/views/ui-components/v1/tables/_benefit_package_summary.html.slim
+++ b/app/views/ui-components/v1/tables/_benefit_package_summary.html.slim
@@ -10,8 +10,8 @@ table.table.benefit-group-contribution-table
     - sorted_tiers = pd.pricing_determination_tiers.sort_by { |pdt| pdt.pricing_unit.order }
     - sorted_tiers.each do |pdt|
       - pdt_total = pdt.price
-      - pdt_employer = BigDecimal.new((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2)
-      - pdt_employee = BigDecimal.new((pdt_total - pdt_employer).to_s).round(2)
+      - pdt_employer = BigDecimal((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2)
+      - pdt_employee = BigDecimal((pdt_total - pdt_employer).to_s).round(2)
       tr class="#{pdt.contribution_level.is_offered ? "offered" : "not-offered"}"
         td = raw(pdt.contribution_level.is_offered ? "<i class='far fa-check-square fa-lg offered'></i>"+ " #{pdt.display_name.try(:humanize)}" : "<i class='far fa-square fa-lg not-offered'></i>"+ " #{pdt.display_name.try(:humanize)}")
         td= number_to_percentage((pdt.sponsor_contribution_factor * 100.0), precision: 0)

--- a/components/benefit_sponsors/app/models/benefit_sponsors/contribution_calculators/cca_shop_reference_plan_contribution_calculator.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/contribution_calculators/cca_shop_reference_plan_contribution_calculator.rb
@@ -29,7 +29,7 @@ module BenefitSponsors
             c_factor = contribution_factor_for(member)
             c_amount = calc_contribution_amount_for(member, c_factor)
             @member_contributions[member.member_id] = c_amount 
-            @total_contribution = BigDecimal.new((@total_contribution + c_amount).to_s).round(2)
+            @total_contribution = BigDecimal((@total_contribution + c_amount).to_s).round(2)
           else
             @member_contributions[member.member_id] = 0.00
           end
@@ -42,7 +42,7 @@ module BenefitSponsors
             0.00
           end
           ref_rate = reference_rate_for(member)
-          ref_contribution = BigDecimal.new((ref_rate * c_factor * @sic_code_factor * @group_size_factor).to_s).round(2)
+          ref_contribution = BigDecimal((ref_rate * c_factor * @sic_code_factor * @group_size_factor).to_s).round(2)
           if member_price <= ref_contribution
             member_price
           else

--- a/components/benefit_sponsors/app/models/benefit_sponsors/contribution_calculators/tiered_percent_contribution_calculator.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/contribution_calculators/tiered_percent_contribution_calculator.rb
@@ -48,14 +48,14 @@ module BenefitSponsors
             end
             cu = @level_map[contribution_unit.id]
             c_factor = cu.contribution_factor
-            max_contribution = BigDecimal.new((@total_price * c_factor).to_s).round(2, BigDecimal::ROUND_HALF_DOWN)
+            max_contribution = BigDecimal((@total_price * c_factor).to_s).round(2, BigDecimal::ROUND_HALF_DOWN)
             @total_contribution = [max_contribution, @total_price].min
             distribution_remaining = @total_contribution
             members_total_price = 0.00
             @member_ids.reverse.each do |m_id|
               member_price = member_prices[m_id]
               member_discount = [distribution_remaining, member_price].min
-              distribution_remaining = BigDecimal.new((distribution_remaining - member_discount).to_s).round(2)
+              distribution_remaining = BigDecimal((distribution_remaining - member_discount).to_s).round(2)
               @member_contributions[m_id] = member_discount
             end
           else

--- a/components/benefit_sponsors/app/models/benefit_sponsors/contribution_calculators/tiered_percent_with_cap_contribution_calculator.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/contribution_calculators/tiered_percent_with_cap_contribution_calculator.rb
@@ -48,13 +48,13 @@ module BenefitSponsors
             end
             cu = @level_map[contribution_unit.id]
             c_factor = integerize_percent(cu.contribution_factor)
-            t_contribution = BigDecimal.new("0.00")
+            t_contribution = BigDecimal("0.00")
             @member_ids.each do |m_id|
               cont_amount = (member_prices[m_id] * c_factor)/100.00
               t_contribution = t_contribution + cont_amount
             end
             cap = cu.contribution_cap
-            @total_contribution = BigDecimal.new(t_contribution.to_s).round(2)
+            @total_contribution = BigDecimal(t_contribution.to_s).round(2)
             rebalance_value = (@total_contribution > cap) ? cap : @total_contribution
             rebalance_contributions(rebalance_value, member_prices)
           else
@@ -70,23 +70,22 @@ module BenefitSponsors
           new_total_contribution = cap
           @total_contribution = new_total_contribution
           adjusted_contribution_factor = (new_total_contribution * 1.00)/@total_price
-          total_assigned = BigDecimal.new("0.00")
+          total_assigned = BigDecimal("0.00")
           @member_ids.each do |m_id|
-            assigned_value = BigDecimal.new((adjusted_contribution_factor * member_prices[m_id]).to_s).round(2, BigDecimal::ROUND_DOWN)
+            assigned_value = BigDecimal((adjusted_contribution_factor * member_prices[m_id]).to_s).round(2, BigDecimal::ROUND_DOWN)
             @member_contributions[m_id] = assigned_value
             total_assigned = total_assigned + assigned_value
           end
           difference = @total_contribution - total_assigned
           if (difference > 0.005) && @member_ids.first.present?
             first_member_id = @member_ids.first
-            @member_contributions[first_member_id] = BigDecimal.new((difference + @member_contributions[first_member_id]).to_s).round(2)
+            @member_contributions[first_member_id] = BigDecimal((difference + @member_contributions[first_member_id]).to_s).round(2)
           end
         end
 
         # Integerize the contribution percent to match the old rounding model
         def integerize_percent(cont_percent)
-          per = BigDecimal.new((cont_percent * 100.00).to_s).round(0).to_i
-          per
+          BigDecimal((cont_percent * 100.00).to_s).round(0).to_i
         end
       end
 

--- a/components/benefit_sponsors/app/models/benefit_sponsors/pricing_calculators/cca_composite_tier_precalculator.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/pricing_calculators/cca_composite_tier_precalculator.rb
@@ -40,13 +40,13 @@ module BenefitSponsors
                                   coverage_age,
                                   @rating_area
                                ) * too_many_kids_make_you_crazy
-          member_price = BigDecimal.new((
+          member_price = BigDecimal((
             member_plan_price *
             @group_size_factor *
             @participation_percent_factor *
             @sic_code_factor
           ).to_s).round(2)
-          @total = BigDecimal.new((@total + member_price).to_s).round(2)
+          @total = BigDecimal((@total + member_price).to_s).round(2)
           self
         end
 
@@ -100,10 +100,10 @@ module BenefitSponsors
           tier_factors[pu.id] = tier_factor
           denominator = denominator + (tier_totals[pu.id] * tier_factor)
         end
-        basis_rate = BigDecimal.new((price_total/denominator).to_s).round(2)
+        basis_rate = BigDecimal((price_total / denominator).to_s).round(2)
         tier_rates = {}
         pricing_model.pricing_units.each do |pu|
-          tier_rates[pu.id] = BigDecimal.new((basis_rate * tier_factors[pu.id]).to_s).round(2)
+          tier_rates[pu.id] = BigDecimal((basis_rate * tier_factors[pu.id]).to_s).round(2)
         end
         tier_rates
       end
@@ -113,7 +113,7 @@ module BenefitSponsors
         tier_totals = Hash.new(0)
         coverage_benefit_roster.each do |cbre|
           tier, group_price = tier_and_total_for(pricing_model, cbre, group_size, participation_percent, sic_code)
-          price_total = BigDecimal.new((price_total + group_price).to_s).round(2)
+          price_total = BigDecimal((price_total + group_price).to_s).round(2)
           tier_totals[tier.id] = tier_totals[tier.id] + 1
         end
         [price_total, tier_totals]

--- a/components/benefit_sponsors/app/models/benefit_sponsors/pricing_calculators/cca_composite_tiered_price_calculator.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/pricing_calculators/cca_composite_tiered_price_calculator.rb
@@ -46,12 +46,12 @@ module BenefitSponsors
           @total = pricing_determination_tier.price
           members_total_price = 0.00
           @member_ids.each do |m_id|
-            member_price = BigDecimal.new((@total / @member_totals).to_s).floor(2)
-            members_total_price = BigDecimal.new((members_total_price + member_price).to_s).round(2)
+            member_price = BigDecimal((@total / @member_totals).to_s).floor(2)
+            members_total_price = BigDecimal((members_total_price + member_price).to_s).round(2)
             @member_pricing[m_id] = member_price
           end
-          member_discrepency = BigDecimal.new((@total - members_total_price).to_s).round(2)
-          @member_pricing[@primary_member_id] = BigDecimal.new((@member_pricing[@primary_member_id] + member_discrepency).to_s).round(2) 
+          member_discrepency = BigDecimal((@total - members_total_price).to_s).round(2)
+          @member_pricing[@primary_member_id] = BigDecimal((@member_pricing[@primary_member_id] + member_discrepency).to_s).round(2)
           self
         end
       end

--- a/components/benefit_sponsors/app/models/benefit_sponsors/pricing_calculators/cca_shop_list_bill_pricing_calculator.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/pricing_calculators/cca_shop_list_bill_pricing_calculator.rb
@@ -44,9 +44,9 @@ module BenefitSponsors
                              @rating_area
                            )
                          end
-          member_value = BigDecimal.new((member_price * @group_size_factor * @sic_code_factor).to_s).round(2)
+          member_value = BigDecimal((member_price * @group_size_factor * @sic_code_factor).to_s).round(2)
           @member_totals[member.member_id] = member_value
-          @total = BigDecimal.new((@total + member_value).to_s).round(2)
+          @total = BigDecimal((@total + member_value).to_s).round(2)
           self
         end
       end

--- a/components/benefit_sponsors/app/models/benefit_sponsors/services/sponsored_benefit_cost_estimation_service.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/services/sponsored_benefit_cost_estimation_service.rb
@@ -14,8 +14,8 @@ module BenefitSponsors
           sorted_tiers = pd.pricing_determination_tiers.sort_by { |pdt| pdt.pricing_unit.order }
           tier_costs = pd.pricing_determination_tiers.map do |pdt|
             pdt_total = pdt.price
-            pdt_employer = BigDecimal.new((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2)
-            BigDecimal.new((pdt_total - pdt_employer).to_s).round(2)
+            pdt_employer = BigDecimal((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2)
+            BigDecimal((pdt_total - pdt_employer).to_s).round(2)
           end
           {
             estimated_total_cost: total,
@@ -32,11 +32,11 @@ module BenefitSponsors
           sponsored_benefit_with_highest_cost_product = group_cost_estimator.calculate(sponsor_contribution.sponsored_benefit, highest_cost_product, package)
   
           minimum_cost = sponsored_benefit_with_lowest_cost_product.lazy.map do |mg|
-            BigDecimal.new((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
+            BigDecimal((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
           end.min
   
           maximum_cost = sponsored_benefit_with_highest_cost_product.lazy.map do |mg|
-            BigDecimal.new((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
+            BigDecimal((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
           end.max
           {
             estimated_total_cost: total,
@@ -60,8 +60,8 @@ module BenefitSponsors
           sorted_tiers = pd.pricing_determination_tiers.sort_by { |pdt| pdt.pricing_unit.order }
           tier_costs = pd.pricing_determination_tiers.map do |pdt|
             pdt_total = pdt.price
-            pdt_employer = BigDecimal.new((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2)
-            BigDecimal.new((pdt_total - pdt_employer).to_s).round(2)
+            pdt_employer = BigDecimal((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2)
+            BigDecimal((pdt_total - pdt_employer).to_s).round(2)
           end
           {
             estimated_total_cost: total,
@@ -78,11 +78,11 @@ module BenefitSponsors
           sponsored_benefit_with_highest_cost_product = group_cost_estimator.calculate(sponsor_contribution.sponsored_benefit, highest_cost_product, package)
   
           minimum_cost = sponsored_benefit_with_lowest_cost_product.lazy.map do |mg|
-            BigDecimal.new((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
+            BigDecimal((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
           end.min
   
           maximum_cost = sponsored_benefit_with_highest_cost_product.lazy.map do |mg|
-            BigDecimal.new((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
+            BigDecimal((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
           end.max
   
           {
@@ -134,8 +134,8 @@ module BenefitSponsors
           sorted_tiers = pd.pricing_determination_tiers.sort_by { |pdt| pdt.pricing_unit.order }
           tier_costs = pd.pricing_determination_tiers.lazy.map do |pdt|
             pdt_total = pdt.price
-            pdt_employer = BigDecimal.new((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2)
-            BigDecimal.new((pdt_total - pdt_employer).to_s).round(2)
+            pdt_employer = BigDecimal((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2)
+            BigDecimal((pdt_total - pdt_employer).to_s).round(2)
           end
           lowest_cost = tier_costs.min
           highest_cost = tier_costs.max
@@ -202,8 +202,8 @@ module BenefitSponsors
           sorted_tiers = pd.pricing_determination_tiers.sort_by { |pdt| pdt.pricing_unit.order }
           tier_costs = pd.pricing_determination_tiers.lazy.map do |pdt|
             pdt_total = pdt.price
-            pdt_employer = BigDecimal.new((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2)
-            BigDecimal.new((pdt_total - pdt_employer).to_s).round(2)
+            pdt_employer = BigDecimal((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2)
+            BigDecimal((pdt_total - pdt_employer).to_s).round(2)
           end
           {
             estimated_total_cost: total,
@@ -220,11 +220,11 @@ module BenefitSponsors
           sponsored_benefit_with_highest_cost_product = group_cost_estimator.calculate(sponsor_contribution.sponsored_benefit, highest_cost_product, package)
   
           minimum_cost = sponsored_benefit_with_lowest_cost_product.lazy.map do |mg|
-            BigDecimal.new((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
+            BigDecimal((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
           end.min
   
           maximum_cost = sponsored_benefit_with_highest_cost_product.lazy.map do |mg|
-            BigDecimal.new((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
+            BigDecimal((mg.group_enrollment.product_cost_total - mg.group_enrollment.sponsor_contribution_total).to_s).round(2)
           end.max
   
           {
@@ -237,7 +237,7 @@ module BenefitSponsors
       end
 
       def employee_cost_from_group_enrollment(group_enrollment)
-        BigDecimal.new((group_enrollment.product_cost_total - group_enrollment.sponsor_contribution_total).to_s).round(2)
+        BigDecimal((group_enrollment.product_cost_total - group_enrollment.sponsor_contribution_total).to_s).round(2)
       end
     end
   end

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_sponsored_benefit.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_sponsored_benefit.html.erb
@@ -98,8 +98,8 @@
             <% sorted_tiers = pd.pricing_determination_tiers.sort_by { |pdt| pdt.pricing_unit.order } %>
             <% sorted_tiers.each do |pdt| %>
             <% pdt_total = pdt.price %>
-            <% pdt_employer = BigDecimal.new((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2) %>
-            <% pdt_employee = BigDecimal.new((pdt_total - pdt_employer).to_s).round(2) %>
+            <% pdt_employer = BigDecimal((pdt_total * pdt.sponsor_contribution_factor).to_s).round(2) %>
+            <% pdt_employee = BigDecimal((pdt_total - pdt_employer).to_s).round(2) %>
             <tr>
               <td>
                 <%= raw(pdt.contribution_level.is_offered ? "<i class='far fa-check-square fa-lg offered'></i>"+ " #{pdt.display_name.gsub("Dependents", "Child(ren)").try(:humanize)}" : "<i class='far fa-square fa-lg not-offered'></i>"+ " #{pdt.display_name.gsub("Dependents", "Child(ren)").try(:humanize)}") %>

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/contribution_calculators/cca_shop_reference_plan_contribution_calculator_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/contribution_calculators/cca_shop_reference_plan_contribution_calculator_spec.rb
@@ -224,8 +224,8 @@ module BenefitSponsors
             family_roster_entry,
             sponsor_contribution
           )
-          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal.new("0.00")) do |acc, m_en|
-            BigDecimal.new((acc + m_en.sponsor_contribution).to_s).round(2)
+          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal("0.00")) do |acc, m_en|
+            BigDecimal((acc + m_en.sponsor_contribution).to_s).round(2)
           end
           expect(member_total).to eq(total_contribution)
         end

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/contribution_calculators/simple_shop_reference_plan_contribution_calculator_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/contribution_calculators/simple_shop_reference_plan_contribution_calculator_spec.rb
@@ -218,8 +218,8 @@ module BenefitSponsors
             family_roster_entry,
             sponsor_contribution
           )
-          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal.new("0.00")) do |acc, m_en|
-            BigDecimal.new((acc + m_en.sponsor_contribution).to_s).round(2)
+          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal("0.00")) do |acc, m_en|
+            BigDecimal((acc + m_en.sponsor_contribution).to_s).round(2)
           end
           expect(member_total).to eq(total_contribution)
         end
@@ -334,8 +334,8 @@ module BenefitSponsors
             family_roster_entry,
             sponsor_contribution
           )
-          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal.new("0.00")) do |acc, m_en|
-            BigDecimal.new((acc + m_en.sponsor_contribution).to_s).round(2)
+          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal("0.00")) do |acc, m_en|
+            BigDecimal((acc + m_en.sponsor_contribution).to_s).round(2)
           end
           expect(member_total).to eq(total_contribution)
         end

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/contribution_calculators/tiered_percent_contribution_calculator_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/contribution_calculators/tiered_percent_contribution_calculator_spec.rb
@@ -203,8 +203,8 @@ module BenefitSponsors
             family_roster_entry,
             sponsor_contribution
           )
-          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal.new("0.00")) do |acc, m_en|
-            BigDecimal.new((acc + m_en.sponsor_contribution).to_s).round(2)
+          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal("0.00")) do |acc, m_en|
+            BigDecimal((acc + m_en.sponsor_contribution).to_s).round(2)
           end
           expect(member_total).to eq(total_contribution)
         end

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/contribution_calculators/tiered_percent_with_cap_contribution_calculator_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/contribution_calculators/tiered_percent_with_cap_contribution_calculator_spec.rb
@@ -163,7 +163,7 @@ module BenefitSponsors
         let(:primary_price) { 106.68 }
         let(:dependent_price) { 106.66 }
 
-        let(:total_contribution) { BigDecimal.new(80.00.to_s) }
+        let(:total_contribution) { BigDecimal(80.00.to_s) }
 
         let(:family_contribution_level) do
           instance_double(
@@ -207,8 +207,8 @@ module BenefitSponsors
             family_roster_entry,
             sponsor_contribution
           )
-          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal.new("0.00")) do |acc, m_en|
-            BigDecimal.new((acc + m_en.sponsor_contribution).to_s).round(2)
+          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal("0.00")) do |acc, m_en|
+            BigDecimal((acc + m_en.sponsor_contribution).to_s).round(2)
           end
           expect(member_total).to eq(total_contribution)
         end
@@ -354,8 +354,8 @@ module BenefitSponsors
             family_roster_entry,
             sponsor_contribution
           )
-          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal.new("0.00")) do |acc, m_en|
-            BigDecimal.new((acc + m_en.sponsor_contribution).to_s).round(2)
+          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal("0.00")) do |acc, m_en|
+            BigDecimal((acc + m_en.sponsor_contribution).to_s).round(2)
           end
           expect(member_total).to eq(contribution_cap)
         end

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/pricing_calculators/cca_composite_tiered_price_calculator_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/pricing_calculators/cca_composite_tiered_price_calculator_spec.rb
@@ -211,8 +211,8 @@ module BenefitSponsors
             family_roster_entry,
             sponsor_contribution
           )
-          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal.new("0.00")) do |acc, m_en|
-            BigDecimal.new((acc + m_en.product_price).to_s).round(2)
+          member_total = calculation_result.group_enrollment.member_enrollments.inject(BigDecimal("0.00")) do |acc, m_en|
+            BigDecimal((acc + m_en.product_price).to_s).round(2)
           end
           expect(member_total).to eq(family_price)
         end

--- a/components/sponsored_benefits/spec/dummy/app/models/plan_cost_decorator.rb
+++ b/components/sponsored_benefits/spec/dummy/app/models/plan_cost_decorator.rb
@@ -95,7 +95,7 @@ class PlanCostDecorator < SimpleDelegator
     relationship_benefit = relationship_benefit_for(member)
     if relationship_benefit && relationship_benefit.offered?
       value = (Caches::PlanDetails.lookup_rate(__getobj__.id, plan_year_start_on, age_of(member)) * large_family_factor(member))
-      BigDecimal.new("#{value}").round(2).to_f
+      BigDecimal("#{value}").round(2).to_f
     else
       0.00
     end

--- a/spec/models/plan_cost_decorator_spec.rb
+++ b/spec/models/plan_cost_decorator_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe PlanCostDecorator, dbclean: :after_each do
       end
 
       it "round premium contribution of a member" do
-        allow(BigDecimal).to receive_message_chain(:new, :round, :to_f).and_return("13.65")
-        expect(plan_cost_decorator.premium_for(three)).to eq "13.65"
+        allow(plan_cost_decorator).to receive(:rate_lookup).and_return(13.65)
+        expect(plan_cost_decorator.premium_for(three)).to eq 13.65
       end
     end
 
@@ -139,8 +139,8 @@ RSpec.describe PlanCostDecorator, dbclean: :after_each do
       end
 
       it "round premium contribution of a member" do
-        allow(BigDecimal).to receive_message_chain(:new, :round, :to_f).and_return("13.65")
-        expect(plan_cost_decorator.premium_for(three)).to eq "13.65"
+        allow(plan_cost_decorator).to receive(:rate_lookup).and_return(13.65)
+        expect(plan_cost_decorator.premium_for(three)).to eq 13.65
       end
     end
   end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe Plan, dbclean: :after_each do
           market: market,
           premium_tables: [{start_on: "2015-01-01",
                             end_on: "2015-12-31",
-                            cost: 500,
+                            cost: 45.45,
                             age: 32}]
       }
     end
@@ -406,8 +406,7 @@ RSpec.describe Plan, dbclean: :after_each do
       end
 
       it "should round premium amount" do
-        allow(BigDecimal).to receive_message_chain(:new, :round, :to_f).and_return("45.45")
-        expect(plan.premium_for(Date.parse("2015-10-01"), plan_params[:premium_tables][0][:age])).to eq "45.45"
+        expect(plan.premium_for(Date.parse("2015-10-01"), plan_params[:premium_tables][0][:age])).to eq 45.45
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/101636

# A brief description of the changes

Current behavior: 
getting lot of  BigDecimal.new deprecate warnings

New behavior:
There will be no BigDecimal.new depreciation warnings from enroll code.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
