### PR TITLE
improve logging for publishing to crm gateway

### DIFF
--- a/app/domain/operations/families/sugar_crm/publish_family.rb
+++ b/app/domain/operations/families/sugar_crm/publish_family.rb
@@ -69,7 +69,7 @@ module Operations
           elsif send_to_gateway?(family, payload_hash.value!)
             payload_hash
           else
-            Failure("No critical changes made to family, no update needed to CRM gateway.")
+            Failure("No critical changes made to family: #{family.id}, no update needed to CRM gateway.")
           end
         rescue StandardError => e
           # Likely failure constructing applications payload

--- a/app/domain/operations/people/sugar_crm/publish_primary_subscriber.rb
+++ b/app/domain/operations/people/sugar_crm/publish_primary_subscriber.rb
@@ -83,7 +83,7 @@ module Operations
           if send_to_gateway?(primary_subscriber_person, payload)
             event('events.crm_gateway.people.primary_subscriber_update', attributes: payload.to_h)
           else
-            Failure("No critical changes made to primary subscriber, no update needed to CRM gateway.")
+            Failure("No critical changes made to primary subscriber: #{primary_subscriber_person.hbx_id}, no update needed to CRM gateway.")
           end
         end
 

--- a/app/models/concerns/crm_gateway/family_concern.rb
+++ b/app/models/concerns/crm_gateway/family_concern.rb
@@ -11,9 +11,9 @@ module CrmGateway
     def trigger_async_publish
       return unless EnrollRegistry.feature_enabled?(:crm_update_family_save)
       return if EnrollRegistry.feature_enabled?(:check_for_crm_updates) && !send_to_gateway?
-      CrmWorker.perform_async(self.id.to_s, self.class.to_s, :trigger_crm_family_update_publish)
+      Rails.logger.info("Triggering CRM family update publish for family #{self.id}")
+      #CrmWorker.perform_async(self.id.to_s, self.class.to_s, :trigger_crm_family_update_publish)
       reset_crm_notifiction_needed if EnrollRegistry.feature_enabled?(:check_for_crm_updates)
-      "Triggered CRM family update publish for family"
     end
 
     def send_to_gateway?
@@ -29,10 +29,11 @@ module CrmGateway
 
     def trigger_crm_family_update_publish
       return unless EnrollRegistry.feature_enabled?(:crm_update_family_save)
-      puts("Triggering CRM family update publish for family with mongo id #{self.id}")
+      puts("Triggered CRM family update publish for family with mongo id #{self.id}")
       result = ::Operations::Families::SugarCrm::PublishFamily.new.call(self)
       # Update column directly without callbacks
       if result.success?
+        Rails.logger.warn("37777777")
         family_payload = result.success.last
         self.set(cv3_payload: family_payload.to_h.with_indifferent_access) unless EnrollRegistry.feature_enabled?(:check_for_crm_updates)
         p family_payload if Rails.env.test?

--- a/app/models/concerns/crm_gateway/family_concern.rb
+++ b/app/models/concerns/crm_gateway/family_concern.rb
@@ -12,7 +12,7 @@ module CrmGateway
       return unless EnrollRegistry.feature_enabled?(:crm_update_family_save)
       return if EnrollRegistry.feature_enabled?(:check_for_crm_updates) && !send_to_gateway?
       Rails.logger.info("Triggering CRM family update publish for family #{self.id}")
-      #CrmWorker.perform_async(self.id.to_s, self.class.to_s, :trigger_crm_family_update_publish)
+      CrmWorker.perform_async(self.id.to_s, self.class.to_s, :trigger_crm_family_update_publish)
       reset_crm_notifiction_needed if EnrollRegistry.feature_enabled?(:check_for_crm_updates)
     end
 

--- a/app/models/concerns/crm_gateway/family_concern.rb
+++ b/app/models/concerns/crm_gateway/family_concern.rb
@@ -33,7 +33,6 @@ module CrmGateway
       result = ::Operations::Families::SugarCrm::PublishFamily.new.call(self)
       # Update column directly without callbacks
       if result.success?
-        Rails.logger.warn("37777777")
         family_payload = result.success.last
         self.set(cv3_payload: family_payload.to_h.with_indifferent_access) unless EnrollRegistry.feature_enabled?(:check_for_crm_updates)
         p family_payload if Rails.env.test?

--- a/app/models/concerns/crm_gateway/person_concern.rb
+++ b/app/models/concerns/crm_gateway/person_concern.rb
@@ -13,12 +13,12 @@ module CrmGateway
       return unless has_active_consumer_role?
       return unless primary_family.present? && self == primary_family.primary_person
       return if EnrollRegistry.feature_enabled?(:check_for_crm_updates) && !self.crm_notifiction_needed
-      CrmWorker.perform_async(self.id.to_s, self.class.to_s, :trigger_primary_subscriber_publish)
-      "Triggering CRM primary subscriber update publish for person"
+      Rails.logger.info("Triggering CRM primary subscriber update publish for person: #{self.hbx_id}")
+      CrmWorker.perform_asyc(self.id.to_s, self.class.to_s, :trigger_primary_subscriber_publish)
     end
 
     def trigger_primary_subscriber_publish
-      puts("Triggering CRM primary subscriber update publish for person with mongo id #{self.id}")
+      puts("Triggered CRM primary subscriber update publish for person with hbx id #{self.hbx_id}")
       result = ::Operations::People::SugarCrm::PublishPrimarySubscriber.new.call(self)
       # Update column directly without callbacks
       if result.success?

--- a/app/models/concerns/crm_gateway/person_concern.rb
+++ b/app/models/concerns/crm_gateway/person_concern.rb
@@ -14,7 +14,7 @@ module CrmGateway
       return unless primary_family.present? && self == primary_family.primary_person
       return if EnrollRegistry.feature_enabled?(:check_for_crm_updates) && !self.crm_notifiction_needed
       Rails.logger.info("Triggering CRM primary subscriber update publish for person: #{self.hbx_id}")
-      CrmWorker.perform_asyc(self.id.to_s, self.class.to_s, :trigger_primary_subscriber_publish)
+      CrmWorker.perform_async(self.id.to_s, self.class.to_s, :trigger_primary_subscriber_publish)
     end
 
     def trigger_primary_subscriber_publish

--- a/spec/domain/operations/families/sugar_crm/publish_family_spec.rb
+++ b/spec/domain/operations/families/sugar_crm/publish_family_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Operations::Families::SugarCrm::PublishFamily, type: :model, dbcl
     end
 
     it "should return failure if no family members critical attributes have been changed" do
-      expect(subject.call(family)).to eq(Failure("No critical changes made to family, no update needed to CRM gateway."))
+      expect(subject.call(family)).to eq(Failure("No critical changes made to family: #{family.id}, no update needed to CRM gateway."))
     end
   end
 

--- a/spec/domain/operations/people/publish_primary_subscriber_spec.rb
+++ b/spec/domain/operations/people/publish_primary_subscriber_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Operations::People::SugarCrm::PublishPrimarySubscriber, type: :mo
     end
 
     it "should return failure if no family members critical attributes have been changed" do
-      expect(subject.call(person)).to eq(Failure("No critical changes made to primary subscriber, no update needed to CRM gateway."))
+      expect(subject.call(person)).to eq(Failure("No critical changes made to primary subscriber: #{person.hbx_id}, no update needed to CRM gateway."))
     end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/185424104/

# A brief description of the changes

Current behavior: We are not logging hbx ids of people where publish_primary_subscriber is failing, thus making debugging more difficult in Graylog.

New behavior: Added logging to include more hbx ids as to make debugging more efficient when errors arise. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.