### PR TITLE
display year layout during oe

### DIFF
--- a/app/views/insured/families/home.html.erb
+++ b/app/views/insured/families/home.html.erb
@@ -33,7 +33,7 @@
       <% end %>
 
       <% if EnrollRegistry.feature_enabled?(:enrollment_plan_tile_update) %>
-        <%= render partial: "enrollment_refactored", :collection => enrollments, :as => :hbx_enrollment, :layout => "insured/families/partial_layouts/wrap_enrollments_by_year" , locals: { read_only: false } %>
+        <%= render partial: "enrollment_refactored", :collection => enrollments, :as => :hbx_enrollment, :layout => ("insured/families/partial_layouts/wrap_enrollments_by_year" if is_under_open_enrollment?) , locals: { read_only: false } %>
       <% else %>
         <%= render partial: "enrollment", :collection => enrollments, :as => :hbx_enrollment, locals: { read_only: false } %>
       <% end %>

--- a/lib/tasks/migrations/create_ivl_packages_DC.rake
+++ b/lib/tasks/migrations/create_ivl_packages_DC.rake
@@ -10,7 +10,7 @@ namespace :import do
 
     # BenefitPackages - HBX
     hbx = HbxProfile.current_hbx
-    puts hbx.blank? ? 'No current HBX present' : "Current HBX: #{hbx.us_state_abbreviation} #{hbx.cms_id}"
+    puts 'No current HBX present' if hbx.blank?
     abort if hbx.blank?
 
     #
@@ -21,9 +21,8 @@ namespace :import do
     #
     # Second lowest cost silver plan
     #
-    slcsp_id = bc_period_for_current_year&.slcsp_id
-    slcsp_hios_id = BenefitMarkets::Products::Product.where(id: slcsp_id)&.first&.hios_id ||
-      hbx.us_state_abbreviation == "ME" ? "96667ME0310072-03" : "94506DC0390005-01"
+    slcsp_id = bc_period_for_current_year.slcsp_id
+    slcsp_hios_id = BenefitMarkets::Products::Product.where(id: slcsp_id).first&.hios_id || "94506DC0390005-01"
     slcs_products = BenefitMarkets::Products::Product.where(hios_id: slcsp_hios_id)
     slcsp_for_current_year =  slcs_products.select{|a| a.active_year == current_year}.first
 
@@ -35,11 +34,11 @@ namespace :import do
       bc_period_for_current_year.slcsp_id = slcsp_for_current_year.id
     else
       # create benefit package and benefit_coverage_period
-      bc_period_for_previous_year = hbx.benefit_sponsorship.benefit_coverage_periods.select { |bcp| bcp.start_on.year == previous_year }&.first || hbx.benefit_sponsorship.benefit_coverage_periods.first
+      bc_period_for_previous_year = hbx.benefit_sponsorship.benefit_coverage_periods.select { |bcp| bcp.start_on.year == previous_year }.first
       bc_period_for_current_year = bc_period_for_previous_year.clone
       bc_period_for_current_year.title = "Individual Market Benefits #{current_year}"
-      bc_period_for_current_year.start_on = Date.new(current_year, 1, 1)
-      bc_period_for_current_year.end_on = Date.new(current_year, 12, 31)
+      bc_period_for_current_year.start_on = bc_period_for_previous_year.start_on + 1.year
+      bc_period_for_current_year.end_on = bc_period_for_previous_year.end_on + 1.year
 
       # if we need to change these dates after running this rake task in test or prod environments,
       # we should write a separate script.

--- a/lib/tasks/migrations/create_ivl_packages_DC.rake
+++ b/lib/tasks/migrations/create_ivl_packages_DC.rake
@@ -10,7 +10,7 @@ namespace :import do
 
     # BenefitPackages - HBX
     hbx = HbxProfile.current_hbx
-    puts 'No current HBX present' if hbx.blank?
+    puts hbx.blank? ? 'No current HBX present' : "Current HBX: #{hbx.us_state_abbreviation} #{hbx.cms_id}"
     abort if hbx.blank?
 
     #
@@ -21,8 +21,9 @@ namespace :import do
     #
     # Second lowest cost silver plan
     #
-    slcsp_id = bc_period_for_current_year.slcsp_id
-    slcsp_hios_id = BenefitMarkets::Products::Product.where(id: slcsp_id).first&.hios_id || "94506DC0390005-01"
+    slcsp_id = bc_period_for_current_year&.slcsp_id
+    slcsp_hios_id = BenefitMarkets::Products::Product.where(id: slcsp_id)&.first&.hios_id ||
+      hbx.us_state_abbreviation == "ME" ? "96667ME0310072-03" : "94506DC0390005-01"
     slcs_products = BenefitMarkets::Products::Product.where(hios_id: slcsp_hios_id)
     slcsp_for_current_year =  slcs_products.select{|a| a.active_year == current_year}.first
 
@@ -34,11 +35,11 @@ namespace :import do
       bc_period_for_current_year.slcsp_id = slcsp_for_current_year.id
     else
       # create benefit package and benefit_coverage_period
-      bc_period_for_previous_year = hbx.benefit_sponsorship.benefit_coverage_periods.select { |bcp| bcp.start_on.year == previous_year }.first
+      bc_period_for_previous_year = hbx.benefit_sponsorship.benefit_coverage_periods.select { |bcp| bcp.start_on.year == previous_year }&.first || hbx.benefit_sponsorship.benefit_coverage_periods.first
       bc_period_for_current_year = bc_period_for_previous_year.clone
       bc_period_for_current_year.title = "Individual Market Benefits #{current_year}"
-      bc_period_for_current_year.start_on = bc_period_for_previous_year.start_on + 1.year
-      bc_period_for_current_year.end_on = bc_period_for_previous_year.end_on + 1.year
+      bc_period_for_current_year.start_on = Date.new(current_year, 1, 1)
+      bc_period_for_current_year.end_on = Date.new(current_year, 12, 31)
 
       # if we need to change these dates after running this rake task in test or prod environments,
       # we should write a separate script.


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: TT6-184990413

# A brief description of the changes

Current behavior:
The tiles are grouped by year with a top level year heading always.

New behavior:
The tiles are grouped by year with a top level year heading only during open enrollment

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: ENROLLMENT_PLAN_TILE_UPDATE_IS_ENABLED

- [ ] DC
- [x] ME
