### PR TITLE
prepend upto 2 zeros for ssn in roster upload

### DIFF
--- a/components/benefit_sponsors/app/models/benefit_sponsors/forms/census_record_form.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/forms/census_record_form.rb
@@ -35,7 +35,12 @@ module BenefitSponsors
       end
 
       def ssn=(val)
-        super(val.to_i.to_s) if val
+        super(parse_ssn(val)) if val
+      end
+
+      def parse_ssn(val)
+        result = val.to_i.to_s.gsub(/\D/, '')
+        result.length.between?(7,8) ? result.rjust(9, "0") : result
       end
 
       def date_format

--- a/components/benefit_sponsors/app/models/benefit_sponsors/services/roster_upload_service.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/services/roster_upload_service.rb
@@ -340,7 +340,9 @@ module BenefitSponsors
       end
 
       def parse_ssn(cell)
-        cell.blank? ? nil : cell.to_i.to_s.gsub(/\D/, '')
+        return nil if cell.blank?
+        value = cell.to_i.to_s.gsub(/\D/, '')
+        value.length.between?(7,8) ? value.rjust(9, "0") : value
       end
 
       def parse_boolean(cell)

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/services/roster_upload_service_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/services/roster_upload_service_spec.rb
@@ -30,16 +30,30 @@ module BenefitSponsors
 
     describe "parse_ssn" do
       let(:params) {{first_name: ce.first_name, last_name: ce.last_name, gender: ce.gender, ssn: 123_456_789.0, dob: ce.dob, hired_on: ce.hired_on.strftime("%m/%d/%Y"), address: ini_address_form }}
+      let(:params_2) {{first_name: ce.first_name, last_name: ce.last_name, gender: ce.gender, ssn: "1234567", dob: ce.dob, hired_on: ce.hired_on.strftime("%m/%d/%Y"), address: ini_address_form }}
+      let(:params_3) {{first_name: ce.first_name, last_name: ce.last_name, gender: ce.gender, ssn: "123456", dob: ce.dob, hired_on: ce.hired_on.strftime("%m/%d/%Y"), address: ini_address_form }}
 
       before :each do
-        file = Dir.glob(File.join(Rails.root, "spec/test_data/census_employee_import/DCHL Employee Census.xlsx")).first
+        @file = Dir.glob(File.join(Rails.root, "spec/test_data/census_employee_import/DCHL Employee Census.xlsx")).first
         allow(user).to receive(:person).and_return(person)
-        @form = BenefitSponsors::Forms::CensusRecordForm.new(params)
-        @result = service_class.new({file: file, profile: benefit_sponsorship.profile}).init_census_record(ce, @form)
       end
 
       it "should return ssn" do
-        expect(@result.ssn).to eq "123456789"
+        form = BenefitSponsors::Forms::CensusRecordForm.new(params)
+        result = service_class.new({file: @file, profile: benefit_sponsorship.profile}).init_census_record(ce, form)
+        expect(result.ssn).to eq "123456789"
+      end
+
+      it "should prepend 0 if given ssn is 7 or 8 digits" do
+        form = BenefitSponsors::Forms::CensusRecordForm.new(params_2)
+        result = service_class.new({file: @file, profile: benefit_sponsorship.profile}).init_census_record(ce, form)
+        expect(result.ssn).to eq "001234567"
+      end
+
+      it "shouldn't prepend 0 if given ssn less than 7 digits" do
+        form = BenefitSponsors::Forms::CensusRecordForm.new(params_3)
+        result = service_class.new({file: @file, profile: benefit_sponsorship.profile}).init_census_record(ce, form)
+        expect(result.ssn).to eq "123456"
       end
     end
 

--- a/components/sponsored_benefits/app/models/sponsored_benefits/forms/census_employee_import.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/forms/census_employee_import.rb
@@ -333,7 +333,10 @@ module SponsoredBenefits
       end
 
       def parse_ssn(cell)
-        cell.blank? ? nil : prepend_zeros(cell.to_i.to_s.gsub(/\D/, ''), 9)
+        return nil if cell.blank?
+
+        value = cell.to_i.to_s.gsub(/\D/, '')
+        value.length.between?(7,8) ? value.rjust(9, "0") : value
       end
 
       def parse_boolean(cell)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/99191

# A brief description of the changes

Current behavior: if excel is removing leading 0's , upload roster action is raising an error.

New behavior:
prepending upto 2 zeros if ssn is 7 or 8 digits

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
