### PR TITLE
refactor applied aptc calculation logic for aptc tax household enrollment

### DIFF
--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -1070,8 +1070,10 @@ class HbxEnrollment
     return if is_shop? || dental? || applied_aptc_amount.zero?
     return unless EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
 
-    thh_enr_premiums = thh_enr_group_ehb_premium_of_aptc_members(aptc_tax_household_enrollments)
-    populate_applied_aptc_for_thh_enrs(aptc_tax_household_enrollments, thh_enr_premiums)
+    eligible_tax_hh_enrs = aptc_tax_household_enrollments
+    group_ehb_premiums = thh_enr_group_ehb_premium_of_aptc_members(eligible_tax_hh_enrs)
+    calculated_applied_aptcs = calculate_applied_aptc_for_thh_enrs(eligible_tax_hh_enrs, group_ehb_premiums)
+    populate_applied_aptc_for_thh_enrs(calculated_applied_aptcs)
   rescue StandardError => e
     Rails.logger.error { "Unable to update tax_household_enrollments due to #{e.backtrace}" }
   end
@@ -2871,23 +2873,26 @@ class HbxEnrollment
     end
   end
 
-  private
+  def tax_household_enrollments
+    TaxHouseholdEnrollment.by_enrollment_id(id)
+  end
 
   def aptc_tax_household_enrollments
-    @aptc_tax_household_enrollments ||=
-      TaxHouseholdEnrollment.by_enrollment_id(id).select do |thh_enr|
-        thh_enr.tax_household_members_enrollment_members.where(
-          :family_member_id.in => thh_enr.tax_household.aptc_members.map(&:applicant_id)
-        ).present?
-      end
+    TaxHouseholdEnrollment.by_enrollment_id(id).select do |thh_enr|
+      thh_enr.tax_household_members_enrollment_members.where(
+        :family_member_id.in => thh_enr.tax_household.aptc_members.map(&:applicant_id)
+      ).present?
+    end
   end
+
+  private
 
   # Calculates sum of enrolled aptc member's of TaxHouseholdEnrollment ehb_premiums including Minimum Responsibility.
   def sum_of_member_ehb_premiums(thh_enr)
     aptc_family_member_ids = thh_enr.tax_household.aptc_members.map(&:applicant_id)
     hbx_enrollment_members.where(:applicant_id.in => aptc_family_member_ids).reduce(0) do |sum, member|
       sum + round_down_float_two_decimals(ivl_decorated_hbx_enrollment.member_ehb_premium(member))
-    end
+    end.to_money
   end
 
   def thh_enr_group_ehb_premium_of_aptc_members(thh_enrs)
@@ -2897,29 +2902,62 @@ class HbxEnrollment
     end
   end
 
-  # Incase of MultipleTaxHouseholdEnrollments, applied_aptc is either
-  #   1. group_ehb_premium (or)
-  #   2. thh_enr.available_max_aptc * elected_aptc_pct
-  # To make this inline with plan shopping logic we are considering tax_household_enrollment level ehb_premium.
-  def populate_applied_aptc_for_thh_enrs(thh_enrs, thh_enr_premiums)
-    if applied_aptc_amount == total_ehb_premium.to_money
-      thh_enrs.each do |thh_enr|
-        thh_enr.update_attributes!(
-          {
-            applied_aptc: thh_enr_premiums[thh_enr][:group_ehb_premium],
-            group_ehb_premium: thh_enr_premiums[thh_enr][:group_ehb_premium]
-          }
-        )
-      end
+  # calculate_assumed_applied_aptcs_using_ratio by comapring available_max_aptcs of Tax Household Enrollments
+  def calculate_assumed_applied_aptcs(thh_enrs)
+    total_available_max_aptc = thh_enrs.reduce(0) do |total, tax_hh_enr|
+      total + (tax_hh_enr.available_max_aptc.positive? ? tax_hh_enr.available_max_aptc : 0)
+    end
+
+    thh_enrs.inject({}) do |assumed_aptcs, thh_enr|
+      assumed_aptcs[thh_enr] = (((thh_enr.available_max_aptc.positive? ? thh_enr.available_max_aptc.to_f : 0) / total_available_max_aptc.to_f) * applied_aptc_amount.to_f).to_money
+      assumed_aptcs
+    end
+  end
+
+  # Assumed Applied Aptcs are less than or equal to both group_ehb_premium and available_max_aptc for each Aptc Tax Household
+  def valid_assumed_aptcs?(assumed_applied_aptcs, group_ehb_premiums)
+    assumed_applied_aptcs.all? do |tax_hh_enr, assumed_aptc|
+      assumed_aptc <= group_ehb_premiums[tax_hh_enr][:group_ehb_premium] &&
+        assumed_aptc <= (tax_hh_enr.available_max_aptc.positive? ? tax_hh_enr.available_max_aptc : 0)
+    end
+  end
+
+  def calculate_applied_aptc_for_thh_enrs(thh_enrs, group_ehb_premiums)
+    if thh_enrs.count == 1
+      group_ehb_premiums[thh_enrs.first][:applied_aptc] = applied_aptc_amount
+      return group_ehb_premiums
+    end
+
+    assumed_applied_aptcs = calculate_assumed_applied_aptcs(thh_enrs)
+    if valid_assumed_aptcs?(assumed_applied_aptcs, group_ehb_premiums)
+      assumed_applied_aptcs.each { |tax_hh_enr, applied_aptc| group_ehb_premiums[tax_hh_enr][:applied_aptc] = applied_aptc }
     else
