### PR TITLE
display correct status for cobra employee on ce roster

### DIFF
--- a/app/helpers/employers/employer_helper.rb
+++ b/app/helpers/employers/employer_helper.rb
@@ -10,11 +10,7 @@ module Employers::EmployerHelper
       return 'Account Linked'
     elsif employee_state == 'eligible'
       return 'No Account Linked'
-    elsif employee_state == "cobra_linked" &&
-          (
-            census_employee.has_cobra_hbx_enrollment? ||
-            census_employee.active_benefit_group_enrollments.present? && census_employee.cobra_begin_date.present?
-          )
+    elsif employee_state == "cobra_linked" && census_employee.has_cobra_hbx_enrollment?
       return "Cobra Enrolled"
     else
       return employee_state.humanize

--- a/spec/helpers/employers/employer_helper_spec.rb
+++ b/spec/helpers/employers/employer_helper_spec.rb
@@ -538,6 +538,12 @@ RSpec.describe Employers::EmployerHelper, :type => :helper, dbclean: :after_each
           allow(census_employee).to receive(:has_cobra_hbx_enrollment?).and_return false
           expect(helper.employee_state_format(census_employee, census_employee.aasm_state, nil)).to eq "Cobra linked"
         end
+
+        it "when cobra employee has no cobra enrollments" do
+          allow(census_employee).to receive(:active_benefit_group_enrollments).and_return [health_enrollment]
+          allow(census_employee).to receive(:cobra_begin_date).and_return TimeKeeper.date_of_record.prev_month.beginning_of_month
+          expect(helper.employee_state_format(census_employee, census_employee.aasm_state, nil)).to eq "Cobra linked"
+        end
       end
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: 
https://redmine.priv.dchbx.org/issues/95784

# A brief description of the changes

Current behavior:
For cobra employee, if cobra date is present and has enrollment in current plan year displaying their status as cobra enrolled

New behavior:
For cobra employee, if cobra enrollment present then displaying their status as cobra enrolled

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
