### PR TITLE
update ivl enrollment renewal service with below osse changes

### DIFF
--- a/app/domain/operations/individual/apply_aggregate_to_enrollment.rb
+++ b/app/domain/operations/individual/apply_aggregate_to_enrollment.rb
@@ -9,6 +9,8 @@ module Operations
     class ApplyAggregateToEnrollment
       include Dry::Monads[:result, :do]
       include FloatHelper
+      include Config::AcaHelper
+
       def call(params)
         validated_eligibility   = yield validate(params)
         eligible_enrollments    = yield fetch_enrollments_to_renew(validated_eligibility)
@@ -55,20 +57,8 @@ module Operations
           return enrollment.elected_aptc_pct if enrollment.elected_aptc_pct >= minimum_applied_aptc_for_osse.to_f
           minimum_applied_aptc_for_osse
         else
-          enrollment.elected_aptc_pct > 0 ? enrollment.elected_aptc_pct : default_applied_aptc
+          enrollment.elected_aptc_pct > 0 ? enrollment.elected_aptc_pct : default_applied_aptc_pct
         end
-      end
-
-      def osse_aptc_minimum_enabled?
-        EnrollRegistry.feature_enabled?(:aca_individual_osse_aptc_minimum)
-      end
-
-      def default_applied_aptc
-        EnrollRegistry[:aca_individual_assistance_benefits].setting(:default_applied_aptc_percentage).item
-      end
-
-      def minimum_applied_aptc_for_osse
-        EnrollRegistry[:aca_individual_assistance_benefits].setting(:minimum_applied_aptc_percentage_for_osse).item
       end
     end
   end

--- a/app/domain/operations/individual/apply_aggregate_to_enrollment.rb
+++ b/app/domain/operations/individual/apply_aggregate_to_enrollment.rb
@@ -51,11 +51,9 @@ module Operations
       end
 
       def applied_aptc_pct_for(enrollment, new_effective_date)
-        subscriber = enrollment.subscriber || enrollment.hbx_enrollment_members.first
-
-        if osse_aptc_minimum_enabled? && subscriber.role_for_subsidy.osse_eligible?(new_effective_date)
-          return enrollment.elected_aptc_pct if enrollment.elected_aptc_pct >= minimum_applied_aptc_for_osse.to_f
-          minimum_applied_aptc_for_osse
+        if osse_aptc_minimum_enabled? && enrollment.ivl_osse_eligible?(new_effective_date)
+          return enrollment.elected_aptc_pct if enrollment.elected_aptc_pct >= minimum_applied_aptc_pct_for_osse.to_f
+          minimum_applied_aptc_pct_for_osse
         else
           enrollment.elected_aptc_pct > 0 ? enrollment.elected_aptc_pct : default_applied_aptc_pct
         end

--- a/app/helpers/config/aca_helper.rb
+++ b/app/helpers/config/aca_helper.rb
@@ -397,4 +397,16 @@ module Config::AcaHelper
       false
     end
   end
+
+  def osse_aptc_minimum_enabled?
+    EnrollRegistry.feature_enabled?(:aca_individual_osse_aptc_minimum)
+  end
+
+  def default_applied_aptc_pct
+    EnrollRegistry[:aca_individual_assistance_benefits].setting(:default_applied_aptc_percentage).item
+  end
+
+  def minimum_applied_aptc_for_osse
+    EnrollRegistry[:aca_individual_assistance_benefits].setting(:minimum_applied_aptc_percentage_for_osse).item
+  end
 end

--- a/app/helpers/config/aca_helper.rb
+++ b/app/helpers/config/aca_helper.rb
@@ -406,7 +406,7 @@ module Config::AcaHelper
     EnrollRegistry[:aca_individual_assistance_benefits].setting(:default_applied_aptc_percentage).item
   end
 
-  def minimum_applied_aptc_for_osse
+  def minimum_applied_aptc_pct_for_osse
     EnrollRegistry[:aca_individual_assistance_benefits].setting(:minimum_applied_aptc_percentage_for_osse).item
   end
 end

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -117,7 +117,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
 
   def verify_and_set_osse_minimum_aptc(renewal_enrollment)
     applied_aptc_pct = applied_aptc_pct_for(renewal_enrollment)
-    # return if applied_aptc_pct == renewal_enrollment.elected_aptc_pct
+    return if applied_aptc_pct == renewal_enrollment.elected_aptc_pct
 
     calculated_aptc_pct = renewal_enrollment.applied_aptc_amount.to_f / aptc_values[:max_aptc]
     if calculated_aptc_pct == renewal_enrollment.elected_aptc_pct

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -135,8 +135,8 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
 
   def applied_aptc_pct_for(renewal_enrollment)
     if renewal_enrollment.ivl_osse_eligible? && osse_aptc_minimum_enabled?
-      return renewal_enrollment.elected_aptc_pct if renewal_enrollment.elected_aptc_pct >= minimum_applied_aptc_for_osse.to_f
-      minimum_applied_aptc_for_osse
+      return renewal_enrollment.elected_aptc_pct if renewal_enrollment.elected_aptc_pct >= minimum_applied_aptc_pct_for_osse.to_f
+      minimum_applied_aptc_pct_for_osse
     else
       renewal_enrollment.elected_aptc_pct > 0 ? renewal_enrollment.elected_aptc_pct : default_applied_aptc_pct
     end

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -35,7 +35,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
         renewal_enrollment.renew_enrollment
       end
 
-      verify_and_set_osse_minimum_aptc(renewal_enrollment)
+      verify_and_set_osse_minimum_aptc(renewal_enrollment) if @assisted
       renewal_enrollment.update_osse_childcare_subsidy
 
       # renewal_enrollment.decorated_hbx_enrollment
@@ -115,30 +115,30 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
                         })
   end
 
-  def verify_and_set_osse_minimum_aptc(enrollment)
-    applied_aptc_pct = applied_aptc_pct_for(enrollment)
-    return if applied_aptc_pct == enrollment.elected_aptc_pct
+  def verify_and_set_osse_minimum_aptc(renewal_enrollment)
+    applied_aptc_pct = applied_aptc_pct_for(renewal_enrollment)
+    # return if applied_aptc_pct == renewal_enrollment.elected_aptc_pct
 
-    calculated_aptc_pct = enrollment.applied_aptc_amount.to_f / aptc_values[:max_aptc].to_f
-    if calculated_aptc_pct == enrollment.elected_aptc_pct
+    calculated_aptc_pct = renewal_enrollment.applied_aptc_amount.to_f / aptc_values[:max_aptc].to_f
+    if calculated_aptc_pct == renewal_enrollment.elected_aptc_pct
       applied_aptc = @aptc_values[:max_aptc] * applied_aptc_pct
     else
-      ehb_premium = enrollment.total_ehb_premium
+      ehb_premium = renewal_enrollment.total_ehb_premium
       applied_aptc = [(@aptc_values[:max_aptc] * applied_aptc_pct), ehb_premium].min
     end
 
-    enrollment.update(
+    renewal_enrollment.update(
       applied_aptc_amount: float_fix(applied_aptc),
       elected_aptc_pct: applied_aptc_pct
     )
   end
 
-  def applied_aptc_pct_for(enrollment)
-    if enrollment.ivl_osse_eligible? && osse_aptc_minimum_enabled?
-      return enrollment.elected_aptc_pct if enrollment.elected_aptc_pct >= minimum_applied_aptc_for_osse.to_f
+  def applied_aptc_pct_for(renewal_enrollment)
+    if renewal_enrollment.ivl_osse_eligible? && osse_aptc_minimum_enabled?
+      return renewal_enrollment.elected_aptc_pct if renewal_enrollment.elected_aptc_pct >= minimum_applied_aptc_for_osse.to_f
       minimum_applied_aptc_for_osse
     else
-      enrollment.elected_aptc_pct > 0 ? enrollment.elected_aptc_pct : default_applied_aptc_pct
+      renewal_enrollment.elected_aptc_pct > 0 ? renewal_enrollment.elected_aptc_pct : default_applied_aptc_pct
     end
   end
 

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   include FloatHelper
+  include Config::AcaHelper
   attr_accessor :enrollment, :renewal_coverage_start, :assisted, :aptc_values
 
   CAT_AGE_OFF_HIOS_IDS = ["94506DC0390008", "86052DC0400004"]
@@ -22,6 +23,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
       raise "Cannot renew enrollment #{enrollment.hbx_id}. Error: #{can_renew.failure}" unless can_renew.success?
 
       save_renewal_enrollment(renewal_enrollment)
+
       # elected aptc should be the minimun between applied_aptc and EHB premium.
       renewal_enrollment = assisted_enrollment(renewal_enrollment) if @assisted.present? && renewal_enrollment.is_health_enrollment?
 
@@ -32,6 +34,9 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
       else
         renewal_enrollment.renew_enrollment
       end
+
+      verify_and_set_osse_minimum_aptc(renewal_enrollment)
+      renewal_enrollment.update_eligible_child_care_subsidy_amount
 
       # renewal_enrollment.decorated_hbx_enrollment
       @dependent_age_off = nil
@@ -108,6 +113,33 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
                           max_aptc: max_aptc,
                           ehb_premium: ehb_premium
                         })
