### PR TITLE
reset member coverage start date on show plans for ivl page

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -246,7 +246,7 @@ class Insured::PlanShoppingsController < ApplicationController
     set_consumer_bookmark_url(family_account_path) if params[:market_kind] == 'individual'
     set_admin_bookmark_url(family_account_path) if params[:market_kind] == 'individual'
     set_resident_bookmark_url(family_account_path) if params[:market_kind] == 'coverall'
-    @hbx_enrollment.reset_member_coverage_start_dates
+    @hbx_enrollment.reset_member_coverage_start_dates # Fixes coverage start date and aptc slider calculation issues related to browser navigation and page reload
     set_plans_by(hbx_enrollment_id: hbx_enrollment_id)
     collect_shopping_filters
 

--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -246,7 +246,7 @@ class Insured::PlanShoppingsController < ApplicationController
     set_consumer_bookmark_url(family_account_path) if params[:market_kind] == 'individual'
     set_admin_bookmark_url(family_account_path) if params[:market_kind] == 'individual'
     set_resident_bookmark_url(family_account_path) if params[:market_kind] == 'coverall'
-    @hbx_enrollment.update_member_start_dates_to_match_with_effective_date
+    @hbx_enrollment.reset_member_coverage_start_dates
     set_plans_by(hbx_enrollment_id: hbx_enrollment_id)
     collect_shopping_filters
 

--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -246,7 +246,7 @@ class Insured::PlanShoppingsController < ApplicationController
     set_consumer_bookmark_url(family_account_path) if params[:market_kind] == 'individual'
     set_admin_bookmark_url(family_account_path) if params[:market_kind] == 'individual'
     set_resident_bookmark_url(family_account_path) if params[:market_kind] == 'coverall'
-    reset_coverage_start_dates
+    @hbx_enrollment.update_member_start_dates_to_match_with_effective_date
     set_plans_by(hbx_enrollment_id: hbx_enrollment_id)
     collect_shopping_filters
 
@@ -256,14 +256,6 @@ class Insured::PlanShoppingsController < ApplicationController
     @waivable = @hbx_enrollment.try(:can_complete_shopping?)
     @max_total_employee_cost = thousand_ceil(@plans.map(&:total_employee_cost).map(&:to_f).max)
     @max_deductible = thousand_ceil(@plans.map(&:deductible).map {|d| d.is_a?(String) ? d.gsub(/[$,]/, '').to_i : 0}.max)
-  end
-
-  def reset_coverage_start_dates
-    effective_on = @hbx_enrollment.effective_on
-    members = @hbx_enrollment.hbx_enrollment_members
-    return if members.pluck(:coverage_start_on).all?(effective_on)
-
-    members.update_all(coverage_start_on: effective_on)
   end
 
   def show_shop(hbx_enrollment_id)

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -1566,7 +1566,7 @@ class HbxEnrollment
     end
   end
 
-  def update_member_start_dates_to_match_with_effective_date
+  def reset_member_coverage_start_dates
     return if hbx_enrollment_members.pluck(:coverage_start_on).all?(effective_on)
 
     hbx_enrollment_members.update_all(coverage_start_on: effective_on)

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -1566,6 +1566,12 @@ class HbxEnrollment
     end
   end
 
+  def update_member_start_dates_to_match_with_effective_date
+    return if hbx_enrollment_members.pluck(:coverage_start_on).all?(effective_on)
+
+    hbx_enrollment_members.update_all(coverage_start_on: effective_on)
+  end
+
   def display_make_changes_for_ivl?
     return true if is_shop?
 

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -1053,8 +1053,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
                         product: product,
                         aasm_state: previous_enrollment_status,
                         terminated_on: terminated_on,
-                        rating_area_id: rating_area.id
-                      )
+                        rating_area_id: rating_area.id)
     end
 
     let!(:hbx_enrollment) do
@@ -1068,8 +1067,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
                         kind: 'individual',
                         consumer_role: person.consumer_role,
                         product: product,
-                        rating_area_id: rating_area.id
-                      )
+                        rating_area_id: rating_area.id)
     end
 
     it 'should update the member coverage start on' do

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -1010,6 +1010,79 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
     end
   end
 
