### PR TITLE
resets full_medicaid_determination value for auto renewals

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
@@ -94,7 +94,8 @@ module FinancialAssistance
                   effective_date: Date.new(validated_params[:renewal_year])
                 )
 
-                renewal_application.full_medicaid_determination = application.full_medicaid_determination unless EnrollRegistry[:enroll_app].setting(:site_key).item == :dc
+                full_medicaid_determination_feature = FinancialAssistanceRegistry[:full_medicaid_determination_step]
+                renewal_application.full_medicaid_determination = application.full_medicaid_determination if full_medicaid_determination_feature.enabled? && full_medicaid_determination_feature.settings(:annual_eligibility_redetermination).item
 
                 renewal_application.save
                 if renewal_application.renewal_draft?

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
@@ -94,8 +94,7 @@ module FinancialAssistance
                   effective_date: Date.new(validated_params[:renewal_year])
                 )
 
-                full_medicaid_determination_feature = FinancialAssistanceRegistry[:full_medicaid_determination_step]
-                renewal_application.full_medicaid_determination = application.full_medicaid_determination if full_medicaid_determination_feature.enabled? && full_medicaid_determination_feature.settings(:annual_eligibility_redetermination).item
+                renewal_application.full_medicaid_determination = application.full_medicaid_determination if full_medicaid_determination_feature_enabled?
 
                 renewal_application.save
                 if renewal_application.renewal_draft?
@@ -104,6 +103,11 @@ module FinancialAssistance
                   Failure("Renewal Application Applicants Update or income_verification_extension required - #{renewal_application.hbx_id}")
                 end
               end.to_result
+            end
+
+            def full_medicaid_determination_feature_enabled?
+              feature = FinancialAssistanceRegistry[:full_medicaid_determination_step]
+              feature.enabled? && feature.settings(:annual_eligibility_redetermination).item
             end
 
             def find_aasm_state(application, family_members_changed)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
@@ -91,9 +91,10 @@ module FinancialAssistance
                   years_to_renew: calculate_years_to_renew(application),
                   renewal_base_year: calculated_renewal_base_year,
                   predecessor_id: application.id,
-                  full_medicaid_determination: application.full_medicaid_determination,
                   effective_date: Date.new(validated_params[:renewal_year])
                 )
+
+                renewal_application.full_medicaid_determination = application.full_medicaid_determination unless EnrollRegistry[:enroll_app].setting(:site_key).item == :dc
 
                 renewal_application.save
                 if renewal_application.renewal_draft?

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credits/renewals/renew_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credits/renewals/renew_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AptcCsrCreditEli
       end
     end
 
-    context 'determined application' do
+    context 'determined application for DC' do
       before do
         application.update_attributes!({ aasm_state: 'determined', years_to_renew: 1 })
         application.reload
@@ -155,8 +155,8 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AptcCsrCreditEli
             expect(@renewal_draft_app.attestation_terms).to eq(application.attestation_terms)
           end
 
-          it 'should return application with full_medicaid_determination' do
-            expect(@renewal_draft_app.full_medicaid_determination).to eq(application.full_medicaid_determination)
+          it 'should return application without full_medicaid_determination' do
+            expect(@renewal_draft_app.full_medicaid_determination).to be nil
           end
         end
       end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credits/renewals/renew_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credits/renewals/renew_spec.rb
@@ -82,8 +82,45 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AptcCsrCreditEli
       end
     end
 
+    context '#full_medicaid_determination' do
+      context 'when full_medicaid_determination feature is enabled' do
+        before do
+          allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:full_medicaid_determination_step).and_return(true)
+          allow(FinancialAssistanceRegistry[:full_medicaid_determination_step].setting(:annual_eligibility_redetermination)).to receive(:item).and_return(true)
+
+          application.update_attributes!({ aasm_state: 'determined', years_to_renew: 1 })
+          application.reload
+          @result = subject.call({ family_id: application.family_id, renewal_year: application.assistance_year.next })
+          @renewal_draft_app = @result.success
+        end
+
+        it 'should return application with full_medicaid_determination value' do
+          expect(@renewal_draft_app.full_medicaid_determination).to eq true
+        end
+      end
+
+      context 'when full_medicaid_determination feature is disabled' do
+        before do
+          allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:full_medicaid_determination_step).and_return(false)
+          allow(FinancialAssistanceRegistry[:full_medicaid_determination_step].setting(:annual_eligibility_redetermination)).to receive(:item).and_return(false)
+
+          application.update_attributes!({ aasm_state: 'determined', years_to_renew: 1 })
+          application.reload
+          @result = subject.call({ family_id: application.family_id, renewal_year: application.assistance_year.next })
+          @renewal_draft_app = @result.success
+        end
+
+        it 'should return application with nil full_medicaid_determination' do
+          expect(@renewal_draft_app.full_medicaid_determination).to eq nil
+        end
+      end
+    end
+
     context 'determined application for DC' do
       before do