+  end
+
+  def verify_and_set_osse_minimum_aptc(enrollment)
+    applied_aptc_pct = applied_aptc_pct_for(enrollment)
+    return if applied_aptc_pct == enrollment.elected_aptc_pct
+
+    calculated_aptc_pct = enrollment.applied_aptc_amount.to_f / aptc_values[:max_aptc].to_f
+    if calculated_aptc_pct == enrollment.elected_aptc_pct
+      applied_aptc = @aptc_values[:max_aptc] * applied_aptc_pct
+    else
+      ehb_premium = enrollment.total_ehb_premium
+      applied_aptc = [(@aptc_values[:max_aptc] * applied_aptc_pct), ehb_premium].min
+    end
+
+    enrollment.update(
+      applied_aptc_amount: float_fix(applied_aptc),
+      elected_aptc_pct: applied_aptc_pct
+    )
+  end
+
+  def applied_aptc_pct_for(enrollment)
+    if enrollment.ivl_osse_eligible? && osse_aptc_minimum_enabled?
+      return enrollment.elected_aptc_pct if enrollment.elected_aptc_pct >= minimum_applied_aptc_for_osse.to_f
+      minimum_applied_aptc_for_osse
+    else
+      enrollment.elected_aptc_pct > 0 ? enrollment.elected_aptc_pct : default_applied_aptc_pct
+    end
   end
 
   def can_renew_assisted_product?(renewal_enrollment)

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -119,7 +119,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
     applied_aptc_pct = applied_aptc_pct_for(renewal_enrollment)
     # return if applied_aptc_pct == renewal_enrollment.elected_aptc_pct
 
-    calculated_aptc_pct = renewal_enrollment.applied_aptc_amount.to_f / aptc_values[:max_aptc].to_f
+    calculated_aptc_pct = renewal_enrollment.applied_aptc_amount.to_f / aptc_values[:max_aptc]
     if calculated_aptc_pct == renewal_enrollment.elected_aptc_pct
       applied_aptc = @aptc_values[:max_aptc] * applied_aptc_pct
     else

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -36,7 +36,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
       end
 
       verify_and_set_osse_minimum_aptc(renewal_enrollment)
-      renewal_enrollment.update_eligible_child_care_subsidy_amount
+      renewal_enrollment.update_osse_childcare_subsidy
 
       # renewal_enrollment.decorated_hbx_enrollment
       @dependent_age_off = nil

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2820,10 +2820,12 @@ class HbxEnrollment
     workflow_state_transitions.order(created_at: :desc).first
   end
 
-  def ivl_osse_eligible?
+  def ivl_osse_eligible?(new_effective_date = nil)
     return false if is_shop? || dental?
 
-    hbx_enrollment_members.any?(&:osse_eligible_on_effective_date?)
+    hbx_enrollment_members.any? do |member|
+      member.osse_eligible_on_effective_date?(new_effective_date)
+    end
   end
 
   def update_osse_childcare_subsidy

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2641,6 +2641,14 @@ class HbxEnrollment
     )
   end
 
+  def update_eligible_child_care_subsidy_amount
+    return if is_shop?
+    return unless ivl_osse_eligible?
+
+    cost_calculator = build_plan_premium(qhp_plan: product, elected_aptc: applied_aptc_amount, apply_aptc: applied_aptc_amount > 0)
+    update(eligible_child_care_subsidy: cost_calculator.total_childcare_subsidy_amount)
+  end
+
   def cancel_ivl_enrollment
     return if is_shop?
 

--- a/app/models/hbx_enrollment_member.rb
+++ b/app/models/hbx_enrollment_member.rb
@@ -80,11 +80,12 @@ class HbxEnrollmentMember
     @age_on_effective_date = age
   end
 
-  def osse_eligible_on_effective_date?
-    return false unless coverage_start_on.present?
-    return false unless ivl_osse_eligibility_is_enabled?(coverage_start_on.year)
+  def osse_eligible_on_effective_date?(new_effective_date = nil)
+    date_for_eligibility = new_effective_date || coverage_start_on
+    return false unless date_for_eligibility.present?
+    return false unless ivl_osse_eligibility_is_enabled?(date_for_eligibility.year)
 
-    role_for_subsidy&.osse_eligible?(coverage_start_on)
+    role_for_subsidy&.osse_eligible?(date_for_eligibility)
   end
 
   def role_for_subsidy

--- a/spec/domain/operations/individual/apply_aggregate_to_enrollment_spec.rb
+++ b/spec/domain/operations/individual/apply_aggregate_to_enrollment_spec.rb
@@ -239,7 +239,6 @@ RSpec.describe Operations::Individual::ApplyAggregateToEnrollment, dbclean: :aft
       double(
         effective_date: Date.new(year, 1, 1),
         product: product,
-        subscriber: subscriber,
         elected_aptc_pct: elected_aptc_pct
       )
     end
@@ -247,8 +246,6 @@ RSpec.describe Operations::Individual::ApplyAggregateToEnrollment, dbclean: :aft
     let(:year) { Date.today.year }
     let(:new_effective_date) { Date.new(year, 5, 1) }
     let(:product) { double(is_hc4cc_plan?: false) }
-    let(:subscriber) { double(role_for_subsidy: role_for_subsidy) }
-    let(:role_for_subsidy) { double }
     let(:elected_aptc_pct) { 0.5 }
     let(:minimum_applied_aptc_percentage_for_osse) { 0.85 }
     let(:default_applied_aptc_percentage) { 0.8 }
@@ -266,7 +263,7 @@ RSpec.describe Operations::Individual::ApplyAggregateToEnrollment, dbclean: :aft
 
       context 'subscriber has osse subsidy enabled' do
         before do
-          allow(role_for_subsidy).to receive(:osse_eligible?).and_return(true)
+          allow(enrollment).to receive(:ivl_osse_eligible?).with(new_effective_date).and_return(true)
         end
 
         context 'when elected aptc pct is less the osse minimum' do
@@ -291,7 +288,7 @@ RSpec.describe Operations::Individual::ApplyAggregateToEnrollment, dbclean: :aft
 
       context 'subscriber has no osse subsidy enabled' do
         before do
-          allow(role_for_subsidy).to receive(:osse_eligible?).and_return(false)
+          allow(enrollment).to receive(:ivl_osse_eligible?).with(new_effective_date).and_return(false)
         end
 
         context 'when elected aptc pct is zero' do
@@ -318,7 +315,7 @@ RSpec.describe Operations::Individual::ApplyAggregateToEnrollment, dbclean: :aft
 
     context 'enrollment with non osse plan' do
       before do
-        allow(role_for_subsidy).to receive(:osse_eligible?).and_return(true)
+        allow(enrollment).to receive(:ivl_osse_eligible?).with(new_effective_date).and_return(true)
       end
 
       let(:product) { double(is_hc4cc_plan?: false) }

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -896,7 +896,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
           context 'when osse minimum aptc enabled' do
             before do
               allow(subject).to receive(:osse_aptc_minimum_enabled?).and_return(true)