-      thh_enrs.each do |thh_enr|
-        thh_enr.update_attributes!(
-          {
-            applied_aptc: thh_enr.available_max_aptc * elected_aptc_pct,
-            group_ehb_premium: thh_enr_premiums[thh_enr][:group_ehb_premium]
-          }
-        )
+      total_thh_enrs_count = thh_enrs.count
+      total_remaining_consumed_aptc = applied_aptc_amount
+      thh_enrs.each_with_index do |tax_hh_enr, indx|
+        break unless total_remaining_consumed_aptc.positive?
+
+        applied_aptc = [assumed_applied_aptcs[tax_hh_enr], group_ehb_premiums[tax_hh_enr][:group_ehb_premium]].min
+        group_ehb_premiums[tax_hh_enr][:applied_aptc] = if indx.next == total_thh_enrs_count
+                                                          total_remaining_consumed_aptc
+                                                        else
+                                                          total_remaining_consumed_aptc -= applied_aptc
+                                                          applied_aptc
+                                                        end
       end
+    end
+
+    group_ehb_premiums
+  end
+
+  def populate_applied_aptc_for_thh_enrs(calculated_applied_aptcs)
+    calculated_applied_aptcs.each do |thh_enr, premium_info|
+      thh_enr.update_attributes!(
+        {
+          applied_aptc: premium_info[:applied_aptc] || 0.0,
+          group_ehb_premium: premium_info[:group_ehb_premium]
+        }
+      )
     end
   end
 

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2878,7 +2878,7 @@ class HbxEnrollment
   end
 
   def aptc_tax_household_enrollments
-    TaxHouseholdEnrollment.by_enrollment_id(id).select do |thh_enr|
+    tax_household_enrollments.select do |thh_enr|
       thh_enr.tax_household_members_enrollment_members.where(
         :family_member_id.in => thh_enr.tax_household.aptc_members.map(&:applicant_id)
       ).present?

--- a/app/models/tax_household_member_enrollment_member.rb
+++ b/app/models/tax_household_member_enrollment_member.rb
@@ -21,4 +21,12 @@ class TaxHouseholdMemberEnrollmentMember
      relationship_with_primary: relationship_with_primary,
      date_of_birth: date_of_birth}
   end
+
+  def hbx_enrollment_member
+    tax_household_enrollment.tax_household.tax_household_members.find(hbx_enrollment_member_id)
+  end
+
+  def tax_household_member
+    tax_household_enrollment.enrollment.hbx_enrollment_members.find(tax_household_member_id)
+  end
 end

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -10,7 +10,7 @@ RSpec.describe HbxEnrollment, type: :model do
   end
 
   let(:start_of_month) { TimeKeeper.date_of_record.beginning_of_month }
-  let(:person) { create(:person, :with_consumer_role, :with_active_consumer_role) }
+  let(:person) { create(:person, :with_consumer_role, :with_active_consumer_role, first_name: 'test1') }
   let(:family) { create(:family, :with_primary_family_member, person: person) }
   let(:aasm_state) { 'coverage_selected' }
   let(:hbx_enrollment) do
@@ -29,17 +29,6 @@ RSpec.describe HbxEnrollment, type: :model do
                                    eligibility_date: start_of_month)
   end
 
