### PR TITLE
Disable the Ability for Admins to Reinstate an Employer's Plan Year #2956

### DIFF
--- a/config/client_config/dc/system/config/templates/features/aca_shop_market/aca_shop_market.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_shop_market/aca_shop_market.yml
@@ -13,7 +13,7 @@ registry:
         is_enabled: false
       - key: :benefit_application_reinstate
         item: BenefitSponsors::Operations::BenefitApplications::Reinstate.new
-        is_enabled: true
+        is_enabled: false
         settings:
            - key: :offset_months
              item: 0

--- a/system/config/templates/features/aca_shop_market/aca_shop_market.yml
+++ b/system/config/templates/features/aca_shop_market/aca_shop_market.yml
@@ -13,7 +13,7 @@ registry:
         is_enabled: false
       - key: :benefit_application_reinstate
         item: BenefitSponsors::Operations::BenefitApplications::Reinstate.new
-        is_enabled: true
+        is_enabled: false
         settings:
            - key: :offset_months
              item: 0


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/102419

# A brief description of the changes

Current behavior:
  Currently, admins have the ability to reinstate a plan year that has been terminated.
New behavior:
  Hide the reinstate button so an Admin can not have the ability to reinstate a plan year.
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.