### PR TITLE
OSSE eligible consumers should see $0 premiums for all plans

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1009,4 +1009,10 @@ module ApplicationHelper
   def forgot_password_recaptcha_enabled?
     EnrollRegistry.feature_enabled?(:forgot_password_recaptcha)
   end
+
+  def plan_childcare_subsidy_eligible(plan)
+    return true unless EnrollRegistry.feature_enabled?("individual_osse_plan_filter")
+
+    plan.ivl_osse_eligible? && plan.is_hc4cc_plan
+  end
 end

--- a/app/models/unassisted_plan_cost_decorator.rb
+++ b/app/models/unassisted_plan_cost_decorator.rb
@@ -213,7 +213,7 @@ class UnassistedPlanCostDecorator < SimpleDelegator
   def total_childcare_subsidy_amount
     return hbx_enrollment.eligible_child_care_subsidy.to_f if hbx_enrollment.is_reinstated_enrollment?
 
-    if ivl_osse_eligible? && is_hc4cc_plan
+    if ivl_osse_eligible? && (is_hc4cc_plan || !EnrollRegistry.feature_enabled?("individual_osse_plan_filter"))
       total_premium - total_aptc_amount
     else
       0.0

--- a/app/views/insured/plan_shoppings/_plan_details.html.erb
+++ b/app/views/insured/plan_shoppings/_plan_details.html.erb
@@ -1,5 +1,5 @@
 <% plan_carrier = Caches::MongoidCache.lookup(BenefitSponsors::Organizations::Organization.issuer_profiles, plan.issuer_profile_id) { plan.issuer_profile } %>
-<div class="module plan-row panel panel-default" data-plan-id="<%= plan.id %>" data-plan-category="<%= plan.product_type ? plan.product_type.downcase : '' %>" data-plan-metal-level="<%= plan.metal_level.downcase %>" data-plan-metal-network="<%= plan.network&.downcase %>" data-plan-metal-premium="<%= plan.total_employee_cost %>" data-plan-metal-ehb-premium="<%= plan.total_ehb_premium %>" data-plan-childcare-subsidy-eligible="<%= plan.ivl_osse_eligible? && plan.is_hc4cc_plan %>" data-plan-metal-deductible="<%= plan.deductible == 'Not Applicable' ? '$0' : plan.deductible %>" data-plan-name="<%= plan.name %>" data-plan-carrier="<%= plan_carrier.try(:legal_name) %>" data-plan-hsa-eligibility="<%= ivl_hsa_status(@plan_hsa_status, plan) %>" data-plan-osse-eligibility="<%= osse_status(plan) %>" data-plan-ehb="<%= plan.ehb %>" data-can-use-aptc="<%= plan.can_use_aptc? %>">
+<div class="module plan-row panel panel-default" data-plan-id="<%= plan.id %>" data-plan-category="<%= plan.product_type ? plan.product_type.downcase : '' %>" data-plan-metal-level="<%= plan.metal_level.downcase %>" data-plan-metal-network="<%= plan.network&.downcase %>" data-plan-metal-premium="<%= plan.total_employee_cost %>" data-plan-metal-ehb-premium="<%= plan.total_ehb_premium %>" data-plan-childcare-subsidy-eligible="<%= plan_childcare_subsidy_eligible(plan) %>" data-plan-metal-deductible="<%= plan.deductible == 'Not Applicable' ? '$0' : plan.deductible %>" data-plan-name="<%= plan.name %>" data-plan-carrier="<%= plan_carrier.try(:legal_name) %>" data-plan-hsa-eligibility="<%= ivl_hsa_status(@plan_hsa_status, plan) %>" data-plan-osse-eligibility="<%= osse_status(plan) %>" data-plan-ehb="<%= plan.ehb %>" data-can-use-aptc="<%= plan.can_use_aptc? %>">
   <div class="panel-body">
     <div class="row">
       <% if plan.try(:is_standard_plan) %>
@@ -108,6 +108,6 @@
 
 <style type="text/css">
     .fa-bookmark, .fa-check-square-o {
-        color: green;
+      color: green;
     }
 </style>

--- a/features/group_selection/ivl_plan_shopping.feature
+++ b/features/group_selection/ivl_plan_shopping.feature
@@ -126,3 +126,20 @@ Feature: IVL plan purchase
     Then consumer should see all the family members names
     And consumer clicked on shop for new plan
     Then consumer should see hc4cc filter
+
+  Scenario: APTC eligible consumers should seeing OSSE subsidy when OSSE eligible and individual_osse_plan_filter disabled
+    Given plan filter feature is disabled and osse subsidy feature is enabled
+    Given a consumer exists
+    And the consumer is logged in
+    And consumer has a dependent in child relationship with age less than 26
+    And consumer has successful ridp
+    And consumer has osse eligibility
+    Given every individual is eligible for Plan shopping for CSR plans
+    When consumer visits home page
+    And consumer clicked on "Married" qle
+    And I select a past qle date
+    Then I should see confirmation and continue
+    When ivl clicked continue on household info page
+    Then consumer should see all the family members names
+    And consumer clicked on shop for new plan
+    Then consumer should see 0 premiums for all plans

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -1247,3 +1247,17 @@ end
 And(/the extended_aptc_individual_agreement_message configuration is enabled/) do
   enable_feature :extended_aptc_individual_agreement_message
 end
+
+Given(/plan filter feature is disabled and osse subsidy feature is enabled/) do
+  year = TimeKeeper.date_of_record.year
+  EnrollRegistry[:aca_ivl_osse_subsidy].feature.stub(:is_enabled).and_return(true)
+  EnrollRegistry["aca_ivl_osse_subsidy_#{year}"].feature.stub(:is_enabled).and_return(true)
+  EnrollRegistry["aca_ivl_osse_subsidy_#{year - 1}"].feature.stub(:is_enabled).and_return(true)
+  EnrollRegistry[:individual_osse_plan_filter].feature.stub(:is_enabled).and_return(false)
+end
+
+Then(/consumer should see 0 premiums for all plans/) do
+  page.all("h2.plan-premium").each do |premium|
+    expect(premium).to have_content("$0.00")
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/n/projects/2640061/stories/185702674

# A brief description of the changes

Current behavior:
APTC eligible consumers not seeing OSSE subsidy used when *individual_osse_plan_filter* is set to FALSE

New behavior:
OSSE-eligible consumers should see $0 premiums for all plans regardless of their eligibility for APTC, even when individual_osse_plan_filter is set to FALSE.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.