### PR TITLE
cv3 failure report task with idempotence and batch processing

### DIFF
--- a/lib/tasks/cv3_family_failures_report.rake
+++ b/lib/tasks/cv3_family_failures_report.rake
@@ -1,41 +1,97 @@
 require 'csv'
-
+# This rake task generates a CSV report from a failure analysis of family to cv3 transformation. It creates a report
+# where each row corresponds to a single family and has the following columns: hbx_id, result, and output. If a
+# family's transformation fails, it logs the failure result or error message. The CSV report is saved in the root directory
+# with the filename 'cv3_family_failures_report.csv'.
+# Additionally, progress of the task and final report status are logged both to stdout and a log file 'cv3_family_failures_report.log'.
+# The task supports continuing from where it left off by checking the last processed family id in 'cv3_report_last_processed_id.txt' or last failing family id in the CSV report file.
+# @param
+#   batch_size [Integer] the number of families to process in a single batch. Defaults to 100.
+# @example
+#   rake cv3_family_failures_report:generate_csv[100]
 namespace :cv3_family_failures_report do
   desc "Generate an error report from Operations::Transformers::FamilyTo::Cv3Family.new.call(family) on all Families"
 
-  task :generate_csv => :environment do
+  task :generate_csv, [:batch_size] => :environment do |t, args|
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    csv_file_path = Rails.root.join("cv3_family_failures_report.csv")
+    last_id_file_path = Rails.root.join("cv3_report_last_processed_id.txt")
+    batch_size = args[:batch_size].nil? ? 100 : args[:batch_size].to_i
 
-    # Define the CSV file path
-    csv_file_path = Rails.root.join("cv3_family_failures_report_#{DateTime.now.strftime("%Y%m%d%H%M%S")}.csv")
-
-    CSV.open(csv_file_path, 'wb') do |csv|
-      # Define the CSV header
-      csv << ['hbx_id', 'result', 'output']
-
-      # Iterate over all Family entries
-      Family.all.no_timeout.each do |family|
-        begin
-          result = Operations::Transformers::FamilyTo::Cv3Family.new.call(family)
-
-          # Check if the method call was successful
-          if result.failure?
-            csv << [family.hbx_assigned_id, 'failure', result.failure]
-          else
-            csv << [family.hbx_assigned_id, 'success', nil]
-          end
-        rescue StandardError => e
-          # Catch any errors raised during the method call
-          csv << [family.hbx_assigned_id, 'failure', e.message]
-        end
+    if File.exists?(csv_file_path)
+      # Ideally there is a last_id_file_path for every csv_file_path accounting for families that are processed but
+      # not saved due to successful transformation, but in case there isn't, we can still
+      # resume from the last family with a failure in the CSV report file.
+      if File.exists?(last_id_file_path)
+        last_family_id = File.read(last_id_file_path).strip
+      else
+        last_line = `tail -n 1 #{csv_file_path}`
+        last_family_id = last_line.strip.split(',').first
       end
+      families = Family.where(:hbx_assigned_id.gt => last_family_id)
+      log "Resuming from family with hbx_id #{last_family_id}."
+    else
+      CSV.open(csv_file_path, 'wb') { |csv| csv << %w[hbx_id result output] }
+      families = Family.all
+
     end
 
-    puts "Report complete. Output file is located at: #{csv_file_path}"
-    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    seconds_elapsed = end_time - start_time
-    hr_min_sec = format("%02dhr %02dmin %02dsec", seconds_elapsed / 3600, seconds_elapsed / 60 % 60, seconds_elapsed % 60)
-    puts "Total time for report to complete: #{hr_min_sec}"
+    total = families.count
+
+    if total.zero?
+      log "There are no families left to process."
+      next
+    end
+
+    total_batches = (total.to_f / batch_size).ceil
+    log "There are #{total} families to process in #{total_batches} batches of #{batch_size}."
+
+    # Process families in batches and write to CSV file logging progress as we go
+    families.asc(:hbx_assigned_id).no_timeout.each_slice(batch_size).with_index do |family_batch, batch_number|
+      CSV.open(csv_file_path, 'ab') do |csv|
+        process_family_batch(family_batch, csv)
+      end
+
+      # write the last processed id to the file in case of interruption
+      File.write(last_id_file_path, family_batch.last.hbx_assigned_id)
+
+      # Log progress
+      progress = ((batch_number + 1).to_f / total_batches * 100).round(2)
+      processed = [batch_size * (batch_number + 1), total].min
+      log "Progress: #{progress}% - Processed #{processed} out of #{total} families."
+      log "Time elapsed: #{time_elapsed(start_time)}."
+    end
+
+    log "Report complete. Output file is located at: #{csv_file_path}"
+    log "Total time for report to complete: #{time_elapsed(start_time)}"
   end
 
+  def process_family_batch(families, csv)
+    families.each do |family|
+      begin
+        result = Operations::Transformers::FamilyTo::Cv3Family.new.call(family)
+        if result.failure?
+          csv << [family.hbx_assigned_id, 'failure', result.failure]
+        end
+      rescue StandardError => e
+        csv << [family.hbx_assigned_id, 'failure', e.message]
+      end
+    end
+  end
+
+  def time_elapsed(start_time)
+    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    seconds_elapsed = end_time - start_time
+    format("%02dhr %02dmin %02dsec", seconds_elapsed / 3600, seconds_elapsed / 60 % 60, seconds_elapsed % 60)
+  end
+
+  def log(message)
+    log_prefix = "[CV3 FAMILY FAILURES REPORT] "
+
+    puts "#{log_prefix}#{message}"
+    Rails.logger.info "#{log_prefix}#{message}"
+    File.open(Rails.root.join('cv3_family_failures_report.log'), 'a') do |f|
+      f.puts(message)
+    end
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185570359

# A brief description of the changes

Current behavior:  Report rake loops through all families and logs results of CV3 transform (both success and failure).

New behavior: Report rake loops through batches of families and batch size can be controlled with a passed in argument.  Report only logs failures. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

This rake task generates a CSV report from a failure analysis of family-to-cv3 transformations. It processes families in batches and attempts to transform each family. If a family transformation fails, the failure result or error message is logged. The CSV report contains rows for each family, with columns for hbx_id, result, and output.

To use the rake task, you can run the following command:
```
rake cv3_family_failures_report:generate_csv[batch_size]
```
where `batch_size` is an optional parameter specifying the number of families to process in a single batch. The default batch size is 100.

The output of the task includes the progress of the transformation process, which is logged both to the console and a log file called `cv3_family_failures_report.log`. The final CSV report is saved in the root directory with the filename `cv3_family_failures_report.csv`.

The task supports resuming from where it left off in case of interruption, as it checks the last processed family id in the `cv3_report_last_processed_id.txt` file or the last failing family id in the CSV report file.