### PR TITLE
create new sep eligibility rule

### DIFF
--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -1707,7 +1707,7 @@ class HbxEnrollment
         end
       when 'individual'
         if qle && family.is_under_special_enrollment_period?
-          family.current_sep.effective_on
+          family.current_sep.calculate_effective_date(TimeKeeper.date_of_record)
         else
           benefit_sponsorship.current_benefit_period.earliest_effective_date
         end

--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -116,12 +116,14 @@ class SpecialEnrollmentPeriod
   end
 
   def qualifying_life_event_kind=(new_qualifying_life_event_kind)
+    puts '119'
     raise ArgumentError.new("expected QualifyingLifeEventKind") unless new_qualifying_life_event_kind.is_a?(QualifyingLifeEventKind)
     unless new_qualifying_life_event_kind.active?
       raise StandardError, "Qualifying life event kind is expired" if (self.created_at.present? && (new_qualifying_life_event_kind.start_on..new_qualifying_life_event_kind.end_on).exclude?(self.created_at.to_date)) || self.created_at.blank?
     end
     self.qualifying_life_event_kind_id = new_qualifying_life_event_kind._id
     self.title = new_qualifying_life_event_kind.title
+    puts "125"
     @qualifying_life_event_kind = new_qualifying_life_event_kind
     set_sep_dates
     @qualifying_life_event_kind
@@ -138,6 +140,16 @@ class SpecialEnrollmentPeriod
     write_attribute(:qle_on, new_qle_date)
     set_sep_dates
     qle_on
+  end
+
+  def calculate_effective_on(enrollment_created_date)
+    puts "1466666666"
+    return self.effective_on
+    puts "147 #{enrollment_created_date}"
+    puts "131 #{effective_on.to_date}"
+    sep_effective_on = [effective_on.to_date, enrollment_created_date.to_date].max
+    self.update_attributes!(effective_on: sep_effective_on.end_of_month + 1.day)
+    effective_on
   end
 
   def effective_on_kind=(new_effective_on_kind)
@@ -276,6 +288,7 @@ private
   end
 
   def set_effective_on
+    puts "280"
     return unless self.start_on.present? && self.qualifying_life_event_kind.present?
     self.effective_on = case effective_on_kind
                         when "date_of_event"
@@ -298,6 +311,9 @@ private
                           first_of_reporting_month_effective_date
                         when "first_of_next_month_reporting"
                           first_of_next_month_reporting_effective_date
+                        when "first_of_the_month_plan_shopping"
+                          puts "315"
+                          first_of_this_month_plan_shopping
                         end
   end
 
@@ -323,6 +339,10 @@ private
   end
 
   def first_of_next_month_plan_selection_effective_date
+    earliest_effective_date.end_of_month + 1.day
+  end
+
+  def first_of_this_month_plan_shopping
     earliest_effective_date.end_of_month + 1.day
   end
 

--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -144,7 +144,7 @@ class SpecialEnrollmentPeriod
     self.update_attributes!(effective_on: enrollment_created_date.end_of_month + 1.day) if (enrollment_created_date > effective_on) && (effective_on_kind == 'first_of_the_month_plan_shopping')
     effective_on
   end
- 
+
   def effective_on_kind=(new_effective_on_kind)
     write_attribute(:effective_on_kind, new_effective_on_kind)
     set_sep_dates

--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -304,8 +304,7 @@ private
                         when "first_of_next_month_reporting"
                           first_of_next_month_reporting_effective_date
                         when "first_of_the_month_plan_shopping"
-                          puts "315"
-                          first_of_this_month_plan_shopping
+                          first_of_the_month_plan_shopping_effective_date
                         end
   end
 
@@ -334,7 +333,7 @@ private
     earliest_effective_date.end_of_month + 1.day
   end
 
-  def first_of_this_month_plan_shopping
+  def first_of_the_month_plan_shopping_effective_date
     earliest_effective_date.end_of_month + 1.day
   end
 

--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -141,7 +141,10 @@ class SpecialEnrollmentPeriod
   end
 
   def calculate_effective_date(enrollment_created_date)
-    self.update_attributes!(effective_on: enrollment_created_date.end_of_month + 1.day) if (enrollment_created_date >= effective_on) && (effective_on_kind == 'first_of_the_month_plan_shopping')
+    if (enrollment_created_date >= effective_on) && (effective_on_kind == 'first_of_the_month_plan_shopping')
+      new_effective_on = enrollment_created_date.end_of_month + 1.day
+      self.update_attributes!(effective_on: new_effective_on, next_poss_effective_date: new_effective_on)
+    end
     effective_on
   end
 