-  let(:tax_household_group) do
-    thhg = family.tax_household_groups.create!(
-      assistance_year: start_of_month.year, source: 'Admin', start_on: start_of_month.year,
-      tax_households: [FactoryBot.build(:tax_household, household: family.active_household)]
-    )
-    thhg.tax_households.first.tax_household_members.create!(
-      applicant_id: family.primary_applicant.id, is_ia_eligible: true
-    )
-    thhg
-  end
-
   let!(:tax_household_enrollment) do
     thh_enr = TaxHouseholdEnrollment.create(
       enrollment_id: hbx_enrollment.id, tax_household_id: tax_household_group.tax_households.first.id,
@@ -55,7 +44,7 @@ RSpec.describe HbxEnrollment, type: :model do
   end
 
   let(:person2) do
-    per = create(:person, :with_consumer_role, :with_active_consumer_role)
+    per = create(:person, :with_consumer_role, :with_active_consumer_role, first_name: 'test2')
     person.ensure_relationship_with(per, 'spouse')
     per
   end
@@ -70,12 +59,20 @@ RSpec.describe HbxEnrollment, type: :model do
                                    eligibility_date: start_of_month)
   end
 
-  let(:tax_household_group2) do
+  let(:tax_household_group) do
     thhg = family.tax_household_groups.create!(
       assistance_year: start_of_month.year, source: 'Admin', start_on: start_of_month.year,
-      tax_households: [FactoryBot.build(:tax_household, household: family.active_household)]
+      tax_households: [
+        FactoryBot.build(:tax_household, household: family.active_household),
+        FactoryBot.build(:tax_household, household: family.active_household)
+      ]
     )
+
     thhg.tax_households.first.tax_household_members.create!(
+      applicant_id: family.primary_applicant.id, is_ia_eligible: true
+    )
+
+    thhg.tax_households[1].tax_household_members.create!(
       applicant_id: family_member.id, is_ia_eligible: true
     )
     thhg
@@ -83,13 +80,13 @@ RSpec.describe HbxEnrollment, type: :model do
 
   let!(:tax_household_enrollment2) do
     thh_enr = TaxHouseholdEnrollment.create(
-      enrollment_id: hbx_enrollment.id, tax_household_id: tax_household_group2.tax_households.first.id,
+      enrollment_id: hbx_enrollment.id, tax_household_id: tax_household_group.tax_households[1].id,
       household_benchmark_ehb_premium: 500.00, available_max_aptc: available_max_aptc2
     )
 
     thh_enr.tax_household_members_enrollment_members.create(
       family_member_id: hbx_enrollment_member2.applicant_id, hbx_enrollment_member_id: hbx_enrollment_member2.id,
-      tax_household_member_id: tax_household_group2.tax_households.first.tax_household_members.first.id,
+      tax_household_member_id: tax_household_group.tax_households[1].tax_household_members.first.id,
       age_on_effective_date: 20, relationship_with_primary: 'self', date_of_birth: start_of_month - 20.years
     )
     thh_enr
@@ -151,17 +148,42 @@ RSpec.describe HbxEnrollment, type: :model do
   describe '#update_tax_household_enrollment' do
     subject { hbx_enrollment.update_tax_household_enrollment }
 
-    context 'with applied_aptc_amount same as total_ehb_premium' do
-      context 'with rounded member premiums' do
-        let(:member1_ehb_premium) { 250.00 }
-        let(:member2_ehb_premium) { 275.00 }
-        let(:available_max_aptc) { 250.00 }
-        let(:available_max_aptc2) { 275.00 }
-        let(:applied_aptc_amount) { available_max_aptc + available_max_aptc2 }
-        let(:enrollment_ehb_premium) { member1_ehb_premium + member2_ehb_premium }
-        let(:elected_aptc_pct) { 1.0 }
+    context 'with one aptc tax household enrollment' do
+      let(:applied_aptc_amount) { 100.00 }
 
-        it 'sets applied_aptc same as ehb_premium' do
+      before do
+        tax_household_group.tax_households.first.tax_household_members.first.update_attributes!(
+          is_ia_eligible: false, is_uqhp_eligible: true
+        )
+      end
+
+      it 'sets applied_aptc same as applied_aptc_amount of the enrollment' do
+        subject
+        expect(tax_household_enrollment2.reload.applied_aptc.to_f).to eq(applied_aptc_amount)
+        expect(tax_household_enrollment2.reload.group_ehb_premium.to_f).to eq(member2_ehb_premium)
+      end
+    end
+
+    context 'with more than one aptc tax household enrollment' do
+
+      context 'eligible applied aptcs are less than or equal to both group_ehb_premium and available_max_aptc' do
+        it 'sets applied_aptc same as available_max_aptc' do
+          subject
+          expect(tax_household_enrollment.reload.applied_aptc.to_f).to eq(available_max_aptc)
+          expect(tax_household_enrollment.reload.group_ehb_premium.to_f).to eq(member1_ehb_premium)
+          expect(tax_household_enrollment2.reload.applied_aptc.to_f).to eq(available_max_aptc2)
+          expect(tax_household_enrollment2.reload.group_ehb_premium.to_f).to eq(member2_ehb_premium)
+        end
+      end
+
+      context 'member ehb premiums less than available max aptc' do
+        let(:member1_ehb_premium) { 100.00 }
+        let(:member2_ehb_premium) { 200.00 }
+        let(:available_max_aptc) { 400.00 }
+        let(:available_max_aptc2) { 500.00 }
+        let(:applied_aptc_amount) { member1_ehb_premium + member2_ehb_premium }
+
+        it 'sets applied_aptc' do
           subject
           expect(tax_household_enrollment.reload.applied_aptc.to_f).to eq(member1_ehb_premium)
           expect(tax_household_enrollment.reload.group_ehb_premium.to_f).to eq(member1_ehb_premium)
