### PR TITLE
Correct float rounding representation for Enrollment TRA in SAML

### DIFF
--- a/app/models/one_login/ruby_saml/saml_generator.rb
+++ b/app/models/one_login/ruby_saml/saml_generator.rb
@@ -13,7 +13,7 @@ require 'xml_security/document'
 module OneLogin
   module RubySaml
     class SamlGenerator < SamlMessage
-      include FloatHelper
+      include EventsHelper
 
       REQUIRED_ATTRIBUTES = ['Payment Transaction ID', 'Market Indicator', 'Assigned QHP Identifier', 'Total Amount Owed', 'Premium Amount Total', 'APTC Amount',
                              'Proposed Coverage Effective Date', 'First Name', 'Last Name', 'Street Name 1', 'Street Name 2', 'City Name', 'State', 'Zip Code',
@@ -130,7 +130,7 @@ module OneLogin
         when 'Assigned QHP Identifier'
           hbx_enrollment.product.hios_id.gsub('-', '')
         when 'Total Amount Owed'
-          float_fix(hbx_enrollment.total_premium - hbx_enrollment.applied_aptc_amount.to_f)
+          policy_responsible_amount(hbx_enrollment)
         when 'Premium Amount Total'
           hbx_enrollment.total_premium
         when 'APTC Amount'

--- a/app/models/one_login/ruby_saml/saml_generator.rb
+++ b/app/models/one_login/ruby_saml/saml_generator.rb
@@ -13,6 +13,8 @@ require 'xml_security/document'
 module OneLogin
   module RubySaml
     class SamlGenerator < SamlMessage
+      include FloatHelper
+
       REQUIRED_ATTRIBUTES = ['Payment Transaction ID', 'Market Indicator', 'Assigned QHP Identifier', 'Total Amount Owed', 'Premium Amount Total', 'APTC Amount',
                              'Proposed Coverage Effective Date', 'First Name', 'Last Name', 'Street Name 1', 'Street Name 2', 'City Name', 'State', 'Zip Code',
                              'Contact Email Address', 'Subscriber Identifier', 'Additional Information'].freeze
@@ -128,7 +130,7 @@ module OneLogin
         when 'Assigned QHP Identifier'
           hbx_enrollment.product.hios_id.gsub('-', '')
         when 'Total Amount Owed'
-          hbx_enrollment.total_premium - hbx_enrollment.applied_aptc_amount.to_f
+          round_down_float_two_decimals(hbx_enrollment.total_premium - hbx_enrollment.applied_aptc_amount.to_f)
         when 'Premium Amount Total'
           hbx_enrollment.total_premium
         when 'APTC Amount'

--- a/app/models/one_login/ruby_saml/saml_generator.rb
+++ b/app/models/one_login/ruby_saml/saml_generator.rb
@@ -130,7 +130,7 @@ module OneLogin
         when 'Assigned QHP Identifier'
           hbx_enrollment.product.hios_id.gsub('-', '')
         when 'Total Amount Owed'
-          round_down_float_two_decimals(hbx_enrollment.total_premium - hbx_enrollment.applied_aptc_amount.to_f)
+          float_fix(hbx_enrollment.total_premium - hbx_enrollment.applied_aptc_amount.to_f)
         when 'Premium Amount Total'
           hbx_enrollment.total_premium
         when 'APTC Amount'

--- a/spec/models/one_login/ruby_saml/saml_generator_spec.rb
+++ b/spec/models/one_login/ruby_saml/saml_generator_spec.rb
@@ -176,5 +176,20 @@ module OneLogin
         expect(saml_generator.send(:embed_custom_xml?)).to eq nil
       end
     end
+
+    context '#set_attribute_values' do
+      let(:premium_amount) { 454.80999999999995 }
+      let(:applied_aptc_amount) { 0.00 }
+      let(:expected_total_amount_owed) { 454.81 } # premium_amount - applied_aptc_amount
+
+      before :each do
+        allow(hbx_enrollment).to receive(:total_premium).and_return(premium_amount)
+        allow(hbx_enrollment).to receive(:applied_aptc_amount).and_return(applied_aptc_amount)
+      end
+
+      it 'should retun rounded total amount owed' do
+        expect(saml_generator.set_attribute_values('Total Amount Owed', hbx_enrollment)).to eq expected_total_amount_owed
+      end
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/101556

**NB**: This ticket is on the Redmine system and viewing requires DC VPN access.

# A brief description of the changes

Current behavior:
The SAML generator currently serializes Total Responsible Amounts by rendering a float to a string.  It doesn't attempt to properly format the string to represent the values as the proper currency.  As a result, some downstream systems which make use of this SAML payload (particularly CareFirst systems) reflect the wrong amounts and have difficulty consuming the generated payload.

New behavior:
Correctly round to the right amount of decimal points for US Currency, and use the same logic that is used to serialize premium amounts for EDI transmissions to avoid discrepancies.

# Environment Variable

No environment variables are needed - this behaviour is incorrect and should be fixed for all clients.