### PR TITLE
fix show previous button during signup

### DIFF
--- a/app/views/shared/_individual_progress.html.haml
+++ b/app/views/shared/_individual_progress.html.haml
@@ -73,7 +73,7 @@
 
 = render partial: 'shared/shopping_nav_panel',
   locals: {show_exit_button: !@no_save_button,
-  show_previous_button: !@no_previous_button || step == 1,
+  show_previous_button: !@no_previous_button && step != 1,
   show_account_button: step > 2 && EnrollRegistry.feature_enabled?(:back_to_account_all_shop),
   is_complete: step == 6,
   show_help_button: step != 1 }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue? 

Ticket: TT6-184980444

# A brief description of the changes

Current behavior:

Previous button is on first pages during signup

New behavior:

Previous button is only after first pages during signup

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.