### PR TITLE
OSSE eligibility set to 1/1 behind a future flag

### DIFF
--- a/app/domain/operations/eligibilities/osse/build_eligibility.rb
+++ b/app/domain/operations/eligibilities/osse/build_eligibility.rb
@@ -33,9 +33,8 @@ module Operations
           errors << 'evidence value missing' unless params[:evidence_value]
           errors << 'effective date missing' unless params[:effective_date]
 
-          if params[:effective_date]
+          if params[:effective_date] && EnrollRegistry.feature_enabled?("aca_ivl_osse_effective_beginning_of_year")
             subject = GlobalID::Locator.locate(params[:subject_gid])
-
             params[:effective_date] = params[:effective_date].beginning_of_year if ['ConsumerRole', 'ResidentRole'].include?(subject.class.to_s)
           end
 

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/contributions.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/contributions.yml
@@ -15,6 +15,9 @@ registry:
         - key: :individual_osse_plan_filter
           item: :individual_osse_plan_filter
           is_enabled: <%= ENV['ACA_INDIVIDUAL_OSSE_PLAN_FILTERING_IS_ENABLED'] || false %>
+        - key: :aca_ivl_osse_effective_beginning_of_year
+          item: :aca_ivl_osse_effective_beginning_of_year
+          is_enabled: <%= ENV['ACA_IVL_OSSE_EFFECTIVE_BEGINNING_OF_YEAR_IS_ENABLED'] || false %>
   - namespace:
     - :enroll_app
     - :aca_individual_market

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/contributions.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/contributions.yml
@@ -15,6 +15,9 @@ registry:
         - key: :individual_osse_plan_filter
           item: :individual_osse_plan_filter
           is_enabled: <%= ENV['ACA_INDIVIDUAL_OSSE_PLAN_FILTERING_IS_ENABLED'] || false %>
+        - key: :aca_ivl_osse_effective_beginning_of_year
+          item: :aca_ivl_osse_effective_beginning_of_year
+          is_enabled: <%= ENV['ACA_IVL_OSSE_EFFECTIVE_BEGINNING_OF_YEAR_IS_ENABLED'] || false %>
   - namespace:
     - :enroll_app
     - :aca_individual_market

--- a/spec/domain/operations/eligibilities/osse/build_eligibility_spec.rb
+++ b/spec/domain/operations/eligibilities/osse/build_eligibility_spec.rb
@@ -5,9 +5,7 @@ require "#{BenefitSponsors::Engine.root}/spec/support/benefit_sponsors_site_spec
 require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_market.rb"
 require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_application.rb"
 
-RSpec.describe ::Operations::Eligibilities::Osse::BuildEligibility,
-               type: :model,
-               dbclean: :after_each do
+RSpec.describe ::Operations::Eligibilities::Osse::BuildEligibility, type: :model, dbclean: :after_each do
 
   let(:site) { ::BenefitSponsors::SiteSpecHelpers.create_site_with_hbx_profile_and_benefit_market }
   let(:benefit_market)  { site.benefit_markets.first }
@@ -75,6 +73,45 @@ RSpec.describe ::Operations::Eligibilities::Osse::BuildEligibility,
       it 'should create eligibility' do
         result = subject.call(required_params)
         expect(result.success).to be_a(AcaEntities::Eligibilities::Osse::Eligibility)
+      end
+    end
+
+    context 'when subject is consumer role' do
+      let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_family) }
+      let(:family) { person.primary_family }
+      let(:consumer_role) { person.consumer_role }
+      let(:subject_ref) { consumer_role.to_global_id }
+
+      it 'should be success' do
+        result = subject.call(required_params)
+        expect(result.success?).to be_truthy
+      end
+
+      it 'should create eligibility' do
+        result = subject.call(required_params)
+        expect(result.success).to be_a(AcaEntities::Eligibilities::Osse::Eligibility)
+      end
+
+      context 'when aca_ivl_osse_effective_beginning_of_year got enabled' do
+        before do
+          EnrollRegistry[:aca_ivl_osse_effective_beginning_of_year].feature.stub(:is_enabled).and_return(true)
+        end
+
+        it "should return eligibility start date as beginning of year" do
+          result = subject.call(required_params)
+          expect(result.success.start_on).to eq effective_date.beginning_of_year
+        end
+      end
+
+      context 'when aca_ivl_osse_effective_beginning_of_year got disabled' do
+        before do
+          EnrollRegistry[:aca_ivl_osse_effective_beginning_of_year].feature.stub(:is_enabled).and_return(false)
+        end
+
+        it "should return eligibility start date as effective_date" do
+          result = subject.call(required_params)
+          expect(result.success.start_on).to eq effective_date
+        end
       end
     end
   end

--- a/system/config/templates/features/aca_individual_market/contributions.yml
+++ b/system/config/templates/features/aca_individual_market/contributions.yml
@@ -15,6 +15,9 @@ registry:
         - key: :individual_osse_plan_filter
           item: :individual_osse_plan_filter
           is_enabled: <%= ENV['ACA_INDIVIDUAL_OSSE_PLAN_FILTERING_IS_ENABLED'] || false %>
+        - key: :aca_ivl_osse_effective_beginning_of_year
+          item: :aca_ivl_osse_effective_beginning_of_year
+          is_enabled: <%= ENV['ACA_IVL_OSSE_EFFECTIVE_BEGINNING_OF_YEAR_IS_ENABLED'] || false %>
   - namespace:
     - :enroll_app
     - :aca_individual_market


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
 https://www.pivotaltracker.com/n/projects/2640061/stories/185669020
# A brief description of the changes

Current behavior:
osse eligibility effective dates to 1/1 on creation is not behind the feature flag

New behavior:
osse eligibility effective dates to 1/1 on creation is behind the feature flag

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: 
`ACA_IVL_OSSE_EFFECTIVE_BEGINNING_OF_YEAR_IS_ENABLED`

- [x] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.