--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -144,7 +144,7 @@ class SpecialEnrollmentPeriod
     self.update_attributes!(effective_on: enrollment_created_date.end_of_month + 1.day) if (enrollment_created_date > self.effective_on) && (effective_on_kind == 'first_of_the_month_plan_shopping')
     self.effective_on
   end
-
+ 
   def effective_on_kind=(new_effective_on_kind)
     write_attribute(:effective_on_kind, new_effective_on_kind)
     set_sep_dates
@@ -281,7 +281,6 @@ private
   end
 
   def set_effective_on
-    puts "280"
     return unless self.start_on.present? && self.qualifying_life_event_kind.present?
     self.effective_on = case effective_on_kind
                         when "date_of_event"

--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -116,14 +116,12 @@ class SpecialEnrollmentPeriod
   end
 
   def qualifying_life_event_kind=(new_qualifying_life_event_kind)
-    puts '119'
     raise ArgumentError.new("expected QualifyingLifeEventKind") unless new_qualifying_life_event_kind.is_a?(QualifyingLifeEventKind)
     unless new_qualifying_life_event_kind.active?
       raise StandardError, "Qualifying life event kind is expired" if (self.created_at.present? && (new_qualifying_life_event_kind.start_on..new_qualifying_life_event_kind.end_on).exclude?(self.created_at.to_date)) || self.created_at.blank?
     end
     self.qualifying_life_event_kind_id = new_qualifying_life_event_kind._id
     self.title = new_qualifying_life_event_kind.title
-    puts "125"
     @qualifying_life_event_kind = new_qualifying_life_event_kind
     set_sep_dates
     @qualifying_life_event_kind
@@ -142,14 +140,9 @@ class SpecialEnrollmentPeriod
     qle_on
   end
 
-  def calculate_effective_on(enrollment_created_date)
-    puts "1466666666"
-    return self.effective_on
-    puts "147 #{enrollment_created_date}"
-    puts "131 #{effective_on.to_date}"
-    sep_effective_on = [effective_on.to_date, enrollment_created_date.to_date].max
-    self.update_attributes!(effective_on: sep_effective_on.end_of_month + 1.day)
-    effective_on
+  def calculate_effective_date(enrollment_created_date)
+    self.update_attributes!(effective_on: enrollment_created_date.end_of_month + 1.day) if (enrollment_created_date > self.effective_on) && (effective_on_kind == 'first_of_the_month_plan_shopping')
+    self.effective_on
   end
 
   def effective_on_kind=(new_effective_on_kind)

--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -141,8 +141,8 @@ class SpecialEnrollmentPeriod
   end
 
   def calculate_effective_date(enrollment_created_date)
-    self.update_attributes!(effective_on: enrollment_created_date.end_of_month + 1.day) if (enrollment_created_date > self.effective_on) && (effective_on_kind == 'first_of_the_month_plan_shopping')
-    self.effective_on
+    self.update_attributes!(effective_on: enrollment_created_date.end_of_month + 1.day) if (enrollment_created_date > effective_on) && (effective_on_kind == 'first_of_the_month_plan_shopping')
+    effective_on
   end
  
   def effective_on_kind=(new_effective_on_kind)

--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -141,7 +141,7 @@ class SpecialEnrollmentPeriod
   end
 
   def calculate_effective_date(enrollment_created_date)
-    self.update_attributes!(effective_on: enrollment_created_date.end_of_month + 1.day) if (enrollment_created_date > effective_on) && (effective_on_kind == 'first_of_the_month_plan_shopping')
+    self.update_attributes!(effective_on: enrollment_created_date.end_of_month + 1.day) if (enrollment_created_date >= effective_on) && (effective_on_kind == 'first_of_the_month_plan_shopping')
     effective_on
   end
 

--- a/config/client_config/me/system/config/templates/features/enroll_app/sep_types.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/sep_types.yml
@@ -130,7 +130,8 @@ registry:
               {first_of_next_month_reporting: First of Month after Reporting},
               {first_of_month: 15th of the Month},
               {first_of_next_month_coinciding: First of Next Month (Coinciding)},
-              {first_of_next_month_plan_selection: First of Next Month (Plan Selection)}]
+              {first_of_next_month_plan_selection: First of Next Month (Plan Selection)},
+              {first_of_the_month_plan_shopping: First of the Month (Plan Shopping)}]
               content_type: :checkbox_select
               default: ''
               description: ''

--- a/spec/models/special_enrollment_period_spec.rb
+++ b/spec/models/special_enrollment_period_spec.rb
@@ -1310,6 +1310,106 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
       end
     end
 
