### PR TITLE
fix typo in kaiser permanente pay now relay state key

### DIFF
--- a/.docker/config/saml_information.rb
+++ b/.docker/config/saml_information.rb
@@ -31,7 +31,7 @@ class SamlInformation
     'kaiser_pay_now_url',
     'kaiser_pay_now_relay_state',
     'kaiser_permanente_pay_now_url',
-    'kaiser_permamente_pay_now_relay_state',
+    'kaiser_permanente_pay_now_relay_state',
     'pay_now_private_key_location',
     'pay_now_x509_cert_location',
     'kaiser_pay_now_audience',


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184918627

# A brief description of the changes

Current behavior:
Pay Now integration is broken for all carriers because the key for the relay state url for Kaiser Permanente has a typo.

New behavior:
Typo is corrected and the key in the saml.yml file matches the key in resource registry.  Pay Now functionality is unblocked.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
