### PR TITLE
remove link info text for enrollment tile generic redirect

### DIFF
--- a/app/views/shared/_pay_now_modal.html.erb
+++ b/app/views/shared/_pay_now_modal.html.erb
@@ -2,12 +2,12 @@
 <% carrier_long_name = carrier_long_name(carrier) %>
 
 <%# using show_pay_now? method makes sure pay now is enabled and other conditions are met for linking to the pay now portal %>
-<%# <% first_payment = show_pay_now?("Enrollment Tile", hbx_enrollment) && before_effective_date?(hbx_enrollment) %>
 <% first_payment = show_pay_now?(source, hbx_enrollment) && before_effective_date?(hbx_enrollment) %>
 <% plan_shopping = carrier_paynow_enabled?(carrier) && source == "Plan Shopping" %>
 <%# use PayNow url if user is making first payment, otherwise use generic carrier url %>
-<%# note: Plan Shopping flow is checked explicitly because it always indicates a first payment, even when effective date is in the past (for example, when enrolling via SEP) %>
 <% url = first_payment || plan_shopping ? pay_now_url(carrier) : carrier_url(carrier) %>
+<%# note: Plan Shopping flow is checked explicitly because it always indicates a first payment,
+    even when effective date is in the past (for example, when enrolling via SEP) %>
 
 <% carrier_key = carrier_paynow_enabled?(carrier) ? fetch_carrier_key_from_legal_name(carrier) : "other" %>
 <div class="modal fade" tabindex="-1" role="dialog" id="payNowModal<%= hbx_enrollment.hbx_id %>">

--- a/app/views/shared/_pay_now_modal.html.erb
+++ b/app/views/shared/_pay_now_modal.html.erb
@@ -1,15 +1,15 @@
 <% carrier = hbx_enrollment.product.carrier_profile.legal_name %>
 <% carrier_long_name = carrier_long_name(carrier) %>
 
-<%# note: using show_pay_now? method makes sure enrollment_tile setting is enabled and other conditions are met for linking to the pay now portal %>
-<% first_payment = carrier_paynow_enabled?(carrier) && before_effective_date?(hbx_enrollment) && show_pay_now?("Enrollment Tile", hbx_enrollment) %>
-<% plan_shopping = carrier_paynow_enabled?(carrier) && source == "Plan Shopping"  %>
-<%# use PayNow url if user is making first payment from enrollment tile or is in plan shopping flow, %>
-<%# otherwise use generic carrier url %>
+<%# using show_pay_now? method makes sure pay now is enabled and other conditions are met for linking to the pay now portal %>
+<%# <% first_payment = show_pay_now?("Enrollment Tile", hbx_enrollment) && before_effective_date?(hbx_enrollment) %>
+<% first_payment = show_pay_now?(source, hbx_enrollment) && before_effective_date?(hbx_enrollment) %>
+<% plan_shopping = carrier_paynow_enabled?(carrier) && source == "Plan Shopping" %>
+<%# use PayNow url if user is making first payment, otherwise use generic carrier url %>
+<%# note: Plan Shopping flow is checked explicitly because it always indicates a first payment, even when effective date is in the past (for example, when enrolling via SEP) %>
 <% url = first_payment || plan_shopping ? pay_now_url(carrier) : carrier_url(carrier) %>
 
 <% carrier_key = carrier_paynow_enabled?(carrier) ? fetch_carrier_key_from_legal_name(carrier) : "other" %>
-<% translation_key = is_kaiser_translation_key?(carrier_key) %>
 <div class="modal fade" tabindex="-1" role="dialog" id="payNowModal<%= hbx_enrollment.hbx_id %>">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -22,7 +22,7 @@
         <p>
           <%= l10n("plans.issuer.pay_now.redirection_message", site_short_name: EnrollRegistry[:enroll_app].setting(:short_name).item, carrier_name: carrier_long_name) %><br/>
           <ul>
-            <% if before_effective_date?(hbx_enrollment) && carrier_key != 'other' %>
+            <% if first_payment %>
               <li><%= l10n("plans.issuer.pay_now.link_info")%></li>
             <% end %>
             <% if !before_effective_date?(hbx_enrollment) %>

--- a/app/views/shared/_pay_now_modal.html.erb
+++ b/app/views/shared/_pay_now_modal.html.erb
@@ -9,7 +9,6 @@
 <%# note: Plan Shopping flow is checked explicitly because it always indicates a first payment,
     even when effective date is in the past (for example, when enrolling via SEP) %>
 
-<% carrier_key = carrier_paynow_enabled?(carrier) ? fetch_carrier_key_from_legal_name(carrier) : "other" %>
 <div class="modal fade" tabindex="-1" role="dialog" id="payNowModal<%= hbx_enrollment.hbx_id %>">
   <div class="modal-dialog" role="document">
     <div class="modal-content">

--- a/spec/views/shared/_pay_now_modal.html.erb_spec.rb
+++ b/spec/views/shared/_pay_now_modal.html.erb_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe "shared/_pay_now_modal.html.erb", dbclean: :after_each do
+  include Insured::PlanShopping::PayNowHelper
 
   after :all do
     DatabaseCleaner.clean
@@ -11,11 +12,17 @@ describe "shared/_pay_now_modal.html.erb", dbclean: :after_each do
 
   let(:family) { FactoryBot.create(:family, :with_primary_family_member)}
   let(:hbx_enrollment) do
-    FactoryBot.create(:hbx_enrollment,
-                      product: health_product,
-                      enrollment_members: family.family_members,
-                      household: family.active_household,
-                      family: family)
+    enrollment = FactoryBot.create(:hbx_enrollment,
+                                   product: health_product,
+                                   enrollment_members: family.family_members,
+                                   household: family.active_household,
+                                   family: family)
+    enrollment.workflow_state_transitions << WorkflowStateTransition.new(
+      from_state: :shopping,
+      to_state: :coverage_selected,
+      event: :select_coverage
+    )
+    enrollment
   end
   let(:health_product) { FactoryBot.create(:benefit_markets_products_health_products_health_product, :with_issuer_profile_kaiser) }
   let(:generic_redirect_double) { double }
@@ -23,10 +30,9 @@ describe "shared/_pay_now_modal.html.erb", dbclean: :after_each do
   let(:kaiser_permanente_pay_now_double) { double }
   let(:enrollment_tile_setting_double) { double }
   let(:plan_shopping_setting_double) { double }
-  let(:generic_redirect_url) do
-    carrier_legal_name = hbx_enrollment.product.issuer_profile.legal_name
-    Insured::PlanShopping::PayNowHelper::LINK_URL[carrier_legal_name.to_s]
-  end
+  let(:pay_now_portal_url) { pay_now_url(carrier_legal_name) }
+  let(:generic_redirect_url) { Insured::PlanShopping::PayNowHelper::LINK_URL[carrier_legal_name.to_s] }
+  let(:carrier_legal_name) { hbx_enrollment.product.issuer_profile.legal_name }
 
   before do
     allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
@@ -35,19 +41,69 @@ describe "shared/_pay_now_modal.html.erb", dbclean: :after_each do
     allow(EnrollRegistry).to receive(:[]).with(:generic_redirect).and_return(generic_redirect_double)
     allow(generic_redirect_double).to receive(:setting).with(:strict_tile_check).and_return(strict_tile_check_double)
     allow(strict_tile_check_double).to receive(:item).and_return(true)
+    allow(kaiser_permanente_pay_now_double).to receive(:setting).with(:plan_shopping).and_return(plan_shopping_setting_double)
+    allow(plan_shopping_setting_double).to receive(:item).and_return(true)
+    allow(EnrollRegistry).to receive(:[]).with(:kaiser_permanente_pay_now).and_return(kaiser_permanente_pay_now_double)
+    allow(kaiser_permanente_pay_now_double).to receive(:setting).with(:enrollment_tile).and_return(enrollment_tile_setting_double)
+    allow(enrollment_tile_setting_double).to receive(:item).and_return(true)
+  end
+
+  context 'when called from the plan shopping flow' do
+    let(:pay_now_partial_options) do
+      { template: "shared/_pay_now_modal.html.erb", locals: {hbx_enrollment: hbx_enrollment, source: 'Plan Shopping'} }
+    end
+
+    context 'and the plan shopping setting is enabled' do
+      it 'should render with a link to the pay now portal' do
+        render pay_now_partial_options
+        expect(rendered).to match(pay_now_portal_url)
+      end
+
+      it 'should render three bullet points' do
+        render pay_now_partial_options
+        expect(rendered.scan(/<li>/).count).to eq(3)
+      end
+
+      context 'and the enrollment effective date is in the past' do
+
+        it 'should not include the link info text' do
+          render pay_now_partial_options
+          expect(rendered).not_to match(l10n("plans.issuer.pay_now.link_info"))
+        end
+
+        it 'should include the processing text' do
+          render pay_now_partial_options
+          expect(rendered).to match(l10n("plans.issuer.pay_now.processing", carrier_name: carrier_legal_name))
+        end
+      end
+
+      context 'and the enrollment effective date is in the future' do
+        before do
+          hbx_enrollment.update(effective_on: Date.today + 1.month)
+
+        end
+
+        it 'should include the link info text' do
+          render pay_now_partial_options
+          expect(rendered).to match(l10n("plans.issuer.pay_now.link_info"))
+        end
+
+        it 'should not include the processing text' do
+          render pay_now_partial_options
+          expect(rendered).not_to match(l10n("plans.issuer.pay_now.processing", carrier_name: carrier_legal_name))
+        end
+      end
+    end
   end
 
   context 'when called from the enrollment tile dropdown' do