+      describe "#calculate_effective_on" do
+        after :all do
+          TimeKeeper.set_date_of_record_unprotected!(Date.today)
+        end
+     
+        context "with effective_on_kind first_of_the_month_plan_shopping" do
+          let(:sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: 'first_of_the_month_plan_shopping') }
+    
+          context 'when plan shopping date is after the SEP effective on date' do
+            let(:plan_shopping_date) { TimeKeeper.date_of_record + 1.month }
+
+            before do
+              sep.save!
+            end
+
+            it "updates the SEP effective on date to the first of the month after the plan shopping date" do
+              expect(sep.calculate_effective_on(plan_shopping_date)).to eq (plan_shopping_date + 1.month).beginning_of_month
+            end
+          end
+
+          context 'when plan shopping date is before the SEP effective date' do
+            let(:plan_shopping_date) { TimeKeeper.date_of_record }
+
+            before do
+              sep.save!
+            end
+
+            it "returns the SEP effective on date" do
+              expect(sep.calculate_effective_on(plan_shopping_date)).to eq (sep.effective_on)
+            end
+          end
+
+          context 'when plan shopping date is the same as the SEP effective date' do
+            let(:plan_shopping_date) { sep.effective_on }
+
+            before do
+              sep.save!
+            end
+
+            it "returns the SEP effective on date" do
+              expect(sep.calculate_effective_on(plan_shopping_date)).to eq (sep.effective_on)
+            end
+          end
+        end
+
+        context "with effective_on_kind not first_of_the_month_plan_shopping" do
+          let(:sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: 'date_of_event') }
+
+          it "should return the SEP effective on date" do
+            expect(sep.calculate_effective_on(TimeKeeper.date_of_record)).to eq (sep.effective_on)
+          end
+
+        end
+      end
+
+    context 'when first_of_the_month_plan_shopping is selected' do
+      after :all do
+        TimeKeeper.set_date_of_record_unprotected!(Date.today)
+      end
+      let(:effective_on_kind) { 'first_of_the_month_plan_shopping' }
+      let(:new_sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: effective_on_kind) }
+
+      let!(:qle) { create(:qualifying_life_event_kind, market_kind: "individual") }
+
+        context 'qle_on is before the submitted at date' do
+          let(:qle_on) { TimeKeeper.date_of_record.beginning_of_month }
+          let(:submitted_at) { TimeKeeper.date_of_record }
+          before do
+            new_sep.update_attributes!(qle_on: qle_on)
+          end
+
+          it 'sets effective date as the beginning of next month after the submitted date' do
+            expect(new_sep.effective_on).to eq submitted_at.end_of_month + 1.day
+          end
+        end
+
+        context 'qle_on after submitted_at date' do
+          let(:qle_on) { TimeKeeper.date_of_record + 1.month }
+          let(:submitted_at) { TimeKeeper.date_of_record}
+          before do
+            new_sep.update_attributes!(qle_on: qle_on)
+          end
+
+          it 'sets effective date as the beginning of next month after the submitted date' do
+            expect(new_sep.effective_on).to eq qle_on.end_of_month + 1.day
+          end
+        end
+
+        context 'qle_on is the same day as the submitted_at date' do
+          let(:qle_on) { TimeKeeper.date_of_record }
+          let(:submitted_at) { TimeKeeper.date_of_record}
+          before do
+          end
+
+          it 'sets effective date as the beginning of next month after the submitted date' do
+            expect(new_sep.effective_on).to eq submitted_at.end_of_month + 1.day
+          end
+        end
+      end
+
     context 'when first_of_next_month_plan_selection is selected' do
       after :all do
         TimeKeeper.set_date_of_record_unprotected!(Date.today)

--- a/spec/models/special_enrollment_period_spec.rb
+++ b/spec/models/special_enrollment_period_spec.rb
@@ -1349,8 +1349,8 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
             sep.save!
           end
 
-          it "returns the SEP effective on date" do
-            expect(sep.calculate_effective_date(plan_shopping_date)).to eq(sep.effective_on)
+          it "returns first of the month after the plan shopping date" do
+            expect(sep.calculate_effective_date(plan_shopping_date)).to eq(plan_shopping_date + 1.month)
           end
         end
       end

--- a/spec/models/special_enrollment_period_spec.rb
+++ b/spec/models/special_enrollment_period_spec.rb
@@ -1310,60 +1310,60 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
       end
     end
 
