### PR TITLE
add date_of_action field to evidence_history model

### DIFF
--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -308,7 +308,7 @@ module Eligibilities
 
     def clone_verification_histories(new_evidence)
       verification_histories.each do |verification|
-        verification_attrs = verification.attributes.deep_symbolize_keys.slice(:action, :modifier, :update_reason, :updated_by, :is_satisfied, :verification_outstanding, :due_on, :aasm_state, :created_at)
+        verification_attrs = verification.attributes.deep_symbolize_keys.slice(:action, :modifier, :update_reason, :updated_by, :is_satisfied, :verification_outstanding, :due_on, :aasm_state, :date_of_action)
         new_evidence.verification_histories.build(verification_attrs)
       end
     end

--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -308,7 +308,7 @@ module Eligibilities
 
     def clone_verification_histories(new_evidence)
       verification_histories.each do |verification|
-        verification_attrs = verification.attributes.deep_symbolize_keys.slice(:action, :modifier, :update_reason, :updated_by, :is_satisfied, :verification_outstanding, :due_on, :aasm_state)
+        verification_attrs = verification.attributes.deep_symbolize_keys.slice(:action, :modifier, :update_reason, :updated_by, :is_satisfied, :verification_outstanding, :due_on, :aasm_state, :created_at)
         new_evidence.verification_histories.build(verification_attrs)
       end
     end

--- a/app/models/eligibilities/verification_history.rb
+++ b/app/models/eligibilities/verification_history.rb
@@ -24,7 +24,7 @@ module Eligibilities
     private
 
     def set_date_of_action
-      write_attribute(:date_of_action, DateTime.now)
+      write_attribute(:date_of_action, DateTime.now) unless date_of_action.present?
     end
   end
 end

--- a/app/models/eligibilities/verification_history.rb
+++ b/app/models/eligibilities/verification_history.rb
@@ -17,6 +17,12 @@ module Eligibilities
     field :verification_outstanding, type: Boolean
     field :due_on, type: Date
     field :aasm_state, type: String
+    field :date_of_action, type: DateTime
 
+    after_create :set_date_of_action
+
+    def set_date_of_action
+      write_attribute(:date_of_action, DateTime.now)
+    end
   end
 end

--- a/app/models/eligibilities/verification_history.rb
+++ b/app/models/eligibilities/verification_history.rb
@@ -21,6 +21,8 @@ module Eligibilities
 
     after_create :set_date_of_action
 
+    private
+
     def set_date_of_action
       write_attribute(:date_of_action, DateTime.now)
     end

--- a/components/financial_assistance/app/views/financial_assistance/applications/verifications/_admin_verification_actions.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/verifications/_admin_verification_actions.html.erb
@@ -86,7 +86,7 @@
 <div class="row">
   <div class="view-history col-md-12" id=<%="#{applicant.id}-#{evidence_type.downcase.split.join('-')}-history"%>>
     <div>
-      <h5>Verification Historyyyy</h5>
+      <h5>Verification History</h5>
       <table class="table table-bordered table-hover table-responsive">
         <thead>
         <tr>

--- a/components/financial_assistance/app/views/financial_assistance/applications/verifications/_admin_verification_actions.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/verifications/_admin_verification_actions.html.erb
@@ -103,7 +103,7 @@
           <% records.each_with_index do |record, index| %>
             <tr>
               <th scope="row"><%= index + 1 %></th>
-              <td><%= record.created_at.in_time_zone('Eastern Time (US & Canada)') %></td>
+              <td><%= record.is_a?(Eligibilities::RequestResult) ? record.created_at.in_time_zone('Eastern Time (US & Canada)') : record.date_of_action&.in_time_zone('Eastern Time (US & Canada)') %></td>
               <td><%= record.is_a?(Eligibilities::RequestResult) ? 'Hub Call' : record.action.capitalize %></td>
               <td><%= record.is_a?(Eligibilities::RequestResult) ? record.source_transaction_id : record.updated_by %></td>
               <td><%= record.is_a?(Eligibilities::RequestResult) ? 'Fdsh Hub Call' : record.update_reason %></td>

--- a/components/financial_assistance/app/views/financial_assistance/applications/verifications/_admin_verification_actions.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/verifications/_admin_verification_actions.html.erb
@@ -86,7 +86,7 @@
 <div class="row">
   <div class="view-history col-md-12" id=<%="#{applicant.id}-#{evidence_type.downcase.split.join('-')}-history"%>>
     <div>
-      <h5>Verification History</h5>
+      <h5>Verification Historyyyy</h5>
       <table class="table table-bordered table-hover table-responsive">
         <thead>
         <tr>
@@ -103,7 +103,7 @@
           <% records.each_with_index do |record, index| %>
             <tr>
               <th scope="row"><%= index + 1 %></th>
-              <td><%= (record.is_a?(Eligibilities::RequestResult) ? record.created_at : record&.date_of_action).in_time_zone('Eastern Time (US & Canada)') %></td>
+              <td><%= (record.is_a?(Eligibilities::RequestResult) ? record.created_at : record&.date_of_action)&.in_time_zone('Eastern Time (US & Canada)') %></td>
               <td><%= record.is_a?(Eligibilities::RequestResult) ? 'Hub Call' : record.action.capitalize %></td>
               <td><%= record.is_a?(Eligibilities::RequestResult) ? record.source_transaction_id : record.updated_by %></td>
               <td><%= record.is_a?(Eligibilities::RequestResult) ? 'Fdsh Hub Call' : record.update_reason %></td>

