### PR TITLE
persist date_of_action field when admin verifies evidence

### DIFF
--- a/app/models/eligibilities/verification_history.rb
+++ b/app/models/eligibilities/verification_history.rb
@@ -24,7 +24,7 @@ module Eligibilities
     private
 
     def set_date_of_action
-      write_attribute(:date_of_action, DateTime.now) unless date_of_action.present?
+      update_attributes!(date_of_action: DateTime.now) unless date_of_action.present?
     end
   end
 end

--- a/features/insured/individual_verification.feature
+++ b/features/insured/individual_verification.feature
@@ -76,3 +76,19 @@ Scenario: Outstanding verification
     Then Individual should see request histories and verification types
     And Individual clicks on cancel button
     Then Individual should not see view history table
+
+  Scenario: Admin verifies consumer's income evidence
+    Given the FAA feature configuration is enabled
+    And FAA display_medicaid_question feature is enabled
+    And FAA mec_check feature is enabled
+    And a family with financial application and applicants in determined state exists with evidences
+    And the user with hbx_staff role is logged in
+    When admin visits home page
+    And Individual clicks on Documents link
+    Then Individual should see cost saving documents for evidences
+    And Individual clicks on Actions dropdown
+    And Individual clicks on verify
+    And Individual Selects Reason
+    And Individual clicks on Actions dropdown
+    And Individual clicks on view history
+    Then Individual should see verification history timestamp

--- a/features/step_definitions/verification_process_steps.rb
+++ b/features/step_definitions/verification_process_steps.rb
@@ -131,10 +131,6 @@ Then(/^Individual should see verification history timestamp/) do
   expect(find_all('td')[0].text).not_to eql("")
 end
 
-Then(/^Individual should see view history option/) do
-  expect(page).to have_content('View History')
-end
-
 And(/^Individual clicks on view history$/) do
   find(:xpath, IvlDocumentsPage.view_history_option).click
 end

--- a/features/step_definitions/verification_process_steps.rb
+++ b/features/step_definitions/verification_process_steps.rb
@@ -117,6 +117,24 @@ Then(/^Individual should see view history option/) do
   expect(page).to have_content('View History')
 end
 
+And(/^Individual clicks on verify/) do
+  find(:xpath, IvlDocumentsPage.verify_option).click
+end
+
+And(/^Individual Selects Reason/) do
+  find('.col-md-3', text: 'Select Reason').click
+  find('li', :text => 'Document in EnrollApp').click
+  find('.v-type-confirm-button').click
+end
+
+Then(/^Individual should see verification history timestamp/) do
+  expect(find_all('td')[0].text).not_to eql("")
+end
+
+Then(/^Individual should see view history option/) do
+  expect(page).to have_content('View History')
+end
+
 And(/^Individual clicks on view history$/) do
   find(:xpath, IvlDocumentsPage.view_history_option).click
 end

--- a/features/support/object_model_pages/ivl/homepage/ivl_documents_page.rb
+++ b/features/support/object_model_pages/ivl/homepage/ivl_documents_page.rb
@@ -22,4 +22,8 @@ class IvlDocumentsPage
   def self.view_history_option
     "//div[@class='selectric-scroll']/ul/li[contains(text(), 'View History')]"
   end
+
+  def self.verify_option
+    "//div[@class='selectric-scroll']/ul/li[contains(text(), 'Verify')]"
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: ME-184847647

# A brief description of the changes

Current behavior: When an admin verifies an evidence, the verification history's date_of_action field is not persisted

New behavior: Persists the date_of_action field when admin verifies an evidence

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
