### PR TITLE
bring new mappings to enroll

### DIFF
--- a/app/event_source/subscribers/atp_subscriber.rb
+++ b/app/event_source/subscribers/atp_subscriber.rb
@@ -20,7 +20,7 @@ module Subscribers
         transfer_response = FinancialAssistance::Operations::Transfers::MedicaidGateway::AccountTransferResponse.new.call(result.value!)
         if transfer_response.failure?
           transfer_details[:result] = "Failed"
-          transfer_details[:failure] = "Unsucessfully built account transfer response by Enroll - #{transfer_response.failure}"
+          transfer_details[:failure] = "Unsuccessfully built account transfer response by Enroll - #{transfer_response.failure}"
         else
           transfer_details.merge!(transfer_response.value!)
         end
@@ -28,10 +28,10 @@ module Subscribers
         logger.info "AtpSubscriber: acked with success: #{result.success}"
       else
         transfer_details[:result] = "Failed"
-        transfer_details[:failure] = "Unsucessfully ingested by Enroll - #{result.failure}"
+        transfer_details[:failure] = "Unsuccessfully ingested by Enroll - #{result.failure.full_messages.join(', ')}"
         errors = result.failure
         nack(delivery_info.delivery_tag)
-        logger.info "AtpSubscriber: nacked with failure, errors: #{errors}"
+        logger.info "AtpSubscriber: nacked with failure, errors: #{errors.full_messages.join(', ')}"
       end
       FinancialAssistance::Operations::Transfers::MedicaidGateway::PublishTransferResponse.new.call(transfer_details)
     rescue StandardError => e

--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -185,7 +185,10 @@ module FinancialAssistance
           end
 
           def build_application(payload, family)
-            app_params = payload["family"]['magi_medicaid_applications'].first.merge!(family_id: family.id, benchmark_product_id: BSON::ObjectId.new, years_to_renew: 5)
+            app = payload["family"]['magi_medicaid_applications'].first
+            attestation_terms = app["parent_living_out_of_home_terms"] ? true : nil
+            # years_to_renew needs to be merged with a hash rocket to properly merge with the existing years_to_renew key
+            app_params = app.merge!(family_id: family.id, benchmark_product_id: BSON::ObjectId.new, attestation_terms: attestation_terms, "years_to_renew" => 5)
             app_params["assistance_year"] = FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s
             ::FinancialAssistance::Operations::Application::Create.new.call(params: app_params.except('applicants').merge(applicants: []))
           rescue StandardError => e

--- a/components/financial_assistance/app/domain/financial_assistance/validators/application_contract.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/validators/application_contract.rb
@@ -14,6 +14,12 @@ module FinancialAssistance
         optional(:is_renewal_authorized).maybe(:bool)
         required(:applicants).array(:hash)
         optional(:transfer_id).maybe(:string)
+        optional(:submission_terms).maybe(:bool)
+        optional(:medicaid_terms).maybe(:bool)
+        optional(:medicaid_insurance_collection_terms).maybe(:bool)
+        optional(:parent_living_out_of_home_terms).maybe(:bool)
+        optional(:report_change_terms).maybe(:bool)
+        optional(:attestation_terms).maybe(:bool)
       end
 
       rule(:years_to_renew, :renewal_consent_through_year, :is_renewal_authorized) do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

According to [this validation](https://github.com/ideacrew/enroll/blob/38a94e9d07264009f0eedd6374e927c1e673a502/components/financial_assistance/app/models/financial_assistance/application.rb#L1551), `attestation_terms` must be set if `parent_living_out_of_home_terms` is true (I'm not sure why but the validation only runs in this scenario which is why when adding parent_living_... as a field in the contract it caused the submitted payloads application to fail). To account for this we add  `attestation_terms` as a field to the contract and params, set according to the rules in place [here](https://github.com/ideacrew/enroll/blob/38a94e9d07264009f0eedd6374e927c1e673a502/app/domain/operations/ffe/migrate_application.rb#L169). It could be we want to have this field passed in from aca_entities.