### PR TITLE
respond with errors if there is an error raised when building familycv

### DIFF
--- a/app/domain/operations/events/build_and_publish.rb
+++ b/app/domain/operations/events/build_and_publish.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'dry/monads/do'
+
+module Operations
+  module Events
+    # Operation is to build and publish an event_source event
+    class BuildAndPublish
+      include Dry::Monads[:result, :do]
+      include EventSource::Command
+
+      # @param [Hash] opts The options build and publish an event_source event
+      # @option opts [String] :event_name
+      # @option opts [Hash] :attributes
+      # @option opts [Hash] :headers
+      # @example
+      #   { event_name: 'events.families.found_by', attributes: { errors: [], family: {} }, headers: { correlation_id: '' } }
+      # @return [Dry::Monads::Result]
+      def call(params)
+        values = yield validate(params)
+        event  = yield build_event(values)
+        result = yield publish(event)
+
+        Success(result)
+      end
+
+      private
+
+      def build_event(values)
+        event(values[:event_name], attributes: values[:attributes], headers: values[:headers] || {})
+      end
+
+      def publish(event)
+        event.publish
+
+        Success("Successfully published event: #{event.name}")
+      end
+
+      def validate(params)
+        errors = []
+        errors << 'event_name is required and must be a string' unless params[:event_name].is_a?(String)
+        errors << 'attributes is required and must be a hash' unless params[:attributes].is_a?(Hash)
+        errors << 'headers is required' unless params.key?(:headers)
+
+        errors.present? ? Failure(errors) : Success(params)
+      end
+    end
+  end
+end

--- a/app/domain/operations/families/find_by.rb
+++ b/app/domain/operations/families/find_by.rb
@@ -19,7 +19,7 @@ module Operations
         person     = yield find_person(params[:response][:person_hbx_id])
         family     = yield find_primary_family(person)
         cv3_family = yield transform_family(family)
-        payload    = yield generate_payload(cv3_family, person)
+        payload    = yield generate_payload(cv3_family)
 
         Success(payload)
       end
@@ -48,7 +48,7 @@ module Operations
         Operations::Transformers::FamilyTo::Cv3Family.new.call(family)
       end
 
-      def generate_payload(cv3_family, person)
+      def generate_payload(cv3_family)
         result = AcaEntities::Contracts::Families::FamilyContract.new.call(cv3_family)
 
         if result.success?

--- a/app/domain/operations/families/find_by.rb
+++ b/app/domain/operations/families/find_by.rb
@@ -5,31 +5,26 @@ require 'dry/monads/do'
 
 module Operations
   module Families
-    # Operation is for finding family with person person hbx_id and publishing an event 'enroll.families.found_by'
+    # Operation finds family using primary person hbx_id and generats a Family CV
     class FindBy
-      include Dry::Monads[:result, :do, :try]
-      include EventSource::Command
+      include Dry::Monads[:result, :do]
 
-      # params = { { person_hbx_id: 10239, year: 2022 } }
+      # @param [Hash] opts The options to generate family_cv for a given primary person Hbx ID
+      # @option opts [String] :person_hbx_id
+      # @option opts [Integer] :year
+      # @example
+      #   { person_hbx_id: '10239', year: 2022 }
+      # @return [Dry::Monads::Result]
       def call(params)
         person     = yield find_person(params[:response][:person_hbx_id])
         family     = yield find_primary_family(person)
         cv3_family = yield transform_family(family)
-        payload    = yield validate_payload(cv3_family, person)
-        event      = yield build_event(payload, params)
-        result     = yield publish(event)
+        payload    = yield generate_payload(cv3_family, person)
 
-        Success(result)
+        Success(payload)
       end
 
       private
-
-      def build_event(payload, params)
-        event('events.families.found_by', attributes: {
-                family: payload.to_h,
-                primary_person_hbx_id: params[:response][:person_hbx_id]
-              }, headers: { correlation_id: params[:correlation_id] })
-      end
 
       def find_person(person_hbx_id)
         person = Person.where(hbx_id: person_hbx_id).first
@@ -49,22 +44,17 @@ module Operations
         end
       end
 
-      def publish(event)
-        event.publish
-        Success("Successfully published event: #{event.name}")
-      end
-
       def transform_family(family)
         Operations::Transformers::FamilyTo::Cv3Family.new.call(family)
       end
 
-      def validate_payload(cv3_family, person)
+      def generate_payload(cv3_family, person)
         result = AcaEntities::Contracts::Families::FamilyContract.new.call(cv3_family)
 
         if result.success?
           Success(result)
         else
-          Failure("Invalid Cv3Family payload for primary_person with hbx_id: #{person.hbx_id} due to #{result.errors.to_h}")
+          Failure(result.errors.to_h)
         end
       end
     end

--- a/app/event_source/subscribers/families/find_by_requested_subscriber.rb
+++ b/app/event_source/subscribers/families/find_by_requested_subscriber.rb
@@ -34,18 +34,47 @@ module Subscribers
 
       def process_find_by_requested_event(subscriber_logger, correlation_id, response)
         subscriber_logger.info "process_find_by_requested_event: ------- start"
