### PR TITLE
matching application_denied_notice rules with actual rules

### DIFF
--- a/components/benefit_sponsors/app/models/benefit_sponsors/observers/notice_observer.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/observers/notice_observer.rb
@@ -276,7 +276,7 @@ module BenefitSponsors
         policy = enrollment_policy_for(benefit_application, :end_open_enrollment)
         return if policy.is_satisfied?(benefit_application)
 
-        return unless policy.fail_results.include?(:minimum_participation_rule) || policy.fail_results.include?(:non_business_owner_enrollment_count)
+        return unless policy.fail_results.include?(:minimum_participation_rule) || policy.fail_results.include?(:non_business_owner_enrollment_count) || policy.fail_results.include?(:all_waived_members_eligiblity)
 
         employer_notice_event = benefit_application.is_renewing? ? "renewal_employer_ineligibility_notice" : "initial_employer_application_denied"
         employee_notice_event = benefit_application.is_renewing? ? "employee_renewal_employer_ineligibility_notice" : "group_ineligibility_notice_to_employee"

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/observers/notice_observer_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/observers/notice_observer_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BenefitSponsors::Observers::NoticeObserver, dbclean: :after_each do
+
+  let(:start_on) { TimeKeeper.date_of_record.beginning_of_month}
+  let!(:site) { create(:benefit_sponsors_site, :with_benefit_market, :as_hbx_profile, :cca) }
+  let!(:organization)     { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_aca_shop_cca_employer_profile, site: site) }
+  let!(:employer_profile)    { organization.employer_profile }
+  let!(:benefit_sponsorship)    { employer_profile.add_benefit_sponsorship }
+  let!(:model_instance) do
+    FactoryBot.create(
+      :benefit_sponsors_benefit_application,
+      :with_benefit_package,
+      :benefit_sponsorship => benefit_sponsorship,
+      :aasm_state => 'active',
+      :effective_period => start_on..(start_on + 1.year) - 1.day
+    )
+  end
+
+
+  subject { BenefitSponsors::Observers::NoticeObserver.new }
+
+  shared_examples_for "benefit application event" do |event|
+    let!(:event_type) {event.to_sym}
+
+    let(:model_event) { BenefitSponsors::ModelEvents::ModelEvent.new(event_type, model_instance, {}) }
+
+    it "deliver event should have" do
+      expect(subject).to receive(:deliver) do |recipient:, event_object:,notice_event:|
+        expect(recipient).to eq model_instance.employer_profile
+        expect(event_object).to eq model_instance
+        expect(notice_event).to match(/#{event}/i)
+      end
+      subject.process_application_events(model_instance, model_event)
+    end
+
+    it "notify event should have" do
+      expect(subject.notifier).to receive(:notify) do |event_name, payload|
+        expect(event_name).to match(/#{event_name}/i)
+        expect(payload[:event_object_kind]).to eq 'BenefitSponsors::BenefitApplications::BenefitApplication'
+      end
+      subject.process_application_events(model_instance, model_event)
+    end
+  end
+
+  describe "notify benefit application events" do
+    it_behaves_like "benefit application event", "application_denied"
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/96067

# A brief description of the changes

Current behavior: Application ineligibility checks for waived_members_eligiblity rule, whereas while sending notice it's not checking waived_members_eligiblity.

New behavior: checking waived_members_eligiblity rule while sending notice as well.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [x] DC
- [x] ME
