### PR TITLE
change enrollment tile header style

### DIFF
--- a/app/javascript/css/enrollment.scss
+++ b/app/javascript/css/enrollment.scss
@@ -1,45 +1,70 @@
 :root {
     .plan-tile {
-        padding: 12px;
-        font-size: medium;
+      font-size: medium;
 
-        .plan-header {
-            display: flex;
-            flex-direction: column;
+      .plan-header {
+        display: flex;
+        align-items: center;
+        border-bottom: 1px solid #ddd;
+        background: #FAF9F8;
 
-            img {
-                flex: 0;
-                object-fit: scale-down;
-                height: 100px;
-            }
-
-            .plan-logo-and-name {
-                display: flex;
-                flex-direction: row;
-                align-items: center;
-                gap: 20px;
-
-                .plan-status-container {
-                    min-height: 20px;
-                }
-
-                h3 {
-                    margin: 0;
-                    justify-self: left;
-                    padding: 8px 0;
-                    flex-basis: 100%;
-
-                    a {
-                        color: black !important;
-                        font-size: 18px;
-                        font-weight: 700;
-                        line-height: 1.5;
-                        display: block;
-                    }
-
-                }
-            }
+        .plan-year {
+          margin: 0;
+          padding-left: 12px;
+          flex-grow: 1;
         }
+
+        .plan-status-container {
+          display: flex;
+          min-height: 36px;
+          align-items: stretch;
+        }
+
+        .label {
+          display: flex;
+          height: 100%;
+          border-radius: 0 .25rem 0 0;
+          align-items: center;
+        }
+      }
+
+      .plan-details-container {
+        padding: 12px;
+      }
+
+      .plan-title {
+        display: flex;
+        flex-direction: column;
+
+        img {
+            flex: 0;
+            object-fit: scale-down;
+            height: 100px;
+        }
+
+        .plan-logo-and-name {
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          gap: 20px;
+
+          h3 {
+            margin: 0;
+            justify-self: left;
+            padding: 8px 0;
+            flex-basis: 100%;
+
+            a {
+              color: black !important;
+              font-size: 18px;
+              font-weight: 700;
+              line-height: 1.5;
+              display: block;
+            }
+
+          }
+        }
+      }
 
         .plan-details {
             display: flex;
@@ -98,7 +123,7 @@
 
                 a {
                     color: inherit;
-                    
+
                     &:hover {
                         text-decoration: none;
                     }

--- a/app/javascript/css/enrollment.scss
+++ b/app/javascript/css/enrollment.scss
@@ -12,6 +12,8 @@
           margin: 0;
           padding-left: 12px;
           flex-grow: 1;
+          line-height: 0;
+          font-size: medium;
         }
 
         .plan-status-container {

--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -1,17 +1,25 @@
 <% product = hbx_enrollment.product %>
 
 <% if hbx_enrollment.is_coverage_waived? %>
-  <%= render partial: 'insured/families/waived_coverage_widget', locals: { read_only: read_only || hbx_enrollment.can_make_changes? , hbx_enrollment: hbx_enrollment } %>
+  <%= render partial: 'insured/families/waived_coverage_widget', locals: { read_only: read_only || hbx_enrollment.can_make_changes?, hbx_enrollment: hbx_enrollment } %>
 <% else %>
-    <div class="hbx-enrollment-refactored-panel plan-tile panel panel-default module <%= "initially_hidden_enrollment hidden" if initially_hide_enrollment?(hbx_enrollment) %>">
-        <div class="plan-header">
-            <div class="plan-status-container"><%= render partial: "insured/families/enrollment_progress", locals: {step: hbx_enrollment.enroll_step, hbx_enrollment: hbx_enrollment} %></div>
-            <div class="plan-logo-and-name">
-                <%= display_carrier_logo(Maybe.new(product), {width: 100}) %>
-                <h3>
-                    <%= link_to product.title, summary_products_plans_path({:standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, active_year: product.active_year}), remote: true %>
-                </h3>
-            </div>
+  <div class="hbx-enrollment-refactored-panel plan-tile panel panel-default module <%= "initially_hidden_enrollment hidden" if initially_hide_enrollment?(hbx_enrollment) %>">
+    <div class="plan-header">
+      <h3 class="plan-year">
+        <%= hbx_enrollment.coverage_year %> <%= product.kind.to_s.titleize %> <%= l10n('coverage').titleize %>
+      </h3>
+      <div class="plan-status-container"><%= render partial: "insured/families/enrollment_progress", locals: { step: hbx_enrollment.enroll_step, hbx_enrollment: hbx_enrollment } %></div>
+    </div>
+
+    <div class="plan-details-container">
+
+        <div class="plan-title">
+          <div class="plan-logo-and-name">
+            <%= display_carrier_logo(Maybe.new(product), { width: 100 }) %>
+            <h3>
+              <%= link_to product.title, summary_products_plans_path({ :standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, active_year: product.active_year }), remote: true %>
+            </h3>
+          </div>
         </div>
 
         <div class="plan-details">
@@ -160,4 +168,5 @@
             <%= render partial: "insured/families/enrollment_actions", locals: { read_only: read_only, hbx_enrollment: hbx_enrollment }  %>
         </div>
     </div>
+  </div>
 <% end %>

--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -17,7 +17,7 @@
           <div class="plan-logo-and-name">
             <%= display_carrier_logo(Maybe.new(product), { width: 100 }) %>
             <h3>
-              <%= link_to product.title, summary_products_plans_path({ :standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, active_year: product.active_year }), remote: true %>
+              <%= sanitize link_to product.title, summary_products_plans_path({ :standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, active_year: product.active_year }), remote: true %>
             </h3>
           </div>
         </div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: TT6-185393482

# A brief description of the changes

Current behavior: 
<img width="512" alt="246109841-f5129261-9576-4d70-bca9-ba12569e1a54" src="https://github.com/ideacrew/enroll/assets/36456900/43050d5a-ddb6-4c05-98f4-559c5cdda8b1">

New behavior:
<img width="639" alt="Screenshot 2023-06-15 at 8 07 10 AM" src="https://github.com/ideacrew/enroll/assets/36456900/477294b9-1aef-4c46-a211-9b0d84437d43">


# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: ENROLLMENT_PLAN_TILE_UPDATE_IS_ENABLED
(This change falls under the feature flag controlling all changes within app/views/insured/families/_enrollment_refactored.html.erb)

- [ ] DC
- [x] ME
