### PR TITLE
fixing post partum language in review error and raw application

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1469,8 +1469,12 @@ module FinancialAssistance
         errors.add(:children_expected_count, "' How many children is this person expecting?' should be answered") if children_expected_count.blank?
       # Nil or "" means unanswered, true/or false boolean will be passed through
       elsif is_post_partum_period.nil? || is_post_partum_period == ""
-        # Even if they aren't pregnant, still need to ask if they were pregnant within the last 60 days
-        errors.add(:is_post_partum_period, "' Was this person pregnant in the last 60 days?' should be answered")
+        if FinancialAssistanceRegistry.feature_enabled?(:post_partum_period_one_year)
+          errors.add(:is_post_partum_period, "'#{l10n('faa.other_ques.pregnant_last_year')}' should be answered")
+        else
+          # Even if they aren't pregnant, still need to ask if they were pregnant within the last 60 days
+          errors.add(:is_post_partum_period, "'#{l10n('faa.other_ques.pregnant_last_60d')}' should be answered")
+        end
       end
       # If they're in post partum period, they need to tell us if they were on medicaid and when the pregnancy ended
       if is_post_partum_period.present?

--- a/components/financial_assistance/app/views/financial_assistance/applications/raw_application_hra.yml.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/raw_application_hra.yml.erb
@@ -55,7 +55,11 @@
         Is this person pregnant?:  <%= applicant.is_pregnant %>
         Pregnancy due date?:  <%=applicant.pregnancy_due_on.to_s.present? ? applicant.pregnancy_due_on.to_s : 'N/A' %>
         How many children is this person expecting?:  <%=applicant.children_expected_count.present? ? applicant.children_expected_count : 'N/A' %>
-        Was this person pregnant in the last 60 days?:  <%= applicant.is_post_partum_period %>
+        <% if FinancialAssistanceRegistry.feature_enabled?(:post_partum_period_one_year) %>
+            <%= l10n("faa.other_ques.pregnant_last_year") %>:  <%= applicant.is_post_partum_period %>
+        <% else %>
+            <%= l10n("faa.other_ques.pregnant_last_60d") %>:  <%= applicant.is_post_partum_period %>
+        <% end %>
         Pregnancy end on date:  <%=applicant.pregnancy_end_on.to_s.present? ? applicant.pregnancy_end_on.to_s : 'N/A' %>
         Was this person on Medicaid during pregnancy?:  <%= applicant.is_enrolled_on_medicaid %>
         Was this person in foster care at age 18 or older?:  <%= applicant.is_former_foster_care %>

--- a/components/financial_assistance/app/views/financial_assistance/applications/review_and_submit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/review_and_submit.html.erb
@@ -433,7 +433,11 @@
 
             <% if @cfl_service.displayable_field?('applicant', applicant.id, :is_post_partum_period) %>
               <div class="row row-form-wrapper ptb no-buffer row-height form-content">
-                <div class="col-md-6">Was this person pregnant in the last 60 days?</div>
+              <% if FinancialAssistanceRegistry.feature_enabled?(:post_partum_period_one_year) %>
+                <div class="col-md-6"><%= l10n('faa.other_ques.pregnant_last_year') %></div>
+              <% else %>
+                <div class="col-md-6"><%= l10n('faa.other_ques.pregnant_last_60d') %></div>
+              <% end %>
                 <div class="col-md-6"><%= human_boolean applicant.is_post_partum_period %></div>
               </div>
             <% end %>

--- a/features/financial_assistance/other_questions_pregnancy.feature
+++ b/features/financial_assistance/other_questions_pregnancy.feature
@@ -25,7 +25,7 @@ Feature: Start a new Financial Assistance Application and answers questions on O
 
   Scenario: Pregnancy response within 60 days Yes with information filled and submitted
     Given the user answers no to being pregnant
-    And the post partum language one year is not enabled
+    And FAA post_partum_period_one_year feature is disabled
     And they answer yes to was this person pregnant in the last 60 days question
     And the user enters a pregnancy end date of one month ago
     And the user fills out the rest of the other questions form and submits it
@@ -33,20 +33,20 @@ Feature: Start a new Financial Assistance Application and answers questions on O
 
   Scenario: Pregnancy question - no
     Given the user answers no to being pregnant
