### PR TITLE
only collect additional esi/hra info when applicant has access to coverage

### DIFF
--- a/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
+++ b/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
@@ -359,5 +359,10 @@ module FinancialAssistance
     def display_minimum_value_standard_question?(insurance_kind)
       FinancialAssistanceRegistry.feature_enabled?(:minimum_value_standard_question) && insurance_kind == 'employer_sponsored_insurance'
     end
+
+    # is this an eligible esi benefit
+    def display_esi_fields?(insurance_kind, kind)
+      ['employer_sponsored_insurance', 'health_reimbursement_arrangement'].include?(insurance_kind) && (kind == "is_eligible" || !FinancialAssistanceRegistry.feature_enabled?(:short_enrolled_esi_forms))
+    end
   end
 end

--- a/components/financial_assistance/app/models/financial_assistance/benefit.rb
+++ b/components/financial_assistance/app/models/financial_assistance/benefit.rb
@@ -269,6 +269,7 @@ module FinancialAssistance
 
     def presence_of_esi_details_if_esi
       return unless insurance_kind == 'employer_sponsored_insurance'
+      return if EnrollRegistry[:short_enrolled_esi_forms].enabled? && is_enrolled?
       errors.add(:employer_name, " ' EMPLOYER NAME' can't be blank ") if employer_name.blank?
       errors.add(:esi_covered, "' Who can be covered?' can't be blank ") if esi_covered.blank?
       errors.add(:start_on, "' Start On' Date can't be blank ") if start_on.blank?

--- a/components/financial_assistance/app/views/financial_assistance/applications/_review_benefits.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/_review_benefits.html.erb
@@ -15,7 +15,7 @@
       <div class="col-md-6 form-content"><%= start_to_end_dates(benefit) %></div>
     </div>
 
-    <% if ['employer_sponsored_insurance', 'health_reimbursement_arrangement'].include?(benefit.insurance_kind) %>
+    <% if ['employer_sponsored_insurance', 'health_reimbursement_arrangement'].include?(benefit.insurance_kind) && (kind == "is_eligible" || !EnrollRegistry[:short_enrolled_esi_forms].enabled?) %>
       <%= render partial: 'financial_assistance/applications/review_esi_benefit', locals: {benefit: benefit} %>
     <% end %>
   <% end %>

--- a/components/financial_assistance/app/views/financial_assistance/applications/_review_benefits.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/_review_benefits.html.erb
@@ -14,8 +14,7 @@
       <div class="col-md-6 form-heading"><%= l10n(term, short_name: EnrollRegistry[:enroll_app].setting(:short_name).item) %></div>
       <div class="col-md-6 form-content"><%= start_to_end_dates(benefit) %></div>
     </div>
-
-    <% if ['employer_sponsored_insurance', 'health_reimbursement_arrangement'].include?(benefit.insurance_kind) && (kind == "is_eligible" || !EnrollRegistry[:short_enrolled_esi_forms].enabled?) %>
+    <% if display_esi_fields?(benefit.insurance_kind, kind) %>
       <%= render partial: 'financial_assistance/applications/review_esi_benefit', locals: {benefit: benefit} %>
     <% end %>
   <% end %>

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit_form.html.erb
@@ -1,5 +1,5 @@
 <%= benefit_form_for @application, @applicant, benefit do |f| %>
-  <div class="focus_effect_module row-edit-border">
+  <div class="focus_effect_module row-edit-border" data-cuke="esi_benefit">
     <%= f.hidden_field :kind, value: kind %>
     <%= f.hidden_field :insurance_kind, value: insurance_kind %>
 

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
@@ -27,7 +27,7 @@
 
     <div class="benefits-list <%= kind %>">
       <% @applicant.benefits.where(kind: kind).of_insurance_kind(insurance_kind).each do |benefit| %>
-        <%if (benefit.insurance_kind == 'employer_sponsored_insurance' || benefit.insurance_kind == 'health_reimbursement_arrangement') && (kind == "is_eligible" || !EnrollRegistry[:short_enrolled_esi_forms].enabled?) %>
+        <% if display_esi_fields?(benefit.insurance_kind, kind) %>
           <%= render partial: 'esi_benefit', locals: { benefit: benefit, insurance_kind: insurance_kind, kind: kind } %>
         <% else %>
           <%= render partial: 'non_esi_benefit', locals: { benefit: benefit, insurance_kind: insurance_kind, kind: kind } %>
