### PR TITLE
display ai/an questions when not applying for coverage

### DIFF
--- a/app/assets/javascripts/demographics_fields.js
+++ b/app/assets/javascripts/demographics_fields.js
@@ -6,36 +6,21 @@ function isApplyingCoverage(target) {
     addEventOnNoSsn(target);
     addEventOnSsn(target);
     if ($(fields).not(':checked').val() == 'true') {
-      $('#consumer_fields_sets').hide();
+      $('.consumer_fields_for_applying_coverage').hide();
       $('#employer-coverage-msg').show();
       if ($("input[name='" + target + "[ssn]']").val() == '' && !$("input[name='" + target + "[no_ssn]']").is(':checked')) {
         $('#ssn-coverage-msg').show();
       }
-      if (!($(fields).not(':checked').val() == 'false') && $('.no_coverage_tribe_details').length > 0 ) {
-        new_tribe_form = $('#indian_tribe_area').clone(true).addClass('tribe-area-clone');
-        $('#indian_tribe_area').remove();
-        new_tribe_form.insertBefore($('#consumer_fields_sets'));
-      }
     }
     $(fields).change(function () {
       if ($(fields).not(':checked').val() == 'true') {
-        $('#consumer_fields_sets').hide();
+        $('.consumer_fields_for_applying_coverage').hide();
         $('#employer-coverage-msg').show();
         if ($("input[name='" + target + "[ssn]']").val() == '' && !$("input[name='" + target + "[no_ssn]']").is(':checked')) {
           $('#ssn-coverage-msg').show();
         }
-        if (!($(fields).not(':checked').val() == 'false') && $('.no_coverage_tribe_details').length > 0 ) {
-          new_tribe_form = $('#indian_tribe_area').clone(true).addClass('tribe-area-clone');
-          $('#indian_tribe_area').remove();
-          new_tribe_form.insertBefore($('#consumer_fields_sets'));
-        }
       } else {
-        if ($('.no_coverage_tribe_details').length > 0) {
-          new_tribe_form = $('#indian_tribe_area').clone(true).removeClass('tribe-area-clone');
-          $('#indian_tribe_area').remove();
-          new_tribe_form.insertAfter($('#vlp_documents_container'));
-        }
-        $('#consumer_fields_sets').show();
+        $('.consumer_fields_for_applying_coverage').show();
         $('#employer-coverage-msg').hide();
         $('#ssn-coverage-msg').hide();
       }

--- a/app/views/shared/_consumer_fields.html.erb
+++ b/app/views/shared/_consumer_fields.html.erb
@@ -5,125 +5,131 @@
     <% if FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) %>
       <%= render :partial => 'shared/optional_field_warning' %>
     <% end %>
-    <div class="row row-form-wrapper no-buffer"> 
-      <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 form-group form-group-lg top-buffer">
-        <label>Is this person a US citizen or US national? *</label>  
-      </div>
-      <div class="col-lg-3 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
-        <div class="radio skinned-form-controls skinned-form-controls-mac">
-          <%= f.radio_button :us_citizen, true, required: true, class: "required floatlabel" %>
-          <%= f.label :us_citizen, :value => true do %>
-            <span class="yes_no_pair">Yes</span>
-          <% end %>
-        </div>
-      </div>
-      <div class="col-lg-1 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
-        <div class="radio skinned-form-controls skinned-form-controls-mac">
-          <%= f.radio_button :us_citizen, false, required: true, class: "required floatlabel" %>
-          <%= f.label :us_citizen, :value => false do %>
-            <span class="yes_no_pair">No</span>
-          <% end %>
-        </div>
-      </div>
-      <div class="col-md-2 not-sure-margin left-seprator">
-        <a href="#us_citizen" data-toggle="modal" data-target="#us_citizen">Not sure?</a>
-        <%= render partial: 'shared/modal_support_text_household', locals: {key: "us_citizen"} %>
-      </div>
-    </div>
 
-    <div class="row row-form-wrapper no-buffer <%= 'hidden_field' unless show_naturalized_citizen_container(f.object) %>" id="naturalized_citizen_container">
-      <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 form-group form-group-lg top-buffer">
-        <label> <%= l10n("insured.consumer_roles.naturalized_question") %> *</label>
-      </div>
-      <div class="col-lg-3 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-        <div class="radio skinned-form-controls skinned-form-controls-mac">
-          <%= f.radio_button :naturalized_citizen, true, required: true, class: "required floatlabel" %>
-          <%= f.label :naturalized_citizen, :value => true do %>
-            <span class="yes_no_pair">Yes</span>
-          <% end %>
+    <div class="consumer_fields_for_applying_coverage">
+      <div class="row row-form-wrapper no-buffer">
+        <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 form-group form-group-lg top-buffer">
+          <label>Is this person a US citizen or US national? *</label>
         </div>
-      </div>
-      <div class="col-lg-1 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-        <div class="radio skinned-form-controls skinned-form-controls-mac">
-          <%= f.radio_button :naturalized_citizen, false, required: true, class: "required floatlabel" %>
-          <%= f.label :naturalized_citizen, :value => false do %>
-            <span class="yes_no_pair">No</span>
-          <% end %>
-        </div>
-      </div>
-      <div class="col-md-2 not-sure-margin left-seprator">
-        <a href="#naturalized_citizen" data-toggle="modal" data-target="#naturalized_citizen">Not sure?</a>
-        <%= render partial: 'shared/modal_support_text_household', locals: {key: "naturalized_citizen"} %>
-      </div>
-    </div>
-
-    <div class="row row-form-wrapper no-buffer <%= 'hidden_field' unless show_immigration_status_container(f.object) %>" id="immigration_status_container">
-      <div class="col-lg-6 col-md-6 col-sm-4 col-xs-6 form-group form-group-lg top-buffer">
-        <label>
-          <%= l10n('faa.question.eligible_immigration_status') %>
-          <%= l10n('faa.question.immigration_continue_note_1') %>
-          <%= l10n('faa.question.immigration_continue_note_2') %>
-        </label>
-      </div>
-      <% if EnrollRegistry[:immigration_status_checkbox].enabled? %>
-        <div class="col-lg-4 col-md-4 col-sm-8 col-xs-6 form-group form-group-lg no-pd">
-          <div id="immigration-checkbox" class="checkbox">
-            <%= f.check_box :eligible_immigration_status, {}, "true", "false" %><%= l10n('yes') %>
+        <div class="col-lg-3 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
+          <div class="radio skinned-form-controls skinned-form-controls-mac">
+            <%= f.radio_button :us_citizen, true, required: true, class: "required floatlabel" %>
+            <%= f.label :us_citizen, :value => true do %>
+              <span class="yes_no_pair">Yes</span>
+            <% end %>
           </div>
         </div>
-      <% else %>
+        <div class="col-lg-1 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
+          <div class="radio skinned-form-controls skinned-form-controls-mac">
+            <%= f.radio_button :us_citizen, false, required: true, class: "required floatlabel" %>
+            <%= f.label :us_citizen, :value => false do %>
+              <span class="yes_no_pair">No</span>
+            <% end %>
+          </div>
+        </div>
+        <div class="col-md-2 not-sure-margin left-seprator">
+          <a href="#us_citizen" data-toggle="modal" data-target="#us_citizen">Not sure?</a>
+          <%= render partial: 'shared/modal_support_text_household', locals: {key: "us_citizen"} %>
+        </div>
+      </div>
+
+      <div class="row row-form-wrapper no-buffer <%= 'hidden_field' unless show_naturalized_citizen_container(f.object) %>" id="naturalized_citizen_container">
+        <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 form-group form-group-lg top-buffer">
+          <label> <%= l10n("insured.consumer_roles.naturalized_question") %> *</label>
+        </div>
         <div class="col-lg-3 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
           <div class="radio skinned-form-controls skinned-form-controls-mac">
-            <%= f.radio_button :eligible_immigration_status, true, class: "required floatlabel" %>
-            <%= f.label :eligible_immigration_status, :value => true do %>
+            <%= f.radio_button :naturalized_citizen, true, required: true, class: "required floatlabel" %>
+            <%= f.label :naturalized_citizen, :value => true do %>
               <span class="yes_no_pair">Yes</span>
             <% end %>
           </div>
         </div>
         <div class="col-lg-1 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
           <div class="radio skinned-form-controls skinned-form-controls-mac">
-            <%= f.radio_button :eligible_immigration_status, false, class: "required floatlabel" %>
-            <%= f.label :eligible_immigration_status, :value => false do %>
+            <%= f.radio_button :naturalized_citizen, false, required: true, class: "required floatlabel" %>
+            <%= f.label :naturalized_citizen, :value => false do %>
               <span class="yes_no_pair">No</span>
             <% end %>
           </div>
         </div>
-      <% end %>
-      <div class="col-md-2 not-sure-margin left-seprator" >
-        <a href="#eligible_immigration_status" data-toggle="modal" data-target="#eligible_immigration_status">Not sure?</a>
-        <%= render partial: 'shared/modal_support_text_household', locals: {key: "eligible_immigration_status"} %>
+        <div class="col-md-2 not-sure-margin left-seprator">
+          <a href="#naturalized_citizen" data-toggle="modal" data-target="#naturalized_citizen">Not sure?</a>
+          <%= render partial: 'shared/modal_support_text_household', locals: {key: "naturalized_citizen"} %>
+        </div>
       </div>
+
+      <div class="row row-form-wrapper no-buffer <%= 'hidden_field' unless show_immigration_status_container(f.object) %>" id="immigration_status_container">
+        <div class="col-lg-6 col-md-6 col-sm-4 col-xs-6 form-group form-group-lg top-buffer">
+          <label>
+            <%= l10n('faa.question.eligible_immigration_status') %>
+            <%= l10n('faa.question.immigration_continue_note_1') %>
+            <%= l10n('faa.question.immigration_continue_note_2') %>
+          </label>
+        </div>
+        <% if EnrollRegistry[:immigration_status_checkbox].enabled? %>
+          <div class="col-lg-4 col-md-4 col-sm-8 col-xs-6 form-group form-group-lg no-pd">
+            <div id="immigration-checkbox" class="checkbox">
+              <%= f.check_box :eligible_immigration_status, {}, "true", "false" %><%= l10n('yes') %>
+            </div>
+          </div>
+        <% else %>
+          <div class="col-lg-3 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
+            <div class="radio skinned-form-controls skinned-form-controls-mac">
+              <%= f.radio_button :eligible_immigration_status, true, class: "required floatlabel" %>
+              <%= f.label :eligible_immigration_status, :value => true do %>
+                <span class="yes_no_pair">Yes</span>
+              <% end %>
+            </div>
+          </div>
+          <div class="col-lg-1 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
+            <div class="radio skinned-form-controls skinned-form-controls-mac">
+              <%= f.radio_button :eligible_immigration_status, false, class: "required floatlabel" %>
+              <%= f.label :eligible_immigration_status, :value => false do %>
+                <span class="yes_no_pair">No</span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+        <div class="col-md-2 not-sure-margin left-seprator" >
+          <a href="#eligible_immigration_status" data-toggle="modal" data-target="#eligible_immigration_status">Not sure?</a>
+          <%= render partial: 'shared/modal_support_text_household', locals: {key: "eligible_immigration_status"} %>
+        </div>
+      </div>
+      <%= f.fields_for find_consumer_role_for_fields(f.object) do |c| %>
+        <%= render :partial => "insured/consumer_roles/immigration_document_fields", locals: {c: c, f: f} %>
+      <% end %>
     </div>
-    <%= f.fields_for find_consumer_role_for_fields(f.object) do |c| %>
-      <%= render :partial => "insured/consumer_roles/immigration_document_fields", locals: {c: c, f: f} %>
-    <% end %>
 
     <%= render :partial => "insured/consumer_roles/tribe_fields", locals: {f: f} %>
 
-    <div class="row row-form-wrapper no-buffer">
-      <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 top-buffer">
-        <label class="required no-pd">Is this person currently incarcerated? *</label>
-      </div>
-      <div class="col-lg-3 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd border_bottom_zero">
-        <div class="radio">
-          <%= f.radio_button :is_incarcerated, true, class: "required floatlabel", id: 'radio_incarcerated_yes', required: true %>
-          <label for="radio_incarcerated_yes"><span class="yes_no_pair">Yes</span></label>
+    <div class="consumer_fields_for_applying_coverage">
+      <div class="row row-form-wrapper no-buffer consumer_fields_for_applying_coverage">
+        <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 top-buffer">
+          <label class="required no-pd">Is this person currently incarcerated? *</label>
+        </div>
+        <div class="col-lg-3 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd border_bottom_zero">
+          <div class="radio">
+            <%= f.radio_button :is_incarcerated, true, class: "required floatlabel", id: 'radio_incarcerated_yes', required: true %>
+            <label for="radio_incarcerated_yes"><span class="yes_no_pair">Yes</span></label>
+          </div>
+        </div>
+        <div class="col-lg-1 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
+          <div class="radio">
+            <%= f.radio_button :is_incarcerated, false, class: "required floatlabel", id: 'radio_incarcerated_no', required: true %>
+            <label for="radio_incarcerated_no"><span class="yes_no_pair">No</span></label>
+          </div>
+        </div>
+        <div class="col-md-2 not-sure-margin left-seprator">
+          <a href="#is_incarcerated" data-toggle="modal" data-target="#is_incarcerated">Not sure?</a>
+          <%= render partial: 'shared/modal_support_text_household', locals: {key: "is_incarcerated"} %>
         </div>
       </div>
-      <div class="col-lg-1 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
-        <div class="radio">
-          <%= f.radio_button :is_incarcerated, false, class: "required floatlabel", id: 'radio_incarcerated_no', required: true %>
-          <label for="radio_incarcerated_no"><span class="yes_no_pair">No</span></label>
-        </div>
-      </div>
-      <div class="col-md-2 not-sure-margin left-seprator">
-        <a href="#is_incarcerated" data-toggle="modal" data-target="#is_incarcerated">Not sure?</a>
-        <%= render partial: 'shared/modal_support_text_household', locals: {key: "is_incarcerated"} %>
-      </div>
+
+      <%= render "shared/race_and_ethnicity_options", f: f %>
     </div>
   </div>
 <%end%>
 
-<%= render "shared/race_and_ethnicity_options", f: f %>
 <%= hidden_field_tag :form_for_consumer_role, f.object.is_a?(Person) %>
 <%= f.hidden_field :is_consumer_role, value: 'true' %>

--- a/features/insured/manage_family_personal_information.feature
+++ b/features/insured/manage_family_personal_information.feature
@@ -3,6 +3,7 @@ Feature: Insured Plan Shopping on Individual market Document Errors
   Background:
     Given Individual has not signed up as an HBX user
     Given the FAA feature configuration is enabled
+    Given AI AN Details feature is enabled
     When Individual visits the Consumer portal during open enrollment
     Then Individual creates a new HBX account
     Then Individual should see a successful sign up message
@@ -11,20 +12,40 @@ Feature: Insured Plan Shopping on Individual market Document Errors
     When Individual clicks on continue
     And Individual sees form to enter personal information
 
-  Scenario: Individual should not see document errors when not applying for coverage.
-    When Individual selects eligible immigration status
-    And Individual selects applying for coverage
-    Then the question Is this person a US citizen or US national? is displayed
-    Then the question Do you have eligible immigration status?  is displayed
-    Then the question Is this person a member of an American Indian Or Alaska Native Tribe? is displayed
-    Then the question Is this person currently incarcerated? is displayed
-    Then the question What is your race/ethnicity? (OPTIONAL - check all that apply) is displayed
+  Scenario: Individual should see consumer fields when applying for coverage.
+    When Individual selects applying for coverage
+    Then the question "Is this person a US citizen or US national?" is displayed
+    Then the question "Is this person a member of an American Indian Or Alaska Native Tribe?" is displayed
+    Then the question "Is this person currently incarcerated?" is displayed
+    Then the question "What is your race/ethnicity? (OPTIONAL - check all that apply)" is displayed
 
-  Scenario: Individual should not see document errors when not applying for coverage.
-    When Individual selects eligible immigration status
-    And Individual selects not applying for coverage
-    Then the question Is this person a US citizen or US national? is not displayed
-    Then the question Do you have eligible immigration status?  is not displayed
-    Then the question Is this person a member of an American Indian Or Alaska Native Tribe? is displayed
-    Then the question Is this person currently incarcerated? is not displayed
-    Then the question What is your race/ethnicity? (OPTIONAL - check all that apply) is not displayed
+  Scenario: Individual should see consumer fields when applying for coverage.
+    When Individual selects applying for coverage
+    Then the question "Is this person a US citizen or US national?" is displayed
+    Then the question "Is this person a member of an American Indian Or Alaska Native Tribe?" is displayed
+    Then the question "Is this person currently incarcerated?" is displayed
+    Then the question "What is your race/ethnicity? (OPTIONAL - check all that apply)" is displayed
+    When AI AN question is answered yes
+    Then the question "Where is this person's tribe located?" is displayed
+    When tribal state dropdown box is clicked
+    Then states dropdown should popup
+
+  Scenario: Individual should not see consumer fields when not applying for coverage.
+    When Individual selects not applying for coverage
+    Then the question "Is this person a US citizen or US national?" is not displayed
+    Then the question "Do you have eligible immigration status? " is not displayed
+    Then the question "Is this person a member of an American Indian Or Alaska Native Tribe?" is displayed
+    Then the question "Is this person currently incarcerated?" is not displayed
+    Then the question "What is your race/ethnicity? (OPTIONAL - check all that apply)" is not displayed
+
+  Scenario: Individual should not see consumer fields when not applying for coverage.
+    When Individual selects not applying for coverage
+    Then the question "Is this person a US citizen or US national?" is not displayed
+    Then the question "Do you have eligible immigration status? " is not displayed
+    Then the question "Is this person a member of an American Indian Or Alaska Native Tribe?" is displayed
+    Then the question "Is this person currently incarcerated?" is not displayed
+    Then the question "What is your race/ethnicity? (OPTIONAL - check all that apply)" is not displayed
+    When AI AN question is answered yes
+    Then the question "Where is this person's tribe located?" is displayed
+    When tribal state dropdown box is clicked
+    Then states dropdown should popup

--- a/features/insured/manage_family_personal_information.feature
+++ b/features/insured/manage_family_personal_information.feature
@@ -1,0 +1,30 @@
+Feature: Insured Plan Shopping on Individual market Document Errors
+
+  Background:
+    Given Individual has not signed up as an HBX user
+    Given the FAA feature configuration is enabled
+    When Individual visits the Consumer portal during open enrollment
+    Then Individual creates a new HBX account
+    Then Individual should see a successful sign up message
+    And Individual sees Your Information page
+    When user registers as an individual
+    When Individual clicks on continue
+    And Individual sees form to enter personal information
+
+  Scenario: Individual should not see document errors when not applying for coverage.
+    When Individual selects eligible immigration status
+    And Individual selects applying for coverage
+    Then the question Is this person a US citizen or US national? is displayed
+    Then the question Do you have eligible immigration status?  is displayed
+    Then the question Is this person a member of an American Indian Or Alaska Native Tribe? is displayed
+    Then the question Is this person currently incarcerated? is displayed
+    Then the question What is your race/ethnicity? (OPTIONAL - check all that apply) is displayed
+
+  Scenario: Individual should not see document errors when not applying for coverage.
+    When Individual selects eligible immigration status
+    And Individual selects not applying for coverage
+    Then the question Is this person a US citizen or US national? is not displayed
+    Then the question Do you have eligible immigration status?  is not displayed
+    Then the question Is this person a member of an American Indian Or Alaska Native Tribe? is displayed
+    Then the question Is this person currently incarcerated? is not displayed
+    Then the question What is your race/ethnicity? (OPTIONAL - check all that apply) is not displayed

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -176,6 +176,14 @@ And(/^.+ selects (.*) for coverage$/) do |coverage|
   end
 end
 
+Then(/^the question (.*) is displayed$/) do |question|
+  expect(page).to have_content(question)
+end
+
+Then(/^the question (.*) is not displayed$/) do |question|
+  expect(page).not_to have_content(question)
+end
+
 Then(/^.+ should see error message (.*)$/) do |text|
   page.should have_content(text)
 end

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -176,12 +176,24 @@ And(/^.+ selects (.*) for coverage$/) do |coverage|
   end
 end
 
-Then(/^the question (.*) is displayed$/) do |question|
+Then(/^the question "(.*)" is displayed$/) do |question|
   expect(page).to have_content(question)
 end
 
-Then(/^the question (.*) is not displayed$/) do |question|
+Then(/^the question "(.*)" is not displayed$/) do |question|
   expect(page).not_to have_content(question)
+end
+
+Then(/^tribal state dropdown box is clicked$/) do
+  find_all(IvlPersonalInformation.tribe_state_dropdown).first.click
+end
+
+When(/^AI AN question is answered yes$/) do
+  find_all(IvlPersonalInformation.american_or_alaskan_native_yes_radiobtn).first.click
+end
+
+Then(/^states dropdown should popup$/) do
+  expect(page.find("#tribal-state-container .selectric-items").present?).to be_truthy
 end
 
 Then(/^.+ should see error message (.*)$/) do |text|


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [pivotal-185343379](https://www.pivotaltracker.com/n/projects/2640059/stories/185343379)

# A brief description of the changes

Current behavior: When the consumer is not applying for coverage, ai/an questions are displayed, but the tribal state dropdown is not working.

New behavior: Instead of cloning the tribal state fields, hide or show the fields when applying for coverage is answered. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME
