### PR TITLE
add ssi_type income validation

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -904,7 +904,7 @@ module FinancialAssistance
           return false if has_unemployment_income.nil? || has_other_income.nil?
           return true if has_unemployment_income == false && has_other_income == false
           return true if has_unemployment_income == true && incomes.unemployment.present? && has_other_income == false
-          return true if has_unemployment_income == false && has_other_income == true && incomes.other.present?
+          return true if has_unemployment_income == false && is_other_income_valid?
           return incomes.unemployment.present? && unemployment_fields_complete && incomes.other.present? if incomes.unemployment && incomes.other
           return incomes.unemployment.present? && unemployment_fields_complete && incomes.other.blank? if incomes.unemployment && !incomes.other
           return incomes.unemployment.blank? && unemployment_fields_complete && incomes.other.present? if !incomes.unemployment && incomes.other
@@ -966,10 +966,15 @@ module FinancialAssistance
       !validations.include?(false)
     end
 
+    def is_other_income_valid?
+      has_other_income == false || (has_other_income == true && incomes.other.present? && other_income_fields_complete)
+    end
+
     def other_income_fields_complete
       validations = []
       incomes.other.each do |other|
         validations << (other[:amount].present? && other[:frequency_kind].present? && other[:start_on].present?)
+        validations << other.ssi_type.present? if other.kind == "social_security_benefit" && FinancialAssistanceRegistry.feature_enabled?(:ssi_income_types)
       end
       !validations.include?(false)
     end

--- a/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
@@ -1528,6 +1528,121 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
           end
         end
       end
+
+      # ssi_income_types
+      context 'when feature ssi_income_types is enabled' do
+        before do
+          allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:ssi_income_types).and_return(true)
+          allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:american_indian_alaskan_native_income).and_return(false)
+        end
+
+        context 'when applicant has other_income with incompleted social security benefit' do
+          before do
+            applicant.update_attributes!(has_other_income: true)
+            inc = ::FinancialAssistance::Income.new({
+                                                      kind: 'social_security_benefit',
+                                                      frequency_kind: 'yearly',
+                                                      amount: 30_000.00,
+                                                      start_on: TimeKeeper.date_of_record.beginning_of_month
+                                                    })
+            applicant.incomes = [inc]
+            applicant.save!
+            @result = applicant.embedded_document_section_entry_complete?(:other_income)
+          end
+
+          it 'should return false' do
+            expect(@result).to be_falsey
+          end
+        end
+
+        context 'when applicant has_other_income without other incomes' do
+          before do
+            applicant.update_attributes!(has_other_income: true)
+            @result = applicant.embedded_document_section_entry_complete?(:other_income)
+          end
+
+          it 'should return false' do
+            expect(@result).to be_falsey
+          end
+        end
+
+        context 'where applicant has_other_income with completed social security benefit' do
+          before do
+            applicant.update_attributes!(has_other_income: true)
+            inc = ::FinancialAssistance::Income.new({
+                                                      kind: 'social_security_benefit',
+                                                      frequency_kind: 'yearly',
+                                                      amount: 30_000.00,
+                                                      start_on: TimeKeeper.date_of_record.beginning_of_month,
+                                                      ssi_type: 'retirement'
+                                                    })
+            applicant.incomes = [inc]
+            applicant.save!
+            @result = applicant.embedded_document_section_entry_complete?(:other_income)
+          end
+
+          it 'should return true' do
+            expect(@result).to be_truthy
+          end
+        end
+      end
+
+      context 'when feature ssi_income_types is disabled' do
+        before do
+          allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:ssi_income_types).and_return(false)
+          allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:american_indian_alaskan_native_income).and_return(false)
+        end
+
+        context 'when applicant has other_income with incompleted social security benefit' do
+          before do
+            applicant.update_attributes!(has_other_income: true)
+            inc = ::FinancialAssistance::Income.new({
+                                                      kind: 'social_security_benefit',
+                                                      frequency_kind: 'yearly',
+                                                      amount: 30_000.00,
+                                                      start_on: TimeKeeper.date_of_record.beginning_of_month
+                                                    })
+            applicant.incomes = [inc]
+            applicant.save!
+            @result = applicant.embedded_document_section_entry_complete?(:other_income)
+          end
+
+          it 'should return false' do
+            expect(@result).to be_truthy
+          end
+        end
+
+        context 'when applicant has_other_income without other incomes' do
+          before do
+            applicant.update_attributes!(has_other_income: true)
+            @result = applicant.embedded_document_section_entry_complete?(:other_income)
+          end
+
+          it 'should return false' do
+            expect(@result).to be_falsey
+          end
+        end
+
+        context 'where applicant has_other_income with completed social security benefit' do
+          before do
+            applicant.update_attributes!(has_other_income: true)
+            inc = ::FinancialAssistance::Income.new({
+                                                      kind: 'social_security_benefit',
+                                                      frequency_kind: 'yearly',
+                                                      amount: 30_000.00,
+                                                      start_on: TimeKeeper.date_of_record.beginning_of_month,
+                                                      ssi_type: 'retirement'
+                                                    })
+            applicant.incomes = [inc]
+            applicant.save!
+            @result = applicant.embedded_document_section_entry_complete?(:other_income)
+          end
+
+          it 'should return true' do
+            expect(@result).to be_truthy
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [Pivotal-185306563](https://www.pivotaltracker.com/n/projects/2640059/stories/185306563#)

# A brief description of the changes

Current behavior: Left Nav for other income is marked for completion even though the ssi_income type  required field is missing.

New behavior: Validation logic on other income is updated so that the check mark for completion is only displayed when ssi_income type  required field is filled.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME
