### PR TITLE
add CRM/Salesforce as verification reason to verify evidence documents

### DIFF
--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -105,7 +105,7 @@ registry:
         item: "Curam"
         is_enabled: true
       - key: :verification_reasons
-        item: ["Document in EnrollApp", "Document in DIMS", "SAVE system", "E-Verified in Curam"]
+        item: ["Document in EnrollApp", "Document in DIMS", "SAVE system", "E-Verified in Curam", "Salesforce"]
         is_enabled: true
       - key: :total_minimum_responsibility
         is_enabled: false

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -107,7 +107,8 @@ registry:
         item: "State Medicaid Agency"
         is_enabled: true
       - key: :verification_reasons
-        item: ["Document in EnrollApp", "Electronic data source", "State Medicaid Agency"]
+        item: ["Document in EnrollApp", "Electronic data source", "State Medicaid Agency",
+               "CRM Document Management System"]
         is_enabled: true
       - key: :total_minimum_responsibility
         is_enabled: true

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -234,6 +234,21 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
       expect(income_evidence.request_results.first.date_of_action).to eql(income_evidence2.request_results.first.date_of_action)
     end
   end
+
+  context "verification reasons" do
+    if EnrollRegistry[:enroll_app].setting(:site_key).item == :me
+      it "should have crm document system as verification reason" do
+        expect(::Eligibilities::Evidence::VERIFY_REASONS).to include("CRM Document Management System")
+        expect(EnrollRegistry[:verification_reasons].item).to include("CRM Document Management System")
+      end
+    end
+    if EnrollRegistry[:enroll_app].setting(:site_key).item == :dc
+      it "should have salesforce as verification reason" do
+        expect(::Eligibilities::Evidence::VERIFY_REASONS).to include("Salesforce")
+        expect(EnrollRegistry[:verification_reasons].item).to include("Salesforce")
+      end
+    end
+  end
 end
 
 def create_embedded_docs_for_evidence(evidence)

--- a/spec/models/ridp_document_spec.rb
+++ b/spec/models/ridp_document_spec.rb
@@ -16,4 +16,18 @@ RSpec.describe RidpDocument, :type => :model do
     end
   end
 
+  context "verification reasons" do
+    if EnrollRegistry[:enroll_app].setting(:site_key).item == :me
+      it "should have crm document system as verification reason" do
+        expect(RidpDocument::VERIFICATION_REASONS).to include("CRM Document Management System")
+        expect(EnrollRegistry[:verification_reasons].item).to include("CRM Document Management System")
+      end
+    end
+    if EnrollRegistry[:enroll_app].setting(:site_key).item == :dc
+      it "should have salesforce as verification reason" do
+        expect(RidpDocument::VERIFICATION_REASONS).to include("Salesforce")
+        expect(EnrollRegistry[:verification_reasons].item).to include("Salesforce")
+      end
+    end
+  end
 end

--- a/spec/models/vlp_document_spec.rb
+++ b/spec/models/vlp_document_spec.rb
@@ -16,5 +16,20 @@ RSpec.describe VlpDocument, :type => :model do
       expect(person2.consumer_role.vlp_documents.select{|d| d.identifier.present?}.count).to eq(1)
     end
   end
+
+  context "verification reasons" do
+    if EnrollRegistry[:enroll_app].setting(:site_key).item == :me
+      it "should have crm document system as verification reason" do
+        expect(VlpDocument::VERIFICATION_REASONS).to include("CRM Document Management System")
+        expect(EnrollRegistry[:verification_reasons].item).to include("CRM Document Management System")
+      end
+    end
+    if EnrollRegistry[:enroll_app].setting(:site_key).item == :dc
+      it "should have salesforce as verification reason" do
+        expect(VlpDocument::VERIFICATION_REASONS).to include("Salesforce")
+        expect(EnrollRegistry[:verification_reasons].item).to include("Salesforce")
+      end
+    end
+  end
 end
 end

--- a/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -105,7 +105,7 @@ registry:
         item: "Curam"
         is_enabled: true
       - key: :verification_reasons
-        item: ["Document in EnrollApp", "Document in DIMS", "SAVE system", "E-Verified in Curam"]
+        item: ["Document in EnrollApp", "Document in DIMS", "SAVE system", "E-Verified in Curam", "Salesforce"]
         is_enabled: true
       - key: :total_minimum_responsibility
         is_enabled: false


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185681347

# A brief description of the changes

Current behavior: At present, the utilization of CRM/Salesforce as a verification reason for SBM or staff to verify documents is not in place.

New behavior: Add CRM/Salesforce as a verification reason to verify evidences/documents

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.