+  context 'GET show for IVL  - reset coverage dates', :dbclean => :around_each do
+    let(:person) {FactoryBot.create(:person, :with_active_consumer_role, :with_consumer_role)}
+    let(:family) {FactoryBot.create(:family, :with_primary_family_member, :person => person)}
+    let(:household) {FactoryBot.create(:household, family: family)}
+    let(:year) {TimeKeeper.date_of_record.year}
+    let(:effective_on) {Date.new(year, 3, 1)}
+    let(:previous_enrollment_status) {'coverage_selected'}
+    let(:terminated_on) {nil}
+    let(:covered_individuals) {family.family_members}
+    let(:newly_covered_individuals) {family.family_members}
+    let(:start_on) {TimeKeeper.date_of_record.beginning_of_month}
+    let(:qualifying_life_event_kind) {FactoryBot.create(:qualifying_life_event_kind)}
+    let(:special_enrollment_period) do
+      special_enrollment = person.primary_family.special_enrollment_periods.build({effective_on_kind: 'first_of_month'})
+      special_enrollment.qualifying_life_event_kind = qualifying_life_event_kind
+      special_enrollment.start_on = TimeKeeper.date_of_record.prev_day
+      special_enrollment.end_on = TimeKeeper.date_of_record + 30.days
+      special_enrollment.save
+      special_enrollment
+    end
+
+    let(:product) do
+      FactoryBot.create(:benefit_markets_products_health_products_health_product,
+                        hios_id: '11111111122301-01',
+                        csr_variant_id: '01',
+                        metal_level_kind: :silver,
+                        benefit_market_kind: :aca_individual,
+                        application_period: Date.new(year, 1, 1)..Date.new(year, 12, 31))
+    end
+
+    let!(:previous_coverage) do
+      FactoryBot.create(:hbx_enrollment, :with_enrollment_members,
+                        enrollment_members: covered_individuals,
+                        family: family,
+                        household: family.latest_household,
+                        coverage_kind: 'health',
+                        effective_on: effective_on.beginning_of_year,
+                        enrollment_kind: 'open_enrollment',
+                        kind: 'individual',
+                        consumer_role: person.consumer_role,
+                        product: product,
+                        aasm_state: previous_enrollment_status,
+                        terminated_on: terminated_on,
+                        rating_area_id: rating_area.id
+                      )
+    end
+
+    let!(:hbx_enrollment) do
+      FactoryBot.create(:hbx_enrollment, :with_enrollment_members,
+                        enrollment_members: newly_covered_individuals,
+                        family: family,
+                        household: family.latest_household,
+                        coverage_kind: 'health',
+                        effective_on: effective_on,
+                        enrollment_kind: 'open_enrollment',
+                        kind: 'individual',
+                        consumer_role: person.consumer_role,
+                        product: product,
+                        rating_area_id: rating_area.id
+                      )
+    end
+
+    it 'should update the member coverage start on' do
+      sign_in(user)
+      allow_any_instance_of(HbxEnrollment).to receive(:decorated_elected_plans).and_return([])
+      hbx_enrollment.hbx_enrollment_members.update_all(coverage_start_on: previous_coverage.effective_on)
+      get :show, params: {id: hbx_enrollment.id, market_kind: "individual"}
+      hbx_enrollment.reload
+      expect(hbx_enrollment.hbx_enrollment_members.first.coverage_start_on).to eq hbx_enrollment.effective_on
+    end
+  end
+
+
   if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
     describe "plan_selection_callback" do
       let(:coverage_kind){"health"}

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -211,4 +211,51 @@ RSpec.describe HbxEnrollment, type: :model do
       end
     end
   end
