### PR TITLE
fix primary member signature bypass

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -314,7 +314,7 @@ class Insured::PlanShoppingsController < ApplicationController
     year = params[:year]
     hios_id = params[:hios_id]
     @enrollment = HbxEnrollment.find(params[:id])
-    market_kind = @enrollment.fehb_profile ? 'fehb' : @enrollment.market_kind
+    market_kind = @enrollment.fehb_profile ? 'fehb' : @enrollment.kind
     selected_plan = if @enrollment.fehb_profile
                       BenefitMarkets::Products::Product.where(:hios_id => hios_id, :"application_period.min" => Date.new(year.to_i, 1, 1), benefit_market_kind: :fehb).first
                     else

--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -314,7 +314,7 @@ class Insured::PlanShoppingsController < ApplicationController
     year = params[:year]
     hios_id = params[:hios_id]
     @enrollment = HbxEnrollment.find(params[:id])
-    market_kind = @enrollment.fehb_profile ? 'fehb' : params[:market_kind]
+    market_kind = @enrollment.fehb_profile ? 'fehb' : @enrollment.market_kind
     selected_plan = if @enrollment.fehb_profile
                       BenefitMarkets::Products::Product.where(:hios_id => hios_id, :"application_period.min" => Date.new(year.to_i, 1, 1), benefit_market_kind: :fehb).first
                     else

--- a/app/views/insured/plan_shoppings/show.html.slim
+++ b/app/views/insured/plan_shoppings/show.html.slim
@@ -548,7 +548,7 @@ javascript:
                       </a>
                     </div>
                     <div class="col-md-5 col-sm-5 col-xs-5 pl-0 pr-0">
-                      <a class="btn btn-default btn-right plan-select select" href="/insured/plan_shoppings/#{@hbx_enrollment.id.to_s}/thankyou?change_plan=&coverage_kind=${result.product.kind}&enrollment_kind=&market_kind=${result.product.benefit_market_kind.replace('aca_shop', 'individual')}&plan_id=${result.product._id}">Select Plan</a>
+                      <a class="btn btn-default btn-right plan-select select" href="/insured/plan_shoppings/#{@hbx_enrollment.id.to_s}/thankyou?change_plan=&coverage_kind=${result.product.kind}&enrollment_kind=&market_kind=${result.product.benefit_market_kind.replace('aca_', '')}&plan_id=${result.product._id}">Select Plan</a>
                       <a class="btn btn-default ml-1" data-remote="true" href="/products/plans/summary?active_year=${result.rate_schedule_date.split('-')[0]}&coverage_kind=${result.product.kind}&enrollment_kind=&hbx_enrollment_id=#{@hbx_enrollment.id.to_s}&market_kind=${result.product.benefit_market_kind.replace('aca_', '')}&standard_component_id=${result.product.hios_id}">See Details</a>
                     </div>
                   </div>

--- a/app/views/insured/plan_shoppings/show.html.slim
+++ b/app/views/insured/plan_shoppings/show.html.slim
@@ -548,7 +548,7 @@ javascript:
                       </a>
                     </div>
                     <div class="col-md-5 col-sm-5 col-xs-5 pl-0 pr-0">
-                      <a class="btn btn-default btn-right plan-select select" href="/insured/plan_shoppings/#{@hbx_enrollment.id.to_s}/thankyou?change_plan=&coverage_kind=${result.product.kind}&enrollment_kind=&market_kind=${result.product.benefit_market_kind.replace('aca_', '')}&plan_id=${result.product._id}">Select Plan</a>
+                      <a class="btn btn-default btn-right plan-select select" href="/insured/plan_shoppings/#{@hbx_enrollment.id.to_s}/thankyou?change_plan=&coverage_kind=${result.product.kind}&enrollment_kind=&market_kind=${result.product.benefit_market_kind.replace('aca_shop', 'individual')}&plan_id=${result.product._id}">Select Plan</a>
                       <a class="btn btn-default ml-1" data-remote="true" href="/products/plans/summary?active_year=${result.rate_schedule_date.split('-')[0]}&coverage_kind=${result.product.kind}&enrollment_kind=&hbx_enrollment_id=#{@hbx_enrollment.id.to_s}&market_kind=${result.product.benefit_market_kind.replace('aca_', '')}&standard_component_id=${result.product.hios_id}">See Details</a>
                     </div>
                   </div>

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -1232,8 +1232,8 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
           get :plan_selection_callback, params: { id: hbx_enrollment.id, hios_id: product.hios_id, year: year, market_kind: nil, coverage_kind: coverage_kind }
         end
 
-        it "should assign market kind" do
-          expect(assigns(:market_kind)).to be_truthy
+        it "should assign market kind to enrollment kind" do
+          expect(response).to redirect_to(thankyou_insured_plan_shopping_path(plan_id: product.id.to_s, id: hbx_enrollment.id,coverage_kind: coverage_kind, market_kind: hbx_enrollment.kind, change_plan: nil))
         end
       end
     end

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -1207,7 +1207,6 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
   if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
     describe "plan_selection_callback" do
       let(:coverage_kind){"health"}
-      let(:market_kind){"individual"}
       let(:person) { FactoryBot.create(:person, :with_active_consumer_role, :with_consumer_role) }
       let(:user)  { FactoryBot.create(:user, person: person) }
       let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
@@ -1218,12 +1217,23 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
       context "When a callback is received" do
         before do
           sign_in user
-          get :plan_selection_callback, params: { id: hbx_enrollment.id, hios_id: product.hios_id, year: year, market_kind: market_kind, coverage_kind: coverage_kind }
+          get :plan_selection_callback, params: { id: hbx_enrollment.id, hios_id: product.hios_id, year: year, market_kind: 'individual', coverage_kind: coverage_kind }
         end
 
         it "should assign market kind and coverage_kind" do
           expect(assigns(:market_kind)).to be_truthy
           expect(assigns(:coverage_kind)).to be_truthy
+        end
+      end
+
+      context "When a callback is received with no market kind" do
+        before do
+          sign_in user
+          get :plan_selection_callback, params: { id: hbx_enrollment.id, hios_id: product.hios_id, year: year, market_kind: nil, coverage_kind: coverage_kind }
+        end
+
+        it "should assign market kind" do
+          expect(assigns(:market_kind)).to be_truthy
         end
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-185715422](https://www.pivotaltracker.com/n/projects/2640060/stories/185715422)

# A brief description of the changes

Current behavior: When loading plan confirmation page from plan compare site, confirm button is enabled and allows user to bypass signature

New behavior: When loading plan confirmation page from plan compare site, confirm button is disabled and restricts user from bypassing signature

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.