### PR TITLE
restore left nav on enrollment details page

### DIFF
--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -17,11 +17,7 @@
           <div class="plan-logo-and-name">
             <%= display_carrier_logo(Maybe.new(product), { width: 100 }) %>
             <h3>
-              <% product_title = sanitize product.title %>
-              <% product_hios_id = sanitize product.hios_id %>
-              <% hbx_enrollment_id = sanitize hbx_enrollment.id %>
-              <% active_year = sanitize product.active_year %>
-              <%= link_to product_title, summary_products_plans_path({ :standard_component_id => product_hios_id, hbx_enrollment_id: hbx_enrollment_id, active_year: active_year }), remote: true %>
+              <%= link_to product.title, summary_products_plans_path({ :standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, active_year: product.active_year }), remote: true %>
             </h3>
           </div>
         </div>

--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -17,7 +17,8 @@
           <div class="plan-logo-and-name">
             <%= display_carrier_logo(Maybe.new(product), { width: 100 }) %>
             <h3>
-              <%= sanitize link_to product.title, summary_products_plans_path({ :standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, active_year: product.active_year }), remote: true %>
+              <% title = sanitize product.title %>
+              <%= link_to title, summary_products_plans_path({ :standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, active_year: product.active_year }), remote: true %>
             </h3>
           </div>
         </div>

--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -17,8 +17,11 @@
           <div class="plan-logo-and-name">
             <%= display_carrier_logo(Maybe.new(product), { width: 100 }) %>
             <h3>
-              <% title = sanitize product.title %>
-              <%= link_to title, summary_products_plans_path({ :standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, active_year: product.active_year }), remote: true %>
+              <% product_title = sanitize product.title %>
+              <% product_hios_id = sanitize product.hios_id %>
+              <% hbx_enrollment_id = sanitize hbx_enrollment.id %>
+              <% active_year = sanitize product.active_year %>
+              <%= link_to product_title, summary_products_plans_path({ :standard_component_id => product_hios_id, hbx_enrollment_id: hbx_enrollment_id, active_year: active_year }), remote: true %>
             </h3>
           </div>
         </div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185510231

# A brief description of the changes

Current behavior:
Left nav disappears when clicking the enrollment title and navigating to the details page.

New behavior:
Left nav remains on the enrollment details page.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

This bug was introduced after including the `sanitize`  method before the `link_to` helper in order to appease the codesweep check for XSS vulnerabilities.  This check is particularly sensitive and known to produce false positives with some of our commonly used patterns. 