### PR TITLE
text edits to dc health link id and hc44cc discount on plan tile

### DIFF
--- a/app/views/insured/families/_enrollment.html.erb
+++ b/app/views/insured/families/_enrollment.html.erb
@@ -135,7 +135,7 @@
         <div class="col-xs-12 vertically-aligned-row">
           <div class="enrollment-type info vertical-align-top">
             <p>
-              <strong class="bullet-separator"><%= HbxProfile::ShortName %>ID:</strong>
+              <strong class="bullet-separator"><%= HbxProfile::ShortName %> ID:</strong>
               <%= hbx_enrollment.hbx_id %>
             </p>
           </div>
@@ -150,8 +150,8 @@
             <% end %>
           </div>
         </div>
-
         <div class="col-xs-12 vertically-aligned-row">
+          <div></div>
           <div class="enrollment-type info vertical-align-top">
             <% if (hbx_enrollment.eligible_child_care_subsidy > 0) %>
               <p>

--- a/spec/views/insured/families/_enrollment.html.erb_spec.rb
+++ b/spec/views/insured/families/_enrollment.html.erb_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "insured/families/_enrollment.html.erb" do
 
         it "should have all expected renders" do
           expect(rendered).to have_content('Individual & Family')
-          expect(rendered).to have_selector('strong', text: HbxProfile::ShortName.to_s)
+          expect(rendered).to have_selector('strong', text: "#{HbxProfile::ShortName} ID")
           expect(rendered).to have_content(/#{hbx_enrollment.hbx_id}/)
           expect(rendered).to have_content('Make a first payment') if EnrollRegistry[:carefirst_pay_now].enabled?
         end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/101607

# A brief description of the changes

Current behavior: HC44CC discount text is displayed on the left and no space between `Link` and `ID` - `LinkID`
<img width="468" alt="image" src="https://user-images.githubusercontent.com/17408895/231872973-3acc51b8-a662-402a-ac68-0f9848f8c858.png">

New behavior: HC44CC discount text is moved to the right and adds space between `Link` and `ID` - `Link ID`
<img width="468" alt="image" src="https://user-images.githubusercontent.com/17408895/231873068-202ea2d3-5fe7-4434-b7ec-59210ba6b14f.png">


# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
