### PR TITLE
add new first of month coinciding SEP rule

### DIFF
--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -141,9 +141,18 @@ class SpecialEnrollmentPeriod
   end
 
   def calculate_effective_date(enrollment_created_date)
+    new_effective_on = enrollment_created_date.end_of_month + 1.day
     if (enrollment_created_date >= effective_on) && (effective_on_kind == 'first_of_the_month_plan_shopping')
       new_effective_on = enrollment_created_date.end_of_month + 1.day
       self.update_attributes!(effective_on: new_effective_on, next_poss_effective_date: new_effective_on)
+    elsif effective_on_kind == 'first_of_the_month_coinciding' 
+      if (enrollment_created_date == effective_on) && !beginning_of_month?
+        self.update_attributes!(effective_on: new_effective_on, next_poss_effective_date: new_effective_on)
+      elsif (enrollment_created_date == effective_on) && qle_on != effective_on
+        self.update_attributes!(effective_on: new_effective_on, next_poss_effective_date: new_effective_on)
+      elsif enrollment_created_date > effective_on
+        self.update_attributes!(effective_on: new_effective_on, next_poss_effective_date: new_effective_on)
+      end
     end
     effective_on
   end
@@ -308,6 +317,8 @@ private
                           first_of_next_month_reporting_effective_date
                         when "first_of_the_month_plan_shopping"
                           first_of_the_month_plan_shopping_effective_date
+                        when "first_of_the_month_coinciding"
+                          first_of_the_month_coinciding_effective_date
                         end
   end
 
@@ -338,6 +349,25 @@ private
 
   def first_of_the_month_plan_shopping_effective_date
     earliest_effective_date.end_of_month + 1.day
+  end
+
+  def first_of_the_month_coinciding_effective_date
+    today = TimeKeeper.date_of_record
+    if qle_on > today
+      if beginning_of_month?
+        qle_on
+      else
+        qle_on.end_of_month.next_day
+      end
+    elsif qle_on == today
+      if beginning_of_month?
+        qle_on
+      else
+        qle_on.end_of_month.next_day
+      end
+    else
+      today.end_of_month.next_day
+    end
   end
 
   def first_of_next_month_coinciding_effective_date

--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -352,6 +352,7 @@ private
 
   def first_of_the_month_coinciding_effective_date
     today = TimeKeeper.date_of_record
+
     if qle_on > today
       if beginning_of_month?
         qle_on

--- a/app/models/special_enrollment_period.rb
+++ b/app/models/special_enrollment_period.rb
@@ -142,14 +142,13 @@ class SpecialEnrollmentPeriod
 
   def calculate_effective_date(enrollment_created_date)
     new_effective_on = enrollment_created_date.end_of_month + 1.day
-    if (enrollment_created_date >= effective_on) && (effective_on_kind == 'first_of_the_month_plan_shopping')
-      new_effective_on = enrollment_created_date.end_of_month + 1.day
-      self.update_attributes!(effective_on: new_effective_on, next_poss_effective_date: new_effective_on)
-    elsif effective_on_kind == 'first_of_the_month_coinciding' 
-      if (enrollment_created_date == effective_on) && !beginning_of_month?
-        self.update_attributes!(effective_on: new_effective_on, next_poss_effective_date: new_effective_on)
-      elsif (enrollment_created_date == effective_on) && qle_on != effective_on
-        self.update_attributes!(effective_on: new_effective_on, next_poss_effective_date: new_effective_on)
+
+    case effective_on_kind
+    when "first_of_the_month_plan_shopping"
+      self.update_attributes!(effective_on: new_effective_on, next_poss_effective_date: new_effective_on) if enrollment_created_date >= effective_on
+    when "first_of_the_month_coinciding"
+      if enrollment_created_date == effective_on
+        self.update_attributes!(effective_on: new_effective_on, next_poss_effective_date: new_effective_on) if qle_on != effective_on
       elsif enrollment_created_date > effective_on
         self.update_attributes!(effective_on: new_effective_on, next_poss_effective_date: new_effective_on)
       end
@@ -363,7 +362,7 @@ private
       if beginning_of_month?
         qle_on
       else
-        qle_on.end_of_month.next_day
+        today.end_of_month.next_day
       end
     else
       today.end_of_month.next_day

--- a/config/client_config/me/system/config/templates/features/enroll_app/sep_types.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/sep_types.yml
@@ -131,7 +131,8 @@ registry:
               {first_of_month: 15th of the Month},
               {first_of_next_month_coinciding: First of Next Month (Coinciding)},
               {first_of_next_month_plan_selection: First of Next Month (Plan Selection)},
-              {first_of_the_month_plan_shopping: First of the Month (Plan Shopping)}]
+              {first_of_the_month_plan_shopping: First of the Month (Plan Shopping)},
+              {first_of_the_month_coinciding: First of the Month (Coinciding)}]
               content_type: :checkbox_select
               default: ''
               description: ''

--- a/spec/models/special_enrollment_period_spec.rb
+++ b/spec/models/special_enrollment_period_spec.rb
@@ -1145,7 +1145,7 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
       context 'qle_on is after the submitted at date, but is not the first of the month' do
         let(:qle_on) { TimeKeeper.date_of_record.end_of_month}
         let(:reporting_date) { TimeKeeper.date_of_record.beginning_of_month }
