### PR TITLE
change hbx id from string to int in dev

### DIFF
--- a/app/models/hbx_id_generator.rb
+++ b/app/models/hbx_id_generator.rb
@@ -112,35 +112,35 @@ class HbxIdGenerator
 
   class SlugSource
     def self.generate_organization_id
-      random_uuid
+      uniq_id
     end
 
     def self.generate_policy_id
-      random_uuid
+      uniq_id
     end
 
     def self.generate_payment_transaction_id
-      random_uuid
+      uniq_id
     end
 
     def self.generate_member_id
-      random_uuid
+      uniq_id
     end
 
-    def self.random_uuid
-      SecureRandom.uuid.gsub("-","")
+    def self.uniq_id
+      Time.now.to_i
     end
 
     def self.generate_application_id
-      random_uuid
+      uniq_id
     end
 
     def self.generate_family_id
-      random_uuid
+      uniq_id
     end
 
     def self.generate_tax_household_group_id
-      random_uuid
+      uniq_id
     end
   end
 end

--- a/components/benefit_sponsors/app/models/benefit_sponsors/organizations/hbx_id_generator.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/organizations/hbx_id_generator.rb
@@ -1,5 +1,3 @@
-require 'securerandom'
-
 module BenefitSponsors
   module Organizations
     class HbxIdGenerator
@@ -76,23 +74,23 @@ module BenefitSponsors
 
       class SlugSource
         def self.generate_organization_id
-          random_uuid
+          uniq_id
         end
 
         def self.generate_benefit_sponsorship_id
-          random_uuid
+          uniq_id
         end
 
         def self.generate_policy_id
-          random_uuid
+          uniq_id
         end
 
         def self.generate_member_id
-          random_uuid
+          uniq_id
         end
 
-        def self.random_uuid
-          SecureRandom.uuid.gsub("-","")
+        def self.uniq_id
+          Time.now.to_i
         end
       end
     end

--- a/components/benefit_sponsors/spec/dummy/app/models/hbx_id_generator.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/hbx_id_generator.rb
@@ -1,21 +1,19 @@
-require 'securerandom'
-
 class HbxIdGenerator
   include Singleton
 
   def self.generate_policy_id
-    random_uuid
+    uniq_id
   end
 
   def self.generate_member_id
-    random_uuid
+    uniq_id
   end
 
   def self.generate_organization_id
-    random_uuid
+    uniq_id
   end
 
-  def self.random_uuid
-    SecureRandom.uuid.gsub("-","")
+  def self.uniq_id
+    Time.now.to_i
   end
 end

--- a/components/financial_assistance/app/models/financial_assistance/hbx_id_generator.rb
+++ b/components/financial_assistance/app/models/financial_assistance/hbx_id_generator.rb
@@ -1,5 +1,3 @@
-require 'securerandom'
-
 module FinancialAssistance
   class HbxIdGenerator
     attr_accessor :provider
@@ -52,15 +50,15 @@ module FinancialAssistance
     class SlugSource
 
       def self.generate_member_id
-        random_uuid
+        uniq_id
       end
 
-      def self.random_uuid
-        SecureRandom.uuid.gsub("-", "")
+      def self.uniq_id
+        Time.now.to_i
       end
 
       def self.generate_application_id
-        random_uuid
+        uniq_id
       end
     end
   end

--- a/components/financial_assistance/spec/dummy/app/models/hbx_id_generator.rb
+++ b/components/financial_assistance/spec/dummy/app/models/hbx_id_generator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'securerandom'
-
 class HbxIdGenerator
   attr_accessor :provider
   include Singleton
@@ -88,27 +86,27 @@ class HbxIdGenerator
 
   class SlugSource
     def self.generate_organization_id
-      random_uuid
+      uniq_id
     end
 
     def self.generate_policy_id
-      random_uuid
+      uniq_id
     end
 
     def self.generate_payment_transaction_id
-      random_uuid
+      uniq_id
     end
 
     def self.generate_member_id
-      random_uuid
+      uniq_id
     end
 
-    def self.random_uuid
-      SecureRandom.uuid.gsub("-","")
+    def self.uniq_id
+      Time.now.to_i
     end
 
     def self.generate_application_id
-      random_uuid
+      uniq_id
     end
   end
 end

--- a/components/sponsored_benefits/app/models/sponsored_benefits/organizations/hbx_id_generator.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/organizations/hbx_id_generator.rb
@@ -1,5 +1,3 @@
-require 'securerandom'
-
 module SponsoredBenefits
   module Organizations
     class HbxIdGenerator
@@ -64,19 +62,19 @@ module SponsoredBenefits
 
       class SlugSource
         def self.generate_organization_id
-          random_uuid
+          uniq_id
         end
 
         def self.generate_policy_id
-          random_uuid
+          uniq_id
         end
 
         def self.generate_member_id
-          random_uuid
+          uniq_id
         end
 
-        def self.random_uuid
-          SecureRandom.uuid.gsub("-","")
+        def self.uniq_id
+          Time.now.to_i
         end
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior:

ACA entities expects hbx_id to be an integer. In production an Int is generated but outside of Production a string was being generated.

New behavior:

hbx_id generators use the current time to generate an id that for development purposes we can consider unique
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [x] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.