### PR TITLE
return empty block if there is not sep present

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 29ce2a4263f3ba1cf83c8c8a52da61195c5329f1
+  revision: 855df8f02ee0f11ed4b38e7b944cb0bd83b1fbd0
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment.rb
+++ b/app/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment.rb
@@ -84,7 +84,8 @@ module Operations
 
         def special_enrollment_period_reference(enrollment)
           sep = enrollment.special_enrollment_period || fetch_special_enrollment_period(enrollment)
-          qle = sep.qualifying_life_event_kind
+          return {} unless sep.present?
+
           {
             qualifying_life_event_kind_reference: construct_qle_reference(sep.qualifying_life_event_kind),
             qle_on: sep.qle_on,

--- a/spec/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment_spec.rb
+++ b/spec/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment_spec.rb
@@ -193,14 +193,12 @@ RSpec.describe ::Operations::Transformers::HbxEnrollmentTo::Cv3HbxEnrollment, db
     end
 
     context "when exclude_seps is passed to cv3 builder" do
-      it 'should not return special enrollment period reference' do
-        expect(@validated_payload[:special_enrollment_period_reference]).to be({})
+      it 'should return hash block' do
+        expect(@validated_payload[:special_enrollment_period_reference].class).to be(Hash)
       end
-    end
 
-    context "when exclude_seps is passed to cv3 builder" do
       it 'should not return special enrollment period reference' do
-        expect(@validated_payload[:special_enrollment_period_reference]).to be({})
+        expect(@validated_payload[:special_enrollment_period_reference].present?).to be_falsy
       end
     end
   end

--- a/spec/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment_spec.rb
+++ b/spec/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment_spec.rb
@@ -164,4 +164,44 @@ RSpec.describe ::Operations::Transformers::HbxEnrollmentTo::Cv3HbxEnrollment, db
       end
     end
   end
+
+  context 'when special_enrollment is outside SEP_period without exclude_seps parameter' do
+    let(:enrollment_kind) { 'special_enrollment' }
+
+    let(:submitted_at) { TimeKeeper.date_of_record }
+    let(:start_on) { submitted_at.prev_day }
+    let(:special_enrollment_period) do
+      build(
+        :special_enrollment_period,
+        family: family,
+        qualifying_life_event_kind_id: qle.id,
+        market_kind: "ivl",
+        start_on: start_on,
+        end_on: start_on
+      )
+    end
+
+    let!(:add_special_enrollment_period) do
+      family.special_enrollment_periods = [special_enrollment_period]
+      family.save
+    end
+    let!(:qle)  { FactoryBot.create(:qualifying_life_event_kind, market_kind: "individual") }
+
+    before do
+      transformed_payload = subject.call(enrollment.reload).success
+      @validated_payload = AcaEntities::Contracts::Enrollments::HbxEnrollmentContract.new.call(transformed_payload).to_h
+    end
+
+    context "when exclude_seps is passed to cv3 builder" do
+      it 'should not return special enrollment period reference' do
+        expect(@validated_payload[:special_enrollment_period_reference]).to be({})
+      end
+    end
+
+    context "when exclude_seps is passed to cv3 builder" do
+      it 'should not return special enrollment period reference' do
+        expect(@validated_payload[:special_enrollment_period_reference]).to be({})
+      end
+    end
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [ME-184933632](https://www.pivotaltracker.com/n/projects/2502930/stories/184933632#)

# A brief description of the changes

Current behavior: For the given SEP enrollment, if there is no SEP the cv3 hbx enrollment build is failing for nil value. 

New behavior: For the given SEP enrollment, if there is no SEP the cv3 hbx enrollment builder will build with empty SEP block and cv3_contract for SEP is also updated to support this change. 

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
