### PR TITLE
Update Pop-up Text After Estimate Your Cost

### DIFF
--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -488,7 +488,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.reset' => "Reset",
   :'en.modal_onscreen' => "We're sending you to DC Health Link's Plan Match tool powered by Consumers'",
   :'en.modal_onscreen1' => "CHECKBOOK. For security reasons, you'll need to login to your DC Health Link",
-  :'en.modal_onscreen2' => "account again after 15 minutes, are you sure?",
+  :'en.modal_onscreen2' => "account again after 15 minutes. Are you sure?",
   :'en.modal_how_is_this_calculated' => "How are Tax Credits calculated?",
   :'en.modal_how_is_this_calculated1' => "We calculate your tax credits based on the information you give us about your household and your income. The ‘Available’ amount is how much you can apply if you update your plan now.",
   :'en.modal_how_is_this_calculated2' => "You can decide to take all of it now, or just part. When you file your taxes for the year, the IRS will compare the amount you took to the amount you qualified for based on your final income. If you took more than you qualified for, you’ll need to repay it on your taxes. If you took less than you qualified for, you will get that back on your taxes. You might want to take just part of your premium reductions if your income might end up being higher than what you predicted for this year.",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -490,7 +490,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.reset' => "Reset",
   :'en.modal_onscreen' => "We're sending you to CoverME.gov's Plan Compare tool powered by Consumers'",
   :'en.modal_onscreen1' => "CHECKBOOK. For security reasons, you'll need to login to your CoverME.gov",
-  :'en.modal_onscreen2' => "account again after 15 minutes, are you sure?",
+  :'en.modal_onscreen2' => "account again after 15 minutes. Are you sure?",
   :'en.modal_how_is_this_calculated' => "How are Tax Credits calculated?",
   :'en.modal_how_is_this_calculated1' => "We calculate your tax credits based on the information you give us about your household and your income. The ‘Available’ amount is how much you can apply if you update your plan now.",
   :'en.modal_how_is_this_calculated2' => "You can decide to take all of it now, or just part. When you file your taxes for the year, the IRS will compare the amount you took to the amount you qualified for based on your final income. If you took more than you qualified for, you’ll need to repay it on your taxes. If you took less than you qualified for, you will get that back on your taxes. You might want to take just part of your premium reductions if your income might end up being higher than what you predicted for this year.",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/101871

# A brief description of the changes

Current behavior:
Current Text
"We're sending you to DC Health Link's Plan Match tool powered by Consumers' CHECKBOOK. For security reasons, you'll need to login to your DC Health Link account again after 15 minutes, are you sure?"
New behavior:
Expected Text
"We're sending you to DC Health Link's Plan Match tool powered by Consumers' CHECKBOOK. For security reasons, you'll need to login to your DC Health Link account again after 15 minutes. Are you sure?"

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.