### PR TITLE
drops children who turned 19 on pediatric only dental plans

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   include FloatHelper
   include Config::AcaHelper
@@ -268,10 +269,31 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
     end
   end
 
+  def slcsp_feature_enabled?(renewal_year)
+    EnrollRegistry.feature_enabled?(:atleast_one_silver_plan_donot_cover_pediatric_dental_cost) &&
+      EnrollRegistry[:atleast_one_silver_plan_donot_cover_pediatric_dental_cost]&.settings(renewal_year)&.item
+  end
+
+  # Check if member turned 19 during renewal and has pediatric only Qualified Dental Plan
+  def turned_19_during_renewal_with_pediatric_only_qdp?(member)
+    return false unless slcsp_feature_enabled?(renewal_coverage_start.year)
+    return false if enrollment.is_health_enrollment?
+    return false unless dental_renewal_product.allows_child_only_offering?
+
+    member.person.age_on(renewal_coverage_start) >= 19
+  end
+
+  # Find the dental product using renewal_product_id
+  def dental_renewal_product
+    @dental_renewal_product ||= ::BenefitMarkets::Products::DentalProducts::DentalProduct.find(renewal_product)
+  end
+
   # rubocop:disable Style/RedundantReturn
   def eligible_to_get_covered?(member)
     child_relations = %w[child ward foster_child adopted_child]
     return true unless child_relations.include?(member.family_member.relationship)
+
+    return false if turned_19_during_renewal_with_pediatric_only_qdp?(member)
 
     return true if member.family_member.age_off_excluded
 

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2463,10 +2463,6 @@ class HbxEnrollment
     coverage_kind == "health"
   end
 
-  def is_dental_enrollment?
-    coverage_kind == "dental"
-  end
-
   def plan_year_check(employee_role)
     covered_plan_year(employee_role).present? && !covered_plan_year(employee_role).send(:can_be_migrated?)
   end

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -193,6 +193,109 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
       TimeKeeper.set_date_of_record_unprotected!(Date.today)
     end
 
+    describe '.turned_19_during_renewal_with_pediatric_only_qdp?' do
+      let(:renewal_coverage_start) { renewal_benefit_coverage_period.start_on }
+      let(:person) { FactoryBot.create(:person, :with_consumer_role, dob: TimeKeeper.date_of_record - dependent_age.years) }
+      let(:dependent) { double('HbxEnrollmentMember', person: person) }
+      let(:dependent_age) { rand(1..18) }
+
+      context 'when slcsp feature is disabled' do
+        before do
+          allow(subject).to receive(:slcsp_feature_enabled?).with(renewal_coverage_start.year).and_return(false)
+        end
+
+        it 'returns false as the feature is disabled' do
+          expect(
+            subject.turned_19_during_renewal_with_pediatric_only_qdp?(dependent)
+          ).to be_falsey
+        end
+      end
+
+      context 'when enrollment is of coverage_kind health' do
+        before do
+          allow(subject).to receive(:slcsp_feature_enabled?).with(renewal_coverage_start.year).and_return(true)
+        end
+
+        it 'returns false as the enrollment is health' do
+          expect(
+            subject.turned_19_during_renewal_with_pediatric_only_qdp?(dependent)
+          ).to be_falsey
+        end
+      end
+
+      context 'when renewal dental product allows adult offerings' do
+        let(:coverage_kind) { 'dental' }
+        let(:dental_renewal_product) do
+          double('::BenefitMarkets::Products::DentalProducts::DentalProduct', allows_child_only_offering?: false)
+        end
+
+        before do
+          allow(subject).to receive(:slcsp_feature_enabled?).with(renewal_coverage_start.year).and_return(true)
+          allow(subject).to receive(:dental_renewal_product).and_return(dental_renewal_product)
+        end
+
+        it 'returns false as the dental product allows adult offerings' do
+          expect(
+            subject.turned_19_during_renewal_with_pediatric_only_qdp?(dependent)
+          ).to be_falsey
+        end
+      end
+
+      context 'when member is aged less than 19 as of the renewal_coverage_start' do
+        let(:coverage_kind) { 'dental' }
+        let(:dental_renewal_product) do
+          double('::BenefitMarkets::Products::DentalProducts::DentalProduct', allows_child_only_offering?: true)
+        end
+
+        before do
+          allow(subject).to receive(:slcsp_feature_enabled?).with(renewal_coverage_start.year).and_return(true)
+          allow(subject).to receive(:dental_renewal_product).and_return(dental_renewal_product)
+        end
+
+        it 'returns false as member is aged less 19' do
+          expect(
+            subject.turned_19_during_renewal_with_pediatric_only_qdp?(dependent)
+          ).to be_falsey
+        end
+      end
+
+      # when slcsp feature enabled
+      # enrollment is dental
+      # renewal dental product only offers child only
+      # member is turning 19 as of renewal_coverage_start
+      context 'member is ineligible for pediatric only dental renewal' do
+        let(:coverage_kind) { 'dental' }
+        let(:dental_renewal_product) do
+          double('::BenefitMarkets::Products::DentalProducts::DentalProduct', allows_child_only_offering?: true)
+        end
+
+        before do
+          allow(subject).to receive(:slcsp_feature_enabled?).with(renewal_coverage_start.year).and_return(true)
+          allow(subject).to receive(:dental_renewal_product).and_return(dental_renewal_product)
+        end
+
+        context 'when member is turning 19 as of renewal_coverage_start' do
+          let(:dependent_age) { 19 }
+
+          it 'returns true as member is ineligible for pediatric only dental renewal' do
+            expect(
+              subject.turned_19_during_renewal_with_pediatric_only_qdp?(dependent)
+            ).to be_truthy
+          end
+        end
+
+        context 'when member is aged more than 19 as of renewal_coverage_start' do
+          let(:dependent_age) { rand(20..100) }
+
+          it 'returns true as member is ineligible for pediatric only dental renewal' do
+            expect(
+              subject.turned_19_during_renewal_with_pediatric_only_qdp?(dependent)
+            ).to be_truthy
+          end
+        end
+      end
+    end
+
     describe ".clone_enrollment_members" do
 
       context "when dependent age off feature is turned off" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 185314908](https://www.pivotaltracker.com/story/show/185314908)

# A brief description of the changes

Current behavior: Children who have turned 19 will be renewed into a pediatric-only('Allows Child-Only') Qualified Dental Product

New behavior: Children who have turned 19 will **not** be renewed into a pediatric-only('Allows Child-Only') Qualified Dental Product

# Feature Flag

We already have an existing feature ":atleast_one_silver_plan_donot_cover_pediatric_dental_cost" which will be used here as well.

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.