### PR TITLE
update supporting text related to feature

### DIFF
--- a/app/views/insured/plan_shoppings/receipt.en.html.erb
+++ b/app/views/insured/plan_shoppings/receipt.en.html.erb
@@ -20,7 +20,7 @@
               <p><strong>Important:</strong> You must pay your first month’s premium directly to your carrier for
                 your coverage to take effect. Select 'How to Pay' to learn more.</p>
             <% end %>
-            <p>When you’re finished, select GO TO MY ACCOUNT to view the status of your enrollment. You can also
+            <p>When you’re finished, select CONTINUE to view the status of your enrollment. You can also
               contact your insurance carrier directly for additional information or to check the status of your
               enrollment.</p>
           <% end %>

--- a/app/views/insured/plan_shoppings/receipt.en.html.erb
+++ b/app/views/insured/plan_shoppings/receipt.en.html.erb
@@ -20,7 +20,7 @@
               <p><strong>Important:</strong> You must pay your first month’s premium directly to your carrier for
                 your coverage to take effect. Select 'How to Pay' to learn more.</p>
             <% end %>
-            <p>When you’re finished, select CONTINUE to view the status of your enrollment. You can also
+            <p>When you’re finished, select <%= EnrollRegistry.feature_enabled?(:back_to_account_all_shop) ? "CONTINUE" : "GO TO MY ACCOUNT" %> to view the status of your enrollment. You can also
               contact your insurance carrier directly for additional information or to check the status of your
               enrollment.</p>
           <% end %>

--- a/app/views/insured/plan_shoppings/receipt.html.erb
+++ b/app/views/insured/plan_shoppings/receipt.html.erb
@@ -20,7 +20,7 @@
               <p><strong>Important:</strong> You must pay your first month’s premium directly to your carrier for
                 your coverage to take effect. Select 'How to Pay' to learn more.</p>
             <% end %>
-            <p>When you’re finished, select GO TO MY ACCOUNT to view the status of your enrollment. You can also
+            <p>When you’re finished, select CONTINUE to view the status of your enrollment. You can also
               contact your insurance carrier directly for additional information or to check the status of your
               enrollment.</p>
           <% end %>

--- a/app/views/insured/plan_shoppings/receipt.html.erb
+++ b/app/views/insured/plan_shoppings/receipt.html.erb
@@ -20,7 +20,7 @@
               <p><strong>Important:</strong> You must pay your first month’s premium directly to your carrier for
                 your coverage to take effect. Select 'How to Pay' to learn more.</p>
             <% end %>
-            <p>When you’re finished, select CONTINUE to view the status of your enrollment. You can also
+            <p>When you’re finished, select <%= EnrollRegistry.feature_enabled?(:back_to_account_all_shop) ? "CONTINUE" : "GO TO MY ACCOUNT" %> to view the status of your enrollment. You can also
               contact your insurance carrier directly for additional information or to check the status of your
               enrollment.</p>
           <% end %>

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -517,7 +517,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.termination_reason' => "Termination Reason",
   :'en.plan_compare_alert' => "Plan Compare Alert",
   :'en.insured.plan_shoppings.show.can_not_select_more_than_n_plans_to_compare' => "Can not select more than %{number} plans to compare.",
-  :'en.insured.plan_shoppings.thankyou.confirm_your_plan_selection.content' => "Please review your current plan selection. Select PREVIOUS if you want to change your plan selection. When you're satisfied with your plan, carefully review and acknowledge the Agreement below along with the Terms and Conditions. You must also provide an electronic signature at the bottom of the page. When you're finished, select CONFIRM to submit your enrollment to your insurance company. You don't have to pay today.",
+  :'en.insured.plan_shoppings.thankyou.confirm_your_plan_selection.content' => "Please review your current plan selection. Select Previous Step if you want to change your plan selection. When you're satisfied with your plan, carefully review and acknowledge the Agreement below along with the Terms and Conditions. You must also provide an electronic signature at the bottom of the page. When you're finished, select CONFIRM to submit your enrollment to your insurance company. You don't have to pay today.",
   :'en.important' => "Important",
   :'en.insured.plan_shoppings.thankyou.you_must_complete_steps_to_enroll' => "You must complete these steps to enroll.",
   :'en.insured.plan_shoppings.thankyou.additional_administration_msg' => "* Your employer may charge an additional administration fee for your COBRA/Continuation coverage. If you have any questions, please direct them to the Employer.",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  TT6-184980444

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: BACK_TO_ACCOUNT_ALL_SHOP_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

1. Per a discussion with Sarah Bagge the text should always be "CONTINUE" in the receipt content to account for the different options in the continue to account button.
2. Update the "Previous" text for Maine to "Previous Step"