-              allow(subject).to receive(:minimum_applied_aptc_for_osse).and_return(0.85)
+              allow(subject).to receive(:minimum_applied_aptc_pct_for_osse).and_return(0.85)
               allow(subject).to receive(:can_renew_assisted_product?).and_return(true)
               allow(subject).to receive(:eligible_to_get_covered?).and_return(true)
             end
@@ -921,7 +921,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
           context 'when osse minimum aptc not enabled' do
             before do
               allow(subject).to receive(:osse_aptc_minimum_enabled?).and_return(false)
-              allow(subject).to receive(:minimum_applied_aptc_for_osse).and_return(0.85)
+              allow(subject).to receive(:minimum_applied_aptc_pct_for_osse).and_return(0.85)
               allow(subject).to receive(:can_renew_assisted_product?).and_return(true)
               allow(subject).to receive(:eligible_to_get_covered?).and_return(true)
             end

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -888,7 +888,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
         context 'when osse eligibility present for renewal year' do
           before do
             allow_any_instance_of(HbxEnrollment).to receive(:ivl_osse_eligible?).and_return(true)
-            allow(EnrollRegistry).to receive(:feature_enabled?).with(:temporary_configuration_enable_multi_tax_household_feature).and_return(false)
+            allow(EnrollRegistry).to receive(:feature_enabled?).with(:temporary_configuration_enable_multi_tax_household_feature).and_return(true)
             allow(EnrollRegistry).to receive(:feature_enabled?).with(:total_minimum_responsibility).and_return(false)
             enrollment.update_osse_childcare_subsidy
           end
@@ -899,6 +899,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
               allow(subject).to receive(:minimum_applied_aptc_pct_for_osse).and_return(0.85)
               allow(subject).to receive(:can_renew_assisted_product?).and_return(true)
               allow(subject).to receive(:eligible_to_get_covered?).and_return(true)
+              allow(subject).to receive(:populate_aptc_hash).and_return(true)
             end
 
             it "should renew and apply child care subsidy" do
@@ -906,7 +907,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
               renewal = subject.renew
               expect(renewal.auto_renewing?).to be_truthy
               expect(renewal.eligible_child_care_subsidy.to_f).to be > 0
-              # expect(renewal.eligible_child_care_subsidy.to_f).to eq(renewal.total_premium.to_f - renewal.applied_aptc_amount.to_f)
+              expect(renewal.eligible_child_care_subsidy.to_f).to eq(renewal.total_premium.to_f - renewal.applied_aptc_amount.to_f)
             end
 
             it "should apply minimum aptc pct" do
@@ -924,6 +925,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
               allow(subject).to receive(:minimum_applied_aptc_pct_for_osse).and_return(0.85)
               allow(subject).to receive(:can_renew_assisted_product?).and_return(true)
               allow(subject).to receive(:eligible_to_get_covered?).and_return(true)
+              allow(subject).to receive(:populate_aptc_hash).and_return(true)
             end
 
             it "should renew and apply child care subsidy" do
@@ -931,15 +933,15 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
               renewal = subject.renew
               expect(renewal.auto_renewing?).to be_truthy
               expect(renewal.eligible_child_care_subsidy.to_f).to be > 0
-              # expect(renewal.eligible_child_care_subsidy.to_f).to eq(renewal.total_premium.to_f - renewal.applied_aptc_amount.to_f)
+              expect(renewal.eligible_child_care_subsidy.to_f).to eq(renewal.total_premium.to_f - renewal.applied_aptc_amount.to_f)
             end
 
             it "should not apply minimum aptc pct" do
               expect(enrollment.eligible_child_care_subsidy.to_f).to be > 0
               renewal = subject.renew
               expect(renewal.auto_renewing?).to be_truthy
-              # expect(renewal.elected_aptc_pct).to be 0.75
-              # expect(renewal.applied_aptc_amount.to_f).to eq(730.0 * 0.75)
+              expect(renewal.elected_aptc_pct).to be 0.75
+              expect(renewal.applied_aptc_amount.to_f).to eq(730.0 * 0.75)
             end
           end
         end

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+ # frozen_string_literal: true
 
 require 'rails_helper'
 require "#{Rails.root}/spec/shared_contexts/enrollment.rb"
