### PR TITLE
update account transfer notice feature flag to be controlled with env var

### DIFF
--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -686,7 +686,7 @@ registry:
       - key: :document_reminder_notice_trigger
         is_enabled: false
       - key: :account_transfer_notice_trigger
-        is_enabled: false
+        is_enabled: <%= ENV['ACCOUNT_TRANSFER_NOTICE_IS_ENABLED'] || false %>
       - key: :verification_type_income_verification
         is_enabled: false
       - key: :show_download_tax_documents

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -691,7 +691,7 @@ registry:
       - key: :document_reminder_notice_trigger
         is_enabled: true
       - key: :account_transfer_notice_trigger
-        is_enabled: <%= ENV['ACCOUNT_TRANSFER_NOTICE_IS_ENABLED'] || false %>
+        is_enabled: <%= ENV['ACCOUNT_TRANSFER_NOTICE_IS_ENABLED'] || true %>
       - key: :verification_type_income_verification
         is_enabled: true
       - key: :tobacco_user_field

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -691,7 +691,7 @@ registry:
       - key: :document_reminder_notice_trigger
         is_enabled: true
       - key: :account_transfer_notice_trigger
-        is_enabled: true
+        is_enabled: <%= ENV['ACCOUNT_TRANSFER_NOTICE_IS_ENABLED'] || false %>
       - key: :verification_type_income_verification
         is_enabled: true
       - key: :tobacco_user_field

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -686,7 +686,7 @@ registry:
       - key: :document_reminder_notice_trigger
         is_enabled: false
       - key: :account_transfer_notice_trigger
-        is_enabled: false
+        is_enabled: <%= ENV['ACCOUNT_TRANSFER_NOTICE_IS_ENABLED'] || false %>
       - key: :verification_type_income_verification
         is_enabled: false
       - key: :show_download_tax_documents


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [TT6-185057409](https://www.pivotaltracker.com/story/show/185057409)

# A brief description of the changes

Current behavior: The account_transfer_notice_trigger feature flag is set only in the config files

New behavior: The account_transfer_notice_trigger feature flag is set with an env variable 

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: ACCOUNT_TRANSFER_NOTICE_IS_ENABLED

- [ ] DC
- [x] ME
