### PR TITLE
add feature flag for atp automatic submission

### DIFF
--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -166,6 +166,8 @@ registry:
       is_enabled: <%= ENV['ATP_ON_RENEWALS_IS_ENABLED'] || false %>
     - key: :load_county_on_inbound_transfer
       is_enabled: <%= ENV['LOAD_COUNTY_ON_INBOUND_TRANSFER_IS_ENABLED'] || false %>
+    - key: :automatic_submission
+      is_enabled: <%= ENV['AUTOMATIC_SUBMISSION_IS_ENABLED'] || false %>
   - namespace:
     - :documents
     features:

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -166,6 +166,8 @@ registry:
       is_enabled: <%= ENV['ATP_ON_RENEWALS_IS_ENABLED'] || false %>
     - key: :load_county_on_inbound_transfer
       is_enabled: <%= ENV['LOAD_COUNTY_ON_INBOUND_TRANSFER_IS_ENABLED'] || true %>
+    - key: :automatic_submission
+      is_enabled: <%= ENV['AUTOMATIC_SUBMISSION_IS_ENABLED'] || false %>
   - namespace:
     - :documents
     features:

--- a/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -166,6 +166,8 @@ registry:
       is_enabled: <%= ENV['ATP_ON_RENEWALS_IS_ENABLED'] || false %>
     - key: :load_county_on_inbound_transfer
       is_enabled: <%= ENV['LOAD_COUNTY_ON_INBOUND_TRANSFER_IS_ENABLED'] || false %>
+    - key: :automatic_submission
+      is_enabled: <%= ENV['AUTOMATIC_SUBMISSION_IS_ENABLED'] || false %>
   - namespace:
     - :documents
     features:


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185072139

# A brief description of the changes

Current behavior:
No feature flag exists for the planned ATP automatic submission feature.

New behavior:
Feature flag is present with 'false' fallback values for all clients.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:  AUTOMATIC_SUBMISSION_IS_ENABLED

- [x] DC
- [ ] ME

# Additional Context
No spec coverage is required on this PR since we are simply adding a new entry to the Resource Registry config.  No functional code changes are introduced at this point.