### PR TITLE
propagate child care subsidy when enrollment reinstated

### DIFF
--- a/app/domain/operations/individual/apply_aggregate_to_enrollment.rb
+++ b/app/domain/operations/individual/apply_aggregate_to_enrollment.rb
@@ -51,7 +51,7 @@ module Operations
       def applied_aptc_pct_for(enrollment, new_effective_date)
         subscriber = enrollment.subscriber || enrollment.hbx_enrollment_members.first
 
-        if osse_aptc_minimum_enabled? && enrollment.product.is_hc4cc_plan? && subscriber.role_for_subsidy.osse_eligible?(new_effective_date)
+        if osse_aptc_minimum_enabled? && subscriber.role_for_subsidy.osse_eligible?(new_effective_date)
           return enrollment.elected_aptc_pct if enrollment.elected_aptc_pct >= minimum_applied_aptc_for_osse.to_f
           minimum_applied_aptc_for_osse
         else

--- a/app/models/enrollments/replicator/reinstatement.rb
+++ b/app/models/enrollments/replicator/reinstatement.rb
@@ -117,9 +117,11 @@ module Enrollments
           assign_attributes_to_reinstate_enrollment(reinstated_enrollment, form_shop_params) if can_be_reinstated?
         elsif base_enrollment.is_ivl_by_kind?
           assign_attributes_to_reinstate_enrollment(reinstated_enrollment, form_ivl_params)
+
           if new_aptc.blank?
             reinstated_enrollment.elected_aptc_pct = base_enrollment.elected_aptc_pct
             reinstated_enrollment.applied_aptc_amount = base_enrollment.applied_aptc_amount
+            reinstated_enrollment.eligible_child_care_subsidy = base_enrollment.eligible_child_care_subsidy
           end
         end
       end

--- a/app/models/unassisted_plan_cost_decorator.rb
+++ b/app/models/unassisted_plan_cost_decorator.rb
@@ -211,7 +211,7 @@ class UnassistedPlanCostDecorator < SimpleDelegator
 
   # For the case of reinstated enrollments, when a hc4cc subsidy propagated from base enrollment, we should apply the subsidy.
   def total_childcare_subsidy_amount
-    return @hbx_enrollment.eligible_child_care_subsidy if @hbx_enrollment.eligible_child_care_subsidy > 0
+    return hbx_enrollment.eligible_child_care_subsidy.to_f if hbx_enrollment.is_reinstated_enrollment?
 
     if ivl_osse_eligible?
       total_premium - total_aptc_amount

--- a/app/models/unassisted_plan_cost_decorator.rb
+++ b/app/models/unassisted_plan_cost_decorator.rb
@@ -209,9 +209,15 @@ class UnassistedPlanCostDecorator < SimpleDelegator
     (mem_premium - result >= 1) ? result : (mem_premium - 1)
   end
 
+  # For the case of reinstated enrollments, when a hc4cc subsidy propagated from base enrollment, we should apply the subsidy.
   def total_childcare_subsidy_amount
-    return 0.00 unless ivl_osse_eligible?
-    total_premium - total_aptc_amount
+    return @hbx_enrollment.eligible_child_care_subsidy if @hbx_enrollment.eligible_child_care_subsidy > 0
+
+    if ivl_osse_eligible?
+      total_premium - total_aptc_amount
+    else
+      0.0
+    end
   end
 
   def ivl_osse_eligible?

--- a/spec/domain/operations/individual/apply_aggregate_to_enrollment_spec.rb
+++ b/spec/domain/operations/individual/apply_aggregate_to_enrollment_spec.rb
@@ -326,20 +326,20 @@ RSpec.describe Operations::Individual::ApplyAggregateToEnrollment, dbclean: :aft
       context 'when elected aptc pct is zero' do
         let(:elected_aptc_pct) { 0.0 }
 
-        it 'should return default applied aptc pct' do
+        it 'should return minimum osse aptc percent' do
           aptc_pct = described_class.new.applied_aptc_pct_for(enrollment, new_effective_date)
 
-          expect(aptc_pct).to eq(default_applied_aptc_percentage)
+          expect(aptc_pct).to eq(minimum_applied_aptc_percentage_for_osse)
         end
       end
 
       context 'when elected aptc pct greater than zero' do
         let(:elected_aptc_pct) { 0.70 }
 
