### PR TITLE
rake task to generate cv3 family failures report

### DIFF
--- a/lib/tasks/cv3_family_failures_report.rake
+++ b/lib/tasks/cv3_family_failures_report.rake
@@ -1,0 +1,41 @@
+require 'csv'
+
+namespace :cv3_family_failures_report do
+  desc "Generate an error report from Operations::Transformers::FamilyTo::Cv3Family.new.call(family) on all Families"
+
+  task :generate_csv => :environment do
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    # Define the CSV file path
+    csv_file_path = Rails.root.join("cv3_family_failures_report_#{DateTime.now.strftime("%Y%m%d%H%M%S")}.csv")
+
+    CSV.open(csv_file_path, 'wb') do |csv|
+      # Define the CSV header
+      csv << ['hbx_id', 'result', 'output']
+
+      # Iterate over all Family entries
+      Family.all.each do |family|
+        begin
+          result = Operations::Transformers::FamilyTo::Cv3Family.new.call(family)
+
+          # Check if the method call was successful
+          if result.failure?
+            csv << [family.hbx_assigned_id, 'failure', result.failure]
+          else
+            csv << [family.hbx_assigned_id, 'success', nil]
+          end
+        rescue StandardError => e
+          # Catch any errors raised during the method call
+          csv << [family.hbx_assigned_id, 'failure', e.message]
+        end
+      end
+    end
+
+    puts "Report complete. Output file is located at: #{csv_file_path}"
+    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    seconds_elapsed = end_time - start_time
+    hr_min_sec = format("%02dhr %02dmin %02dsec", seconds_elapsed / 3600, seconds_elapsed / 60 % 60, seconds_elapsed % 60)
+    puts "Total time for report to complete: #{hr_min_sec}"
+  end
+
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185570359

# A brief description of the changes

Current behavior:
No report exists that logs all the CV3 Family transform errors.

New behavior:
Rake task exists that can generate a report of all the CV3 Family transform errors.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

To generate this report you can run `rake cv3_family_failures_report:generate_csv`