@@ -170,44 +192,21 @@ RSpec.describe HbxEnrollment, type: :model do
         end
       end
 
-      context 'with non-rounded member premiums' do
-        let(:member1_ehb_premium) { 250.196032 }
-        let(:member2_ehb_premium) { 275.00 }
-        let(:available_max_aptc) { 250.00 }
-        let(:available_max_aptc2) { 275.00 }
-        let(:applied_aptc_amount) { available_max_aptc + available_max_aptc2 }
-        let(:enrollment_ehb_premium) { member1_ehb_premium + member2_ehb_premium }
-        let(:elected_aptc_pct) { 1.0 }
+      context 'applied aptc amount is less than both ehb_premiums and available_max_aptcs' do
+        let(:member1_ehb_premium) { 100.00 }
+        let(:member2_ehb_premium) { 100.00 }
+        let(:available_max_aptc) { 400.00 }
+        let(:available_max_aptc2) { 500.00 }
+        let(:applied_aptc_amount) { 200.00 }
 
-        it 'sets applied_aptc same as ehb_premium' do
+        it 'applied_aptc_amount is split b/w aptc tax household enrollments' do
           subject
-          expect(tax_household_enrollment.reload.applied_aptc.to_f).to eq(available_max_aptc)
-          expect(
-            tax_household_enrollment.reload.group_ehb_premium.to_f
-          ).to eq(
-            round_down_float_two_decimals(member1_ehb_premium)
-          )
-          expect(tax_household_enrollment2.reload.applied_aptc.to_f).to eq(member2_ehb_premium)
+          expect(tax_household_enrollment.reload.group_ehb_premium.to_f).to eq(member1_ehb_premium)
           expect(tax_household_enrollment2.reload.group_ehb_premium.to_f).to eq(member2_ehb_premium)
+          expect(
+            tax_household_enrollment.applied_aptc + tax_household_enrollment2.applied_aptc
+          ).to eq(applied_aptc_amount.to_money)
         end
-      end
-    end
-
-    context 'with applied_aptc_amount not same as total_ehb_premium' do
-      let(:member1_ehb_premium) { 350.00 }
-      let(:member2_ehb_premium) { 375.00 }
-      let(:available_max_aptc) { 250.00 }
-      let(:available_max_aptc2) { 275.00 }
-      let(:applied_aptc_amount) { available_max_aptc + available_max_aptc2 }
-      let(:enrollment_ehb_premium) { member1_ehb_premium + member2_ehb_premium }
-      let(:elected_aptc_pct) { 1.0 }
-
-      it 'sets applied_aptc same as available_max_aptc * elected_aptc_pct' do
-        subject
-        expect(tax_household_enrollment.reload.applied_aptc.to_f).to eq(available_max_aptc)
-        expect(tax_household_enrollment.reload.group_ehb_premium.to_f).to eq(member1_ehb_premium)
-        expect(tax_household_enrollment2.reload.applied_aptc.to_f).to eq(available_max_aptc2)
-        expect(tax_household_enrollment2.reload.group_ehb_premium.to_f).to eq(member2_ehb_premium)
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development-184998925](https://www.pivotaltracker.com/n/projects/2640059/stories/184998925)

# A brief description of the changes

Current behavior: Applied APTC per Aptc Tax Household Enrollment is recalculated based on the eligibility

New behavior: Enrollment's Applied APTC amount is split between Aptc Tax Household Enrollments based on Available Max APTC.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: `TEMPORARY_CONFIGURATION_OF_MULTI_TAX_HOUSEHOLD_FEATURE_IS_ENABLED` is the environment variable that is being used currently. This feature is currently enabled for ME and not DC.

- [ ] DC
- [x] ME
