### PR TITLE
consider available max aptc in finding the applied aptc for aptc thh enr

### DIFF
--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2937,7 +2937,12 @@ class HbxEnrollment
       thh_enrs.each_with_index do |tax_hh_enr, indx|
         break unless total_remaining_consumed_aptc.positive?
 
-        applied_aptc = [applied_aptcs_by_available_aptc_ratio[tax_hh_enr], group_ehb_premiums[tax_hh_enr][:group_ehb_premium]].min
+        applied_aptc = [
+          group_ehb_premiums[tax_hh_enr][:group_ehb_premium],
+          tax_hh_enr.available_max_aptc,
+          total_remaining_consumed_aptc
+        ].min
+
         group_ehb_premiums[tax_hh_enr][:applied_aptc] = if indx.next == total_thh_enrs_count
                                                           total_remaining_consumed_aptc
                                                         else

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -208,6 +208,52 @@ RSpec.describe HbxEnrollment, type: :model do
           ).to eq(applied_aptc_amount.to_money)
         end
       end
+
+      context "one of the applied_aptcs_by_ratio's are greater than the group_ehb_premium" do
+        let(:member1_ehb_premium) { 1054.31 }
+        let(:member2_ehb_premium) { 302.19 }
+        let(:available_max_aptc) { 1126.00 }
+        let(:available_max_aptc2) { 343.00 }
+        let(:applied_aptc_amount) { 1356.50 }
+
+        it 'returns applied_aptc for aptc tax household enrollments which are below group_ehb_premium and available_max_aptc' do
+          subject
+          expect(
+            tax_household_enrollment.reload.applied_aptc.to_f <= tax_household_enrollment.group_ehb_premium.to_f &&
+              tax_household_enrollment.applied_aptc.to_f <= tax_household_enrollment.available_max_aptc.to_f
+          ).to be_truthy
+          expect(
+            tax_household_enrollment2.reload.applied_aptc.to_f <= tax_household_enrollment2.group_ehb_premium.to_f &&
+              tax_household_enrollment2.applied_aptc.to_f <= tax_household_enrollment2.available_max_aptc.to_f
+          ).to be_truthy
+          expect(
+            tax_household_enrollment.applied_aptc + tax_household_enrollment2.applied_aptc
+          ).to eq(applied_aptc_amount.to_money)
+        end
+      end
+
+      context "applied_aptc_amount is less than both aptc tax household enrollment's group_ehb_premium, available_max_aptc" do
+        let(:member1_ehb_premium) { 1054.31 }
+        let(:member2_ehb_premium) { 302.19 }
+        let(:available_max_aptc) { 1126.00 }
+        let(:available_max_aptc2) { 343.00 }
+        let(:applied_aptc_amount) { 100.00 }
+
+        it 'returns applied_aptc for aptc tax household enrollments which are below group_ehb_premium and available_max_aptc' do
+          subject
+          expect(
+            tax_household_enrollment.reload.applied_aptc.to_f <= tax_household_enrollment.group_ehb_premium.to_f &&
+              tax_household_enrollment.applied_aptc.to_f <= tax_household_enrollment.available_max_aptc.to_f
+          ).to be_truthy
+          expect(
+            tax_household_enrollment2.reload.applied_aptc.to_f <= tax_household_enrollment2.group_ehb_premium.to_f &&
+              tax_household_enrollment2.applied_aptc.to_f <= tax_household_enrollment2.available_max_aptc.to_f
+          ).to be_truthy
+          expect(
+            tax_household_enrollment.applied_aptc + tax_household_enrollment2.applied_aptc
+          ).to eq(applied_aptc_amount.to_money)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development-184998925](https://www.pivotaltracker.com/n/projects/2640059/stories/184998925)

# A brief description of the changes

Current behavior: Currently, the available_max_aptc is not included in the calculation of the applied_aptc amount when applied_aptcs are calculated based on the ratio.

New behavior: The available_max_aptc is included in the calculation of the applied_aptc amount when applied_aptcs are calculated based on the ratio.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: `TEMPORARY_CONFIGURATION_OF_MULTI_TAX_HOUSEHOLD_FEATURE_IS_ENABLED` is the environment variable that is being used currently. This feature is currently enabled for ME and not DC.

- [ ] DC
- [ ] ME