-      describe "#calculate_effective_on" do
-        after :all do
-          TimeKeeper.set_date_of_record_unprotected!(Date.today)
-        end
-     
-        context "with effective_on_kind first_of_the_month_plan_shopping" do
-          let(:sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: 'first_of_the_month_plan_shopping') }
-    
-          context 'when plan shopping date is after the SEP effective on date' do
-            let(:plan_shopping_date) { TimeKeeper.date_of_record + 1.month }
+    describe "#calculate_effective_on" do
+      after :all do
+        TimeKeeper.set_date_of_record_unprotected!(Date.today)
+      end
 
-            before do
-              sep.save!
-            end
+      context "with effective_on_kind first_of_the_month_plan_shopping" do
+        let(:sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: 'first_of_the_month_plan_shopping') }
 
-            it "updates the SEP effective on date to the first of the month after the plan shopping date" do
-              expect(sep.calculate_effective_on(plan_shopping_date)).to eq (plan_shopping_date + 1.month).beginning_of_month
-            end
+        context 'when plan shopping date is after the SEP effective on date' do
+          let(:plan_shopping_date) { TimeKeeper.date_of_record + 1.month }
+
+          before do
+            sep.save!
           end
 
-          context 'when plan shopping date is before the SEP effective date' do
-            let(:plan_shopping_date) { TimeKeeper.date_of_record }
-
-            before do
-              sep.save!
-            end
-
-            it "returns the SEP effective on date" do
-              expect(sep.calculate_effective_on(plan_shopping_date)).to eq (sep.effective_on)
-            end
-          end
-
-          context 'when plan shopping date is the same as the SEP effective date' do
-            let(:plan_shopping_date) { sep.effective_on }
-
-            before do
-              sep.save!
-            end
-
-            it "returns the SEP effective on date" do
-              expect(sep.calculate_effective_on(plan_shopping_date)).to eq (sep.effective_on)
-            end
+          it "updates the SEP effective on date to the first of the month after the plan shopping date" do
+            expect(sep.calculate_effective_on(plan_shopping_date)).to eq (plan_shopping_date + 1.month).beginning_of_month
           end
         end
 
-        context "with effective_on_kind not first_of_the_month_plan_shopping" do
-          let(:sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: 'date_of_event') }
+        context 'when plan shopping date is before the SEP effective date' do
+          let(:plan_shopping_date) { TimeKeeper.date_of_record }
 
-          it "should return the SEP effective on date" do
-            expect(sep.calculate_effective_on(TimeKeeper.date_of_record)).to eq (sep.effective_on)
+          before do
+            sep.save!
           end
 
+          it "returns the SEP effective on date" do
+            expect(sep.calculate_effective_on(plan_shopping_date)).to eq(sep.effective_on)
+          end
+        end
+
+        context 'when plan shopping date is the same as the SEP effective date' do
+          let(:plan_shopping_date) { sep.effective_on }
+
+          before do
+            sep.save!
+          end
+
+          it "returns the SEP effective on date" do
+            expect(sep.calculate_effective_on(plan_shopping_date)).to eq(sep.effective_on)
+          end
         end
       end
+
+      context "with effective_on_kind not first_of_the_month_plan_shopping" do
+        let(:sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: 'date_of_event') }
+
+        it "should return the SEP effective on date" do
+          expect(sep.calculate_effective_on(TimeKeeper.date_of_record)).to eq(sep.effective_on)
+        end
+
+      end
+    end
 
     context 'when first_of_the_month_plan_shopping is selected' do
       after :all do
@@ -1374,41 +1374,39 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
 
       let!(:qle) { create(:qualifying_life_event_kind, market_kind: "individual") }
 
-        context 'qle_on is before the submitted at date' do
-          let(:qle_on) { TimeKeeper.date_of_record.beginning_of_month }
-          let(:submitted_at) { TimeKeeper.date_of_record }
-          before do
-            new_sep.update_attributes!(qle_on: qle_on)
-          end
-
-          it 'sets effective date as the beginning of next month after the submitted date' do
-            expect(new_sep.effective_on).to eq submitted_at.end_of_month + 1.day
-          end
+      context 'qle_on is before the submitted at date' do
+        let(:qle_on) { TimeKeeper.date_of_record.beginning_of_month }
+        let(:submitted_at) { TimeKeeper.date_of_record }
+        before do
+          new_sep.update_attributes!(qle_on: qle_on)
         end
 
