### PR TITLE
seperate ivl, shop settings to send secure email on enr purchase

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -443,12 +443,12 @@ class Insured::PlanShoppingsController < ApplicationController
   def send_receipt_emails
     email = @person.work_email_or_best
     UserMailer.generic_consumer_welcome(@person.first_name, @person.hbx_id, email).deliver_now
-    send_email_enabled = if @enrollment.is_shop?
-                           EnrollRegistry.feature_enabled?(:send_shop_secure_purchase_confirmation_email)
-                         else
-                           EnrollRegistry.feature_enabled?(:send_ivl_secure_purchase_confirmation_email)
-                         end
-    return unless send_email_enabled
+    is_confirmation_email_enabled = if @enrollment.is_shop?
+                                      EnrollRegistry.feature_enabled?(:send_shop_secure_purchase_confirmation_email)
+                                    else
+                                      EnrollRegistry.feature_enabled?(:send_ivl_secure_purchase_confirmation_email)
+                                    end
+    return unless is_confirmation_email_enabled
 
     body = render_to_string 'user_mailer/secure_purchase_confirmation.html.erb', layout: false
     from_provider = HbxProfile.current_hbx

--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -443,7 +443,13 @@ class Insured::PlanShoppingsController < ApplicationController
   def send_receipt_emails
     email = @person.work_email_or_best
     UserMailer.generic_consumer_welcome(@person.first_name, @person.hbx_id, email).deliver_now
