### PR TITLE
render glossary only when it is available

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
@@ -54,17 +54,22 @@
 
       <br />
 
-      <% FinancialAssistance::Deduction::KINDS.each do |deduction_kind| %>
+      <% FinancialAssistance::Deduction::DEDUCTION_TYPE.each do |deduction_kind, label| %>
         <div id="<%= deduction_kind %>"class="deduction-kind">
           <div class="row row-form-wrapper lightgray radio-align fa-text-color no-buffer row-height">
             <div class="col-md-1 checkbox-mr">
               <%=check_box_tag "deduction_kind", deduction_kind, @applicant.deductions.of_kind(deduction_kind).present?, class: "deduction-checkbox-#{deduction_kind}" %>
             </div>
-
-            <div class="col-md-9 no-pd <%= deduction_kind %>">
-              <%= render partial:"shared/glossary", locals: {key: deduction_kind, term: FinancialAssistance::Deduction::DEDUCTION_TYPE[deduction_kind.to_sym] } %>
-              <%= l10n('faa.deductions.divorce_agreement') if deduction_kind == "alimony_paid" && FinancialAssistanceRegistry.feature_enabled?(:divorce_agreement_year) %>
-            </div>
+            <%if  I18n.exists?("glossary."+deduction_kind.to_s)%>
+              <div class="col-md-9 no-pd <%= deduction_kind %>">
+                <%= render partial:"shared/glossary", locals: {key: deduction_kind, term: FinancialAssistance::Deduction::DEDUCTION_TYPE[deduction_kind.to_sym] } %>
+                <%= l10n('faa.deductions.divorce_agreement') if deduction_kind == "alimony_paid" && FinancialAssistanceRegistry.feature_enabled?(:divorce_agreement_year) %>
+              </div>
+            <%else%>
+              <div class="col-md-9 no-pd">
+                <%= label %> <%= l10n('faa.deductions.divorce_agreement') if deduction_kind == "alimony_paid" && FinancialAssistanceRegistry.feature_enabled?(:divorce_agreement_year) %>
+              </div>
+            <%end%>
           </div>
 
           <div class="deductions-list">

--- a/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
@@ -55,14 +55,15 @@
       <br />
 
       <% FinancialAssistance::Deduction::DEDUCTION_TYPE.each do |deduction_kind, label| %>
+       <% deduction_kind = deduction_kind.to_s %>
         <div id="<%= deduction_kind %>"class="deduction-kind">
           <div class="row row-form-wrapper lightgray radio-align fa-text-color no-buffer row-height">
             <div class="col-md-1 checkbox-mr">
               <%=check_box_tag "deduction_kind", deduction_kind, @applicant.deductions.of_kind(deduction_kind).present?, class: "deduction-checkbox-#{deduction_kind}" %>
             </div>
-            <%if  I18n.exists?("glossary."+deduction_kind.to_s)%>
+            <%if  I18n.exists?("glossary."+deduction_kind)%>
               <div class="col-md-9 no-pd <%= deduction_kind %>">
-                <%= render partial:"shared/glossary", locals: {key: deduction_kind, term: FinancialAssistance::Deduction::DEDUCTION_TYPE[deduction_kind.to_sym] } %>
+                <%= render partial:"shared/glossary", locals: {key: deduction_kind, term: label } %>
                 <%= l10n('faa.deductions.divorce_agreement') if deduction_kind == "alimony_paid" && FinancialAssistanceRegistry.feature_enabled?(:divorce_agreement_year) %>
               </div>
             <%else%>

--- a/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
@@ -67,7 +67,7 @@
                 <%= l10n('faa.deductions.divorce_agreement') if deduction_kind == "alimony_paid" && FinancialAssistanceRegistry.feature_enabled?(:divorce_agreement_year) %>
               </div>
             <%else%>
-              <div class="col-md-9 no-pd">
+              <div class="col-md-9 no-pd <%= deduction_kind %>">
                 <%= label %> <%= l10n('faa.deductions.divorce_agreement') if deduction_kind == "alimony_paid" && FinancialAssistanceRegistry.feature_enabled?(:divorce_agreement_year) %>
               </div>
             <%end%>

--- a/features/financial_assistance/income_adjustments_page.feature
+++ b/features/financial_assistance/income_adjustments_page.feature
@@ -79,3 +79,12 @@ Feature: Start a new Financial Assistance Application and fills out Income Adjus
     And they visit the income adjustments page via the left nav
     Given the user answers yes to having income adjustments
     Then the divorce agreement copy should show
+
+  Scenario: Health Savings Account glossary display
+    Given the user answers yes to having income adjustments
+    Then the health_savings_account have glossary link
+    Then the health_savings_account have glossary content
+
+  Scenario: Alimony Paid glossary does not display
+    Given the user answers yes to having income adjustments
+    Then the alimony_paid does not have glossary link

--- a/features/financial_assistance/step_definitions/income_adjustments_page_steps.rb
+++ b/features/financial_assistance/step_definitions/income_adjustments_page_steps.rb
@@ -97,6 +97,7 @@ Then(/^the health_savings_account have glossary content$/) do
 end
 
 Then(/^the alimony_paid does not have glossary link$/) do
