### PR TITLE
send member determination data to add eligibility operation

### DIFF
--- a/app/domain/operations/families/tax_household_groups/create_on_fa_determination.rb
+++ b/app/domain/operations/families/tax_household_groups/create_on_fa_determination.rb
@@ -80,7 +80,19 @@ module Operations
 
         def member_determinations(applicant)
           applicant.member_determinations&.map do |member_determination|
-            member_determination.attributes.except('_id', 'created_at', 'updated_at')
+            # need to exclude id and timestamps on eligibility overrides as well
+            # md_attributes = member_determination.attributes.except('_id', 'created_at', 'updated_at')
+            # md_attributes["eligibility_overrides"] = member_determination.eligibility_overrides&.map do |eligibility_override|
+            #   eligibility_override.attributes.except('_id', 'created_at', 'updated_at')
+            # end
+            # md_attributes
+            md_attributes = member_determination.attributes
+            md_attributes.except!('_id', 'created_at', 'updated_at')
+            eo_attributes = member_determination.eligibility_overrides&.map do |eo|
+              eo.attributes.except!('_id', 'created_at', 'updated_at')
+            end
+            md_attributes['eligibility_overrides'] = eo_attributes
+            md_attributes
           end
         end
       end

--- a/app/domain/operations/families/tax_household_groups/create_on_fa_determination.rb
+++ b/app/domain/operations/families/tax_household_groups/create_on_fa_determination.rb
@@ -80,12 +80,6 @@ module Operations
 
         def member_determinations(applicant)
           applicant.member_determinations&.map do |member_determination|
-            # need to exclude id and timestamps on eligibility overrides as well
-            # md_attributes = member_determination.attributes.except('_id', 'created_at', 'updated_at')
-            # md_attributes["eligibility_overrides"] = member_determination.eligibility_overrides&.map do |eligibility_override|
-            #   eligibility_override.attributes.except('_id', 'created_at', 'updated_at')
-            # end
-            # md_attributes
             md_attributes = member_determination.attributes
             md_attributes.except!('_id', 'created_at', 'updated_at')
             eo_attributes = member_determination.eligibility_overrides&.map do |eo|

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -561,7 +561,11 @@ module FinancialAssistance
     def send_determination_to_ea
       return if EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
 
-      result = ::Operations::Families::AddFinancialAssistanceEligibilityDetermination.new.call(params: self.attributes)
+      # result = ::Operations::Families::AddFinancialAssistanceEligibilityDetermination.new.call(params: self.attributes)
+      # include member determinations data in params when adding eligibility determination
+      # member_determinations = self.member_determinations.map(&:to_hash)
+      # params = self.attributes.merge()
+      result = ::Operations::Families::AddFinancialAssistanceEligibilityDetermination.new.call(self)
       if result.success?
         rt_transfer
         true

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -561,10 +561,6 @@ module FinancialAssistance
     def send_determination_to_ea
       return if EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
 
-      # result = ::Operations::Families::AddFinancialAssistanceEligibilityDetermination.new.call(params: self.attributes)
-      # include member determinations data in params when adding eligibility determination
-      # member_determinations = self.member_determinations.map(&:to_hash)
-      # params = self.attributes.merge()
       result = ::Operations::Families::AddFinancialAssistanceEligibilityDetermination.new.call(self)
       if result.success?
         rt_transfer

--- a/spec/domain/operations/families/tax_household_groups/create_on_fa_determination_spec.rb
+++ b/spec/domain/operations/families/tax_household_groups/create_on_fa_determination_spec.rb
@@ -91,5 +91,13 @@ RSpec.describe Operations::Families::TaxHouseholdGroups::CreateOnFaDetermination
       expect(member_determination.criteria_met).to eq(applicant['member_determinations'].first['criteria_met'])
       expect(member_determination.determination_reasons).to eq(applicant['member_determinations'].first['determination_reasons'])
     end
+
+    it 'should create Eligibility Override objects' do
+      eligibility_overrides = @result.value!.tax_households.first.tax_household_members.first.member_determinations.first.eligibility_overrides
+      eligibility_overrides.each do |override|
+        expect(override.override_rule.present?).to be_truthy
+        expect(override.override_applied.is_a?(Boolean)).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: TT6-185060666

# A brief description of the changes

Current behavior:
The AddFinancialAssistanceEligibilityDetermination operation accepts Application attributes as params.  Data from embedded documents, specifically Member Determination data, are not sent as part of the params, so this data is not persisted on the Tax Household Member as it should be in the operation. 

New behavior:
The Application record is sent to the operation and Member Determination data is persisted on the Tax Household Member.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME

Note:
This is a system update to how data is modeled and saved to the database. It is a feature of the system and intended to work with all clients, so does not require a feature flag.