### PR TITLE
update aca_entities rev to include CF pay now domestic partner mapping 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: a2f5934cbcde8b6882147e27662d1e703203d071
+  revision: 5cf8f6079674c5ffe1fd283322a848b26bb2dfa3
   branch: trunk
   specs:
     aca_entities (0.10.0)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [TT6-185183520](https://www.pivotaltracker.com/story/show/185183520)

# A brief description of the changes

Current behavior: 
Pay now link for CareFirst enrollments errors out when dependent is a domestic partner of primary applicant.

New behavior:
Clicking the Pay Now link for a CareFirst enrollment where dependent is a domestic partner takes the user to the carrier's payment portal.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable names: 

- [ ] DC
- [ ] ME
