### PR TITLE
create condition for coverage reinstated label

### DIFF
--- a/app/helpers/insured/families_helper.rb
+++ b/app/helpers/insured/families_helper.rb
@@ -207,7 +207,9 @@ module Insured::FamiliesHelper
   def enrollment_state_label(enrollment)
     return if enrollment.blank?
 
-    # The colors correspond to those set in enrollment.scss as label-{color}
+    # The colors correspond to those set in enrollment.scss as label-{color}. We use color as an indicator of the
+    # enrollment status. For example, green indicates that the enrollment is active, red indicates that the enrollment
+    # is terminated, yellow indicates that the enrollment requires action, etc.
     state_groups = {
       auto_renewing: {
         has_outstanding_verification: { text: 'Action Needed', color: 'yellow' },
@@ -246,6 +248,8 @@ module Insured::FamiliesHelper
     group = state_groups[enrollment.aasm_state.to_sym] || state_groups[:default]
     condition = determine_condition(enrollment, group)
     label = group[condition] || { text: enrollment.aasm_state.to_s.titleize, color: 'grey' }
+    # Coverage reinstated is a special case where the aasm state is something else but we want to show it as reinstated in "green" (active) scenarios
+    label = state_groups[:coverage_reinstated][:default] if enrollment.is_reinstated_enrollment? && label[:color] == 'green'
     content_tag(:span, label[:text], class: "label label-#{label[:color]}")
   end
 

--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -57,12 +57,6 @@
                     </div>
                 <% end %>
 
-                <% if hbx_enrollment.is_reinstated_enrollment? %>
-                    <div class="reinstated-enrollment enrollment-effective">
-                        <label><%= l10n("reinstated_enrollment") %></label>
-                    </div>
-                <% end %>
-
                 <% if current_user.has_hbx_staff_role? %>
                     <div class="plan-id">
                         <label for="<%=hbx_enrollment.hbx_id%>"><%= HbxProfile::ShortName %> ID:</label>

--- a/spec/helpers/insured/families_helper_spec.rb
+++ b/spec/helpers/insured/families_helper_spec.rb
@@ -704,7 +704,7 @@ RSpec.describe Insured::FamiliesHelper, :type => :helper, dbclean: :after_each  
   # expected html elements as a positive indicator. If the related state_groups hash fields are updated, this test will
   # need to be updated as well.
   describe 'enrollment_state_label' do
-    let(:enrollment) { instance_double(HbxEnrollment, is_shop?: false, is_reinstated_enrollment?: false ) }
+    let(:enrollment) { instance_double(HbxEnrollment, is_shop?: false, is_reinstated_enrollment?: false) }
 
     shared_examples 'a label checker' do |aasm_state, terminate_reason, is_outstanding, expected_label|
       before do

--- a/spec/helpers/insured/families_helper_spec.rb
+++ b/spec/helpers/insured/families_helper_spec.rb
@@ -704,7 +704,7 @@ RSpec.describe Insured::FamiliesHelper, :type => :helper, dbclean: :after_each  
   # expected html elements as a positive indicator. If the related state_groups hash fields are updated, this test will
   # need to be updated as well.
   describe 'enrollment_state_label' do
-    let(:enrollment) { instance_double(HbxEnrollment, is_shop?: false) }
+    let(:enrollment) { instance_double(HbxEnrollment, is_shop?: false, is_reinstated_enrollment?: false ) }
 
     shared_examples 'a label checker' do |aasm_state, terminate_reason, is_outstanding, expected_label|
       before do
@@ -734,6 +734,15 @@ RSpec.describe Insured::FamiliesHelper, :type => :helper, dbclean: :after_each  
       context 'when condition is present in state group' do
         it_behaves_like 'a label checker', 'coverage_canceled', HbxEnrollment::TermReason::NON_PAYMENT, false, ['red', 'Canceled by Insurance Company']
         it_behaves_like 'a label checker', 'auto_renewing', nil, true, ['yellow', 'Action Needed']
+      end
+
+      context 'when is reinstated' do
+        before do
+          allow(enrollment).to receive(:is_reinstated_enrollment?).and_return(true)
+        end
+        # should return Coverage Reinstated only if the color is green (active)
+        it_behaves_like 'a label checker', 'coverage_selected', nil, true, ['yellow', 'Action Needed']
+        it_behaves_like 'a label checker', 'coverage_selected', nil, false, ['green', 'Coverage Reinstated']
       end
 
       context 'when condition is not present in state group' do

--- a/spec/views/insured/families/_enrollment_refactored.html.erb_spec.rb
+++ b/spec/views/insured/families/_enrollment_refactored.html.erb_spec.rb
@@ -384,9 +384,6 @@ RSpec.describe "insured/families/_enrollment_refactored.html.erb" do
       render partial: "insured/families/enrollment_refactored", collection: [hbx_enrollment], as: :hbx_enrollment, locals: { read_only: false }
     end
 
-    it "should have reinstated enrollment text" do
-      expect(rendered).to have_text("Reinstated Enrollment")
-    end
     it "should show month text" do
       expect(rendered).to match(/month/)
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185393486

# A brief description of the changes

Current behavior:
Coverage Reinstated indicator is within the enrollment tile.

New behavior:
Coverage Reinstated is a label in header when the enrollment is active and removed from the enrollment tile itself.

# Feature Flag
This lives under
For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:
ENROLLMENT_PLAN_TILE_UPDATE_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context

The text that is currently rendered in the body of the tile does not technically reflect the current aasm state. It indicates that the enrollment was reinstated at some point.

Based on the other label updates, we are inferring that the client wishes to see the new "Reinstated Enrollment" label (green color) only if the current aasm state would render as a green label as well (auto_renewing, coverage_selected, renewing_coverage_selected).

In other words, we are assuming that the tile should NOT have a green "Reinstated Enrollment" label if the coverage was cancelled, terminated, expired or has an outstanding verification (these are the red, blue, grey or yellow labels).