-  
+
         before do
           new_sep.save!
           TimeKeeper.set_date_of_record_unprotected!(reporting_date)
@@ -1175,17 +1175,17 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
 
       context 'qle_on is the same as the submitted at date' do
         let(:qle_on) { TimeKeeper.date_of_record }
-        
-          it 'should set effective date as the qle_on date' do
-            if qle_on == qle_on.beginning_of_month
-              expect(new_sep.effective_on).to eq(qle_on)
-            else
-              expect(new_sep.effective_on).to eq(qle_on.next_month.beginning_of_month)
-            end
+
+        it 'should set effective date as the qle_on date' do
+          if qle_on == qle_on.beginning_of_month
+            expect(new_sep.effective_on).to eq(qle_on)
+          else
+            expect(new_sep.effective_on).to eq(qle_on.next_month.beginning_of_month)
           end
+        end
       end
     end
-    
+
     context 'when first_of_next_month_coinciding is selected' do
       after :all do
         TimeKeeper.set_date_of_record_unprotected!(Date.today)
@@ -1437,10 +1437,10 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
         after :all do
           TimeKeeper.set_date_of_record_unprotected!(Date.today)
         end
-        
+
         context "when plan shopping date is the same as the effective date and the event date is not the first of the month" do
           let(:qle_on) {TimeKeeper.date_of_record.beginning_of_month + 1.day }
-         
+
           let(:plan_shopping_date) { sep.effective_on }
 
           before do
@@ -1467,13 +1467,13 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
 
         context "when plan shopping date is after the effective date" do
           let(:qle_on) {TimeKeeper.date_of_record.beginning_of_month + 1.day }
-         
+
           let(:plan_shopping_date) { sep.effective_on + 1.day }
-  
+
           before do
             allow(TimeKeeper).to receive(:date_of_record).and_return(TimeKeeper.date_of_record.beginning_of_month + 1.day)
           end
-  
+
           it "should return the SEP effective on date" do
             expect(sep.calculate_effective_date(plan_shopping_date)).to eq((plan_shopping_date + 1.month).beginning_of_month)
           end

--- a/spec/models/special_enrollment_period_spec.rb
+++ b/spec/models/special_enrollment_period_spec.rb
@@ -1354,6 +1354,7 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
         context 'qle_on future, reporting_date after 15th of month' do
           let(:qle_on) { TimeKeeper.date_of_record.next_month }
           let!(:reporting_date) { TimeKeeper.date_of_record }
+
           before do
             TimeKeeper.set_date_of_record_unprotected!(reporting_date)
           end
@@ -1386,7 +1387,6 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
         let(:sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: 'first_of_the_month_plan_shopping') }
 
         context 'when plan shopping date is after the SEP effective on date' do
-          #! this is good
           let(:plan_shopping_date) { TimeKeeper.date_of_record + 1.month }
 
           before do
@@ -1404,7 +1404,6 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
         end
 
         context 'when plan shopping date is before the SEP effective date' do
-          #!this is good
           let(:plan_shopping_date) { TimeKeeper.date_of_record }
 
           before do
@@ -1417,7 +1416,6 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
         end
 
         context 'when plan shopping date is the same as the SEP effective date' do
-          #!THIS IS GOOD
           let(:plan_shopping_date) { sep.effective_on }
 
           before do

--- a/spec/models/special_enrollment_period_spec.rb
+++ b/spec/models/special_enrollment_period_spec.rb
@@ -1119,6 +1119,73 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
       end
     end
 
+    context 'when first_of_the_month_coinciding is selected' do
+      after :all do
+        TimeKeeper.set_date_of_record_unprotected!(Date.today)
+      end
+
+      let(:effective_on_kind) { 'first_of_the_month_coinciding' }
+      let(:new_sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: effective_on_kind) }
+
+      let!(:qle) { create(:qualifying_life_event_kind, market_kind: "individual") }
+
+      context 'qle_on is before the submitted date and qle on is not first of the month' do
+        let(:qle_on) { TimeKeeper.date_of_record - 1.day }
+        let(:reporting_date) { TimeKeeper.date_of_record }
+
+        before do
+          TimeKeeper.set_date_of_record_unprotected!(reporting_date)
+        end
+
+        it 'should set effective on as the next month beginning of month from the submitted date' do
+          expect(sep.effective_on).to eq reporting_date.end_of_month + 1.day
+        end
+      end
+
+      context 'qle_on is after the submitted at date, but is not the first of the month' do
+        let(:qle_on) { TimeKeeper.date_of_record.end_of_month}
+        let(:reporting_date) { TimeKeeper.date_of_record.beginning_of_month }
+  
+        before do
+          new_sep.save!
+          TimeKeeper.set_date_of_record_unprotected!(reporting_date)
+        end
+
+        it 'should set effective date as next month beginning of month from qle' do
+          expect(new_sep.effective_on).to eq qle_on.next_month.beginning_of_month
+        end
+      end
+
+      context 'qle_on is after the submitted at date, and is the first of the month' do
+        let(:qle_on) { TimeKeeper.date_of_record.next_month.beginning_of_month}
+
+        it 'should set effective date as the qle_on' do
+          expect(new_sep.effective_on).to eq qle_on
+        end
+      end
+
+      context 'qle_on is the first of the month and is before the submitted at date' do
+        let(:qle_on) { TimeKeeper.date_of_record.prev_month.beginning_of_month }
+        let(:reporting_date) { TimeKeeper.date_of_record }
+
+        it 'should set effective date as the first of the month after the submitted at date' do
+          expect(new_sep.effective_on).to eq (reporting_date + 1.month).beginning_of_month
+        end
+      end
+
+      context 'qle_on is the same as the submitted at date' do
+        let(:qle_on) { TimeKeeper.date_of_record }
+        
+          it 'should set effective date as the qle_on date' do
+            if qle_on == qle_on.beginning_of_month
+              expect(new_sep.effective_on).to eq(qle_on)
+            else
+              expect(new_sep.effective_on).to eq(qle_on.next_month.beginning_of_month)
+            end
+          end
+      end
+    end
+    
     context 'when first_of_next_month_coinciding is selected' do
       after :all do
         TimeKeeper.set_date_of_record_unprotected!(Date.today)
@@ -1319,6 +1386,7 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
         let(:sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: 'first_of_the_month_plan_shopping') }
 
         context 'when plan shopping date is after the SEP effective on date' do
+          #! this is good
           let(:plan_shopping_date) { TimeKeeper.date_of_record + 1.month }
 
           before do
@@ -1336,6 +1404,7 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
         end
 
         context 'when plan shopping date is before the SEP effective date' do
+          #!this is good
           let(:plan_shopping_date) { TimeKeeper.date_of_record }
 
           before do
@@ -1348,6 +1417,7 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
         end
 
         context 'when plan shopping date is the same as the SEP effective date' do
+          #!THIS IS GOOD
           let(:plan_shopping_date) { sep.effective_on }
 
           before do
@@ -1360,13 +1430,62 @@ RSpec.describe SpecialEnrollmentPeriod, :type => :model, :dbclean => :after_each
         end
       end
 
-      context "with effective_on_kind not first_of_the_month_plan_shopping" do
+      context "when effective_on_kind is first_of_the_month_coinciding" do
+
+        let(:sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: 'first_of_the_month_coinciding') }
+
+        after :all do
+          TimeKeeper.set_date_of_record_unprotected!(Date.today)
+        end
+        
+        context "when plan shopping date is the same as the effective date and the event date is not the first of the month" do
+          let(:qle_on) {TimeKeeper.date_of_record.beginning_of_month + 1.day }
+         
+          let(:plan_shopping_date) { sep.effective_on }
+
+          before do
+            allow(TimeKeeper).to receive(:date_of_record).and_return(TimeKeeper.date_of_record.beginning_of_month + 1.day)
+          end
+
+          it "should return the SEP effective on date" do
+            expect(sep.calculate_effective_date(plan_shopping_date)).to eq((plan_shopping_date + 1.month).beginning_of_month)
+          end
+        end
+
+        context "with plan shopping date the same as the effective date and event date is the first of the month" do
+          let(:qle_on) { TimeKeeper.date_of_record.next_month.beginning_of_month }
+          let(:plan_shopping_date) { sep.effective_on }
+
+          before do
+            TimeKeeper.set_date_of_record_unprotected!(TimeKeeper.date_of_record.beginning_of_month)
+          end
+
+          it "should return the SEP effective on date" do
+            expect(sep.calculate_effective_date(plan_shopping_date)).to eq(plan_shopping_date)
+          end
+        end
+
+        context "when plan shopping date is after the effective date" do
+          let(:qle_on) {TimeKeeper.date_of_record.beginning_of_month + 1.day }
+         
+          let(:plan_shopping_date) { sep.effective_on + 1.day }
+  
+          before do
+            allow(TimeKeeper).to receive(:date_of_record).and_return(TimeKeeper.date_of_record.beginning_of_month + 1.day)
+          end
+  
+          it "should return the SEP effective on date" do
+            expect(sep.calculate_effective_date(plan_shopping_date)).to eq((plan_shopping_date + 1.month).beginning_of_month)
+          end
+        end
+      end
+
+      context "with effective_on_kind not first_of_the_month_plan_shopping or first_of_the_month_coinciding" do
         let(:sep) { family.special_enrollment_periods.build(qualifying_life_event_kind: ivl_qle, qle_on: qle_on, effective_on_kind: 'date_of_event') }
 
         it "should return the SEP effective on date" do
           expect(sep.calculate_effective_date(TimeKeeper.date_of_record)).to eq(sep.effective_on)
         end
-
       end
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/185649264

# A brief description of the changes

Current behavior: The first of the next month coinciding rule does not take into account when the consumer goes plan shopping

New behavior: Create new rule that will take into account when the consumer goes plan shopping.

# Feature Flag

**first_of_then_month_coinciding rule is only present in the ME context. Will not impact DC**

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.