+        allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:full_medicaid_determination_step).and_return(true)
+        allow(FinancialAssistanceRegistry[:full_medicaid_determination_step].setting(:annual_eligibility_redetermination)).to receive(:item).and_return(false)
+
         application.update_attributes!({ aasm_state: 'determined', years_to_renew: 1 })
         application.reload
         @result = subject.call({ family_id: application.family_id, renewal_year: application.assistance_year.next })

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -264,6 +264,9 @@ registry:
           item: false
     - key: :full_medicaid_determination_step
       is_enabled: true
+      settings:
+        - key: :annual_eligibility_redetermination
+          item: <%= ENV['ANNUAL_ELIGIBILITY_REDETERMINATION_IS_ENABLED'] || false %>
     - key: :native_american_csr
       is_enabled: true
     - key: :filing_as_head_of_household

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -266,7 +266,7 @@ registry:
       is_enabled: true
       settings:
         - key: :annual_eligibility_redetermination
-          item: <%= ENV['ANNUAL_ELIGIBILITY_REDETERMINATION_IS_ENABLED'] || false %>
+          item: <%= ENV['FULL_MEDICAID_DETERMINATION_FOR_ANNUAL_ELIGIBILITY_REDETERMINATION_IS_ENABLED'] || false %>
     - key: :native_american_csr
       is_enabled: true
     - key: :filing_as_head_of_household

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -264,6 +264,9 @@ registry:
           item: true
     - key: :full_medicaid_determination_step
       is_enabled: false
+      settings:
+        - key: :annual_eligibility_redetermination
+          item: <%= ENV['ANNUAL_ELIGIBILITY_REDETERMINATION_IS_ENABLED'] || false %>
     - key: :native_american_csr
       is_enabled: true
     - key: :display_medicaid_question

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -266,7 +266,7 @@ registry:
       is_enabled: false
       settings:
         - key: :annual_eligibility_redetermination
-          item: <%= ENV['ANNUAL_ELIGIBILITY_REDETERMINATION_IS_ENABLED'] || false %>
+          item: <%= ENV['FULL_MEDICAID_DETERMINATION_FOR_ANNUAL_ELIGIBILITY_REDETERMINATION_IS_ENABLED'] || false %>
     - key: :native_american_csr
       is_enabled: true
     - key: :display_medicaid_question

--- a/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -264,6 +264,9 @@ registry:
           item: false
     - key: :full_medicaid_determination_step
       is_enabled: true
+      settings:
+        - key: :annual_eligibility_redetermination
+          item: <%= ENV['ANNUAL_ELIGIBILITY_REDETERMINATION_IS_ENABLED'] || false %>
     - key: :native_american_csr
       is_enabled: true
     - key: :filing_as_head_of_household

--- a/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -266,7 +266,7 @@ registry:
       is_enabled: true
       settings:
         - key: :annual_eligibility_redetermination
-          item: <%= ENV['ANNUAL_ELIGIBILITY_REDETERMINATION_IS_ENABLED'] || false %>
+          item: <%= ENV['FULL_MEDICAID_DETERMINATION_FOR_ANNUAL_ELIGIBILITY_REDETERMINATION_IS_ENABLED'] || false %>
     - key: :native_american_csr
       is_enabled: true
     - key: :filing_as_head_of_household


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/185681354

# A brief description of the changes

Current behavior: At the time of auto renewing, full_medicaid_determination value is copied over to renewal application.

New behavior: full_medicaid_determination value will be set to nil when creating renewal applications for DC

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.