-        result = ::Operations::Families::FindBy.new.call({correlation_id: correlation_id, response: response})
-
-        if result.success?
-          message = result.success
-          subscriber_logger.info "on_find_by_requested acked #{message.is_a?(Hash) ? message[:event] : message}"
-        else
-          subscriber_logger.info "process_find_by_requested_event: failure: #{error_messages(result)}"
-        end
+        generate_and_publish_payload(subscriber_logger, correlation_id, response)
         subscriber_logger.info "process_find_by_requested_event: ------- end"
       rescue StandardError => e
         subscriber_logger.error "process_find_by_requested_event: error: #{e} backtrace: #{e.backtrace}"
         subscriber_logger.error "process_find_by_requested_event: ------- end"
+      end
+
+      def generate_event_payload(subscriber_logger, response)
+        generate_payload_result = ::Operations::Families::FindBy.new.call({ response: response })
+
+        if generate_payload_result.success?
+          subscriber_logger.info "Successfully generated valid family_cv for primary person with hbx_id: #{response[:person_hbx_id]}"
+          { errors: [], family: generate_payload_result.success }
+        else
+          subscriber_logger.error "Unable to generate valid family_cv for primary person with hbx_id: #{response[:person_hbx_id]}"
+          { errors: [generate_payload_result.failure], family: {} }
+        end
+      end
+
+      def publish_payload(subscriber_logger, correlation_id, response, event_payload)
+        published_result = ::Operations::Events::BuildAndPublish.new.call(
+          {
+            attributes: event_payload,
+            event_name: 'events.families.found_by',
+            headers: { correlation_id: correlation_id }
+          }
+        )
+
+        if published_result.success?
+          subscriber_logger.info "Successfully published event_payload: #{
+            event_payload} for primary person with hbx_id: #{response[:person_hbx_id]}"
+        else
+          subscriber_logger.error "Unable to publish event_payload: #{
+            event_payload} for primary person with hbx_id: #{
+              response[:person_hbx_id]} with failure: #{published_result.failure.inspect}"
+        end
+      end
+
+      def generate_and_publish_payload(subscriber_logger, correlation_id, response)
+        event_payload = generate_event_payload(subscriber_logger, response)
+        publish_payload(subscriber_logger, correlation_id, response, event_payload)
       end
 
       def subscriber_logger_for(event)

--- a/app/event_source/subscribers/families/find_by_requested_subscriber.rb
+++ b/app/event_source/subscribers/families/find_by_requested_subscriber.rb
@@ -46,10 +46,10 @@ module Subscribers
 
         if generate_payload_result.success?
           subscriber_logger.info "Successfully generated valid family_cv for primary person with hbx_id: #{response[:person_hbx_id]}"
-          { errors: [], family: generate_payload_result.success }
+          { errors: [], family: generate_payload_result.success, primary_person_hbx_id: response[:person_hbx_id] }
         else
           subscriber_logger.error "Unable to generate valid family_cv for primary person with hbx_id: #{response[:person_hbx_id]}"
-          { errors: [generate_payload_result.failure], family: {} }
+          { errors: [generate_payload_result.failure], family: {}, primary_person_hbx_id: response[:person_hbx_id] }
         end
       end
 

--- a/spec/domain/operations/events/build_and_publish_spec.rb
+++ b/spec/domain/operations/events/build_and_publish_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::Operations::Events::BuildAndPublish, dbclean: :after_each do
+  subject { described_class.new.call(input_params) }
+
+  describe '#call' do
+    context 'with valid input params' do
+      let(:input_params) do
+        {
+          event_name: 'events.families.found_by',
+          attributes: { test: 'test' },
+          headers: { correlation_id: 'correlation_id' }
+        }
+      end
+
+      it 'returns success with a message' do
+        expect(subject.success).to eq(
+          "Successfully published event: #{input_params[:event_name]}"
+        )
+      end
+    end
+
+    context 'with invalid input params' do
+      context 'without key named event_name' do
+        let(:input_params) { { attributes: { test: 'test' }, headers: { correlation_id: 'correlation_id' } } }
+
+        it 'returns a failure with a message' do
+          expect(
+            subject.failure
+          ).to include('event_name is required and must be a string')
+        end
+      end
+
+      context 'without key named attributes' do
+        let(:input_params) { { event_name: 'events.families.found_by', headers: { correlation_id: 'correlation_id' } } }
+
+        it 'returns a failure with a message' do
+          expect(
+            subject.failure
+          ).to include('attributes is required and must be a hash')
+        end
+      end
+
+      context 'without key named headers' do
+        let(:input_params) { { event_name: 'events.families.found_by', attributes: { test: 'test' } } }
+
+        it 'returns a failure with a message' do
+          expect(
+            subject.failure
+          ).to include('headers is required')
+        end
+      end
+    end
+  end
+end

--- a/spec/domain/operations/families/find_by_spec.rb
+++ b/spec/domain/operations/families/find_by_spec.rb
@@ -16,10 +16,8 @@ RSpec.describe ::Operations::Families::FindBy, dbclean: :after_each do
       let(:year) { TimeKeeper.date_of_record.year }
       let(:correlation_id) { "12345" }
 
-      it 'returns a success with a message' do
-        expect(
-          subject.success
-        ).to eq('Successfully published event: events.families.found_by')
+      it 'returns a success' do
+        expect(subject.success).to be_truthy
       end
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes

# What is the ticket # detailing the issue?

Ticket: IVL-185026076

# A brief description of the changes

Current behavior: A message is not returned back to the requester(in this case EdiGW) in case of an error while generating Family CV.

New behavior: A message with errors will be returned back to the requester(in this case EdiGW) in case of an error while generating Family CV.

# Environment Variable
A feature flag is not needed as this is a bug fix or enhancement to the system itself and specific to a feature or client.
