### PR TITLE
copy eligibility grants when copying quote

### DIFF
--- a/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_proposals/proposal_copies_controller.rb
+++ b/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_proposals/proposal_copies_controller.rb
@@ -12,7 +12,9 @@ module SponsoredBenefits
           sponsorship = proposal.profile.benefit_sponsorships.first
           assign_benefit_group(sponsorship: sponsorship, old_sponsorship: plan_design_form.proposal.profile.benefit_sponsorships.first)
           assign_roster_employees(sponsorship: sponsorship, roster: existing_roster)
-
+          plan_design_form.proposal.osse_eligibility.grants.each do |grant|
+            proposal.osse_eligibility.grants << grant.dup
+          end
           proposal.plan_design_organization.save!
           flash[:success] = "Proposal successfully copied"
         else

--- a/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_proposals/proposal_copies_controller.rb
+++ b/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_proposals/proposal_copies_controller.rb
@@ -12,7 +12,7 @@ module SponsoredBenefits
           sponsorship = proposal.profile.benefit_sponsorships.first
           assign_benefit_group(sponsorship: sponsorship, old_sponsorship: plan_design_form.proposal.profile.benefit_sponsorships.first)
           assign_roster_employees(sponsorship: sponsorship, roster: existing_roster)
-          plan_design_form.proposal.osse_eligibility.grants.each do |grant|
+          plan_design_form.proposal.osse_eligibility&.grants&.each do |grant|
             proposal.osse_eligibility.grants << grant.dup
           end
           proposal.plan_design_organization.save!

--- a/features/brokers/broker_create_hc4cc_quote.feature
+++ b/features/brokers/broker_create_hc4cc_quote.feature
@@ -49,4 +49,6 @@ Feature: Broker HC4CC quote creation
     Then Primary Broker clicks Back to All Quotes
     And the broker clicks Actions dropdown
     And the broker clicks copy quote
-    Then the broker should see Yes for HC4CC
+    And the broker should see Yes for HC4CC
+    And Primary broker clicks on Select Health Benefits button
+    Then Primary broker should see metal level non bronze options


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[185512577](https://www.pivotaltracker.com/n/projects/2640061/stories/185512577)

# A brief description of the changes

Current behavior:
When copying an HC4CC quote, metal level restrictions are not applied to the new quote.

New behavior:
Eligibility grants are copied to the new quote, enabling metal level restrictions.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.