+  sleep 1
   expect(page.has_css?(IvlIapIncomeAdjustmentsPage.alimony_paid)).to be_truthy
   expect(page.has_css?(IvlIapIncomeAdjustmentsPage.alimony_paid_glossary_link)).to be_falsy
 end

--- a/features/financial_assistance/step_definitions/income_adjustments_page_steps.rb
+++ b/features/financial_assistance/step_definitions/income_adjustments_page_steps.rb
@@ -97,7 +97,7 @@ Then(/^the health_savings_account have glossary content$/) do
 end
 
 Then(/^the alimony_paid does not have glossary link$/) do
-  sleep 1
+  sleep 3
   expect(page.has_css?(IvlIapIncomeAdjustmentsPage.alimony_paid)).to be_truthy
   expect(page.has_css?(IvlIapIncomeAdjustmentsPage.alimony_paid_glossary_link)).to be_falsy
 end

--- a/features/financial_assistance/step_definitions/income_adjustments_page_steps.rb
+++ b/features/financial_assistance/step_definitions/income_adjustments_page_steps.rb
@@ -86,6 +86,19 @@ Then(/^the divorce agreement copy should show$/) do
   expect(page).to have_content 'from a divorce agreement finalized before January 1, 2019'
 end
 
+Then(/^the health_savings_account have glossary link$/) do
+  expect(page.has_xpath?("//*[@id='health_savings_account']/div[1]/div[2]/span")).to be_truthy
+end
+
+Then(/^the health_savings_account have glossary content$/) do
+  find(:xpath, "//*[@id='health_savings_account']/div[1]/div[2]/span").click
+  expect(page).to have_content 'If you have a High Deductible Health Plan, you may be eligible for a Health Savings Account'
+end
+
+Then(/^the alimony_paid does not have glossary link$/) do
+  expect(page.has_xpath?("//*[@id='alimony_paid']/div[1]/div[2]/span")).to be_falsy
+end
+
 Then(/^the divorce agreement copy should not show$/) do
   expect(page).to_not have_content 'from a divorce agreement finalized before January 1, 2019'
 end

--- a/features/financial_assistance/step_definitions/income_adjustments_page_steps.rb
+++ b/features/financial_assistance/step_definitions/income_adjustments_page_steps.rb
@@ -97,7 +97,6 @@ Then(/^the health_savings_account have glossary content$/) do
 end
 
 Then(/^the alimony_paid does not have glossary link$/) do
-  sleep 3
   expect(page.has_css?(IvlIapIncomeAdjustmentsPage.alimony_paid)).to be_truthy
   expect(page.has_css?(IvlIapIncomeAdjustmentsPage.alimony_paid_glossary_link)).to be_falsy
 end

--- a/features/financial_assistance/step_definitions/income_adjustments_page_steps.rb
+++ b/features/financial_assistance/step_definitions/income_adjustments_page_steps.rb
@@ -87,16 +87,18 @@ Then(/^the divorce agreement copy should show$/) do
 end
 
 Then(/^the health_savings_account have glossary link$/) do
-  expect(page.has_xpath?("//*[@id='health_savings_account']/div[1]/div[2]/span")).to be_truthy
+  expect(page.has_css?(IvlIapIncomeAdjustmentsPage.health_savings_account)).to be_truthy
+  expect(page.has_css?(IvlIapIncomeAdjustmentsPage.health_savings_account_glossary_link)).to be_truthy
 end
 
 Then(/^the health_savings_account have glossary content$/) do
-  find(:xpath, "//*[@id='health_savings_account']/div[1]/div[2]/span").click
+  find(IvlIapIncomeAdjustmentsPage.health_savings_account_glossary_link).click
   expect(page).to have_content 'If you have a High Deductible Health Plan, you may be eligible for a Health Savings Account'
 end
 
 Then(/^the alimony_paid does not have glossary link$/) do
-  expect(page.has_xpath?("//*[@id='alimony_paid']/div[1]/div[2]/span")).to be_falsy
+  expect(page.has_css?(IvlIapIncomeAdjustmentsPage.alimony_paid)).to be_truthy
+  expect(page.has_css?(IvlIapIncomeAdjustmentsPage.alimony_paid_glossary_link)).to be_falsy
 end
 
 Then(/^the divorce agreement copy should not show$/) do

--- a/features/support/object_model_pages/ivl/iap/ivl_iap_income_adjustments_page.rb
+++ b/features/support/object_model_pages/ivl/iap/ivl_iap_income_adjustments_page.rb
@@ -214,4 +214,20 @@ class IvlIapIncomeAdjustmentsPage
   def self.taxable_income_select_monthly
     'li[class="interaction-choice-control-deduction-frequency-kind-100 interaction-choice-control-deduction-frequency-kind-4"]'
   end
+
+  def self.health_savings_account
+    '.health_savings_account'
+  end
+
+  def self.health_savings_account_glossary_link
+    '.health_savings_account span'
+  end
+
+  def self.alimony_paid
+    '.alimony_paid'
+  end
+
+  def self.alimony_paid_glossary_link
+    '.alimony_paid span'
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [Pivotal-185069247](https://www.pivotaltracker.com/n/projects/2640060/stories/185069247)

# A brief description of the changes

Current behavior: Glossary is always rendered to respective glossary or a default value irrespective of it presence, which is causing incorrect UI display.

New behavior: Render glossary only when the respective glossary is present, if not render text.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
