### PR TITLE
add check for org active bs eligibilities

### DIFF
--- a/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
@@ -54,7 +54,12 @@ module SponsoredBenefits
       end
 
       def osse_eligibility
-        benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
+        org = BenefitSponsors::Organizations::Organization.find_by(fein: plan_design_organization.fein)
+        org_eligibilities = org.active_benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
+        pdo_eligibilities = benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
+
+        return pdo_eligibilities if pdo_eligibilities.present?
+        org_eligibilities
       end
 
       def metal_level_products_restricted?

--- a/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
@@ -57,8 +57,6 @@ module SponsoredBenefits
         org_eligibilities = if plan_design_organization.fein.present?
                               org = BenefitSponsors::Organizations::Organization.find_by(fein: plan_design_organization.fein)
                               org.active_benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
-                            else
-                              nil
                             end
         pdo_eligibilities = benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
 

--- a/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
@@ -55,8 +55,8 @@ module SponsoredBenefits
 
       def osse_eligibility
         org_eligibilities = if plan_design_organization.fein.present?
-                              org = BenefitSponsors::Organizations::Organization.find_by(fein: plan_design_organization.fein)
-                              org.active_benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
+                              org = BenefitSponsors::Organizations::Organization.where(fein: plan_design_organization.fein)&.first
+                              org&.active_benefit_sponsorship&.eligibility_for(:osse_subsidy, effective_date)
                             end
         pdo_eligibilities = benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
 

--- a/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
@@ -54,8 +54,12 @@ module SponsoredBenefits
       end
 
       def osse_eligibility
-        org = BenefitSponsors::Organizations::Organization.find_by(fein: plan_design_organization.fein)
-        org_eligibilities = org.active_benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
+        org_eligibilities = if plan_design_organization.fein.present?
+                              org = BenefitSponsors::Organizations::Organization.find_by(fein: plan_design_organization.fein)
+                              org.active_benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
+                            else
+                              nil
+                            end
         pdo_eligibilities = benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
 
         return pdo_eligibilities if pdo_eligibilities.present?

--- a/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
@@ -54,14 +54,12 @@ module SponsoredBenefits
       end
 
       def osse_eligibility
-        org_eligibilities = if plan_design_organization.fein.present?
-                              org = BenefitSponsors::Organizations::Organization.where(fein: plan_design_organization.fein)&.first
-                              org&.active_benefit_sponsorship&.eligibility_for(:osse_subsidy, effective_date)
-                            end
         pdo_eligibilities = benefit_sponsorship.eligibility_for(:osse_subsidy, effective_date)
-
         return pdo_eligibilities if pdo_eligibilities.present?
-        org_eligibilities
+
+        return nil unless plan_design_organization.fein.present?
+        org = BenefitSponsors::Organizations::Organization.where(fein: plan_design_organization.fein)&.first
+        org&.active_benefit_sponsorship&.eligibility_for(:osse_subsidy, effective_date)
       end
 
       def metal_level_products_restricted?


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: 
[185060566](https://www.pivotaltracker.com/n/projects/2640061/stories/185060566)

# A brief description of the changes

Current behavior:
Plan design proposal will occasionally not pick up an existing OSSE eligibility from the created plan design organization.

New behavior:
Adds a check to the employer org's active benefit sponsorship in case the PDO faultily returns no eligibility.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
