### PR TITLE
exclude thh enrollments which does not have positive available max aptc

### DIFF
--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -1070,7 +1070,7 @@ class HbxEnrollment
     return if is_shop? || dental? || applied_aptc_amount.zero?
     return unless EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
 
-    eligible_tax_hh_enrs = aptc_tax_household_enrollments
+    eligible_tax_hh_enrs = aptc_tax_household_enrollments.select { |thh_enr| thh_enr.available_max_aptc.positive? }
     group_ehb_premiums = thh_enr_group_ehb_premium_of_aptc_members(eligible_tax_hh_enrs)
     calculated_applied_aptcs = calculate_applied_aptc_for_thh_enrs(eligible_tax_hh_enrs, group_ehb_premiums)
     populate_applied_aptc_for_thh_enrs(calculated_applied_aptcs)

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -254,6 +254,19 @@ RSpec.describe HbxEnrollment, type: :model do
           ).to eq(applied_aptc_amount.to_money)
         end
       end
+
+      context "available_max_aptc of one aptc tax household is not positive" do
+        let(:member1_ehb_premium) { 500.00 }
+        let(:member2_ehb_premium) { 300.00 }
+        let(:available_max_aptc) { -100.00 }
+        let(:available_max_aptc2) { 400.00 }
+        let(:applied_aptc_amount) { 350.00 }
+
+        it 'returns applied_aptc of second tax household same as applied_aptc_amount' do
+          subject
+          expect(tax_household_enrollment2.reload.applied_aptc).to eq(applied_aptc_amount.to_money)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 184998925](https://www.pivotaltracker.com/n/projects/2640059/stories/184998925)

# A brief description of the changes

Current behavior: Currently, aptc tax household enrollments that have negative available max aptc are considered for applied aptc calculation.

New behavior: Aptc tax household enrollments that have negative available max aptc are not considered for applied aptc calculation.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name: `TEMPORARY_CONFIGURATION_OF_MULTI_TAX_HOUSEHOLD_FEATURE_IS_ENABLED` is the environment variable that is being used currently. This feature is currently enabled for ME and not DC.

- [ ] DC
- [ ] ME
