### PR TITLE
populate min verification due date if nil

### DIFF
--- a/app/domain/operations/transformers/family_to/cv3_family.rb
+++ b/app/domain/operations/transformers/family_to/cv3_family.rb
@@ -45,13 +45,18 @@ module Operations
             # broker_accounts = transform_broker_accounts(family.broker_accounts), #TO DO
             # updated_by: construct_updated_by(updated_by)
           }
-          payload.merge!(min_verification_due_date: family.min_verification_due_date) if family.min_verification_due_date.present?
+          payload.merge!(min_verification_due_date: transform_min_verification_due_date(family))
           payload.merge!(irs_groups: transform_irs_groups(family.irs_groups)) if family.irs_groups.present?
           payload.merge!(households: transform_households(family.households, options)) if family.households.present?
           payload.merge!(tax_household_groups: transform_tax_household_groups(family.tax_household_groups)) if family.tax_household_groups.present?
           failed_payloads = payload.values.select { |value| value.is_a?(Dry::Monads::Result::Failure) }
           return Failure("Unable to transform payload values: #{failed_payloads}") if failed_payloads.present?
           Success(payload)
+        end
+
+        def transform_min_verification_due_date(family)
+          return family.min_verification_due_date if family.min_verification_due_date.present?
+          family&.eligibility_determination&.default_earliest_verification_due_date
         end
 
         def transform_applications(family, exclude_applications)

--- a/app/models/eligibilities/determination.rb
+++ b/app/models/eligibilities/determination.rb
@@ -15,5 +15,12 @@ module Eligibilities
     field :outstanding_verification_document_status, type: String
 
     accepts_nested_attributes_for :subjects, :grants
+
+    def default_earliest_verification_due_date
+      if outstanding_verification_status == 'outstanding'
+        verification_document_due = EnrollRegistry[:verification_document_due_in_days].item
+        outstanding_verification_earliest_due_date || TimeKeeper.date_of_record + verification_document_due.days
+      end
+    end
   end
 end

--- a/app/models/eligibilities/determination.rb
+++ b/app/models/eligibilities/determination.rb
@@ -17,10 +17,9 @@ module Eligibilities
     accepts_nested_attributes_for :subjects, :grants
 
     def default_earliest_verification_due_date
-      if outstanding_verification_status == 'outstanding'
-        verification_document_due = EnrollRegistry[:verification_document_due_in_days].item
-        outstanding_verification_earliest_due_date || TimeKeeper.date_of_record + verification_document_due.days
-      end
+      return unless outstanding_verification_status == 'outstanding'
+      verification_document_due = EnrollRegistry[:verification_document_due_in_days].item
+      outstanding_verification_earliest_due_date || TimeKeeper.date_of_record + verification_document_due.days
     end
   end
 end

--- a/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
+++ b/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
@@ -297,4 +297,39 @@ RSpec.describe ::Operations::Transformers::FamilyTo::Cv3Family, dbclean: :around
       expect(tax_household_members.count).to eq(1)
     end
   end
+
+  describe "#transform_min_verification_due_date" do
+
+    
+   
+    context "with nil min verification due date" do
+      subject { Operations::Transformers::FamilyTo::Cv3Family.new.transform_min_verification_due_date(family) }
+      let!(:eligibility_determination) do
+        determination = family.create_eligibility_determination(effective_date: TimeKeeper.date_of_record.beginning_of_year)
+        
+        determination
+      end
+
+      before do
+        family.eligibility_determination.update_attributes!(outstanding_verification_earliest_due_date: TimeKeeper.date_of_record + 96.days, outstanding_verification_document_status: 'outstanding')
+      end
+
+      it "should return eligibility_determination earliest_verification_due_date" do
+        expect(subject).to eql(family.eligibility_determination.default_earliest_verification_due_date)
+      end
+    end
+
+    context "with present min verification due date" do
+      let(:family_2) { FactoryBot.create(:family, :with_primary_family_member) }
+      subject { Operations::Transformers::FamilyTo::Cv3Family.new.transform_min_verification_due_date(family_2) }
+
+      before do
+        family_2.update_attributes!(min_verification_due_date: TimeKeeper.date_of_record)
+      end
+
+      it "should return min verification_due_date" do
+        expect(subject).to eql(family_2.min_verification_due_date)
+      end
+    end
+  end
 end

--- a/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
+++ b/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
@@ -300,13 +300,11 @@ RSpec.describe ::Operations::Transformers::FamilyTo::Cv3Family, dbclean: :around
 
   describe "#transform_min_verification_due_date" do
 
-    
-   
     context "with nil min verification due date" do
       subject { Operations::Transformers::FamilyTo::Cv3Family.new.transform_min_verification_due_date(family) }
       let!(:eligibility_determination) do
         determination = family.create_eligibility_determination(effective_date: TimeKeeper.date_of_record.beginning_of_year)
-        
+
         determination
       end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

# What is the ticket # detailing the issue?

Ticket: [ME-185361432](https://www.pivotaltracker.com/n/projects/2640060/stories/185361432)

# A brief description of the changes

Current behavior: the family's min verification due date is not populated in notices if it's nil

New behavior: If the family's min verification due date is nil, we will copy the behavior in the UI and display the family's eligibility determination outstanding_verification_earliest_due_date

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME
