### PR TITLE
pass in correct source name to pay now modal from enrollment tile

### DIFF
--- a/app/views/insured/families/_enrollment.html.erb
+++ b/app/views/insured/families/_enrollment.html.erb
@@ -263,7 +263,7 @@
   </div>
 
   <% if hbx_enrollment.product.present? && enrollment_is_ivl_or_coverall?(hbx_enrollment) %>
-    <%= render "shared/pay_now_modal", hbx_enrollment: hbx_enrollment, source: "enrollment_tile" %>
+    <%= render "shared/pay_now_modal", hbx_enrollment: hbx_enrollment, source: "Enrollment Tile" %>
   <% end %>
 
 <% end %>

--- a/app/views/insured/families/_enrollment_actions.html.erb
+++ b/app/views/insured/families/_enrollment_actions.html.erb
@@ -55,5 +55,5 @@
 </div>
 
 <% if hbx_enrollment.product.present? && enrollment_is_ivl_or_coverall?(hbx_enrollment) %>
-    <%= render "shared/pay_now_modal", hbx_enrollment: hbx_enrollment, source: "enrollment_tile" %>
+    <%= render "shared/pay_now_modal", hbx_enrollment: hbx_enrollment, source: "Enrollment Tile" %>
 <% end %>

--- a/app/views/insured/families/_enrollment_actions.html.erb
+++ b/app/views/insured/families/_enrollment_actions.html.erb
@@ -54,6 +54,6 @@
     <% end %>
 </div>
 
-<% if hbx_enrollment.product.present?  && enrollment_is_ivl_or_coverall?(hbx_enrollment) %>
+<% if hbx_enrollment.product.present? && enrollment_is_ivl_or_coverall?(hbx_enrollment) %>
     <%= render "shared/pay_now_modal", hbx_enrollment: hbx_enrollment, source: "enrollment_tile" %>
 <% end %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185730947

# A brief description of the changes

Current behavior:
Carriers with Pay Now enabled on enrollment tile are behaving as if Pay Now is disabled when clicking on the enrollment tile actions menu.

New behavior:
Carriers with Pay Now enabled on enrollment tile see the correct text and linking behavior on the enrollment tile drop down.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

In the initial implementation, the `source` local variable was not actually used when rendering the Pay Now modal from the enrollment tile context.  A recent refactor updated the Pay Now modal to use the `source` local variable, which revealed that the variable was incorrectly being set in the enrollment tile context.