### PR TITLE
add service area to enrollment details page

### DIFF
--- a/app/views/ui-components/v1/cards/_summary.html.slim
+++ b/app/views/ui-components/v1/cards/_summary.html.slim
@@ -112,6 +112,11 @@
           = l10n('rating_area.exchange_provided_code')
         = @hbx_enrollment&.rating_area&.exchange_provided_code || l10n('not_available')
         br/
+        span.ttu.lg.twelve.font-weight-bold
+          = l10n('service_area')
+          | :
+        =< @hbx_enrollment&.product&.service_area&.issuer_provided_code || l10n('not_available')
+        br/
         br/
         span.h3 data-cuke='enrollment_member_detail'
           = l10n('enrollment.members.header')

--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -426,6 +426,7 @@ How to find the SEVIS ID: On the DS-2019, the number is on the top right hand si
   :'en.enrollment.latest_transition_data' => "From %{from_state} to %{to_state} at %{created_at}",
   :'en.product_hios_id' => 'Product HIOS ID: ',
   :'en.rating_area.exchange_provided_code' => 'Rating Area: ',
+  :'en.service_area' => 'Service Area',
   :'en.enrollment.tobbaco_user' => 'Tobacco User',
   :'en.enrollment_member.coverage_state_date' => 'Coverage Start Date',
   :'en.not_available' => 'NA',

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -565,6 +565,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.enrollment.latest_transition_data' => "From %{from_state} to %{to_state} at %{created_at}",
   :'en.product_hios_id' => 'Product HIOS ID: ',
   :'en.rating_area.exchange_provided_code' => 'Rating Area: ',
+  :'en.service_area' => 'Service Area',
   :'en.enrollment.tobbaco_user' => 'Tobacco User',
   :'en.enrollment_member.coverage_state_date' => 'Coverage Start Date',
   :'en.not_available' => 'NA',

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -567,6 +567,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.enrollment.latest_transition_data' => "From %{from_state} to %{to_state} at %{created_at}",
   :'en.product_hios_id' => 'Product HIOS ID: ',
   :'en.rating_area.exchange_provided_code' => 'Rating Area: ',
+  :'en.service_area' => 'Service Area',
   :'en.enrollment.tobbaco_user' => 'Tobacco User',
   :'en.enrollment_member.coverage_state_date' => 'Coverage Start Date',
   :'en.not_available' => 'NA',

--- a/features/admin/enrollment_summary.feature
+++ b/features/admin/enrollment_summary.feature
@@ -8,7 +8,6 @@ Feature: Display Enrollment Summary
     And consumer also has a health enrollment with primary person covered
     And the family has an active tax household
     And consumer has successful ridp
-    And the enrollment is a Health plan
     
   Scenario: Consumer views the Enrollment Summary page
     And the consumer is logged in
@@ -26,3 +25,14 @@ Feature: Display Enrollment Summary
     Then Admin clicks on the Actions button
     When Admin clicks on the View my coverage details
     Then additional Enrollment Summary exists
+
+  Scenario: Admin navigates to Enrollment Summary page and sees service area value
+    And a Hbx admin logs on to Portal
+    When Hbx Admin click Families link
+    And Hbx Admin clicks on a family member
+    When Admin should be able to see Actions dropdown
+    Then Admin clicks on the Actions button
+    When Admin clicks on the View my coverage details
+    And navigates to Enrollment Summary page
+    Then the Admin should see "Service Area" text
+    Then the Admin should see "Rating Area" text

--- a/features/step_definitions/enrollment_summary.rb
+++ b/features/step_definitions/enrollment_summary.rb
@@ -25,3 +25,12 @@ end
 Given(/^the display enrollment summary configuration is enabled$/) do
   enable_feature :display_enr_summary
 end
+
+And(/^navigates to Enrollment Summary page$/) do
+  sleep(3)
+  expect(page).to have_content(l10n('enrollment.details.header'))
+end
+
+Then(/^the \w+ should see "(.*)" text$/) do |label|
+  expect(page).to have_content(label)
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [pivotal-185362845](https://www.pivotaltracker.com/n/projects/2640059/stories/185362845#)

# A brief description of the changes

New behavior: With this feature, service area value of the enrollment is displayed on enrollment summary page.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME
