### PR TITLE
fetch effective date from enrollment

### DIFF
--- a/app/domain/operations/hbx_enrollments/relocate_enrollment.rb
+++ b/app/domain/operations/hbx_enrollments/relocate_enrollment.rb
@@ -68,7 +68,7 @@ module Operations
         reinstatement = Enrollments::Replicator::Reinstatement.new(base_enrollment, new_effective_date, base_enrollment.applied_aptc_amount).build
 
         if reinstatement.save!
-          result = if base_enrollment.has_aptc? && EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
+          result = if reinstatement.is_health_enrollment? && base_enrollment.has_aptc? && EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
                      default_percentage = EnrollRegistry[:aca_individual_assistance_benefits].setting(:default_applied_aptc_percentage).item
                      elected_aptc_pct = base_enrollment.elected_aptc_pct > 0 ? base_enrollment.elected_aptc_pct : default_percentage
                      aptc_context = ::HbxEnrollments::UpdateMthhAptcValuesOnEnrollment.call(enrollment: reinstatement, elected_aptc_pct: elected_aptc_pct, new_effective_date: reinstatement.effective_on)
@@ -91,6 +91,7 @@ module Operations
         end
       end
 
+      # TODO: Implement this method for emitting events once enrollment_relocation is done
       # families.individual_market.hbx_enrollments.dental_product_terminated
       # families.individual_market.hbx_enrollments.health_product_terminated
       # families.individual_market.hbx_enrollments.dental_product_relocated

--- a/app/domain/operations/hbx_enrollments/relocate_enrollment.rb
+++ b/app/domain/operations/hbx_enrollments/relocate_enrollment.rb
@@ -71,7 +71,7 @@ module Operations
           result = if base_enrollment.has_aptc? && EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
                      default_percentage = EnrollRegistry[:aca_individual_assistance_benefits].setting(:default_applied_aptc_percentage).item
                      elected_aptc_pct = base_enrollment.elected_aptc_pct > 0 ? base_enrollment.elected_aptc_pct : default_percentage
-                     aptc_context = ::HbxEnrollments::UpdateMthhAptcValuesOnEnrollment.call(enrollment: reinstatement, elected_aptc_pct: elected_aptc_pct, new_effective_date: new_effective_date)
+                     aptc_context = ::HbxEnrollments::UpdateMthhAptcValuesOnEnrollment.call(enrollment: reinstatement, elected_aptc_pct: elected_aptc_pct, new_effective_date: reinstatement.effective_on)
                      aptc_context.success? ? true : aptc_context.message
                    else
                      true
@@ -84,7 +84,7 @@ module Operations
             result_hash.merge!(:relocated_enrollment => {:hbx_id => reinstatement.hbx_id, :aasm_state => reinstatement.aasm_state, :coverage_kind => reinstatement.coverage_kind, :kind => reinstatement.kind})
             Success(result_hash)
           else
-            Failure(result)
+            Failure([result, "reinstatement_shopping_enrollment: #{reinstatement}"])
           end
         else
           Failure(reinstatement.errors.full_messages)

--- a/spec/domain/operations/hbx_enrollments/relocate_enrollment_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/relocate_enrollment_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe ::Operations::HbxEnrollments::RelocateEnrollment, dbclean: :after
       family.reload
       expect(family.active_household.hbx_enrollments.map(&:rating_area_id)).to eq([@rating_area.id, rating_area2.id])
     end
+
+    it "should generate new enrollment with different rating area" do
+      subject.call(@params)
+      family.reload
+      date_context = ::HbxEnrollments::CalculateEffectiveOnForEnrollment.call(base_enrollment_effective_on: enrollment.effective_on, system_date: TimeKeeper.date_of_record.in_time_zone('Eastern Time (US & Canada)'))
+      expect(family.active_household.hbx_enrollments.last.effective_on).to eq(date_context.new_effective_on.to_date)
+    end
   end
 
   context "when expected_enrollment_action is Terminate Enrollment Effective End of the Month" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket:  [pivotal-185344074](https://www.pivotaltracker.com/n/projects/2640059/stories/185344074#)

# A brief description of the changes

Current behavior: For calculating APTC, effective date of the enrollment is calculated on the fly.

New behavior: With this fix, the effective date of the enrollment is pulled from reinstatement enrollment.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME
