### PR TITLE
adds spousal relationship validation for fa application

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -602,16 +602,17 @@ module FinancialAssistance
     def has_spouse
       spouse_relationship.present?
     end
-
-    def valid_relationships?
-      # checks that an applicant cannot have more than one spousal relationship
+    
+    # Checks that an applicant cannot have more than one spousal relationship
+    def valid_spousal_relationship?
+      
       partner_relationships = application.relationships.where({
         "$or" => [
         {:applicant_id => id, :kind.in => ['spouse', 'domestic_partner']},
         {:relative_id => id, :kind.in => ['spouse', 'domestic_partner']}
         ]
       })
-      return false if partner_relationships.size > 1
+      return false if partner_relationships.size > 2
       true
     end
 

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -603,6 +603,18 @@ module FinancialAssistance
       spouse_relationship.present?
     end
 
+    def valid_relationships?
+      # checks that an applicant cannot have more than one spousal relationship
+      partner_relationships = application.relationships.where({
+        "$or" => [
+        {:applicant_id => id, :kind.in => ['spouse', 'domestic_partner']},
+        {:relative_id => id, :kind.in => ['spouse', 'domestic_partner']}
+        ]
+      })
+      return false if partner_relationships.size > 1
+      true
+    end
+
     # Checks to see if there is a relationship for Application where current applicant is spouse to PrimaryApplicant.
     def is_spouse_of_primary
       application.relationships.where(applicant_id: id, kind: 'spouse', relative_id: application.primary_applicant.id).present?

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -602,16 +602,15 @@ module FinancialAssistance
     def has_spouse
       spouse_relationship.present?
     end
-    
+
     # Checks that an applicant cannot have more than one spousal relationship
     def valid_spousal_relationship?
-      
       partner_relationships = application.relationships.where({
-        "$or" => [
-        {:applicant_id => id, :kind.in => ['spouse', 'domestic_partner']},
-        {:relative_id => id, :kind.in => ['spouse', 'domestic_partner']}
-        ]
-      })
+                                                                "$or" => [
+                                                                { :applicant_id => id, :kind.in => ['spouse', 'domestic_partner'] },
+                                                                { :relative_id => id, :kind.in => ['spouse', 'domestic_partner'] }
+                                                                ]
+                                                              })
       return false if partner_relationships.size > 2
       true
     end

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -644,35 +644,19 @@ module FinancialAssistance
       all_relationships = find_all_relationships(matrix)
       spouse_relation = all_relationships.select{|hash| hash[:relation] == "spouse"}.first
       return true unless spouse_relation.present?
-
       spouse_rel_id = spouse_relation.to_a.flatten.select{|a| a.is_a?(BSON::ObjectId) && a != primary_applicant.id}.first
-      # assumes the primary is a spouse
       primary_parent_relations = relationships.where(applicant_id: primary_applicant.id, kind: 'parent')
-      #dad has 3 relationships where he is the parent
-
-      # find all the parent relationships
       child_ids = primary_parent_relations.map(&:relative_id)
-      # find all the children
       spouse_parent_relations = relationships.where(:relative_id.in => child_ids.flatten, applicant_id: spouse_rel_id, kind: 'parent')
-      # find all the spouse's children
-      # return false if the primary and the spouse have different amounts of children
+
       if spouse_parent_relations.count == child_ids.flatten.count
         true
       else
         self.errors[:base] << I18n.t("faa.errors.invalid_household_relationships")
         false
-
       end
     end
-    # if you list bob as your brother and you list tom as your dad, but bob lists tom as their spouse
-
-    # applicant.relationships.each do |relationship|
-    #   look at this person's relationship types
-    #   look at all the relative's relationship types and who they coorespond with
-   # spouse_or_domestic_partner = applicant.relationships.select {|relationship| relationship.kind == "spouse" || relationship.kind == "domestic_partner"}
-    #if spouse_or_domestic_partner.count > 1
-      #return false if spouse_or_domestic_partner.count > 1
-    # end
+    
 
 
     def apply_rules_and_update_relationships(matrix) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
@@ -734,6 +718,9 @@ module FinancialAssistance
         end
       end
 
+      # Spouse Rule
+      # When MemberA is child of MemberB, And MemberC is child to MemberD,
+      # And MemberB, MemberD are spouse to eachother, Then MemberA, MemberC are Siblings
       missing_relationships.each do |rel|
         first_rel = rel.to_a.flatten.first
         second_rel = rel.to_a.flatten.second

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -656,7 +656,7 @@ module FinancialAssistance
 
     def validate_relationships(matrix)
       # validates the child has relationship as parent for 'spouse of the primary'.
-      return false if applicants.any? {|applicant| !applicant.valid_relationships?}
+      return false if applicants.any? { |applicant| !applicant.valid_spousal_relationship? }
       all_relationships = find_all_relationships(matrix)
       spouse_relation = all_relationships.select{|hash| hash[:relation] == "spouse"}.first
       return true unless spouse_relation.present?
@@ -750,9 +750,6 @@ module FinancialAssistance
         end
       end
 
-      # Spouse Rule
-      # When MemberA is child of MemberB, And MemberC is child to MemberD,
-      # And MemberB, MemberD are spouse to eachother, Then MemberA, MemberC are Siblings
       missing_relationships.each do |rel|
         first_rel = rel.to_a.flatten.first
         second_rel = rel.to_a.flatten.second

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -644,6 +644,7 @@ module FinancialAssistance
       all_relationships = find_all_relationships(matrix)
       spouse_relation = all_relationships.select{|hash| hash[:relation] == "spouse"}.first
       return true unless spouse_relation.present?
