### PR TITLE
embed eligibility override in tax household member

### DIFF
--- a/app/models/member_determination.rb
+++ b/app/models/member_determination.rb
@@ -5,6 +5,7 @@ class MemberDetermination
   include Mongoid::Timestamps
 
   embedded_in :tax_household_member
+  embeds_many :eligibility_overrides, cascade_callbacks: true
 
   # The kind of determination.
   field :kind, type: String

--- a/components/financial_assistance/app/models/financial_assistance/member_determination.rb
+++ b/components/financial_assistance/app/models/financial_assistance/member_determination.rb
@@ -6,7 +6,7 @@ module FinancialAssistance
     include Mongoid::Timestamps
 
     embedded_in :applicant, class_name: '::FinancialAssistance::Applicant'
-    embeds_many :eligibility_overrides, class_name: '::FinancialAssistance::EligibilityOverride'
+    embeds_many :eligibility_overrides, class_name: '::FinancialAssistance::EligibilityOverride', cascade_callbacks: true
 
       # The kind of determination.
     field :kind, type: String


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: TT6-185060666

# A brief description of the changes

Current behavior:
Eligibility override data is not embedded and persisted on the member determination for tax household member.  Timestamps were also not being populated for the eligibility override object.

New behavior:
Eligibility override data is persisted on the member determination for tax household member and timestamps are present after record creation.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME

Note:
This is a system update to how data is modeled and saved to the database. It is a feature of the system and intended to work with all clients, so does not require a feature flag. 

