### PR TITLE
update aptc session variables for continuous coverage enrollments

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -374,6 +374,8 @@ class Insured::PlanShoppingsController < ApplicationController
     percentage = @elected_aptc / @max_aptc
     @max_aptc = ::Operations::PremiumCredits::FindAptc.new.call({ hbx_enrollment: @enrollment, effective_on: @enrollment.effective_on }).value!
     @elected_aptc = percentage * @max_aptc
+    session[:elected_aptc] = @elected_aptc.to_f if session[:elected_aptc].to_d != @elected_aptc.to_d
+    session[:max_aptc] = @max_aptc.to_f if session[:max_aptc].to_d != @max_aptc.to_d
   end
 
   def dependents_with_existing_coverage(enrollment)

--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -374,8 +374,8 @@ class Insured::PlanShoppingsController < ApplicationController
     percentage = @elected_aptc / @max_aptc
     @max_aptc = ::Operations::PremiumCredits::FindAptc.new.call({ hbx_enrollment: @enrollment, effective_on: @enrollment.effective_on }).value!
     @elected_aptc = percentage * @max_aptc
-    session[:elected_aptc] = @elected_aptc.to_f if session[:elected_aptc].to_d != @elected_aptc.to_d
-    session[:max_aptc] = @max_aptc.to_f if session[:max_aptc].to_d != @max_aptc.to_d
+    session[:elected_aptc] = @elected_aptc.to_f
+    session[:max_aptc] = @max_aptc.to_f
   end
 
   def dependents_with_existing_coverage(enrollment)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development-184942992](https://www.pivotaltracker.com/n/projects/2640059/stories/184942992)

# A brief description of the changes

Current behavior: When the Multi Tax Household feature is enabled and the user is purchasing a continuous coverage enrollment with APTC the `available_aptc` is correct on the `thankyou` page and incorrect on the `receipt` page

New behavior: When the Multi Tax Household feature is enabled and the user is purchasing a continuous coverage enrollment with APTC the `available_aptc` is correct on both the `thankyou` and `receipt` pages

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: `TEMPORARY_CONFIGURATION_OF_MULTI_TAX_HOUSEHOLD_FEATURE_IS_ENABLED` is the environment variable that is being used currently. This feature is currently enabled for ME and not DC.

- [ ] DC
- [x] ME