+
+  describe ".update_member_start_dates_to_match_with_effective_date" do
+    context "for one member coverage_start_on update" do
+      let!(:effective_on) {hbx_enrollment.effective_on}
+      let!(:beginning_of_year) {effective_on.beginning_of_year}
+      let!(:enrollment_update) {hbx_enrollment.update_attributes(effective_on: beginning_of_year + 3.months)}
+      let!(:member1_update) {hbx_enrollment.hbx_enrollment_members[0].update_attributes(coverage_start_on: beginning_of_year + 3.months)}
+      let!(:member2_update) {hbx_enrollment.hbx_enrollment_members[1].update_attributes(coverage_start_on: beginning_of_year)}
+
+      it 'should match with enrollment effective on' do
+        enrollment_effective_on = hbx_enrollment.effective_on
+        expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([enrollment_effective_on, beginning_of_year])
+        hbx_enrollment.update_member_start_dates_to_match_with_effective_date
+        expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([enrollment_effective_on, enrollment_effective_on])
+      end
+    end
+
+    context "for all members coverage_start_on update" do
+      let!(:effective_on) {hbx_enrollment.effective_on}
+      let!(:beginning_of_year) {effective_on.beginning_of_year}
+      let!(:enrollment_update) {hbx_enrollment.update_attributes(effective_on: beginning_of_year + 3.months)}
+      let!(:member1_update) {hbx_enrollment.hbx_enrollment_members[0].update_attributes(coverage_start_on: beginning_of_year)}
+      let!(:member2_update) {hbx_enrollment.hbx_enrollment_members[1].update_attributes(coverage_start_on: beginning_of_year)}
+
+      it 'should match with enrollment effective on' do
+        enrollment_effective_on = hbx_enrollment.effective_on
+        expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([beginning_of_year, beginning_of_year])
+        hbx_enrollment.update_member_start_dates_to_match_with_effective_date
+        expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([enrollment_effective_on, enrollment_effective_on])
+      end
+    end
+
+    context "when coverage_start_on matches with effective_on" do
+      let!(:effective_on) {hbx_enrollment.effective_on}
+      let!(:beginning_of_year) {effective_on.beginning_of_year}
+      let!(:enrollment_update) {hbx_enrollment.update_attributes(effective_on: beginning_of_year + 3.months)}
+      let!(:member1_update) {hbx_enrollment.hbx_enrollment_members[0].update_attributes(coverage_start_on: beginning_of_year + 3.months)}
+      let!(:member2_update) {hbx_enrollment.hbx_enrollment_members[1].update_attributes(coverage_start_on: beginning_of_year + 3.months)}
+
+      it 'should not update coverage_start_on' do
+        enrollment_effective_on = hbx_enrollment.effective_on
+        expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([enrollment_effective_on, enrollment_effective_on])
+        hbx_enrollment.update_member_start_dates_to_match_with_effective_date
+        expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([enrollment_effective_on, enrollment_effective_on])
+      end
+    end
+  end
 end

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -212,7 +212,7 @@ RSpec.describe HbxEnrollment, type: :model do
     end
   end
 
-  describe ".update_member_start_dates_to_match_with_effective_date" do
+  describe ".reset_member_coverage_start_dates" do
     context "for one member coverage_start_on update" do
       let!(:effective_on) {hbx_enrollment.effective_on}
       let!(:beginning_of_year) {effective_on.beginning_of_year}
@@ -223,7 +223,7 @@ RSpec.describe HbxEnrollment, type: :model do
       it 'should match with enrollment effective on' do
         enrollment_effective_on = hbx_enrollment.effective_on
         expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([enrollment_effective_on, beginning_of_year])
-        hbx_enrollment.update_member_start_dates_to_match_with_effective_date
+        hbx_enrollment.reset_member_coverage_start_dates
         expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([enrollment_effective_on, enrollment_effective_on])
       end
     end
@@ -238,7 +238,7 @@ RSpec.describe HbxEnrollment, type: :model do
       it 'should match with enrollment effective on' do
         enrollment_effective_on = hbx_enrollment.effective_on
         expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([beginning_of_year, beginning_of_year])
-        hbx_enrollment.update_member_start_dates_to_match_with_effective_date
+        hbx_enrollment.reset_member_coverage_start_dates
         expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([enrollment_effective_on, enrollment_effective_on])
       end
     end
@@ -253,7 +253,7 @@ RSpec.describe HbxEnrollment, type: :model do
       it 'should not update coverage_start_on' do
         enrollment_effective_on = hbx_enrollment.effective_on
         expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([enrollment_effective_on, enrollment_effective_on])
-        hbx_enrollment.update_member_start_dates_to_match_with_effective_date
+        hbx_enrollment.reset_member_coverage_start_dates
         expect(hbx_enrollment.hbx_enrollment_members.pluck(:coverage_start_on)).to eq([enrollment_effective_on, enrollment_effective_on])
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [pivotal-184252112](https://www.pivotaltracker.com/n/projects/2502930/stories/184252112#)

# A brief description of the changes

Current behavior:  When consumer navigates back to choose plan page from thank you page for continuous coverage scenario and reloads the page, the coverage start date is updated with current active coverage effective date.

New behavior: After the code fix the coverage start date will remain same with the effective date of the shopping enrollment on choose plan page.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
