### PR TITLE
fixed aptc attestation visibility logic

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -101,8 +101,6 @@ class Insured::PlanShoppingsController < ApplicationController
       set_aptcs_for_continuous_coverage
       @plan = @enrollment.build_plan_premium(qhp_plan: @plan, apply_aptc: can_apply_aptc?(@plan), elected_aptc: @elected_aptc)
       @enrollment.update(eligible_child_care_subsidy: @plan.total_childcare_subsidy_amount)
-      # Used for determing whether or not to show the extended APTC message
-      @any_aptc_present = @enrollment.hbx_enrollment_members.any? { |member| @plan.aptc_amount(member) > 0 } if EnrollRegistry.feature_enabled?(:extended_aptc_individual_agreement_message)
     end
 
     @family = @person.primary_family

--- a/app/views/insured/plan_shoppings/_individual_agreement.en.html.erb
+++ b/app/views/insured/plan_shoppings/_individual_agreement.en.html.erb
@@ -8,7 +8,7 @@
           <p><%= l10n("insured.individual_agreement.agreement.report_changes", contact_center_name: contact_center_name, contact_center_phone_number: contact_center_phone_number) %></p>
           <p><%= l10n("insured.individual_agreement.agreement.i_am_signature") %></p>
           <p><%= l10n("insured.individual_agreement.agreement.reviewed_info") %></p>
-          <% if EnrollRegistry.feature_enabled?(:extended_aptc_individual_agreement_message) && locals[:aptc_present].present? == true %>
+          <% if EnrollRegistry.feature_enabled?(:extended_aptc_individual_agreement_message) && @plan.total_aptc_amount > 0 %>
             <% cov_year = locals[:coverage_year] %>
             <p><%= l10n("insured.individual_agreement.agreement.aptc.on_my_behalf") %></p>
             <ul>

--- a/app/views/insured/plan_shoppings/_individual_agreement.en.html.erb
+++ b/app/views/insured/plan_shoppings/_individual_agreement.en.html.erb
@@ -8,7 +8,7 @@
           <p><%= l10n("insured.individual_agreement.agreement.report_changes", contact_center_name: contact_center_name, contact_center_phone_number: contact_center_phone_number) %></p>
           <p><%= l10n("insured.individual_agreement.agreement.i_am_signature") %></p>
           <p><%= l10n("insured.individual_agreement.agreement.reviewed_info") %></p>
-          <% if EnrollRegistry.feature_enabled?(:extended_aptc_individual_agreement_message) && @plan&.total_aptc_amount > 0 %>
+          <% if EnrollRegistry.feature_enabled?(:extended_aptc_individual_agreement_message) && @plan.total_aptc_amount > 0 %>
             <% cov_year = locals[:coverage_year] %>
             <p><%= l10n("insured.individual_agreement.agreement.aptc.on_my_behalf") %></p>
             <ul>

--- a/app/views/insured/plan_shoppings/_individual_agreement.en.html.erb
+++ b/app/views/insured/plan_shoppings/_individual_agreement.en.html.erb
@@ -8,7 +8,7 @@
           <p><%= l10n("insured.individual_agreement.agreement.report_changes", contact_center_name: contact_center_name, contact_center_phone_number: contact_center_phone_number) %></p>
           <p><%= l10n("insured.individual_agreement.agreement.i_am_signature") %></p>
           <p><%= l10n("insured.individual_agreement.agreement.reviewed_info") %></p>
-          <% if EnrollRegistry.feature_enabled?(:extended_aptc_individual_agreement_message) && @plan.total_aptc_amount > 0 %>
+          <% if EnrollRegistry.feature_enabled?(:extended_aptc_individual_agreement_message) && @plan&.total_aptc_amount > 0 %>
             <% cov_year = locals[:coverage_year] %>
             <p><%= l10n("insured.individual_agreement.agreement.aptc.on_my_behalf") %></p>
             <ul>

--- a/app/views/insured/plan_shoppings/thankyou.html.erb
+++ b/app/views/insured/plan_shoppings/thankyou.html.erb
@@ -31,7 +31,7 @@
             <%= render "insured/plan_shoppings/coverage_information" %>
           <% else %>
             <%= render partial: "insured/plan_shoppings/individual_coverage_information", locals: {calculate: true} %>
-            <%= render "insured/plan_shoppings/individual_agreement", locals: {aptc_present: @any_aptc_present.present?, coverage_year: @enrollment.effective_on.year.to_s} %>
+            <%= render "insured/plan_shoppings/individual_agreement", locals: {coverage_year: @enrollment.effective_on.year.to_s} %>
           <% end %>
 
           <% if @enrollment.is_cobra_status? %>

--- a/spec/views/insured/plan_shoppings/_individual_agreement.html.erb_spec.rb
+++ b/spec/views/insured/plan_shoppings/_individual_agreement.html.erb_spec.rb
@@ -8,16 +8,21 @@ RSpec.describe "insured/plan_shoppings/_individual_agreement.html.erb" do
       "HbxEnrollment", id: "hbx enrollment id"
     )
   end
+
   context "normal message" do
     before :each do
       EnrollRegistry[:aca_individual_market].feature.stub(:is_enabled).and_return(true)
       assign(:person, person)
       assign(:hbx_enrollment, hbx_enrollment)
-      render "insured/plan_shoppings/individual_agreement", locals: {aptc_present: false, coverage_year: TimeKeeper.date_of_record.year.to_s}
+      render "insured/plan_shoppings/individual_agreement", locals: { coverage_year: TimeKeeper.date_of_record.year.to_s }
     end
 
     it "should display the title" do
       expect(rendered).to have_selector('h3', text: "Terms and Conditions")
+    end
+
+    it "should not have the exteneded aptc message" do
+      expect(rendered).to_not have_content(l10n("insured.individual_agreement.agreement.aptc.on_my_behalf"))
     end
 
     it "should have required fields" do
@@ -36,6 +41,7 @@ RSpec.describe "insured/plan_shoppings/_individual_agreement.html.erb" do
       EnrollRegistry[:aca_individual_market].feature.stub(:is_enabled).and_return(true)
       assign(:person, person)
       assign(:hbx_enrollment, hbx_enrollment)
+      allow(@plan).to receive(:total_aptc_amount).and_return(50)
       EnrollRegistry[:extended_aptc_individual_agreement_message].feature.stub(:is_enabled).and_return(true)
       change_target_translation_text("en.insured.individual_agreement.agreement.aptc.on_my_behalf.file_return", "me", "insured")
       render "insured/plan_shoppings/individual_agreement", locals: {aptc_present: true, coverage_year: TimeKeeper.date_of_record.year.to_s}
@@ -43,6 +49,7 @@ RSpec.describe "insured/plan_shoppings/_individual_agreement.html.erb" do
 
     it 'should show the proper translation' do
       expect(rendered).to match("I must file a federal income tax return")
+      expect(rendered).to have_content(l10n("insured.individual_agreement.agreement.aptc.on_my_behalf"))
     end
   end
 end

--- a/spec/views/insured/plan_shoppings/_individual_agreement.html.erb_spec.rb
+++ b/spec/views/insured/plan_shoppings/_individual_agreement.html.erb_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "insured/plan_shoppings/_individual_agreement.html.erb" do
       allow(@plan).to receive(:total_aptc_amount).and_return(50)
       EnrollRegistry[:extended_aptc_individual_agreement_message].feature.stub(:is_enabled).and_return(true)
       change_target_translation_text("en.insured.individual_agreement.agreement.aptc.on_my_behalf.file_return", "me", "insured")
-      render "insured/plan_shoppings/individual_agreement", locals: {aptc_present: true, coverage_year: TimeKeeper.date_of_record.year.to_s}
+      render "insured/plan_shoppings/individual_agreement", locals: { coverage_year: TimeKeeper.date_of_record.year.to_s}
     end
 
     it 'should show the proper translation text' do

--- a/spec/views/insured/plan_shoppings/_individual_agreement.html.erb_spec.rb
+++ b/spec/views/insured/plan_shoppings/_individual_agreement.html.erb_spec.rb
@@ -47,8 +47,7 @@ RSpec.describe "insured/plan_shoppings/_individual_agreement.html.erb" do
       render "insured/plan_shoppings/individual_agreement", locals: {aptc_present: true, coverage_year: TimeKeeper.date_of_record.year.to_s}
     end
 
-    it 'should show the proper translation' do
-      expect(rendered).to match("I must file a federal income tax return")
+    it 'should show the proper translation text' do
       expect(rendered).to have_content(l10n("insured.individual_agreement.agreement.aptc.on_my_behalf"))
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: IVL-184928514

# A brief description of the changes

Current behavior: Attestation pertaining to APTC on thank you page in plan shopping does not show in all cases where a user has APTC, specifically newer user accounts

New behavior:Attestation pertaining to APTC on thank you page in plan shopping shows in all cases where a user has APTC

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
