### PR TITLE
checking filter setting for self serve osse eligible

### DIFF
--- a/app/controllers/concerns/config/site_concern.rb
+++ b/app/controllers/concerns/config/site_concern.rb
@@ -43,6 +43,10 @@ module Config::SiteConcern
     EnrollRegistry.feature_enabled?(:aca_individual_market)
   end
 
+  def ivl_osse_filtering_enabled?
+    EnrollRegistry.feature_enabled?("individual_osse_plan_filter")
+  end
+
   def is_shop_and_individual_market_enabled?
     EnrollRegistry.feature_enabled?(:aca_shop_market) && EnrollRegistry.feature_enabled?(:aca_individual_market)
   end

--- a/app/controllers/insured/group_selection_controller.rb
+++ b/app/controllers/insured/group_selection_controller.rb
@@ -234,8 +234,8 @@ class Insured::GroupSelectionController < ApplicationController
     aptc_applied = params[:aptc_applied_total].delete_prefix('$')
     hbx_enrollment = HbxEnrollment.find(enrollment_id)
     max_aptc = params[:max_aptc]&.to_f
-
-    return aptc_applied unless hbx_enrollment&.ivl_osse_eligible?(hbx_enrollment.effective_on) && max_aptc > 0.00
+    osse_eligible = hbx_enrollment&.ivl_osse_eligible?(hbx_enrollment.effective_on) && ivl_osse_filtering_enabled?
+    return aptc_applied unless osse_eligible && max_aptc > 0.00
 
     aptc_pct = (aptc_applied.to_f / max_aptc).round(2)
     aptc_pct < 0.85 ? (max_aptc * 0.85) : aptc_applied

--- a/app/views/insured/group_selection/_change_tax_credit_form.html.erb
+++ b/app/views/insured/group_selection/_change_tax_credit_form.html.erb
@@ -28,8 +28,8 @@
         </span>
         <%# Specify the value attribute on slider to move to right starting spot %>
         <% slider_starting_value = @self_term_or_cancel_form[:elected_aptc_pct] %>
-        <% min_aptc = @self_term_or_cancel_form[:enrollment].osse_eligible? ? 0.85 : 0 %>
-        <% step = @self_term_or_cancel_form[:enrollment].osse_eligible? ? 0.005 : 0.05 %>
+        <% min_aptc = @self_term_or_cancel_form[:enrollment].osse_eligible? && ivl_osse_filtering_enabled? ? 0.85 : 0 %>
+        <% step = @self_term_or_cancel_form[:enrollment].osse_eligible? && ivl_osse_filtering_enabled? ? 0.005 : 0.05 %>
         <input id="applied_pct_1" name='applied_pct_1' type="range" min="<%= min_aptc %>" value="<%= slider_starting_value %>" max="1" step="<%= step %>" style = "padding: 0px;" data-cuke="aptc_slider">
         <h5><b><%= l10n("tax_credit_value") %></b></h5>
         <input type="text" name="aptc_applied_total" id="aptc_applied_total"

--- a/features/group_selection/change_tax_credits.feature
+++ b/features/group_selection/change_tax_credits.feature
@@ -50,7 +50,7 @@ Feature: Change Tax Credit button
     When the user clicks on the Change Tax Credit button
     Then the user should see that applied tax credit has been set accordingly
 
-  Scenario: APTC slider should be minimum 85% when enrollment is OSSE eligible
+  Scenario: APTC slider should be minimum 85% when enrollment is OSSE eligible and feature enabled
     Given self service osse feature is enabled
     Given active enrollment is OSSE eligible with APTC
     And the tax household has at least one member that is APTC eligible

--- a/features/step_definitions/edit_aptc_csr_steps.rb
+++ b/features/step_definitions/edit_aptc_csr_steps.rb
@@ -68,6 +68,7 @@ Given(/self service osse feature is enabled/) do
   EnrollRegistry["aca_ivl_osse_subsidy_#{year}"].feature.stub(:is_enabled).and_return(true)
   EnrollRegistry["aca_ivl_osse_subsidy_#{year - 1}"].feature.stub(:is_enabled).and_return(true)
   EnrollRegistry[:self_service_osse_subsidy].feature.stub(:is_enabled).and_return(true)
+  EnrollRegistry[:individual_osse_plan_filter].feature.stub(:is_enabled).and_return(true)
 end
 
 Given(/active enrollment is OSSE eligible with APTC/) do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640061/stories/185547236

# A brief description of the changes

Current behavior:
85% on self service APTC change being enforced when env variable is disabled

New behavior:
85% on self service APTC change is not enforced when env variable is disabled

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:
`ACA_INDIVIDUAL_OSSE_PLAN_FILTERING_IS_ENABLED`

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.