### PR TITLE
fix webdriver unable to find chrome version

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -74,6 +74,7 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 # Capybara::Screenshot.webkit_options = { width: 2280, height: 1800 }
 # Capybara::Screenshot.prune_strategy = :keep_last_run
 Webdrivers.cache_time = 86_400
+Webdrivers::Chromedriver.required_version = "114.0.5735.90"
 
 # Selenium::WebDriver::Chrome.path = '/opt/homebrew-cask/Caskroom/google-chrome/latest/Google Chrome.app/Contents/MacOS/Google Chrome'
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: N/A

# A brief description of the changes

Current behavior:

New behavior: Cucumbers are failing because they are unable to find the correct Chrome verison. 

Reference used:
https://github.com/titusfortner/webdrivers/issues/247

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.