### PR TITLE
add env variable for broker email and npn resource registry features

### DIFF
--- a/config/client_config/dc/system/config/templates/features/brokers/brokers.yml
+++ b/config/client_config/dc/system/config/templates/features/brokers/brokers.yml
@@ -25,9 +25,9 @@ registry:
         is_enabled: true
         item: ""
       - key: :allow_edit_broker_email
-        is_enabled: false
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL'] || false %>
       - key: :allow_edit_broker_npn
-        is_enabled: false
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_NPN'] || false %>
       - key: :send_broker_hired_event_to_edi
         is_enabled: <%= ENV['BROKER_HIRED_EVENT_TO_EDI_IS_ENABLED'] || false %>
       - key: :send_broker_fired_event_to_edi

--- a/config/client_config/dc/system/config/templates/features/brokers/brokers.yml
+++ b/config/client_config/dc/system/config/templates/features/brokers/brokers.yml
@@ -25,9 +25,9 @@ registry:
         is_enabled: true
         item: ""
       - key: :allow_edit_broker_email
-        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL'] || false %>
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL_IS_ENABLED'] || false %>
       - key: :allow_edit_broker_npn
-        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_NPN'] || false %>
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_NPN_IS_ENABLED'] || false %>
       - key: :send_broker_hired_event_to_edi
         is_enabled: <%= ENV['BROKER_HIRED_EVENT_TO_EDI_IS_ENABLED'] || false %>
       - key: :send_broker_fired_event_to_edi

--- a/config/client_config/me/system/config/templates/features/brokers/brokers.yml
+++ b/config/client_config/me/system/config/templates/features/brokers/brokers.yml
@@ -25,7 +25,7 @@ registry:
         is_enabled: true
         item: "https://coverme.inquisiqlms.com/"
       - key: :allow_edit_broker_email
-        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL_IS_ENABLED'] || true %>
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL_IS_ENABLED'] || false %>
       - key: :allow_edit_broker_npn
         is_enabled: <%= ENV['ALLOW_EDIT_BROKER_NPN_IS_ENABLED'] || false %>
       - key: :send_broker_hired_event_to_edi

--- a/config/client_config/me/system/config/templates/features/brokers/brokers.yml
+++ b/config/client_config/me/system/config/templates/features/brokers/brokers.yml
@@ -25,9 +25,9 @@ registry:
         is_enabled: true
         item: "https://coverme.inquisiqlms.com/"
       - key: :allow_edit_broker_email
-        is_enabled: true
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL'] || true %>
       - key: :allow_edit_broker_npn
-        is_enabled: true
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_NPN'] || false %>
       - key: :send_broker_hired_event_to_edi
         is_enabled: <%= ENV['BROKER_HIRED_EVENT_TO_EDI_IS_ENABLED'] || true %>
       - key: :send_broker_fired_event_to_edi

--- a/config/client_config/me/system/config/templates/features/brokers/brokers.yml
+++ b/config/client_config/me/system/config/templates/features/brokers/brokers.yml
@@ -25,9 +25,9 @@ registry:
         is_enabled: true
         item: "https://coverme.inquisiqlms.com/"
       - key: :allow_edit_broker_email
-        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL'] || true %>
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL_IS_ENABLED'] || true %>
       - key: :allow_edit_broker_npn
-        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_NPN'] || false %>
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_NPN_IS_ENABLED'] || false %>
       - key: :send_broker_hired_event_to_edi
         is_enabled: <%= ENV['BROKER_HIRED_EVENT_TO_EDI_IS_ENABLED'] || true %>
       - key: :send_broker_fired_event_to_edi

--- a/system/config/templates/features/brokers/brokers.yml
+++ b/system/config/templates/features/brokers/brokers.yml
@@ -25,9 +25,9 @@ registry:
         is_enabled: true
         item: ""
       - key: :allow_edit_broker_email
-        is_enabled: false
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL'] || false %>
       - key: :allow_edit_broker_npn
-        is_enabled: false
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_NPN'] || false %>
       - key: :send_broker_hired_event_to_edi
         is_enabled: <%= ENV['BROKER_HIRED_EVENT_TO_EDI_IS_ENABLED'] || false %>
       - key: :send_broker_fired_event_to_edi

--- a/system/config/templates/features/brokers/brokers.yml
+++ b/system/config/templates/features/brokers/brokers.yml
@@ -25,9 +25,9 @@ registry:
         is_enabled: true
         item: ""
       - key: :allow_edit_broker_email
-        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL'] || false %>
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL_IS_ENABLED'] || false %>
       - key: :allow_edit_broker_npn
-        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_NPN'] || false %>
+        is_enabled: <%= ENV['ALLOW_EDIT_BROKER_NPN_IS_ENABLED'] || false %>
       - key: :send_broker_hired_event_to_edi
         is_enabled: <%= ENV['BROKER_HIRED_EVENT_TO_EDI_IS_ENABLED'] || false %>
       - key: :send_broker_fired_event_to_edi


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/185130795

# A brief description of the changes

Current behavior:
NO env variables for allow_edit_broker_email & allow_edit_broker_npn

allow_edit_broker_npn is set to TRUE

New behavior:
add ENV variables for allow_edit_broker_email & allow_edit_broker_npn

Default feature "allow_edit_broker_npn" key value for CoverME.gov to be FALSE
No change for "allow_edit_broker_email


# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:
ALLOW_EDIT_BROKER_EMAIL
ALLOW_EDIT_BROKER_NPN

-  [x] DC
-  [x] ME