-        context 'qle_on after submitted_at date' do
-          let(:qle_on) { TimeKeeper.date_of_record + 1.month }
-          let(:submitted_at) { TimeKeeper.date_of_record}
-          before do
-            new_sep.update_attributes!(qle_on: qle_on)
-          end
-
-          it 'sets effective date as the beginning of next month after the submitted date' do
-            expect(new_sep.effective_on).to eq qle_on.end_of_month + 1.day
-          end
-        end
-
-        context 'qle_on is the same day as the submitted_at date' do
-          let(:qle_on) { TimeKeeper.date_of_record }
-          let(:submitted_at) { TimeKeeper.date_of_record}
-          before do
-          end
-
-          it 'sets effective date as the beginning of next month after the submitted date' do
-            expect(new_sep.effective_on).to eq submitted_at.end_of_month + 1.day
-          end
+        it 'sets effective date as the beginning of next month after the submitted date' do
+          expect(new_sep.effective_on).to eq submitted_at.end_of_month + 1.day
         end
       end
+
+      context 'qle_on after submitted_at date' do
+        let(:qle_on) { TimeKeeper.date_of_record + 1.month }
+        let(:submitted_at) { TimeKeeper.date_of_record}
+        before do
+          new_sep.update_attributes!(qle_on: qle_on)
+        end
+
+        it 'sets effective date as the beginning of next month after the submitted date' do
+          expect(new_sep.effective_on).to eq qle_on.end_of_month + 1.day
+        end
+      end
+
+      context 'qle_on is the same day as the submitted_at date' do
+        let(:qle_on) { TimeKeeper.date_of_record }
+        let(:submitted_at) { TimeKeeper.date_of_record}
+
+        it 'sets effective date as the beginning of next month after the submitted date' do
+          expect(new_sep.effective_on).to eq submitted_at.end_of_month + 1.day
+        end
+      end
+    end
 
     context 'when first_of_next_month_plan_selection is selected' do
       after :all do

--- a/spec/models/special_enrollment_period_spec.rb
+++ b/spec/models/special_enrollment_period_spec.rb
@@ -1310,7 +1310,7 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
       end
     end
 
-    describe "#calculate_effective_on" do
+    describe "#calculate_effective_date" do
       after :all do
         TimeKeeper.set_date_of_record_unprotected!(Date.today)
       end
@@ -1326,7 +1326,7 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
           end
 
           it "updates the SEP effective on date to the first of the month after the plan shopping date" do
-            expect(sep.calculate_effective_on(plan_shopping_date)).to eq (plan_shopping_date + 1.month).beginning_of_month
+            expect(sep.calculate_effective_date(plan_shopping_date)).to eq (plan_shopping_date + 1.month).beginning_of_month
           end
         end
 
@@ -1338,7 +1338,7 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
           end
 
           it "returns the SEP effective on date" do
-            expect(sep.calculate_effective_on(plan_shopping_date)).to eq(sep.effective_on)
+            expect(sep.calculate_effective_date(plan_shopping_date)).to eq(sep.effective_on)
           end
         end
 
@@ -1350,7 +1350,7 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
           end
 
           it "returns the SEP effective on date" do
-            expect(sep.calculate_effective_on(plan_shopping_date)).to eq(sep.effective_on)
+            expect(sep.calculate_effective_date(plan_shopping_date)).to eq(sep.effective_on)
           end
         end
       end
@@ -1359,7 +1359,7 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
         let(:sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: 'date_of_event') }
 
         it "should return the SEP effective on date" do
-          expect(sep.calculate_effective_on(TimeKeeper.date_of_record)).to eq(sep.effective_on)
+          expect(sep.calculate_effective_date(TimeKeeper.date_of_record)).to eq(sep.effective_on)
         end
 
       end

--- a/spec/models/special_enrollment_period_spec.rb
+++ b/spec/models/special_enrollment_period_spec.rb
@@ -1328,6 +1328,11 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
           it "updates the SEP effective on date to the first of the month after the plan shopping date" do
             expect(sep.calculate_effective_date(plan_shopping_date)).to eq (plan_shopping_date + 1.month).beginning_of_month
           end
+
+          it "updates the SEP next possible effective date" do
+            sep.calculate_effective_date(plan_shopping_date)
+            expect(sep.next_poss_effective_date).to eq (plan_shopping_date + 1.month).beginning_of_month
+          end
         end
 
         context 'when plan shopping date is before the SEP effective date' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-185649245](https://www.pivotaltracker.com/n/projects/2640060/stories/185649245)

# A brief description of the changes

Current behavior: There is not a SEP eligibility rule in place that takes into account the date that a family shops for plans.

New behavior: This PR creates a new eligibility rule that updates the SEP and Enrollment effective date to be the first of the month after plan shopping if the plan shopping date is greater than the original SEP effective date.

# Feature Flag. The eligibility rule first_of_the_month_plan_shopping is only added to ME context. Shouldn't have impact in DC market.

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.