### PR TITLE
fetching selected carrier from reference plan

### DIFF
--- a/app/models/benefit_group.rb
+++ b/app/models/benefit_group.rb
@@ -501,7 +501,7 @@ class BenefitGroup
 
   def elected_dental_plans_by_option_kind
     if dental_plan_option_kind == "single_carrier"
-      Plan.by_active_year(self.start_on.year).shop_market.dental_coverage.by_carrier_profile(self.carrier_for_elected_dental_plan)
+      Plan.by_active_year(self.start_on.year).shop_market.dental_coverage.by_carrier_profile(self.carrier_for_elected_dental_plan || dental_reference_plan.carrier_profile)
     else
       Plan.by_active_year(self.start_on.year).shop_market.dental_coverage
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/story/show/185100130
# A brief description of the changes

Current behavior: we've code in place to look for carrier_for_elected_dental_plan to fetch carrier profile, where as it is fetching from reference plan in all other places

New behavior:
added an additional check to look for reference plan when carrier_for_elected_dental_plan is not set
# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
