### PR TITLE
fix compare plan warning

### DIFF
--- a/app/views/insured/plan_shoppings/show.html.slim
+++ b/app/views/insured/plan_shoppings/show.html.slim
@@ -79,9 +79,9 @@
           span aria-hidden="true" &times;
         h4.modal-title = l10n("plan_compare_alert")
       .modal-body
-        p style='color:red;' = l10n(".can_not_select_more_than_n_plans_to_compare", number: 3)
+        p' = l10n(".can_not_select_more_than_n_plans_to_compare", number: 3)
       .modal-footer
-        button.btn.btn-default type="button" data-dismiss="modal"
+        button.btn.btn-default type="button" data-dismiss="modal" Close
 
 = render :partial => "ui-components/v1/modals/waive_confirmation_during_shopping", :locals => {:enrollment => @hbx_enrollment} if @hbx_enrollment.is_shop?
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-185734580](https://www.pivotaltracker.com/n/projects/2640060/stories/185734580)

# A brief description of the changes

Current behavior: Compare plan warning displays with red text and close button does not display

New behavior: Compare plan warning displays with black text and close button displays

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.