-    return unless EnrollRegistry.feature_enabled?(:send_secure_purchase_confirmation_email)
+    send_email_enabled = if @enrollment.is_shop?
+                           EnrollRegistry.feature_enabled?(:send_shop_secure_purchase_confirmation_email)
+                         else
+                           EnrollRegistry.feature_enabled?(:send_ivl_secure_purchase_confirmation_email)
+                         end
+    return unless send_email_enabled
+
     body = render_to_string 'user_mailer/secure_purchase_confirmation.html.erb', layout: false
     from_provider = HbxProfile.current_hbx
     message_params = {

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -813,9 +813,12 @@ registry:
         is_enabled: false
       - key: :zero_permium_policy
         is_enabled: false
-      - key: :send_secure_purchase_confirmation_email
-        item: :send_secure_purchase_confirmation_email
+      - key: :send_ivl_secure_purchase_confirmation_email
+        item: :send_ivl_secure_purchase_confirmation_email
         is_enabled: false
+      - key: :send_shop_secure_purchase_confirmation_email
+        item: :send_shop_secure_purchase_confirmation_email
+        is_enabled: true
       - key: :custom_exceptions_controller
         item: :custom_exceptions_controller
         is_enabled: false

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -800,9 +800,12 @@ registry:
         is_enabled: true
       - key: :zero_permium_policy
         is_enabled: true
-      - key: :send_secure_purchase_confirmation_email
-        item: :send_secure_purchase_confirmation_email
+      - key: :send_ivl_secure_purchase_confirmation_email
+        item: :send_ivl_secure_purchase_confirmation_email
         is_enabled: false
+      - key: :send_shop_secure_purchase_confirmation_email
+        item: :send_shop_secure_purchase_confirmation_email
+        is_enabled: true
       - key: :custom_exceptions_controller
         item: :custom_exceptions_controller
         is_enabled: true

--- a/features/support/worlds/census_employee_world.rb
+++ b/features/support/worlds/census_employee_world.rb
@@ -187,7 +187,6 @@ And(/^census employee (.*?) is a (.*) employee$/) do |named_person, state|
 end
 
 Given(/^there exists (.*?) employee for employer (.*?)(?: and (.*?))?$/) do |named_person, legal_name, legal_name2|
-  EnrollRegistry[:send_secure_purchase_confirmation_email].feature.stub(:is_enabled).and_return(true)
   person = people[named_person]
   sponsorship = employer(legal_name).benefit_sponsorships.first
   census_employees 1,

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -140,26 +140,58 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
     end
 
     context "#send_receipt_emails" do
-      before :each do
-        EnrollRegistry[:send_secure_purchase_confirmation_email].feature.stub(:is_enabled).and_return(true)
+      context 'shop' do
+        before do
+          allow(hbx_enrollment).to receive(:is_shop?).and_return(true)
+          sign_in(user)
+        end
+
+        context 'when send_secure_purchase_confirmation_email enabled' do
+          it 'should send secure message' do
+            EnrollRegistry[:send_shop_secure_purchase_confirmation_email].feature.stub(:is_enabled).and_return(true)
+            expect(person.inbox.messages.count).to eq(1)
+            get :receipt, params: {id: "id"}
+            expect(person.inbox.messages.count).to eq(2)
+            expect(person.inbox.messages.last.subject).to eq("Your Enrollment Confirmation")
+          end
+        end
+
+        context 'when send_secure_purchase_confirmation_email disabled' do
+          it 'should not send secure message' do
+            EnrollRegistry[:send_shop_secure_purchase_confirmation_email].feature.stub(:is_enabled).and_return(false)
+            expect(person.inbox.messages.count).to eq(1)
+            get :receipt, params: {id: "id"}
+            expect(person.inbox.messages.count).to eq(1)
+            expect(person.inbox.messages.last.subject).not_to eq("Your Enrollment Confirmation")
+          end
+        end
       end
 
-      it "should send send secure message to IVL person inbox" do
-        allow(hbx_enrollment).to receive(:is_shop?).and_return(false)
-        sign_in(user)
-        expect(person.inbox.messages.count).to eq(1)
-        get :receipt, params: {id: "id"}
-        expect(person.inbox.messages.count).to eq(2)
-        expect(person.inbox.messages.last.subject).to eq("Your Enrollment Confirmation")
-      end
+      context 'ivl' do
+        before do
+          allow(hbx_enrollment).to receive(:is_shop?).and_return(false)
+          sign_in(user)
+        end
 
-      it "should send send secure message to SHOP person inbox"do
-        allow(hbx_enrollment).to receive(:is_shop?).and_return(true)
-        sign_in(user)
-        expect(person.inbox.messages.count).to eq(1)
-        get :receipt, params: {id: "id"}
-        expect(person.inbox.messages.count).to eq(2)
-        expect(person.inbox.messages.last.subject).to eq("Your Enrollment Confirmation")
+        context 'when send_secure_purchase_confirmation_email enabled' do
+          it 'should send secure message' do
+            EnrollRegistry[:send_ivl_secure_purchase_confirmation_email].feature.stub(:is_enabled).and_return(true)
+            expect(person.inbox.messages.count).to eq(1)
+            get :receipt, params: {id: "id"}
+            expect(person.inbox.messages.count).to eq(2)
+            expect(person.inbox.messages.last.subject).to eq("Your Enrollment Confirmation")
+          end
+        end
+
+        context 'when send_secure_purchase_confirmation_email disabled' do
+          it 'should not send secure message' do
+            EnrollRegistry[:send_ivl_secure_purchase_confirmation_email].feature.stub(:is_enabled).and_return(false)
+            expect(person.inbox.messages.count).to eq(1)
+            get :receipt, params: {id: "id"}
+            expect(person.inbox.messages.count).to eq(1)
+            expect(person.inbox.messages.last.subject).not_to eq("Your Enrollment Confirmation")
+          end
+        end
       end
     end
   end

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -813,9 +813,12 @@ registry:
         is_enabled: false
       - key: :zero_permium_policy
         is_enabled: false
-      - key: :send_secure_purchase_confirmation_email
-        item: :send_secure_purchase_confirmation_email
+      - key: :send_ivl_secure_purchase_confirmation_email
+        item: :send_ivl_secure_purchase_confirmation_email
         is_enabled: false
+      - key: :send_shop_secure_purchase_confirmation_email
+        item: :send_shop_secure_purchase_confirmation_email
+        is_enabled: true
       - key: :custom_exceptions_controller
         item: :custom_exceptions_controller
         is_enabled: false


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/97126

# A brief description of the changes

Current behavior: Sending ENR confirmation notice for IVL through IVL enrollment service by disabling send secure message feature flag. But, as we have same flag for both ivl & shop market, disabling this flag caused missing enr notice on shop market.

New behavior: Added seperate feature flags for ivl & shop markets and enabled send secure message feature flag for shop market and disabled it for ivl market. This enables sending enrollment purchase confirmation email for shop market.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [x] DC
- [ ] ME
