### PR TITLE
updating linux version from stretch to buster, b/c stretch is now 'archive'

### DIFF
--- a/.docker/production/Dockerfile.gha
+++ b/.docker/production/Dockerfile.gha
@@ -3,7 +3,7 @@
 ############################################
 
 ARG RUBY_VERSION=2.5.9
-FROM ruby:$RUBY_VERSION-slim-stretch as base
+FROM ruby:$RUBY_VERSION-slim-buster as base
 LABEL author="IdeaCrew"
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -24,10 +24,10 @@ RUN apt-get update \
       fontconfig \
       libcurl4-openssl-dev \
       libffi6 \
-      libsodium18 \
+      libsodium23 \
       libxext6 \
       libxrender1 \
-      libyaml-cpp0.5v5 \
+      libyaml-cpp0.6 \
       nano \
       openssl \
       sshpass \
@@ -117,7 +117,7 @@ FROM builder as prod_gems_and_assets
 
 RUN apt-get update -qq \
     && apt-get install -yq --no-install-recommends \
-      shared-mime-info \
+      shared-mime-info python \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && truncate -s 0 /var/log/*log


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes

# What is the ticket # detailing the issue?

Ticket: 
No ticket

# A brief description of the changes

Current behavior:
The base image used for building the production release is based on Debian stretch, all the packages were moved from release to 'archive'.
https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html

New behavior:
Moves the image base to buster, which is the next major Debian.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

No env variable

- [ ] DC
- [ ] ME