@@ -827,6 +827,119 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
               expect(renewal.is_a?(HbxEnrollment)).to eq true
               expect(subject.aptc_values).to eq({ })
               expect(subject.assisted).to be_falsey
+            end
+          end
+        end
+      end
+
+      context 'osse unassisted enrollment renewal' do
+
+        before do
+          BenefitMarkets::Products::ProductRateCache.initialize_rate_cache!
+        end
+
+        let(:child1_dob) { current_date.next_month - 24.years }
+
+        context 'when osse eligibility present for renewal year' do
+
+          it "should renew and apply child care subsidy" do
+            allow_any_instance_of(HbxEnrollment).to receive(:ivl_osse_eligible?).and_return(true)
+            enrollment.update_osse_childcare_subsidy 
+            expect(enrollment.eligible_child_care_subsidy.to_f).to be > 0
+
+            renewal = subject.renew
+            expect(renewal.auto_renewing?).to be_truthy
+            expect(renewal.eligible_child_care_subsidy.to_f).to be > 0
+            expect(renewal.eligible_child_care_subsidy.to_f).to eq(renewal.total_premium.to_f)
+          end
+        end
+
+        context 'when osse eligibility not present for renewal year' do
+
+          it "should renew and don't apply child care subsidy" do
+            allow(enrollment).to receive(:ivl_osse_eligible?).and_return(true)
+            enrollment.update_osse_childcare_subsidy 
+            expect(enrollment.eligible_child_care_subsidy.to_f).to be > 0
+
+            renewal = subject.renew
+            expect(renewal.auto_renewing?).to be_truthy
+            expect(renewal.eligible_child_care_subsidy.to_f).to eq(0.0)
+          end
+        end
+      end
+
+      context 'osse assisted enrollment renewal' do
+
+        let(:assisted) { true }
+        let(:aptc_values) do
+          {
+            applied_percentage: 0.75,
+            applied_aptc: 547.5,
+            max_aptc: 730.0,
+            csr_amt: 73
+          }
+        end
+        let(:child1_dob) { current_date.next_month - 24.years }
+
+        before do
+          BenefitMarkets::Products::ProductRateCache.initialize_rate_cache!
+        end
+
+        context 'when osse eligibility present for renewal year' do
+          before do
+            allow_any_instance_of(HbxEnrollment).to receive(:ivl_osse_eligible?).and_return(true)
+            allow(EnrollRegistry).to receive(:feature_enabled?).with(:temporary_configuration_enable_multi_tax_household_feature).and_return(false)
+            allow(EnrollRegistry).to receive(:feature_enabled?).with(:total_minimum_responsibility).and_return(false)
+            enrollment.update_osse_childcare_subsidy
+          end
+
+          context 'when osse minimum aptc enabled' do 
+            before do
+              allow(subject).to receive(:osse_aptc_minimum_enabled?).and_return(true)
+              allow(subject).to receive(:minimum_applied_aptc_for_osse).and_return(0.85)   
+              allow(subject).to receive(:can_renew_assisted_product?).and_return(true)
+              allow(subject).to receive(:eligible_to_get_covered?).and_return(true)
+            end
+
+            it "should renew and apply child care subsidy" do
+              expect(enrollment.eligible_child_care_subsidy.to_f).to be > 0
+              renewal = subject.renew
+              expect(renewal.auto_renewing?).to be_truthy
+              expect(renewal.eligible_child_care_subsidy.to_f).to be > 0
+              # expect(renewal.eligible_child_care_subsidy.to_f).to eq(renewal.total_premium.to_f - renewal.applied_aptc_amount.to_f)
+            end
+
+            it "should apply minimum aptc pct" do
+              expect(enrollment.eligible_child_care_subsidy.to_f).to be > 0
+              renewal = subject.renew
+              expect(renewal.auto_renewing?).to be_truthy
+              expect(renewal.elected_aptc_pct).to be 0.85
+              expect(renewal.applied_aptc_amount.to_f).to eq(730.0 * 0.85)
+            end
+          end
+
+          context 'when osse minimum aptc not enabled' do 
+            before do
+              allow(subject).to receive(:osse_aptc_minimum_enabled?).and_return(false)
+              allow(subject).to receive(:minimum_applied_aptc_for_osse).and_return(0.85)   
+              allow(subject).to receive(:can_renew_assisted_product?).and_return(true)
+              allow(subject).to receive(:eligible_to_get_covered?).and_return(true)
+            end
+
+            it "should renew and apply child care subsidy" do
+              expect(enrollment.eligible_child_care_subsidy.to_f).to be > 0
+              renewal = subject.renew
+              expect(renewal.auto_renewing?).to be_truthy
+              expect(renewal.eligible_child_care_subsidy.to_f).to be > 0
+              # expect(renewal.eligible_child_care_subsidy.to_f).to eq(renewal.total_premium.to_f - renewal.applied_aptc_amount.to_f)
+            end
+
+            it "should not apply minimum aptc pct" do
+              expect(enrollment.eligible_child_care_subsidy.to_f).to be > 0
+              renewal = subject.renew
+              expect(renewal.auto_renewing?).to be_truthy
+              # expect(renewal.elected_aptc_pct).to be 0.75
+              # expect(renewal.applied_aptc_amount.to_f).to eq(730.0 * 0.75)
             end
           end
         end

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -844,7 +844,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
 
           it "should renew and apply child care subsidy" do
             allow_any_instance_of(HbxEnrollment).to receive(:ivl_osse_eligible?).and_return(true)
-            enrollment.update_osse_childcare_subsidy 
+            enrollment.update_osse_childcare_subsidy
             expect(enrollment.eligible_child_care_subsidy.to_f).to be > 0
 
             renewal = subject.renew
@@ -858,7 +858,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
 
           it "should renew and don't apply child care subsidy" do
             allow(enrollment).to receive(:ivl_osse_eligible?).and_return(true)
-            enrollment.update_osse_childcare_subsidy 
+            enrollment.update_osse_childcare_subsidy
             expect(enrollment.eligible_child_care_subsidy.to_f).to be > 0
 
             renewal = subject.renew
@@ -893,10 +893,10 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
             enrollment.update_osse_childcare_subsidy
           end
 
-          context 'when osse minimum aptc enabled' do 
+          context 'when osse minimum aptc enabled' do
             before do
               allow(subject).to receive(:osse_aptc_minimum_enabled?).and_return(true)
-              allow(subject).to receive(:minimum_applied_aptc_for_osse).and_return(0.85)   
+              allow(subject).to receive(:minimum_applied_aptc_for_osse).and_return(0.85)
               allow(subject).to receive(:can_renew_assisted_product?).and_return(true)
               allow(subject).to receive(:eligible_to_get_covered?).and_return(true)
             end
@@ -918,10 +918,10 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
             end
           end
 
-          context 'when osse minimum aptc not enabled' do 
+          context 'when osse minimum aptc not enabled' do
             before do
               allow(subject).to receive(:osse_aptc_minimum_enabled?).and_return(false)
-              allow(subject).to receive(:minimum_applied_aptc_for_osse).and_return(0.85)   
+              allow(subject).to receive(:minimum_applied_aptc_for_osse).and_return(0.85)
               allow(subject).to receive(:can_renew_assisted_product?).and_return(true)
               allow(subject).to receive(:eligible_to_get_covered?).and_return(true)
             end


### PR DESCRIPTION
 Update ivl enrollment renewals with below OSSE changes
 
  1. apply osse minimum aptc when enabled
  2. set osse childcare subsidy on the enrollment

# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185056342

# A brief description of the changes

Current behavior:  When you plan shop during OE or with SEP or reinstate, if you already have OSSE eligibility, OSSE subsidy will be applied along with OSSE Aptc Minimum. 

New behavior: OSSE subsidy and Aptc minimum rules will applied for renewed coverages as well.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: ACA_INDIVIDUAL_OSSE_APTC_MINIMUM (Note* don't enable this in production until osse_plans are loaded)

- [x] DC
- [ ] ME