-        it 'should return elected aptc pct' do
+        it 'should return minimum osse aptc percent' do
           aptc_pct = described_class.new.applied_aptc_pct_for(enrollment, new_effective_date)
 
-          expect(aptc_pct).to eq(elected_aptc_pct)
+          expect(aptc_pct).to eq(minimum_applied_aptc_percentage_for_osse)
         end
       end
     end

--- a/spec/domain/operations/individual/on_new_determination_spec.rb
+++ b/spec/domain/operations/individual/on_new_determination_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Operations::Individual::OnNewDetermination, type: :model, dbclean
           )
         )
       )
-      allow(UnassistedPlanCostDecorator).to receive(:new).and_return(double(total_ehb_premium: 1500, total_premium: 1600))
+      allow(UnassistedPlanCostDecorator).to receive(:new).and_return(double(total_ehb_premium: 1500, total_premium: 1600, total_childcare_subsidy_amount: 0))
     end
 
     let(:max_aptc) { 1200.0 }
@@ -160,7 +160,7 @@ RSpec.describe Operations::Individual::OnNewDetermination, type: :model, dbclean
     context 'when ehb premium less than aptc' do
       before do
         hbx_profile.benefit_sponsorship.current_benefit_period.start_on
-        allow(UnassistedPlanCostDecorator).to receive(:new).and_return(double(total_ehb_premium: 393.76, total_premium: 410))
+        allow(UnassistedPlanCostDecorator).to receive(:new).and_return(double(total_ehb_premium: 393.76, total_premium: 410, total_childcare_subsidy_amount: 16.24))
       end
 
       it 'creates enrollment with ehb premium' do

--- a/spec/models/insured/factories/self_service_factory_spec.rb
+++ b/spec/models/insured/factories/self_service_factory_spec.rb
@@ -295,7 +295,7 @@ module Insured
               )
             )
           )
-          allow(UnassistedPlanCostDecorator).to receive(:new).and_return(double(total_ehb_premium: 1500, total_premium: 1600))
+          allow(UnassistedPlanCostDecorator).to receive(:new).and_return(double(total_ehb_premium: 1500, total_premium: 1600, total_childcare_subsidy_amount: 0))
         end
 
         let(:max_aptc) { 1200.0 }
@@ -348,7 +348,7 @@ module Insured
         context 'when ehb premium less than aptc' do
           before do
             effective_on = hbx_profile.benefit_sponsorship.current_benefit_period.start_on
-            allow(UnassistedPlanCostDecorator).to receive(:new).and_return(double(total_ehb_premium: 393.76, total_premium: 410))
+            allow(UnassistedPlanCostDecorator).to receive(:new).and_return(double(total_ehb_premium: 393.76, total_premium: 410, total_childcare_subsidy_amount: 0))
           end
 
           it 'creates enrollment with ehb premium' do

--- a/spec/models/insured/factories/self_service_factory_spec.rb
+++ b/spec/models/insured/factories/self_service_factory_spec.rb
@@ -150,6 +150,7 @@ module Insured
         allow(::BenefitMarkets::Products::ProductRateCache).to receive(:lookup_rate).with(@product, enrollment.effective_on, 61, "R-#{site_key}001", 'N').and_return(679.8)
         person.update_attributes!(dob: (enrollment.effective_on - 61.years))
         family.family_members[1].person.update_attributes!(dob: (enrollment.effective_on - 59.years))
+        allow(enrollment).to receive(:ivl_osse_eligible?).and_return(true)
       end
 
       it 'should return updated enrollment with aptc fields' do
@@ -171,6 +172,13 @@ module Insured
         enrollment.reload
         expect(enrollment.applied_aptc_amount.to_f).to eq 500
         expect(enrollment.elected_aptc_pct).to eq 0.25
+      end
+
+      it 'should set eligible child care subsidy amount' do
+        subject.update_enrollment_for_apcts(enrollment, 500)
+        enrollment.reload
+        expected_subsidy = enrollment.total_premium.to_f - enrollment.applied_aptc_amount.to_f
+        expect(enrollment.eligible_child_care_subsidy.to_f).to eq expected_subsidy.round(2)
       end
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185024021

# A brief description of the changes

Current behavior: Currently when enrollment reinstated  we don't copy child care subsidy amount from base enrollment. This will result in loss of subsidy, when they don't have active OSSE eligibility

New behavior:  As per the new requirement, reinstated enrollment should always get child care subsidy if the base enrollment has it.

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [ ] ME
