### PR TITLE
use carrier url instead of pay now url on enrollment tile when setting is disabled

### DIFF
--- a/app/views/shared/_pay_now_modal.html.erb
+++ b/app/views/shared/_pay_now_modal.html.erb
@@ -1,8 +1,13 @@
 <% carrier = hbx_enrollment.product.carrier_profile.legal_name %>
 <% carrier_long_name = carrier_long_name(carrier) %>
-<% first_payment = carrier_paynow_enabled?(carrier) && before_effective_date?(hbx_enrollment) %>
+
+<%# note: using show_pay_now? method makes sure enrollment_tile setting is enabled and all other conditions are met %>
+<% first_payment = carrier_paynow_enabled?(carrier) && before_effective_date?(hbx_enrollment) && show_pay_now?("Enrollment Tile", hbx_enrollment) %>
 <% plan_shopping = carrier_paynow_enabled?(carrier) && source == "Plan Shopping"  %>
+<%# use PayNow url if user is making first payment from enrollment tile or is in plan shopping flow, %>
+<%# otherwise use generic carrier url %>
 <% url = first_payment || plan_shopping ? pay_now_url(carrier) : carrier_url(carrier) %>
+
 <% carrier_key = carrier_paynow_enabled?(carrier) ? fetch_carrier_key_from_legal_name(carrier) : "other" %>
 <% translation_key = is_kaiser_translation_key?(carrier_key) %>
 <div class="modal fade" tabindex="-1" role="dialog" id="payNowModal<%= hbx_enrollment.hbx_id %>">

--- a/app/views/shared/_pay_now_modal.html.erb
+++ b/app/views/shared/_pay_now_modal.html.erb
@@ -1,7 +1,7 @@
 <% carrier = hbx_enrollment.product.carrier_profile.legal_name %>
 <% carrier_long_name = carrier_long_name(carrier) %>
 
-<%# note: using show_pay_now? method makes sure enrollment_tile setting is enabled and all other conditions are met %>
+<%# note: using show_pay_now? method makes sure enrollment_tile setting is enabled and other conditions are met for linking to the pay now portal %>
 <% first_payment = carrier_paynow_enabled?(carrier) && before_effective_date?(hbx_enrollment) && show_pay_now?("Enrollment Tile", hbx_enrollment) %>
 <% plan_shopping = carrier_paynow_enabled?(carrier) && source == "Plan Shopping"  %>
 <%# use PayNow url if user is making first payment from enrollment tile or is in plan shopping flow, %>

--- a/spec/views/shared/_pay_now_modal.html.erb_spec.rb
+++ b/spec/views/shared/_pay_now_modal.html.erb_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+require 'spec_helper'
+
+describe "shared/_pay_now_modal.html.erb", dbclean: :after_each do
+
+  after :all do
+    DatabaseCleaner.clean
+  end
+
+  let(:family) { FactoryBot.create(:family, :with_primary_family_member)}
+  let(:hbx_enrollment) do
+    FactoryBot.create(:hbx_enrollment,
+                      product: health_product,
+                      enrollment_members: family.family_members,
+                      household: family.active_household,
+                      family: family)
+  end
+  let(:health_product) { FactoryBot.create(:benefit_markets_products_health_products_health_product, :with_issuer_profile_kaiser) }
+  let(:generic_redirect_double) { double }
+  let(:strict_tile_check_double) { double }
+  let(:kaiser_permanente_pay_now_double) { double }
+  let(:enrollment_tile_setting_double) { double }
+  let(:plan_shopping_setting_double) { double }
+  let(:generic_redirect_url) do 
+    carrier_legal_name = hbx_enrollment.product.issuer_profile.legal_name
+    Insured::PlanShopping::PayNowHelper::LINK_URL["#{carrier_legal_name}"]
+  end
+
+  before do
+    allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+    allow(EnrollRegistry).to receive(:feature_enabled?).with(:kaiser_permanente_pay_now).and_return(true)
+    allow(EnrollRegistry).to receive(:[]).and_call_original
+    allow(EnrollRegistry).to receive(:[]).with(:generic_redirect).and_return(generic_redirect_double)
+    allow(generic_redirect_double).to receive(:setting).with(:strict_tile_check).and_return(strict_tile_check_double)
+    allow(strict_tile_check_double).to receive(:item).and_return(true)
+  end
+
+  context 'when called from the enrollment tile dropdown' do
+    context 'and the plan shopping setting is enabled' do
+      before do
+        allow(kaiser_permanente_pay_now_double).to receive(:setting).with(:plan_shopping).and_return(plan_shopping_setting_double)
+        allow(plan_shopping_setting_double).to receive(:item).and_return(true)
+      end
+
+      context 'and the enrollment tile setting is disabled' do
+        before do
+          allow(EnrollRegistry).to receive(:[]).with(:kaiser_permanente_pay_now).and_return(kaiser_permanente_pay_now_double)
+          allow(kaiser_permanente_pay_now_double).to receive(:setting).with(:enrollment_tile).and_return(enrollment_tile_setting_double)
+          allow(enrollment_tile_setting_double).to receive(:item).and_return(false)
+        end
+
+        context 'and the generic redirect feature is enabled' do
+          before do
+            allow(EnrollRegistry).to receive(:feature_enabled?).with(:generic_redirect).and_return(true)
+          end
+
+          context 'and the strict tile check feature is disabled' do
+            before do
+              allow(strict_tile_check_double).to receive(:item).and_return(false)
+            end
+
+            it 'should render with a link to the generic redirect' do
+                render template: "shared/_pay_now_modal.html.erb", locals: {hbx_enrollment: hbx_enrollment, source: 'Enrollment Tile'}
+                expect(rendered).to match(generic_redirect_url)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/views/shared/_pay_now_modal.html.erb_spec.rb
+++ b/spec/views/shared/_pay_now_modal.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require 'spec_helper'
 
@@ -21,9 +23,9 @@ describe "shared/_pay_now_modal.html.erb", dbclean: :after_each do
   let(:kaiser_permanente_pay_now_double) { double }
   let(:enrollment_tile_setting_double) { double }
   let(:plan_shopping_setting_double) { double }
-  let(:generic_redirect_url) do 
+  let(:generic_redirect_url) do
     carrier_legal_name = hbx_enrollment.product.issuer_profile.legal_name
-    Insured::PlanShopping::PayNowHelper::LINK_URL["#{carrier_legal_name}"]
+    Insured::PlanShopping::PayNowHelper::LINK_URL[carrier_legal_name.to_s]
   end
 
   before do
@@ -60,8 +62,8 @@ describe "shared/_pay_now_modal.html.erb", dbclean: :after_each do
             end
 
             it 'should render with a link to the generic redirect' do
-                render template: "shared/_pay_now_modal.html.erb", locals: {hbx_enrollment: hbx_enrollment, source: 'Enrollment Tile'}
-                expect(rendered).to match(generic_redirect_url)
+              render template: "shared/_pay_now_modal.html.erb", locals: {hbx_enrollment: hbx_enrollment, source: 'Enrollment Tile'}
+              expect(rendered).to match(generic_redirect_url)
             end
           end
         end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185597840

# A brief description of the changes

Current behavior:
For carriers with the following configuration:
```
Pay Now: Enabled 
  - Plan Shopping: Enabled
  - Enrollment Tile: Disabled
Generic Redirect: Enabled 
  - Strict tile check: False
```
The 'Make Payments' button in the enrollment tile drop down menu links to the Pay Now carrier portal.   

New behavior:
For carriers with the configuration described above, the generic redirect url is used and user is navigated to the carrier's member portal home page.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.