@@ -36,7 +36,7 @@
     </div>
 
     <div class='new-benefit-form hidden <%= insurance_kind %>'>
-      <% if (insurance_kind == 'employer_sponsored_insurance' || insurance_kind == 'health_reimbursement_arrangement') && (kind == "is_eligible" || !EnrollRegistry[:short_enrolled_esi_forms].enabled?) %>
+      <% if display_esi_fields?(insurance_kind, kind) %>
         <%= render partial: 'financial_assistance/benefits/esi_benefit_form', locals: { benefit: @applicant.benefits.build, insurance_kind: insurance_kind, kind: kind} %>
       <% else %>
         <%= render partial: 'financial_assistance/benefits/non_esi_benefit_form', locals: { benefit: @applicant.benefits.build, insurance_kind: insurance_kind, kind: kind} %>

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
@@ -27,7 +27,8 @@
 
     <div class="benefits-list <%= kind %>">
       <% @applicant.benefits.where(kind: kind).of_insurance_kind(insurance_kind).each do |benefit| %>
-        <%if benefit.insurance_kind == 'employer_sponsored_insurance' || benefit.insurance_kind == 'health_reimbursement_arrangement'%>
+        <%if (benefit.insurance_kind == 'employer_sponsored_insurance' || benefit.insurance_kind == 'health_reimbursement_arrangement') && (kind == "is_eligible" || !EnrollRegistry[:short_enrolled_esi_forms].enabled?) %>
+         fdkgjhfdjkghdjkfghfdjkghjk
           <%= render partial: 'esi_benefit', locals: { benefit: benefit, insurance_kind: insurance_kind, kind: kind } %>
         <% else %>
           <%= render partial: 'non_esi_benefit', locals: { benefit: benefit, insurance_kind: insurance_kind, kind: kind } %>
@@ -36,7 +37,7 @@
     </div>
 
     <div class='new-benefit-form hidden <%= insurance_kind %>'>
-      <% if insurance_kind == 'employer_sponsored_insurance' || insurance_kind == 'health_reimbursement_arrangement' %>
+      <% if (insurance_kind == 'employer_sponsored_insurance' || insurance_kind == 'health_reimbursement_arrangement') && (kind == "is_eligible" || !EnrollRegistry[:short_enrolled_esi_forms].enabled?) %>
         <%= render partial: 'financial_assistance/benefits/esi_benefit_form', locals: { benefit: @applicant.benefits.build, insurance_kind: insurance_kind, kind: kind} %>
       <% else %>
         <%= render partial: 'financial_assistance/benefits/non_esi_benefit_form', locals: { benefit: @applicant.benefits.build, insurance_kind: insurance_kind, kind: kind} %>

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
@@ -13,8 +13,8 @@
 <% insurance_kinds.each do |insurance_kind| %>
   <div id="<%= insurance_kind %>"class="benefit-kind">
     <div class="row row-form-wrapper radio-align fa-text-color lightgray no-buffer row-height">
-      <div class="col-md-10 benefits-check <%= insurance_kind %>">
-        <%=check_box_tag "insurance_kind", insurance_kind, @applicant.benefits.where(kind: kind).of_insurance_kind(insurance_kind).present?, class: "benefit-checkbox" %>
+      <div class="col-md-10 benefits-check">
+        <%=check_box_tag "insurance_kind", insurance_kind, @applicant.benefits.where(kind: kind).of_insurance_kind(insurance_kind).present?, class: "benefit-checkbox", data: {cuke: "#{insurance_kind}_benefit_checkbox"} %>
         <% eligible_esi = kind == "is_eligible" && insurance_kind == 'employer_sponsored_insurance' && FinancialAssistanceRegistry.feature_enabled?(:minimum_value_standard_question) %>
         <% term = eligible_esi ? "faa.question.#{insurance_kind}_eligible" : "faa.question.#{insurance_kind}" %>
         <% if I18n.exists?("glossary."+insurance_kind) %>
@@ -28,7 +28,6 @@
     <div class="benefits-list <%= kind %>">
       <% @applicant.benefits.where(kind: kind).of_insurance_kind(insurance_kind).each do |benefit| %>
         <%if (benefit.insurance_kind == 'employer_sponsored_insurance' || benefit.insurance_kind == 'health_reimbursement_arrangement') && (kind == "is_eligible" || !EnrollRegistry[:short_enrolled_esi_forms].enabled?) %>
-         fdkgjhfdjkghdjkfghfdjkghjk
           <%= render partial: 'esi_benefit', locals: { benefit: benefit, insurance_kind: insurance_kind, kind: kind } %>
         <% else %>
           <%= render partial: 'non_esi_benefit', locals: { benefit: benefit, insurance_kind: insurance_kind, kind: kind } %>

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_insurance_kinds.html.erb
@@ -13,7 +13,7 @@
 <% insurance_kinds.each do |insurance_kind| %>
   <div id="<%= insurance_kind %>"class="benefit-kind">
     <div class="row row-form-wrapper radio-align fa-text-color lightgray no-buffer row-height">
-      <div class="col-md-10 benefits-check">
+      <div class="col-md-10 benefits-check <%= insurance_kind %>">
         <%=check_box_tag "insurance_kind", insurance_kind, @applicant.benefits.where(kind: kind).of_insurance_kind(insurance_kind).present?, class: "benefit-checkbox", data: {cuke: "#{insurance_kind}_benefit_checkbox"} %>
         <% eligible_esi = kind == "is_eligible" && insurance_kind == 'employer_sponsored_insurance' && FinancialAssistanceRegistry.feature_enabled?(:minimum_value_standard_question) %>
         <% term = eligible_esi ? "faa.question.#{insurance_kind}_eligible" : "faa.question.#{insurance_kind}" %>

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_non_esi_benefit_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_non_esi_benefit_form.html.erb
@@ -1,5 +1,5 @@
 <%= benefit_form_for @application, @applicant, benefit do |f| %>
-  <div class="focus_effect_module">
+  <div class="focus_effect_module" data-cuke="non_esi_benefit">
     <%= f.hidden_field :kind, value: kind %>
     <%= f.hidden_field :insurance_kind, value: insurance_kind %>
       <div class="row row-form-wrapper no-buffer row-height row-edit-border">

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_replace.js.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_replace.js.erb
@@ -1,6 +1,6 @@
 stopEditingBenefit();
  $("<%= id %>").closest(".benefit-kind").find('#add_new_insurance_kind').removeClass("hidden");
-<%if (@benefit.insurance_kind == 'employer_sponsored_insurance' || @benefit.insurance_kind == 'health_reimbursement_arrangement') && (@benefit.kind == "is_eligible" || !EnrollRegistry[:short_enrolled_esi_forms].enabled?) %>
+<% if display_esi_fields?(@benefit.insurance_kind, @benefit.kind) %>
     $('<%= id %>').replaceWith("<%= escape_javascript render(partial: 'esi_benefit', locals: { benefit: @benefit, insurance_kind: @benefit_insurance_kind, kind: @benefit_kind }) %>");
 <% else %>
     $('<%= id %>').replaceWith("<%= escape_javascript render(partial: 'non_esi_benefit', locals: { benefit: @benefit, insurance_kind: @benefit_insurance_kind, kind: @benefit_kind }) %>");

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_replace.js.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_replace.js.erb
@@ -1,6 +1,6 @@
 stopEditingBenefit();
  $("<%= id %>").closest(".benefit-kind").find('#add_new_insurance_kind').removeClass("hidden");
-<%if @benefit.insurance_kind == 'employer_sponsored_insurance' || @benefit.insurance_kind == 'health_reimbursement_arrangement' %>
+<%if (@benefit.insurance_kind == 'employer_sponsored_insurance' || @benefit.insurance_kind == 'health_reimbursement_arrangement') && (@benefit.kind == "is_eligible" || !EnrollRegistry[:short_enrolled_esi_forms].enabled?) %>
     $('<%= id %>').replaceWith("<%= escape_javascript render(partial: 'esi_benefit', locals: { benefit: @benefit, insurance_kind: @benefit_insurance_kind, kind: @benefit_kind }) %>");
 <% else %>
     $('<%= id %>').replaceWith("<%= escape_javascript render(partial: 'non_esi_benefit', locals: { benefit: @benefit, insurance_kind: @benefit_insurance_kind, kind: @benefit_kind }) %>");

--- a/components/financial_assistance/spec/helpers/financial_assistance/application_helper_spec.rb
+++ b/components/financial_assistance/spec/helpers/financial_assistance/application_helper_spec.rb
@@ -452,4 +452,44 @@ RSpec.describe ::FinancialAssistance::ApplicationHelper, :type => :helper, dbcle
       end
     end
   end
+
+  describe '#display_esi_fields?' do
+    before do
+      allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:short_enrolled_esi_forms).and_return(enabled)
+    end
+
+    context 'RR configuration turned OFF' do
+      let(:enabled) { false }
+      let(:insurance_kind) { 'health_reimbursement_arrangement' }
+
+      it 'should return true if enrolled' do
+        expect(
+          helper.display_esi_fields?(insurance_kind, 'is_enrolled')
+        ).to eq(true)
+      end
+
+      it 'should return true if eligible' do
+        expect(
+          helper.display_esi_fields?(insurance_kind, 'is_eligible')
+        ).to eq(true)
+      end
+    end
+
+    context 'RR configuration turned ON' do
+      let(:enabled) { true }
+      let(:insurance_kind) { 'employer_sponsored_insurance' }
+
+      it 'should return false if enrolled' do
+        expect(
+          helper.display_esi_fields?(insurance_kind, 'is_enrolled')
+        ).to eq(false)
+      end
+
+      it 'should return true if eligible' do
+        expect(
+          helper.display_esi_fields?(insurance_kind, 'is_eligible')
+        ).to eq(true)
+      end
+    end
+  end
 end

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -134,6 +134,9 @@ registry:
       - key: :oe_application_warning_display
         item: :oe_application_warning_display
         is_enabled: <%= ENV['OE_APPLICATION_WARNING_DISPLAY_IS_ENABLED'] || false %>
+      - key: :short_enrolled_esi_forms
+        item: :short_enrolled_esi_forms
+        is_enabled: <%= ENV['SHORT_ENROLLED_ESI_IS_ENABLED'] || false %>
   - namespace:
     - :request_determination
     features:

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -134,6 +134,9 @@ registry:
       - key: :oe_application_warning_display
         item: :oe_application_warning_display
         is_enabled: <%= ENV['OE_APPLICATION_WARNING_DISPLAY_IS_ENABLED'] || false %>
+      - key: :short_enrolled_esi_forms
+        item: :short_enrolled_esi_forms
+        is_enabled: <%= ENV['SHORT_ENROLLED_ESI_IS_ENABLED'] || false %>
   - namespace:
     - :request_determination
     features:

--- a/features/financial_assistance/health_coverage_currently_has.feature
+++ b/features/financial_assistance/health_coverage_currently_has.feature
@@ -56,3 +56,18 @@ Feature: Start a new Financial Assistance Application and answers questions on h
   Scenario: Health coverage form shows after checking an option (currently have coverage)
     Given the user answers yes to currently having health coverage
     Then the coverage_obtained_through_another_exchange does not have glossary link
+  Scenario: User enters job coverage without the short form feature being enabled
+    Given the user answers yes to currently having health coverage
+    And the user checks on job coverage checkbox
+    Then the user should see the esi form
+
+  Scenario: User enters job coverage with the short form feature being enabled
+    Given the FAA short_enrolled_esi_forms feature is enabled
+    And they visit the Health Coverage page via the left nav (also confirm they are on the Health Coverage page)
+    Given the user answers yes to currently having health coverage
+    And the user checks on job coverage checkbox
+    Then the user should see the non_esi form
+    And the user fills out the required health coverage information
+    Then the save button should be enabled
+    And the user saves the health coverage information
+    Then the health coverage should be saved on the page

--- a/features/financial_assistance/health_coverage_currently_has.feature
+++ b/features/financial_assistance/health_coverage_currently_has.feature
@@ -71,3 +71,12 @@ Feature: Start a new Financial Assistance Application and answers questions on h
     Then the save button should be enabled
     And the user saves the health coverage information
     Then the health coverage should be saved on the page
+
+  Scenario: Health coverage form shows after checking an option (currently have coverage)
+    Given the user answers yes to currently having health coverage
+    Then the medicare have glossary link
+    Then the medicare have glossary content
+
+  Scenario: Health coverage form shows after checking an option (currently have coverage)
+    Given the user answers yes to currently having health coverage
+    Then the coverage_obtained_through_another_exchange does not have glossary link

--- a/features/financial_assistance/step_definitions/health_coverage_steps.rb
+++ b/features/financial_assistance/step_definitions/health_coverage_steps.rb
@@ -105,6 +105,23 @@ Then(/^the esi question should be about your job rather than a job$/) do
   expect(page).to have_content('Coverage through your job (also known as employer-sponsored health insurance)')
 end
 
+And(/^the user checks on job coverage checkbox$/) do
+  find(:css, CostSavingsApplicationPage.employer_sponsored_insurance_benefit_checkbox).set(true)
+end
+
+Given(/the FAA short_enrolled_esi_forms feature is enabled/) do
+  enable_feature :short_enrolled_esi_forms, {registry_name: FinancialAssistanceRegistry}
+  enable_feature :short_enrolled_esi_forms
+end
+
+Then(/^the user should see the esi form$/) do
+  expect(page.has_css?(CostSavingsApplicationPage.esi_benefit)).to eq true
+end
+
+Then(/^the user should see the non_esi form$/) do
+  expect(page.has_css?(CostSavingsApplicationPage.non_esi_benefit)).to eq true
+end
+
 Given(/^the user fills out the required health coverage information$/) do
   fill_in 'benefit[start_on]', with: "02/01/2018"
 end

--- a/features/support/object_model_pages/financial_assistance/cost_savings_application_page.rb
+++ b/features/support/object_model_pages/financial_assistance/cost_savings_application_page.rb
@@ -17,6 +17,18 @@ class CostSavingsApplicationPage
 
   def self.index_with_filter
     "[data-cuke='index_with_filter']"
+
+  def self.employer_sponsored_insurance_benefit_checkbox
+    "[data-cuke='employer_sponsored_insurance_benefit_checkbox']"
+  end
+
+  def self.esi_benefit
+    "[data-cuke='esi_benefit']"
+  end
+
+  def self.non_esi_benefit
+    "[data-cuke='non_esi_benefit']"
+
   end
 
   def self.meets_mvs_and_affordable

--- a/features/support/object_model_pages/financial_assistance/cost_savings_application_page.rb
+++ b/features/support/object_model_pages/financial_assistance/cost_savings_application_page.rb
@@ -17,6 +17,7 @@ class CostSavingsApplicationPage
 
   def self.index_with_filter
     "[data-cuke='index_with_filter']"
+  end
 
   def self.employer_sponsored_insurance_benefit_checkbox
     "[data-cuke='employer_sponsored_insurance_benefit_checkbox']"
@@ -28,7 +29,6 @@ class CostSavingsApplicationPage
 
   def self.non_esi_benefit
     "[data-cuke='non_esi_benefit']"
-
   end
 
   def self.meets_mvs_and_affordable

--- a/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -134,6 +134,9 @@ registry:
       - key: :oe_application_warning_display
         item: :oe_application_warning_display
         is_enabled: <%= ENV['OE_APPLICATION_WARNING_DISPLAY_IS_ENABLED'] || false %>
+      - key: :short_enrolled_esi_forms
+        item: :short_enrolled_esi_forms
+        is_enabled: <%= ENV['SHORT_ENROLLED_ESI_IS_ENABLED'] || false %>
   - namespace:
     - :request_determination
     features:


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185060660

# A brief description of the changes

Current behavior:
'Coverage from a job' and 'Health Reimbursement Arrangement' benefit forms collect employer/affordability details for both cases: enrolled OR eligible for the coverage.

New behavior:
'Coverage from a job' and 'Health Reimbursement Arrangement' forms match the From/To format used for other coverage types when applicant indicates they are enrolled in the coverage. Additional info still collected if applicant indicates they are eligible for the coverage.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:
- SHORT_ENROLLED_ESI_IS_ENABLED

- [ ] DC
- [x] ME
