### PR TITLE
allow environment specific configuration of local mec evidence for DC client

### DIFF
--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -93,7 +93,7 @@ registry:
           - key: :evidence_ref
             item: 'gid://enroll_app/FinancialAssitance::Application'
       - key: :local_mec_evidence
-        is_enabled: false
+        is_enabled: <%= ENV['LOCAL_MEC_EVIDENCE_IS_ENABLED'] || false %>
         settings:
           - key: :subject_ref
             item: 'gid://enroll_app/Family::FamilyMember'

--- a/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -93,7 +93,7 @@ registry:
           - key: :evidence_ref
             item: 'gid://enroll_app/FinancialAssitance::Application'
       - key: :local_mec_evidence
-        is_enabled: false
+        is_enabled: <%= ENV['LOCAL_MEC_EVIDENCE_IS_ENABLED'] || false %>
         settings:
           - key: :subject_ref
             item: 'gid://enroll_app/Family::FamilyMember'


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640057/stories/185042340#

# A brief description of the changes

Current behavior:
The setting for local mec evidence functionality is hardcoded to false in the DC client.

New behavior:
An environment variable is used to initialize this setting, so functionality can be set on an environment-specific basis.  This will be used for testing of enabling this setting in a lower DC env.  Note: no update to the ME config is necessary; issue is specific to DC.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: LOCAL_MEC_EVIDENCE_IS_ENABLED

- [x] DC
- [ ] ME
