### PR TITLE
deactivate financial assistance on family member add or drop

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -1382,6 +1382,23 @@ class Family
     tax_household_groups.active.by_year(year).first
   end
 
+  # Currently implemented to handle only when Multi Tax Household feature is enabled
+  def deactivate_financial_assistance(effective_date)
+    return unless EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
+    return if !effective_date.is_a?(Date) || active_thhg(effective_date.year).blank?
+
+    deactivated = ::Operations::TaxHouseholdGroups::Deactivate.new.call({ family: self, new_effective_date: effective_date })
+
+    if deactivated.failure?
+      Rails.logger.error { "Failed to deactivate tax household groups for family with hbx_id: #{hbx_assigned_id}, Failure: #{deactivated.failure}" }
+    else
+      build_determination = ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: self.reload, effective_date: effective_date)
+      return if build_determination.success?
+
+      Rails.logger.error { "Failed to build family determination for family with hbx_id: #{hbx_assigned_id}, Failure: #{build_determination.failure}" }
+    end
+  end
+
 private
   def build_household
     if households.size == 0

--- a/app/models/family_member.rb
+++ b/app/models/family_member.rb
@@ -198,7 +198,10 @@ class FamilyMember
   end
 
   def deactivate_tax_households
-    return unless family.persisted? && family.active_household.tax_households.present?
+    return unless family.persisted?
+
+    family.deactivate_financial_assistance(TimeKeeper.date_of_record)
+    return if family.active_household.latest_active_tax_household_with_year(TimeKeeper.date_of_record.year).blank?
 
     Operations::Households::DeactivateFinancialAssistanceEligibility.new.call(params: {family_id: family.id, date: TimeKeeper.date_of_record})
   rescue StandardError => e


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 185011059 ](https://www.pivotaltracker.com/n/projects/2640059/stories/185011059)

# A brief description of the changes

Current behavior: When the Multi Tax Household feature is enabled, Financial Assistance is still active on a member add or drop.

New behavior: When the Multi Tax Household feature is enabled, Financial Assitance is deactivated on member add or drop.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: `TEMPORARY_CONFIGURATION_OF_MULTI_TAX_HOUSEHOLD_FEATURE_IS_ENABLED` is the environment variable that is being used currently. This feature is currently enabled for ME and not DC.

- [ ] DC
- [x] ME
