### PR TITLE
moves gems that are not needed in prod group to dev test groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.5.9'
 gem 'rails', '~> 5.2.4.3'
 gem 'sidekiq'
-gem 'ffaker'
 gem 'globalid'
 #######################################################
 # FIXME
@@ -25,8 +24,6 @@ gem 'prawn', :git => 'https://github.com/prawnpdf/prawn.git', :ref => '8028ca0cd
 ## Fix this dependency -- bring into project
 gem 'simple_calendar', :git => 'https://github.com/harshared/simple_calendar.git'
 
-## Verify Rails 5 eliminates need for this gem with MongoDB
-gem 'database_cleaner',       '~> 1.7'
 #######################################################
 
 #######################################################
@@ -122,10 +119,6 @@ gem 'loofah', '~> 2.3.1'
 gem 'stimulus_reflex', '3.4.1'
 gem 'rack-cors'
 
-group :doc do
-  gem 'sdoc',                   '~> 1.0'
-end
-
 group :development do
   gem "certified",              '~> 1'
   gem 'overcommit',             '~> 0.47'
@@ -151,12 +144,14 @@ group :development, :test do
   gem 'climate_control',        '~> 0.2.0'
   gem 'email_spec',             '~> 2'
   gem 'factory_bot_rails',      '~> 4.11'
+  gem 'ffaker'
   gem 'forgery',                '~> 0.7.0'
   gem 'parallel_tests',         '~> 2.26.2'
   gem 'rails-controller-testing'
   gem 'railroady',              '~> 1.5.3'
   gem 'rspec-rails'
   gem 'rspec_junit_formatter'
+  gem 'sdoc',                    '~> 1.0'
   gem 'stimulus_reflex_testing', '~> 0.3.0'
   gem 'yard',                   '~> 0.9.20',  require: false
   gem 'yard-mongoid',           '~> 0.1',     require: false
@@ -167,6 +162,9 @@ group :test do
   gem 'capybara',                     '~> 3.12'
   gem 'capybara-screenshot',          '~> 1.0.18'
   gem 'cucumber-rails',               '2.0', :require => false
+
+  ## Verify Rails 5 eliminates need for this gem with MongoDB
+  gem 'database_cleaner',             '~> 1.7'
   gem 'fakeredis',                    '~> 0.7.0', :require => 'fakeredis/rspec'
   gem 'mongoid-rspec',                '~> 4'
   gem 'rspec-instafail',              '~> 1'

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,6 @@ gem 'mongoid_rails_migrations', '~> 1.2'
 
 ## General gems
 gem 'aasm',                     '~> 4.8'
-gem 'addressable',              '~> 2.3'
 gem 'animate-rails',            '~> 1.0.10'
 gem 'recurring_select'
 
@@ -137,6 +136,7 @@ end
 group :development, :test do
   gem 'dotenv-rails'
   gem 'action-cable-testing'
+  gem 'addressable',            '~> 2.3'
   # gem 'bundler-audit',          '~> 0.6'
   gem 'brakeman'
   gem 'capistrano',             '~> 3.1'

--- a/components/benefit_markets/Rakefile
+++ b/components/benefit_markets/Rakefile
@@ -6,12 +6,14 @@ end
 
 require 'rdoc/task'
 
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'BenefitMarkets'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+if !Rails.env.production?
+  RDoc::Task.new(:rdoc) do |rdoc|
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.title    = 'BenefitMarkets'
+    rdoc.options << '--line-numbers'
+    rdoc.rdoc_files.include('README.rdoc')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
 end
 
 APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)

--- a/components/benefit_sponsors/Rakefile
+++ b/components/benefit_sponsors/Rakefile
@@ -6,12 +6,14 @@ end
 
 require 'rdoc/task'
 
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'BenefitSponsors'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+if !Rails.env.production?
+  RDoc::Task.new(:rdoc) do |rdoc|
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.title    = 'BenefitSponsors'
+    rdoc.options << '--line-numbers'
+    rdoc.rdoc_files.include('README.rdoc')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
 end
 
 APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)

--- a/components/financial_assistance/Rakefile
+++ b/components/financial_assistance/Rakefile
@@ -8,12 +8,14 @@ end
 
 require 'rdoc/task'
 
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'FinancialAssistance'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.md')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+if !Rails.env.production?
+  RDoc::Task.new(:rdoc) do |rdoc|
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.title    = 'FinancialAssistance'
+    rdoc.options << '--line-numbers'
+    rdoc.rdoc_files.include('README.md')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
 end
 
 APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)

--- a/components/notifier/Rakefile
+++ b/components/notifier/Rakefile
@@ -6,12 +6,14 @@ end
 
 require 'rdoc/task'
 
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'Notifier'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+if !Rails.env.production?
+  RDoc::Task.new(:rdoc) do |rdoc|
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.title    = 'Notifier'
+    rdoc.options << '--line-numbers'
+    rdoc.rdoc_files.include('README.rdoc')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
 end
 
 

--- a/components/sponsored_benefits/Rakefile
+++ b/components/sponsored_benefits/Rakefile
@@ -6,12 +6,14 @@ end
 
 require 'rdoc/task'
 
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'SponsoredBenefits'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+if !Rails.env.production?
+  RDoc::Task.new(:rdoc) do |rdoc|
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.title    = 'SponsoredBenefits'
+    rdoc.options << '--line-numbers'
+    rdoc.rdoc_files.include('README.rdoc')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
 end
 
 APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)

--- a/components/transport_gateway/Rakefile
+++ b/components/transport_gateway/Rakefile
@@ -6,12 +6,14 @@ end
 
 require 'rdoc/task'
 
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'TransportGateway'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+if !Rails.env.production?
+  RDoc::Task.new(:rdoc) do |rdoc|
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.title    = 'TransportGateway'
+    rdoc.options << '--line-numbers'
+    rdoc.rdoc_files.include('README.rdoc')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
 end
 
 

--- a/components/transport_profiles/Rakefile
+++ b/components/transport_profiles/Rakefile
@@ -6,12 +6,14 @@ end
 
 require 'rdoc/task'
 
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'TransportProfiles'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+if !Rails.env.production?
+  RDoc::Task.new(:rdoc) do |rdoc|
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.title    = 'TransportProfiles'
+    rdoc.options << '--line-numbers'
+    rdoc.rdoc_files.include('README.rdoc')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
 end
 
 

--- a/components/ui_helpers/Rakefile
+++ b/components/ui_helpers/Rakefile
@@ -8,12 +8,14 @@ end
 
 require 'rdoc/task'
 
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'UIHelpers'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.rdoc')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+if !Rails.env.production?
+  RDoc::Task.new(:rdoc) do |rdoc|
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.title    = 'UIHelpers'
+    rdoc.options << '--line-numbers'
+    rdoc.rdoc_files.include('README.rdoc')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
 end
 
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes
- [x] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development 185641494](https://www.pivotaltracker.com/story/show/185641494)

# A brief description of the changes

Current behavior: There are some gems that are not needed in the Production group in Gemfile

New behavior: Moves all the gems that are not needed in the Production group to the Development Test groups

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.