### PR TITLE
More selectively run github actions.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   prep:
-    if: github.repository_owner == 'ideacrew' && ((github.event_name == 'push') || (github.event.pull_request.head.repo.owner.login == "ideacrew"))
+    if: github.repository_owner == 'ideacrew' && ((github.event_name == 'push') || (github.event.pull_request.head.repo.owner.login == 'ideacrew'))
     runs-on: ubuntu-latest
     outputs:
       taggedImage: ${{ steps.prep.outputs.tagged_image }}
@@ -50,7 +50,7 @@ jobs:
 
   # Uses buildx to build and push the image
   build-and-upload-image:
-    if: github.repository_owner == 'ideacrew' && ((github.event_name == 'push') || (github.event.pull_request.head.repo.owner.login == "ideacrew"))
+    if: github.repository_owner == 'ideacrew' && ((github.event_name == 'push') || (github.event.pull_request.head.repo.owner.login == 'ideacrew'))
     needs: [prep]
     strategy:
       matrix:
@@ -216,7 +216,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.YELLR_BOT_TOKEN }}
 
   notify-slack:
-    if: github.event_name != 'pull_request'
+    if: github.repository_owner == 'ideacrew' && github.event_name != 'pull_request'
     needs: [new-image-notification, prep, build-and-upload-image]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   prep:
+    if: github.repository_owner == 'ideacrew' && ((github.event_name == 'push') || (github.event.pull_request.head.repo.owner.login == "ideacrew"))
     runs-on: ubuntu-latest
     outputs:
       taggedImage: ${{ steps.prep.outputs.tagged_image }}
@@ -49,6 +50,7 @@ jobs:
 
   # Uses buildx to build and push the image
   build-and-upload-image:
+    if: github.repository_owner == 'ideacrew' && ((github.event_name == 'push') || (github.event.pull_request.head.repo.owner.login == "ideacrew"))
     needs: [prep]
     strategy:
       matrix:
@@ -187,7 +189,7 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   new-image-notification:
-    if: github.event_name != 'pull_request'
+    if: github.repository_owner == 'ideacrew' && github.event_name != 'pull_request'
     needs: [prep, build-and-upload-image]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codesweep.yml
+++ b/.github/workflows/codesweep.yml
@@ -1,0 +1,28 @@
+name: CodeSweep Checks
+on:
+  push:
+    branches:
+      - 'trunk'
+  pull_request:
+    branches:
+      - trunk
+
+concurrency:
+  group: cs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codesweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run AppScan CodeSweep
+        uses: HCL-TECH-SOFTWARE/appscan-codesweep-action@v1
+        with:
+          asoc_key: ${{secrets.ASOC_KEY}}
+          asoc_secret: ${{secrets.ASOC_SECRET}}
+          status: failure
+    env:
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,17 +21,3 @@ jobs:
           git config diff.renameLimit 800
           git fetch --no-tags --depth=1 origin trunk
           bundle exec rubocop-git origin/trunk | grep "no offenses detected"
-  codesweep:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Run AppScan CodeSweep
-        uses: HCL-TECH-SOFTWARE/appscan-codesweep-action@v1
-        with:
-          asoc_key: ${{secrets.ASOC_KEY}}
-          asoc_secret: ${{secrets.ASOC_SECRET}}
-          status: failure
-    env:
-      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [X] CI related changes

# What is the ticket # detailing the issue?

No ticket is associated, we are improving the workflow and external code acceptance process.

# A brief description of the changes

Current behavior:

CodeSweep runs only when a PR is created.

Other repositories will attempt to build and create docker images for Enroll, which will fail.

New behavior:

CodeSweep should be run not only when a pull request is created, but also when we put that pull request into trunk, to ensure stability.

Additionally, images should only be built if the PR originates from within the IdeaCrew organization.

# Environment Variables

Not a feature - there are no environment variables involved.