### PR TITLE
Change offset delivery date for document reminder  2 from 70 days to 65

### DIFF
--- a/config/client_config/me/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -176,7 +176,7 @@ registry:
         is_enabled: true
         settings:
           - key: :offset_prior_to_due_date
-            item: 70
+            item: 65
           - key: :units
             item: :days
           - key: :event_name

--- a/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -176,7 +176,7 @@ registry:
         is_enabled: true
         settings:
           - key: :offset_prior_to_due_date
-            item: 70
+            item: 65
           - key: :units
             item: :days
           - key: :event_name

--- a/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -176,7 +176,7 @@ registry:
         is_enabled: true
         settings:
           - key: :offset_prior_to_due_date
-            item: 65
+            item: 70
           - key: :units
             item: :days
           - key: :event_name


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185491655

# A brief description of the changes

Current behavior: Document reminder 2 will be sent after 70 days

New behavior: Document reminder 2 will be sent after 65 days

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.