--- a/components/financial_assistance/app/views/financial_assistance/applications/verifications/_admin_verification_actions.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/verifications/_admin_verification_actions.html.erb
@@ -103,7 +103,7 @@
           <% records.each_with_index do |record, index| %>
             <tr>
               <th scope="row"><%= index + 1 %></th>
-              <td><%= record.is_a?(Eligibilities::RequestResult) ? record.created_at.in_time_zone('Eastern Time (US & Canada)') : record.date_of_action&.in_time_zone('Eastern Time (US & Canada)') %></td>
+              <td><%= (record.is_a?(Eligibilities::RequestResult) ? record.created_at : record&.date_of_action).in_time_zone('Eastern Time (US & Canada)') %></td>
               <td><%= record.is_a?(Eligibilities::RequestResult) ? 'Hub Call' : record.action.capitalize %></td>
               <td><%= record.is_a?(Eligibilities::RequestResult) ? record.source_transaction_id : record.updated_by %></td>
               <td><%= record.is_a?(Eligibilities::RequestResult) ? 'Fdsh Hub Call' : record.update_reason %></td>

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -191,6 +191,8 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
 
     before do
       create_embedded_docs_for_evidence(income_evidence)
+      income_evidence.verification_histories.first.update_attributes!(date_of_action: TimeKeeper.date_of_record - 1.day)
+      binding.irb
       income_evidence.clone_embedded_documents(income_evidence2)
       @new_verification_history = income_evidence.verification_histories.first
       @new_request_result = income_evidence.request_results.first
@@ -222,10 +224,8 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
       expect(@new_document.updated_at).not_to be_nil
     end
 
-    it 'should maintain the created_at of the cloned document' do
-      income_evidence2.save
-      income_evidence2.reload
-      expect(income_evidence.verification_histories.first.created_at).to eql(income_evidence2.verification_histories.first.created_at)
+    it 'should copy the date_of_action of the copied document' do
+      expect(income_evidence.verification_histories.first.date_of_action).to eql(income_evidence2.verification_histories.first.date_of_action)
     end
   end
 end
@@ -238,7 +238,7 @@ def create_embedded_docs_for_evidence(evidence)
 end
 
 def create_verification_history(evidence)
-  evidence.verification_histories.create(created_at: Date.today - 1.day, action: 'verify', update_reason: 'Document in EnrollApp', updated_by: 'admin@user.com')
+  evidence.verification_histories.create(date_of_action: Date.today - 1.day, action: 'verify', update_reason: 'Document in EnrollApp', updated_by: 'admin@user.com')
 end
 
 def create_request_result(evidence)

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -224,6 +224,7 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
     end
 
     it 'should copy the date_of_action of the copied document' do
+      income_evidence2.verification_histories.first.save
       expect(income_evidence.verification_histories.first.date_of_action).to eql(income_evidence2.verification_histories.first.date_of_action)
     end
   end
@@ -237,7 +238,7 @@ def create_embedded_docs_for_evidence(evidence)
 end
 
 def create_verification_history(evidence)
-  evidence.verification_histories.create(date_of_action: Date.today - 1.day, action: 'verify', update_reason: 'Document in EnrollApp', updated_by: 'admin@user.com')
+  evidence.verification_histories.create(action: 'verify', update_reason: 'Document in EnrollApp', updated_by: 'admin@user.com')
 end
 
 def create_request_result(evidence)

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -192,7 +192,6 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
     before do
       create_embedded_docs_for_evidence(income_evidence)
       income_evidence.verification_histories.first.update_attributes!(date_of_action: TimeKeeper.date_of_record - 1.day)
-      binding.irb
       income_evidence.clone_embedded_documents(income_evidence2)
       @new_verification_history = income_evidence.verification_histories.first
       @new_request_result = income_evidence.request_results.first

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -221,6 +221,12 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
       expect(@new_document.created_at).not_to be_nil
       expect(@new_document.updated_at).not_to be_nil
     end
+
+    it 'should maintain the created_at of the cloned document' do
+      income_evidence2.save
+      income_evidence2.reload
+      expect(income_evidence.verification_histories.first.created_at).to eql(income_evidence2.verification_histories.first.created_at)
+    end
   end
 end
 
@@ -232,7 +238,7 @@ def create_embedded_docs_for_evidence(evidence)
 end
 
 def create_verification_history(evidence)
-  evidence.verification_histories.create(action: 'verify', update_reason: 'Document in EnrollApp', updated_by: 'admin@user.com')
+  evidence.verification_histories.create(created_at: Date.today - 1.day, action: 'verify', update_reason: 'Document in EnrollApp', updated_by: 'admin@user.com')
 end
 
 def create_request_result(evidence)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: Me-184847647

# A brief description of the changes

Current behavior: While looking at evidences, prior evidence histories include incorrect created at dates.

New behavior: evidence histories will include correct created_at timestamp.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
