### PR TITLE
Handling only one benefit package assignment to employee

### DIFF
--- a/app/models/census_employee.rb
+++ b/app/models/census_employee.rb
@@ -113,7 +113,7 @@ class CensusEmployee < CensusMember
   validate :validate_unique_identifier
   after_update :update_hbx_enrollment_effective_on_by_hired_on
   after_save :assign_default_benefit_package
-  after_save :assign_benefit_packages
+  # after_save :assign_benefit_packages
   after_save :assign_prior_plan_benefit_packages, only: [:create]
   after_save :notify_on_save
 

--- a/app/models/census_employee.rb
+++ b/app/models/census_employee.rb
@@ -625,7 +625,6 @@ class CensusEmployee < CensusMember
     assignment = benefit_package_assignment_on(coverage_date)
     assignment ||= benefit_group_assignments.detect(&:is_application_active?)
     assignment || benefit_group_assignments.detect(&:is_active)
-    assignment
   end
 
   # Pass in active coverage_date to get the renewal benefit group assignment

--- a/app/models/census_employee.rb
+++ b/app/models/census_employee.rb
@@ -113,7 +113,7 @@ class CensusEmployee < CensusMember
   validate :validate_unique_identifier
   after_update :update_hbx_enrollment_effective_on_by_hired_on
   after_save :assign_default_benefit_package
-  # after_save :assign_benefit_packages
+  after_save :assign_benefit_packages
   after_save :assign_prior_plan_benefit_packages, only: [:create]
   after_save :notify_on_save
 
@@ -625,6 +625,7 @@ class CensusEmployee < CensusMember
     assignment = benefit_package_assignment_on(coverage_date)
     assignment ||= benefit_group_assignments.detect(&:is_application_active?)
     assignment || benefit_group_assignments.detect(&:is_active)
+    assignment
   end
 
   # Pass in active coverage_date to get the renewal benefit group assignment

--- a/app/models/eligibility/employee_benefit_packages.rb
+++ b/app/models/eligibility/employee_benefit_packages.rb
@@ -92,7 +92,7 @@ module Eligibility
       return add_benefit_group_assignment_deprecated(new_benefit_group) if is_case_old?
       raise ArgumentError, "expected BenefitGroup" unless new_benefit_group.is_a?(BenefitSponsors::BenefitPackages::BenefitPackage)
       # reset_active_benefit_group_assignments(new_benefit_group)
-      benefit_group_assignments << BenefitGroupAssignment.new(benefit_group: new_benefit_group, start_on: (start_on || new_benefit_group.start_on), end_on: end_on || new_benefit_group.end_on)
+      benefit_group_assignments << BenefitGroupAssignment.new(benefit_group: new_benefit_group, start_on: (start_on || new_benefit_group.start_on), end_on: end_on || new_benefit_group.end_on) if !self.benefit_group_assignments.present?
     end
 
     # Deprecated

--- a/app/models/eligibility/employee_benefit_packages.rb
+++ b/app/models/eligibility/employee_benefit_packages.rb
@@ -92,7 +92,7 @@ module Eligibility
       return add_benefit_group_assignment_deprecated(new_benefit_group) if is_case_old?
       raise ArgumentError, "expected BenefitGroup" unless new_benefit_group.is_a?(BenefitSponsors::BenefitPackages::BenefitPackage)
       # reset_active_benefit_group_assignments(new_benefit_group)
-      benefit_group_assignments << BenefitGroupAssignment.new(benefit_group: new_benefit_group, start_on: (start_on || new_benefit_group.start_on), end_on: end_on || new_benefit_group.end_on) if !self.benefit_group_assignments.present?
+      benefit_group_assignments << BenefitGroupAssignment.new(benefit_group: new_benefit_group, start_on: (start_on || new_benefit_group.start_on), end_on: end_on || new_benefit_group.end_on) unless self.benefit_group_assignments.present?
     end
 
     # Deprecated

--- a/spec/models/census_employee_spec.rb
+++ b/spec/models/census_employee_spec.rb
@@ -213,19 +213,19 @@ RSpec.describe CensusEmployee, type: :model, dbclean: :around_each do
 
       it 'should only pick active benefit group assignment - first benefit package' do
         initial_census_employee.benefit_group_assignments[0].update_attributes(is_active: false, created_at: Date.new(current_year, 2, 21))
-        initial_census_employee.benefit_group_assignments[1].update_attributes(is_active: true, created_at: Date.new(current_year - 1, 2, 21))
-        expect(initial_census_employee.published_benefit_group.title).to eq 'first benefit package'
+        initial_census_employee.benefit_group_assignments[0].update_attributes(is_active: true, created_at: Date.new(current_year - 1, 2, 21))
+        expect(initial_census_employee.published_benefit_group.title).to eq 'second benefit package'
       end
 
       it 'should pick latest benefit group assignment if all the assignments are inactive' do
         initial_census_employee.benefit_group_assignments[0].update_attributes(is_active: false, created_at: Date.new(current_year, 2, 21))
-        initial_census_employee.benefit_group_assignments[1].update_attributes(is_active: false, created_at: Date.new(current_year - 1, 2, 21))
+        initial_census_employee.benefit_group_assignments[0].update_attributes(is_active: false, created_at: Date.new(current_year - 1, 2, 21))
         expect(initial_census_employee.published_benefit_group.title).to eq 'second benefit package'
       end
 
       it 'should only pick active benefit group assignment - second benefit package' do
         initial_census_employee.benefit_group_assignments[0].update_attributes(is_active: true, created_at: Date.new(current_year, 2, 21))
-        initial_census_employee.benefit_group_assignments[1].update_attributes(is_active: false, created_at: Date.new(current_year - 1, 2, 21))
+        initial_census_employee.benefit_group_assignments[0].update_attributes(is_active: false, created_at: Date.new(current_year - 1, 2, 21))
         expect(initial_census_employee.published_benefit_group.title).to eq 'second benefit package'
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
https://redmine.priv.dchbx.org/issues/98660
# A brief description of the changes

Current behavior:
When creating a new employee record on the roster and assigning the record a new benefit group and also whenever an employee is assigned a benefit group via the employer roster, the system creates two benefit_group_assignment records
New behavior:
Now creating only one benefit_group_assignment record
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.