-    And the post partum language one year is not enabled
+    And FAA post_partum_period_one_year feature is disabled
     And was this person pregnant in the last 60 days question should display
     When they answer yes to was this person pregnant in the last 60 days question
     Then pregnancy end date question should display
 
   Scenario: If they were pregnant, were they on medicaid?
     Given the user answers no to being pregnant
-    And the post partum language one year is not enabled
+    And FAA post_partum_period_one_year feature is disabled
     And they answer yes to was this person pregnant in the last 60 days question
     Then the has this person ever been in foster care question should display
 
   Scenario: If they were pregnant, were they on medicaid? Answer "Yes" with form submitted.
     Given the user answers no to being pregnant
-    And the post partum language one year is not enabled
+    And FAA post_partum_period_one_year feature is disabled
     And they answer yes to was this person pregnant in the last 60 days question
     And the user enters a pregnancy end date of one month ago
     And the user fills out the rest of form with medicaid during pregnancy as yes and submits it

--- a/features/financial_assistance/other_questions_pregnancy.feature
+++ b/features/financial_assistance/other_questions_pregnancy.feature
@@ -25,6 +25,7 @@ Feature: Start a new Financial Assistance Application and answers questions on O
 
   Scenario: Pregnancy response within 60 days Yes with information filled and submitted
     Given the user answers no to being pregnant
+    And the post partum language one year is not enabled
     And they answer yes to was this person pregnant in the last 60 days question
     And the user enters a pregnancy end date of one month ago
     And the user fills out the rest of the other questions form and submits it
@@ -32,17 +33,20 @@ Feature: Start a new Financial Assistance Application and answers questions on O
 
   Scenario: Pregnancy question - no
     Given the user answers no to being pregnant
+    And the post partum language one year is not enabled
     And was this person pregnant in the last 60 days question should display
     When they answer yes to was this person pregnant in the last 60 days question
     Then pregnancy end date question should display
 
   Scenario: If they were pregnant, were they on medicaid?
     Given the user answers no to being pregnant
+    And the post partum language one year is not enabled
     And they answer yes to was this person pregnant in the last 60 days question
     Then the has this person ever been in foster care question should display
 
   Scenario: If they were pregnant, were they on medicaid? Answer "Yes" with form submitted.
     Given the user answers no to being pregnant
+    And the post partum language one year is not enabled
     And they answer yes to was this person pregnant in the last 60 days question
     And the user enters a pregnancy end date of one month ago
     And the user fills out the rest of form with medicaid during pregnancy as yes and submits it

--- a/features/financial_assistance/step_definitions/other_questions_page_steps.rb
+++ b/features/financial_assistance/step_definitions/other_questions_page_steps.rb
@@ -253,6 +253,10 @@ Given(/^the user answers no to being pregnant$/) do
   choose('is_pregnant_no')
 end
 
+And(/the post partum language one year is not enabled/) do
+  FinancialAssistanceRegistry[:post_partum_period_one_year].feature.stub(:is_enabled).and_return(false)
+end
+
 And(/^was this person pregnant in the last (\d+) days question should display$/) do |_arg1|
   expect(page).to have_content('Was this person pregnant in the last 60 days?')
 end

--- a/features/financial_assistance/step_definitions/other_questions_page_steps.rb
+++ b/features/financial_assistance/step_definitions/other_questions_page_steps.rb
@@ -253,10 +253,6 @@ Given(/^the user answers no to being pregnant$/) do
   choose('is_pregnant_no')
 end
 
-And(/the post partum language one year is not enabled/) do
-  FinancialAssistanceRegistry[:post_partum_period_one_year].feature.stub(:is_enabled).and_return(false)
-end
-
 And(/^was this person pregnant in the last (\d+) days question should display$/) do |_arg1|
   expect(page).to have_content('Was this person pregnant in the last 60 days?')
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640057/stories/185060658

# A brief description of the changes

Current behavior: Text does not match "the last year" wording in review, error message, and raw application

New behavior: Text will match other questions page for post partum language

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: POST_PARTUM_PERIOD_ONE_YEAR_IS_ENABLED

- [ ] DC
- [x] ME
