### PR TITLE
configuring aptc agreement message to env var

### DIFF
--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -93,7 +93,7 @@ registry:
         is_enabled: :false
       - key: :extended_aptc_individual_agreement_message
         item: :extended_aptc_individual_agreement_message
-        is_enabled: false
+        is_enabled: <%= ENV['EXTENDED_APTC_INDIVIDUAL_AGREEMENT_MESSAGE_IS_ENABLED'] || false %>
       - key: :application_type_options
         item: ["Phone", "Paper", "Curam", "Mobile"]
         is_enabled: true

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -95,7 +95,7 @@ registry:
         is_enabled: :true
       - key: :extended_aptc_individual_agreement_message
         item: :extended_aptc_individual_agreement_message
-        is_enabled: true
+        is_enabled: <%= ENV['EXTENDED_APTC_INDIVIDUAL_AGREEMENT_MESSAGE_IS_ENABLED'] || false %>
       - key: :application_type_options
         item: ["Phone", "Paper", "State Medicaid Agency"]
         is_enabled: true

--- a/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -93,7 +93,7 @@ registry:
         is_enabled: :false
       - key: :extended_aptc_individual_agreement_message
         item: :extended_aptc_individual_agreement_message
-        is_enabled: false
+        is_enabled: <%= ENV['EXTENDED_APTC_INDIVIDUAL_AGREEMENT_MESSAGE_IS_ENABLED'] || false %>
       - key: :application_type_options
         item: ["Phone", "Paper", "Curam", "Mobile"]
         is_enabled: true


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640057/stories/185034571

# A brief description of the changes

Current behavior: extended_aptc_individual_agreement_message is currently hardcoded into the yml file and not controlled by environment variable

New behavior: extended_aptc_individual_agreement_message is now controlled by env variable
 
# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: EXTENDED_APTC_INDIVIDUAL_AGREEMENT_MESSAGE_IS_ENABLED

- [ ] DC
- [x] ME
