### PR TITLE
render glossary if the respective glossary is present

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
@@ -13,11 +13,11 @@
 <% insurance_kinds.each do |insurance_kind| %>
   <div id="<%= insurance_kind %>"class="benefit-kind">
     <div class="row row-form-wrapper radio-align fa-text-color lightgray no-buffer row-height">
-      <div class="col-md-10 benefits-check">
+      <div class="col-md-10 benefits-check <%= insurance_kind %>">
         <%=check_box_tag "insurance_kind", insurance_kind, @applicant.benefits.where(kind: kind).of_insurance_kind(insurance_kind).present?, class: "benefit-checkbox" %>
         <% eligible_esi = kind == "is_eligible" && insurance_kind == 'employer_sponsored_insurance' && FinancialAssistanceRegistry.feature_enabled?(:minimum_value_standard_question) %>
         <% term = eligible_esi ? "faa.question.#{insurance_kind}_eligible" : "faa.question.#{insurance_kind}" %>
-        <%if I18n.exists?("glossary."+insurance_kind) %>
+        <% if I18n.exists?("glossary."+insurance_kind) %>
             <%= render partial:'shared/glossary', locals: {key: insurance_kind, term: l10n(term, short_name: EnrollRegistry[:enroll_app].setting(:short_name).item) } %>
         <% else %>
             <%= l10n(term, short_name: EnrollRegistry[:enroll_app].setting(:short_name).item) %>

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
@@ -17,7 +17,11 @@
         <%=check_box_tag "insurance_kind", insurance_kind, @applicant.benefits.where(kind: kind).of_insurance_kind(insurance_kind).present?, class: "benefit-checkbox" %>
         <% eligible_esi = kind == "is_eligible" && insurance_kind == 'employer_sponsored_insurance' && FinancialAssistanceRegistry.feature_enabled?(:minimum_value_standard_question) %>
         <% term = eligible_esi ? "faa.question.#{insurance_kind}_eligible" : "faa.question.#{insurance_kind}" %>
-        <%= render partial:'shared/glossary', locals: {key: insurance_kind, term: l10n(term, short_name: EnrollRegistry[:enroll_app].setting(:short_name).item) } %>
+        <%if I18n.exists?("glossary."+insurance_kind) %>
+            <%= render partial:'shared/glossary', locals: {key: insurance_kind, term: l10n(term, short_name: EnrollRegistry[:enroll_app].setting(:short_name).item) } %>
+        <% else %>
+            <%= l10n(term, short_name: EnrollRegistry[:enroll_app].setting(:short_name).item) %>
+        <% end %>
       </div>
     </div>
 

--- a/features/financial_assistance/health_coverage_currently_has.feature
+++ b/features/financial_assistance/health_coverage_currently_has.feature
@@ -47,3 +47,12 @@ Feature: Start a new Financial Assistance Application and answers questions on h
     Given the user answers yes to currently having health coverage
     And the user checks on not sure link for hra checkbox
     Then should see not sure modal pop up
+
+  Scenario: Health coverage form shows after checking an option (currently have coverage)
+    Given the user answers yes to currently having health coverage
+    Then the medicare have glossary link
+    Then the medicare have glossary content
+
+  Scenario: Health coverage form shows after checking an option (currently have coverage)
+    Given the user answers yes to currently having health coverage
+    Then the coverage_obtained_through_another_exchange does not have glossary link

--- a/features/financial_assistance/step_definitions/health_coverage_steps.rb
+++ b/features/financial_assistance/step_definitions/health_coverage_steps.rb
@@ -85,7 +85,7 @@ end
 
 Then(/^the medicare have glossary content$/) do
   find(IvlIapHealthCoveragePage.medicare_glossary_link).click
-  expect(page).to have_content 'Medicare is a federal health insurance program for people who are 65 or older'
+  expect(page).to have_content 'A federal health insurance program for people who are 65 or older'
 end
 
 Then(/^the coverage_obtained_through_another_exchange does not have glossary link$/) do

--- a/features/financial_assistance/step_definitions/health_coverage_steps.rb
+++ b/features/financial_assistance/step_definitions/health_coverage_steps.rb
@@ -85,7 +85,7 @@ end
 
 Then(/^the medicare have glossary content$/) do
   find(IvlIapHealthCoveragePage.medicare_glossary_link).click
-  expect(page).to have_content 'If you have a High Deductible Health Plan, you may be eligible for a Health Savings Account'
+  expect(page).to have_content 'Medicare is a federal health insurance program for people who are 65 or older'
 end
 
 Then(/^the coverage_obtained_through_another_exchange does not have glossary link$/) do

--- a/features/financial_assistance/step_definitions/health_coverage_steps.rb
+++ b/features/financial_assistance/step_definitions/health_coverage_steps.rb
@@ -78,6 +78,21 @@ Then(/^the user should be see proper text in the modal popup$/) do
   expect(page).to have_content('The minimum value is a standard used to see if a health plan offered by your employer meets the basic requirements of the Affordable Care Act.')
 end
 
+Then(/^the medicare have glossary link$/) do
+  expect(page.has_css?(IvlIapHealthCoveragePage.medicare)).to be_truthy
+  expect(page.has_css?(IvlIapHealthCoveragePage.medicare_glossary_link)).to be_truthy
+end
+
+Then(/^the medicare have glossary content$/) do
+  find(IvlIapHealthCoveragePage.medicare_glossary_link).click
+  expect(page).to have_content 'If you have a High Deductible Health Plan, you may be eligible for a Health Savings Account'
+end
+
+Then(/^the coverage_obtained_through_another_exchange does not have glossary link$/) do
+  expect(page.has_css?(IvlIapHealthCoveragePage.coverage_obtained_through_another_exchange)).to be_truthy
+  expect(page.has_css?(IvlIapHealthCoveragePage.coverage_obtained_through_another_exchange_glossary_link)).to be_falsy
+end
+
 Then(/^the health coverage form should show$/) do
   expect(page).to have_xpath("//*[@id='acf_refugee_medical_assistance']/div[2]/div")
 end

--- a/features/support/object_model_pages/ivl/iap/ivl_iap_health_coverage_page.rb
+++ b/features/support/object_model_pages/ivl/iap/ivl_iap_health_coverage_page.rb
@@ -194,4 +194,20 @@ class IvlIapHealthCoveragePage
   def self.back_to_all_house_members
     'a[class=interaction-click-control-back-to-all-household-members]'
   end
+
+  def self.medicare
+    '.medicare'
+  end
+
+  def self.medicare_glossary_link
+    '.medicare span'
+  end
+
+  def self.coverage_obtained_through_another_exchange
+    '.coverage_obtained_through_another_exchange'
+  end
+
+  def self.coverage_obtained_through_another_exchange_glossary_link
+    '.coverage_obtained_through_another_exchange span'
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [Redmine-98401](https://redmine.priv.dchbx.org/issues/98401)

# A brief description of the changes

Current behavior:  Glossary is always rendered to respective glossary or a default value irrespective of it presence, which is causing incorrect UI display.

New behavior: Render glossary only when the respective glossary is present, if not render text.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