+
       spouse_rel_id = spouse_relation.to_a.flatten.select{|a| a.is_a?(BSON::ObjectId) && a != primary_applicant.id}.first
       primary_parent_relations = relationships.where(applicant_id: primary_applicant.id, kind: 'parent')
       child_ids = primary_parent_relations.map(&:relative_id)
@@ -656,8 +657,6 @@ module FinancialAssistance
         false
       end
     end
-    
-
 
     def apply_rules_and_update_relationships(matrix) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
       missing_relationships = find_missing_relationships(matrix)

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -545,22 +545,6 @@ module FinancialAssistance
       end
       self.errors[:base] << I18n.t("faa.errors.missing_relationships")
       missing_relationships
-
-      # loop through all their relationships if the relative id appears more than once, that's an issue right?
-    end
-
-    def check_inconsistent_relationships
-      applicants.each do |applicant|
-        relationships = []
-       relative_ids = applicant.relationships.map(&:relative_id)
-       filtered_relative_ids = relative_ids.uniq
-       inconsistent_relationships = if relative_ids.size != filtered_relative_ids.size
-        false
-        else
-          true
-       end
-      end
-      inconsistent_relationships
     end
 
     def update_response_attributes(attrs)
@@ -660,7 +644,7 @@ module FinancialAssistance
       all_relationships = find_all_relationships(matrix)
       spouse_relation = all_relationships.select{|hash| hash[:relation] == "spouse"}.first
       return true unless spouse_relation.present?
-    
+
       spouse_rel_id = spouse_relation.to_a.flatten.select{|a| a.is_a?(BSON::ObjectId) && a != primary_applicant.id}.first
       # assumes the primary is a spouse
       primary_parent_relations = relationships.where(applicant_id: primary_applicant.id, kind: 'parent')
@@ -677,7 +661,7 @@ module FinancialAssistance
       else
         self.errors[:base] << I18n.t("faa.errors.invalid_household_relationships")
         false
-      
+
       end
     end
     # if you list bob as your brother and you list tom as your dad, but bob lists tom as their spouse
@@ -689,7 +673,7 @@ module FinancialAssistance
     #if spouse_or_domestic_partner.count > 1
       #return false if spouse_or_domestic_partner.count > 1
     # end
-  
+
 
     def apply_rules_and_update_relationships(matrix) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
       missing_relationships = find_missing_relationships(matrix)

--- a/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
@@ -1060,7 +1060,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
         application.ensure_relationship_with_primary(applicant2, 'spouse')
         applicant.save!
       end
-      
+
       let!(:relationship_2) do
         application.add_or_update_relationships(applicant2, applicant3, 'siblings')
         applicant2.save!
@@ -1070,7 +1070,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
         application.add_or_update_relationships(applicant3, applicant, 'domestic_partner')
         applicant3.save!
       end
-   
+
       it "returns false" do
         expect(applicant.valid_spousal_relationship?).to eq false
       end
@@ -1082,7 +1082,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
         application.ensure_relationship_with_primary(applicant2, 'spouse')
         application.reload
       end
-      
+
       let!(:relationship_2) do
         application.add_or_update_relationships(applicant2, applicant3, 'parent')
         applicant2.save!
@@ -1092,7 +1092,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
         application.add_or_update_relationships(applicant3, applicant, 'child')
         applicant3.save!
       end
-      
+
       it "returns true" do
         expect(applicant.valid_spousal_relationship?).to eq true
       end

--- a/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
@@ -1888,6 +1888,25 @@ RSpec.describe ::FinancialAssistance::Application, type: :model, dbclean: :after
       end
     end
 
+    context "when an applicant has more than one spouse relationship" do
+      let!(:applicant1) { FactoryBot.create(:financial_assistance_applicant, application: relationship_application, family_member_id: BSON::ObjectId.new) }
+      let!(:applicant2) { FactoryBot.create(:financial_assistance_applicant, application: relationship_application, family_member_id: BSON::ObjectId.new) }
+      let(:set_up_relationships) do
+        relationship_application.ensure_relationship_with_primary(applicant1, 'spouse')
+        relationship_application.ensure_relationship_with_primary(applicant2, 'spouse')
+        relationship_application.add_or_update_relationships(applicant1, applicant2, 'parent')
+        relationship_application.build_relationship_matrix
+        relationship_application.save(validate: false)
+      end
+
+      before do
+        set_up_relationships
+      end
+      it "returns false" do
+        expect(relationship_application.valid_relations?).to eq(false)
+      end
+    end
+
     context "when there are two applicants with spouse relationship" do
       let!(:applicant1) { FactoryBot.create(:financial_assistance_applicant, application: relationship_application, family_member_id: BSON::ObjectId.new) }
       let(:set_up_relationships) do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-185698166](https://www.pivotaltracker.com/n/projects/2640060/stories/185698166)

# A brief description of the changes

Current behavior: We allow an applicant to submit an faa application with having more than one spouse or domestic partner. This is throwing a MITC error.

New behavior: We prevent an applicant from submitting an application with more than one spouse and throw a warning message.

# Feature Flag This is the `RR feature EnrollRegistry.feature_enabled?(:mitc_relationships)`. Enabled in both ME and DC

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.