### PR TITLE
add atp attestation mappings to enroll

### DIFF
--- a/app/event_source/subscribers/atp_subscriber.rb
+++ b/app/event_source/subscribers/atp_subscriber.rb
@@ -20,7 +20,7 @@ module Subscribers
         transfer_response = FinancialAssistance::Operations::Transfers::MedicaidGateway::AccountTransferResponse.new.call(result.value!)
         if transfer_response.failure?
           transfer_details[:result] = "Failed"
-          transfer_details[:failure] = "Unsucessfully built account transfer response by Enroll - #{transfer_response.failure}"
+          transfer_details[:failure] = "Unsuccessfully built account transfer response by Enroll - #{transfer_response.failure}"
         else
           transfer_details.merge!(transfer_response.value!)
         end
@@ -28,10 +28,10 @@ module Subscribers
         logger.info "AtpSubscriber: acked with success: #{result.success}"
       else
         transfer_details[:result] = "Failed"
-        transfer_details[:failure] = "Unsucessfully ingested by Enroll - #{result.failure}"
+        transfer_details[:failure] = "Unsuccessfully ingested by Enroll - #{result.failure.full_messages.join(', ')}"
         errors = result.failure
         nack(delivery_info.delivery_tag)
-        logger.info "AtpSubscriber: nacked with failure, errors: #{errors}"
+        logger.info "AtpSubscriber: nacked with failure, errors: #{errors.full_messages.join(', ')}"
       end
       FinancialAssistance::Operations::Transfers::MedicaidGateway::PublishTransferResponse.new.call(transfer_details)
     rescue StandardError => e

--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -186,9 +186,8 @@ module FinancialAssistance
 
           def build_application(payload, family)
             app = payload["family"]['magi_medicaid_applications'].first
-            attestation_terms = app["parent_living_out_of_home_terms"] ? true : nil
             # years_to_renew needs to be merged with a hash rocket to properly merge with the existing years_to_renew key
-            app_params = app.merge!(family_id: family.id, benchmark_product_id: BSON::ObjectId.new, attestation_terms: attestation_terms, "years_to_renew" => 5)
+            app_params = app.merge!(family_id: family.id, benchmark_product_id: BSON::ObjectId.new, "years_to_renew" => 5)
             app_params["assistance_year"] = FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s
             ::FinancialAssistance::Operations::Application::Create.new.call(params: app_params.except('applicants').merge(applicants: []))
           rescue StandardError => e

--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -185,7 +185,10 @@ module FinancialAssistance
           end
 
           def build_application(payload, family)
-            app_params = payload["family"]['magi_medicaid_applications'].first.merge!(family_id: family.id, benchmark_product_id: BSON::ObjectId.new, years_to_renew: 5)
+            app = payload["family"]['magi_medicaid_applications'].first
+            attestation_terms = app["parent_living_out_of_home_terms"] ? true : nil
+            # years_to_renew needs to be merged with a hash rocket to properly merge with the existing years_to_renew key
+            app_params = app.merge!(family_id: family.id, benchmark_product_id: BSON::ObjectId.new, attestation_terms: attestation_terms, "years_to_renew" => 5)
             app_params["assistance_year"] = FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s
             ::FinancialAssistance::Operations::Application::Create.new.call(params: app_params.except('applicants').merge(applicants: []))
           rescue StandardError => e

--- a/components/financial_assistance/app/domain/financial_assistance/validators/application_contract.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/validators/application_contract.rb
@@ -14,6 +14,12 @@ module FinancialAssistance
         optional(:is_renewal_authorized).maybe(:bool)
         required(:applicants).array(:hash)
         optional(:transfer_id).maybe(:string)
+        optional(:submission_terms).maybe(:bool)
+        optional(:medicaid_terms).maybe(:bool)
+        optional(:medicaid_insurance_collection_terms).maybe(:bool)
+        optional(:parent_living_out_of_home_terms).maybe(:bool)
+        optional(:report_change_terms).maybe(:bool)
+        optional(:attestation_terms).maybe(:bool)
       end
 
       rule(:years_to_renew, :renewal_consent_through_year, :is_renewal_authorized) do

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
         @result = subject.call(@transformed)
       end
 
-      it 'should set the transferred_at field'  do
+      it 'should set the transferred_at field' do
         app = FinancialAssistance::Application.find(@result.value!)
         expect(app.transferred_at).not_to eq nil
       end
@@ -181,6 +181,23 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
           end
         end
       end
+
+      context 'valid attestations' do
+        it 'should create valid attestations for the application' do
+          attributes = @transformed["family"]['magi_medicaid_applications'].first
+          application = FinancialAssistance::Application.find(@result.value!)
+          attestation_vals = { "years_to_renew": attributes["years_to_renew"],
+                               "submission_terms": attributes["submission_terms"],
+                               "medicaid_terms": attributes["medicaid_terms"],
+                               "medicaid_insurance_collection_terms": attributes["medicaid_insurance_collection_terms"],
+                               "parent_living_out_of_home_terms": attributes["parent_living_out_of_home_terms"],
+                               "report_change_terms": attributes["report_change_terms"],
+                               "attestation_terms": attributes["attestation_terms"] }
+
+          attributes = attestation_vals.keys.map { |name| [name, application.attributes[name]] }.to_h
+          expect(attributes).to eq attestation_vals
+        end
+      end
     end
   end
 
@@ -193,7 +210,7 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
             allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:automatic_submission).and_return(false)
             allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:load_county_on_inbound_transfer).and_return(true)
             missing_counties_xml = Nokogiri::XML(xml)
-            missing_counties_xml.xpath("//ns3:LocationCountyName", {"ns3" => "http://niem.gov/niem/niem-core/2.0"}).remove
+            missing_counties_xml.xpath("//ns3:LocationCountyName", { "ns3" => "http://niem.gov/niem/niem-core/2.0" }).remove
             record = serializer.parse(missing_counties_xml)
             transformed = transformer.transform(record.to_hash(identifier: true)).deep_stringify_keys!
             @result = subject.call(transformed)
@@ -211,7 +228,7 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
     before do
       ::BenefitMarkets::Locations::CountyZip.create(zip: "04330", state: "ME", county_name: "Kennebec")
       missing_counties_xml = Nokogiri::XML(xml)
-      missing_counties_xml.xpath("//ns3:LocationCountyName", {"ns3" => "http://niem.gov/niem/niem-core/2.0"}).remove
+      missing_counties_xml.xpath("//ns3:LocationCountyName", { "ns3" => "http://niem.gov/niem/niem-core/2.0" }).remove
       record = serializer.parse(missing_counties_xml)
       @transformed = transformer.transform(record.to_hash(identifier: true)).deep_stringify_keys!
     end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -186,8 +186,7 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
         it 'should create valid attestations for the application' do
           attributes = @transformed["family"]['magi_medicaid_applications'].first
           application = FinancialAssistance::Application.find(@result.value!)
-          attestation_vals = { "years_to_renew": attributes["years_to_renew"],
-                               "submission_terms": attributes["submission_terms"],
+          attestation_vals = { "submission_terms": attributes["submission_terms"],
                                "medicaid_terms": attributes["medicaid_terms"],
                                "medicaid_insurance_collection_terms": attributes["medicaid_insurance_collection_terms"],
                                "parent_living_out_of_home_terms": attributes["parent_living_out_of_home_terms"],

--- a/components/financial_assistance/spec/shared_examples/medicaid_gateway/Simple_Test_Case_E_New.xml
+++ b/components/financial_assistance/spec/shared_examples/medicaid_gateway/Simple_Test_Case_E_New.xml
@@ -59,14 +59,14 @@
             </ns5:InsuranceApplicantIncarceration>
             <ns5:InsuranceApplicantLawfulPresenceStatus>
                 <ns5:LawfulPresenceStatusArrivedBefore1996Indicator>true</ns5:LawfulPresenceStatusArrivedBefore1996Indicator>
-                <ns5:LawfulPresenceStatusImmigrationDocument> 
-                    <ns5:LawfulPresenceDocumentNumber> 
-                        <ns2:IdentificationID>123456</ns2:IdentificationID> 
-                    </ns5:LawfulPresenceDocumentNumber> 
-                    <ns5:LawfulPresenceDocumentPersonIdentification> 
-                        <ns2:IdentificationID>123456789</ns2:IdentificationID> 
-                        <ns2:IdentificationCategoryText>Alien Number</ns2:IdentificationCategoryText> 
-                    </ns5:LawfulPresenceDocumentPersonIdentification> 
+                <ns5:LawfulPresenceStatusImmigrationDocument>
+                    <ns5:LawfulPresenceDocumentNumber>
+                        <ns2:IdentificationID>123456</ns2:IdentificationID>
+                    </ns5:LawfulPresenceDocumentNumber>
+                    <ns5:LawfulPresenceDocumentPersonIdentification>
+                        <ns2:IdentificationID>123456789</ns2:IdentificationID>
+                        <ns2:IdentificationCategoryText>Alien Number</ns2:IdentificationCategoryText>
+                    </ns5:LawfulPresenceDocumentPersonIdentification>
                     <ns5:LawfulPresenceDocumentCategoryCode>NaturalizationCertificate</ns5:LawfulPresenceDocumentCategoryCode>
                 </ns5:LawfulPresenceStatusImmigrationDocument>
                 <ns5:LawfulPresenceStatusEligibility>
@@ -145,6 +145,7 @@
             </ns5:SSFSignerAuthorizedRepresentativeAssociation>
             <ns5:SSFAttestation>
                 <ns5:SSFAttestationCollectionsAgreementIndicator>false</ns5:SSFAttestationCollectionsAgreementIndicator>
+                <ns5:SSFAttestationMedicaidObligationsIndicator>true</ns5:SSFAttestationMedicaidObligationsIndicator>
                 <ns5:SSFAttestationNonPerjuryIndicator>true</ns5:SSFAttestationNonPerjuryIndicator>
                 <ns5:SSFAttestationNotIncarceratedIndicator ns1:metadata="vm2009583325215611507">true</ns5:SSFAttestationNotIncarceratedIndicator>
                 <ns5:SSFAttestationNotIncarceratedIndicator>true</ns5:SSFAttestationNotIncarceratedIndicator>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185610738

# A brief description of the changes

Current behavior:
The fields outlined in the ticket are missing from the application contract, preventing them from being allowed as parameters.

New behavior:
The fields are added to the contract enabling them to successfully be passed as parameters.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

I have also updated the error output to use the full message since just the error object is unhelpful.