-    context 'and the plan shopping setting is enabled' do
-      before do
-        allow(kaiser_permanente_pay_now_double).to receive(:setting).with(:plan_shopping).and_return(plan_shopping_setting_double)
-        allow(plan_shopping_setting_double).to receive(:item).and_return(true)
-      end
+    let(:pay_now_partial_options) do
+      { template: "shared/_pay_now_modal.html.erb", locals: {hbx_enrollment: hbx_enrollment, source: 'Enrollment Tile'} }
+    end
 
+    context 'and the plan shopping setting is enabled' do
       context 'and the enrollment tile setting is disabled' do
         before do
-          allow(EnrollRegistry).to receive(:[]).with(:kaiser_permanente_pay_now).and_return(kaiser_permanente_pay_now_double)
-          allow(kaiser_permanente_pay_now_double).to receive(:setting).with(:enrollment_tile).and_return(enrollment_tile_setting_double)
           allow(enrollment_tile_setting_double).to receive(:item).and_return(false)
         end
 
@@ -62,8 +118,47 @@ describe "shared/_pay_now_modal.html.erb", dbclean: :after_each do
             end
 
             it 'should render with a link to the generic redirect' do
-              render template: "shared/_pay_now_modal.html.erb", locals: {hbx_enrollment: hbx_enrollment, source: 'Enrollment Tile'}
+              render pay_now_partial_options
               expect(rendered).to match(generic_redirect_url)
+            end
+
+            context 'and the enrollment effective date is in the past' do
+
+              it 'should render three bullet points' do
+                render pay_now_partial_options
+                expect(rendered.scan(/<li>/).count).to eq(3)
+              end
+
+              it 'should not include the link info text' do
+                render pay_now_partial_options
+                expect(rendered).not_to match(l10n("plans.issuer.pay_now.link_info"))
+              end
+
+              it 'should include the processing text' do
+                render pay_now_partial_options
+                expect(rendered).to match(l10n("plans.issuer.pay_now.processing", carrier_name: carrier_legal_name))
+              end
+            end
+
+            context 'and the enrollment effective date is in the future' do
+              before do
+                hbx_enrollment.update(effective_on: Date.today + 1.month)
+              end
+
+              it 'should only render two bullet points' do
+                render pay_now_partial_options
+                expect(rendered.scan(/<li>/).count).to eq(2)
+              end
+
+              it 'should not include the link info text' do
+                render pay_now_partial_options
+                expect(rendered).not_to match(l10n("plans.issuer.pay_now.link_info"))
+              end
+
+              it 'should not include the processing text' do
+                render pay_now_partial_options
+                expect(rendered).not_to match(l10n("plans.issuer.pay_now.processing", carrier_name: carrier_legal_name))
+              end
             end
           end
         end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185641807

# A brief description of the changes

Current behavior:
For carriers with these Pay Now settings:
```
Plan Shopping -> Enabled
Enrollment Tile -> Disabled
Generic Redirect -> Enabled (Strict tile check -> False)
```
The PayNow modal renders this text as the first bullet point when enrollment effective date is in the future: 
'This link is provided for your convenience to allow you to pay your first month’s insurance premium. It’s only available to make your first payment.'

New behavior:
The text above is not rendered for the described scenario.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CAREFIRST_PAY_NOW_IS_ENABLED

- [x] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.