### PR TITLE
Add mapping 'net self-employment income' to 'other' type

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
@@ -425,7 +425,7 @@ module FinancialAssistance
             # JobIncome(wages_and_salaries) & SelfEmploymentIncome(net_self_employment)
             def wages_and_salaries(current_incomes)
               ws_incomes = current_incomes.select do |inc|
-                ['wages_and_salaries', 'net_self_employment'].include?(inc.kind)
+                ['wages_and_salaries'].include?(inc.kind)
               end
               ws_incomes.inject(0) do |result, income|
                 frequency = income.frequency_kind
@@ -501,7 +501,8 @@ module FinancialAssistance
             end
 
             def other_income(current_incomes)
-              other_kinds = ["dividend", "rental_and_royalty", "social_security_benefit", "american_indian_and_alaskan_native",
+              binding.pry
+              other_kinds = ["net_self_employment", "dividend", "rental_and_royalty", "social_security_benefit", "american_indian_and_alaskan_native",
                              "employer_funded_disability", "estate_trust", "foreign", "other", "prizes_and_awards"]
               otr_incomes = current_incomes.select do |inc|
                 other_kinds.include?(inc.kind)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
@@ -501,7 +501,6 @@ module FinancialAssistance
             end
 
             def other_income(current_incomes)
-              binding.pry
               other_kinds = ["net_self_employment", "dividend", "rental_and_royalty", "social_security_benefit", "american_indian_and_alaskan_native",
                              "employer_funded_disability", "estate_trust", "foreign", "other", "prizes_and_awards"]
               otr_incomes = current_incomes.select do |inc|

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
@@ -1182,7 +1182,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Transformers::Ap
     end
 
     it 'should be able to successfully return mitc_income with amount' do
-      expect(@mitc_income[:amount]).to eq(30000)
+      expect(@mitc_income[:amount]).to eq(30_000)
     end
 
     it 'should return taxable_interest for mitc_income as zero' do
@@ -1211,7 +1211,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Transformers::Ap
 
     it 'should return other_income for mitc_income as zero' do
       expect(@mitc_income[:other_income]).not_to be_zero
-      expect(@mitc_income[:other_income]).to eq(30000)
+      expect(@mitc_income[:other_income]).to eq(30_000)
     end
   end
 

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
@@ -1182,7 +1182,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Transformers::Ap
     end
 
     it 'should be able to successfully return mitc_income with amount' do
-      expect(@mitc_income[:amount]).to eq(60_000.00)
+      expect(@mitc_income[:amount]).to eq(30000)
     end
 
     it 'should return taxable_interest for mitc_income as zero' do
@@ -1210,7 +1210,56 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Transformers::Ap
     end
 
     it 'should return other_income for mitc_income as zero' do
-      expect(@mitc_income[:other_income]).to be_zero
+      expect(@mitc_income[:other_income]).not_to be_zero
+      expect(@mitc_income[:other_income]).to eq(30000)
+    end
+  end
+
+  context 'for mitc_income negative income' do
+    let!(:create_job_income1) do
+      inc = ::FinancialAssistance::Income.new({ kind: 'wages_and_salaries',
+                                                frequency_kind: 'yearly',
+                                                amount: 30_000.00,
+                                                start_on: TimeKeeper.date_of_record.beginning_of_month,
+                                                employer_name: 'Testing employer' })
+      applicant.incomes << inc
+      applicant.save!
+    end
+
+    let!(:income2) do
+      inc = ::FinancialAssistance::Income.new({ kind: 'net_self_employment',
+                                                frequency_kind: 'monthly',
+                                                amount: -100.00,
+                                                start_on: TimeKeeper.date_of_record.beginning_of_month })
+      applicant.incomes << inc
+      applicant.save!
+    end
+
+    before do
+      result = subject.call(application.reload)
+      @entity_init = AcaEntities::MagiMedicaid::Operations::InitializeApplication.new.call(result.success)
+      @mitc_income = result.success[:applicants].first[:mitc_income]
+    end
+
+    it 'should be able to successfully init Application Entity' do
+      expect(@entity_init).to be_success
+    end
+
+    it 'should be able to successfully return mitc_income with amount' do
+      expect(@mitc_income[:amount]).to eq(30_000.00)
+    end
+
+    it 'should return taxable_interest for mitc_income as zero' do
+      expect(@mitc_income[:taxable_interest]).to be_zero
+    end
+
+    it 'should return alimony for mitc_income as zero' do
+      expect(@mitc_income[:alimony]).to be_zero
+    end
+
+    it 'should return other_income for mitc_income as zero' do
+      expect(@mitc_income[:other_income]).not_to be_zero
+      expect(@mitc_income[:other_income]).to eq(-1200.00)
     end
   end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue? 
Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/185008747#


# A brief description of the changes

Current behavior:
'Net self-employment income' is mapped to mitc amount for total calculation in cv3 payload builder.

New behavior:
Move mapping of 'net self-employment income' to 'other income' type when passing application to MitC so that MitC will accept negative amount

# Environment Variable

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. Please share the name of the variable below that would enable/disable the feature and which client it applies to.

Variable name:

- [ ] DC
- [] ME
