### PR TITLE
shop plan link color

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -4964,6 +4964,10 @@ input:required:valid {
    font-weight: bold;
  }
 
+ .font-color-inherit *, .font-color-inherit *:hover{
+   color: inherit;
+ }
+
  .fa-chevron-right {
    transition: all 0.3s ease;
  }

--- a/app/views/insured/families/_sep_message.html.erb
+++ b/app/views/insured/families/_sep_message.html.erb
@@ -5,7 +5,7 @@
       <% if EnrollRegistry.feature_enabled?(:verbose_sep_message) %>
           <div style="color: #323130;">
             <%= l10n("insured.sep_verbose_eligibility_alert", sep_end_date: @active_sep.end_on ) %>
-            <span style="text-decoration: underline; color: #323130;" class="font-weight-bold font-color-inherit">
+            <span style="text-decoration: underline" class="font-weight-bold font-color-inherit">
               <%= build_link_for_sep_type(@active_sep, nil, local_assigns[:family_id]) %>
             </span>
           </div>

--- a/app/views/insured/families/_sep_message.html.erb
+++ b/app/views/insured/families/_sep_message.html.erb
@@ -5,7 +5,7 @@
       <% if EnrollRegistry.feature_enabled?(:verbose_sep_message) %>
           <div style="color: #323130;">
             <%= l10n("insured.sep_verbose_eligibility_alert", sep_end_date: @active_sep.end_on ) %>
-            <span style="text-decoration: underline;" class="font-weight-bold">
+            <span style="text-decoration: underline; color: #323130;" class="font-weight-bold font-color-inherit">
               <%= build_link_for_sep_type(@active_sep, nil, local_assigns[:family_id]) %>
             </span>
           </div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185453339

# A brief description of the changes

Current behavior:
shop plan link is blue and fails contrast test
New behavior:
shop plan link is black
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:
VERBOSE_SEP_MESSAGE_IS_ENABLED
- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.