### PR TITLE
prevent default when hitting tab on enrollment page

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -786,7 +786,7 @@ $(document).on('click', '#terms_check_thank_you', function() {
   last_name_thank_you = $("#last_name_thank_you").val().toLowerCase().trim();
   subscriber_first_name = $("#subscriber_first_name").val();
   subscriber_last_name = $("#subscriber_last_name").val();
-  
+
   if($(this).prop("checked") == true){
     if( first_name_thank_you == subscriber_first_name && last_name_thank_you == subscriber_last_name){
       $('#btn-continue').removeClass('disabled');

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -798,6 +798,12 @@ $(document).on('click', '#terms_check_thank_you', function() {
   }
 });
 
+$(document).on('keydown', 'input.thank_you_field', function() {
+  if(event.code === "Tab") {
+     event.preventDefault();
+  }
+})
+
 $(document).on('blur keyup', 'input.thank_you_field', function() {
   first_name_thank_you = $("#first_name_thank_you").val().toLowerCase().trim();
   last_name_thank_you = $("#last_name_thank_you").val().toLowerCase().trim();

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -804,7 +804,7 @@ $(document).on('keydown', '#btn-continue', function() {
   subscriber_first_name = $("#subscriber_first_name").val();
   subscriber_last_name = $("#subscriber_last_name").val();
 
-  if (first_name_thank_you != subscriber_first_name || last_name_thank_you != subscriber_last_name) {
+  if ((first_name_thank_you != subscriber_first_name || last_name_thank_you != subscriber_last_name) && event.code == 'Enter') {
     event.preventDefault();
   } 
 })

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -786,7 +786,7 @@ $(document).on('click', '#terms_check_thank_you', function() {
   last_name_thank_you = $("#last_name_thank_you").val().toLowerCase().trim();
   subscriber_first_name = $("#subscriber_first_name").val();
   subscriber_last_name = $("#subscriber_last_name").val();
-
+  
   if($(this).prop("checked") == true){
     if( first_name_thank_you == subscriber_first_name && last_name_thank_you == subscriber_last_name){
       $('#btn-continue').removeClass('disabled');
@@ -798,10 +798,15 @@ $(document).on('click', '#terms_check_thank_you', function() {
   }
 });
 
-$(document).on('keydown', 'input.thank_you_field', function() {
-  if(event.code === "Tab") {
-     event.preventDefault();
-  }
+$(document).on('keydown', '#btn-continue', function() {
+  first_name_thank_you = $("#first_name_thank_you").val().toLowerCase().trim();
+  last_name_thank_you = $("#last_name_thank_you").val().toLowerCase().trim();
+  subscriber_first_name = $("#subscriber_first_name").val();
+  subscriber_last_name = $("#subscriber_last_name").val();
+
+  if (first_name_thank_you != subscriber_first_name || last_name_thank_you != subscriber_last_name) {
+    event.preventDefault();
+  } 
 })
 
 $(document).on('blur keyup', 'input.thank_you_field', function() {

--- a/features/group_selection/ivl_plan_shopping.feature
+++ b/features/group_selection/ivl_plan_shopping.feature
@@ -14,7 +14,7 @@ Feature: IVL plan purchase
     And consumer clicked on shop for new plan
     Then consumer should see both dependent and primary
 
-  Scenario: when IVL purchase plan only for dependent
+  Scenario: when consumer selects a plan only primary should be able to confirm plan selection
     Given a consumer exists
     And the consumer is logged in
     And consumer has a dependent in child relationship with age less than 26
@@ -25,9 +25,10 @@ Feature: IVL plan purchase
     Then I should see confirmation and continue
     When ivl clicked continue on household info page
     Then consumer should see all the family members names
-    When consumer unchecks the primary person
     And consumer clicked on shop for new plan
-    Then consumer should only see the dependent name
+    And Individual selects a plan on plan shopping page
+    And Individual hits tab
+    Then page should not automatically scroll to the continue button
 
   Scenario: IVL having an ineligible family member & doing plan shop
     Given a consumer exists

--- a/features/group_selection/ivl_plan_shopping.feature
+++ b/features/group_selection/ivl_plan_shopping.feature
@@ -42,8 +42,8 @@ Feature: IVL plan purchase
     Then consumer should see all the family members names
     And consumer clicked on shop for new plan
     And Individual selects a plan on plan shopping page
-    And Individual hits tab
-    Then page should not automatically scroll to the continue button
+    And Individual hits tab and enter
+    Then Individual does not navigate to the enrollment submitted page
 
   Scenario: IVL having an ineligible family member & doing plan shop
     Given a consumer exists

--- a/features/group_selection/ivl_plan_shopping.feature
+++ b/features/group_selection/ivl_plan_shopping.feature
@@ -14,10 +14,14 @@ Feature: IVL plan purchase
     And consumer clicked on shop for new plan
     Then consumer should see both dependent and primary
 
-  Scenario: when IVL purchase plan only for dependent
+    Scenario: when IVL purchase plan only for dependent
     Given a consumer exists
     And the consumer is logged in
     And consumer has a dependent in child relationship with age less than 26
+    And consumer has successful ridp
+    When consumer visits home page
+    And consumer clicked on "Married" qle
+    And I select a past qle date
     Then I should see confirmation and continue
     When ivl clicked continue on household info page
     Then consumer should see all the family members names

--- a/features/group_selection/ivl_plan_shopping.feature
+++ b/features/group_selection/ivl_plan_shopping.feature
@@ -14,7 +14,7 @@ Feature: IVL plan purchase
     And consumer clicked on shop for new plan
     Then consumer should see both dependent and primary
 
-    Scenario: when IVL purchase plan only for dependent
+  Scenario: when IVL purchase plan only for dependent
     Given a consumer exists
     And the consumer is logged in
     And consumer has a dependent in child relationship with age less than 26

--- a/features/group_selection/ivl_plan_shopping.feature
+++ b/features/group_selection/ivl_plan_shopping.feature
@@ -14,6 +14,17 @@ Feature: IVL plan purchase
     And consumer clicked on shop for new plan
     Then consumer should see both dependent and primary
 
+  Scenario: when IVL purchase plan only for dependent
+    Given a consumer exists
+    And the consumer is logged in
+    And consumer has a dependent in child relationship with age less than 26
+    Then I should see confirmation and continue
+    When ivl clicked continue on household info page
+    Then consumer should see all the family members names
+    When consumer unchecks the primary person
+    And consumer clicked on shop for new plan
+    Then consumer should only see the dependent name
+
   Scenario: when consumer selects a plan only primary should be able to confirm plan selection
     Given a consumer exists
     And the consumer is logged in

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -1187,8 +1187,9 @@ And(/Individual hits tab/) do
 end
 
 Then(/page should not automatically scroll to the continue button/) do
-  scroll_position = page.evaluate_script("window.pageYOffset")
-  expect(scroll_position).to eq(1028)
+  element = find_all(".thank_you_field")[1]
+  cursor_position = page.evaluate_script('arguments[0].selectionStart', element)
+  expect(cursor_position).to eql(0)
 end
 
 And(/(.*) should have a ER sponsored enrollment/) do |named_person|

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -1182,14 +1182,13 @@ Then("user will click on New Employee Paper Application link") do
   find('.new_employee_paper_application').click
 end
 
-And(/Individual hits tab/) do
+And(/Individual hits tab and enter/) do
   find_all(".thank_you_field")[1].send_keys(:tab)
+  find("#btn-continue").send_keys(:return)
 end
 
-Then(/page should not automatically scroll to the continue button/) do
-  element = find_all(".thank_you_field")[1]
-  cursor_position = page.evaluate_script('arguments[0].selectionStart', element)
-  expect(cursor_position).to eql(0)
+Then(/Individual does not navigate to the enrollment submitted page/) do
+  expect(page).to_not have_content IvlEnrollmentSubmitted.enrollment_submitted_text
 end
 
 And(/(.*) should have a ER sponsored enrollment/) do |named_person|

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -1182,6 +1182,15 @@ Then("user will click on New Employee Paper Application link") do
   find('.new_employee_paper_application').click
 end
 
+And(/Individual hits tab/) do
+  find_all(".thank_you_field")[1].send_keys(:tab)
+end
+
+Then(/page should not automatically scroll to the continue button/) do
+  scroll_position = page.evaluate_script("window.pageYOffset")
+  expect(scroll_position).to eq(1028)
+end
+
 And(/(.*) should have a ER sponsored enrollment/) do |named_person|
   person = people[named_person]
   ce = CensusEmployee.where(:first_name => /#{person[:first_name]}/i, :last_name => /#{person[:last_name]}/i).first


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: ME-184874008

# A brief description of the changes

Current behavior: While on the enrollment confirmation page, if a consumer hits tab and then enter, they can by pass the continue button which is disabled until the primary signs their name.

New behavior: This fix will prevent the consumer from being able to skip the continue button.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
