### PR TITLE
add logging for on_new_determination success

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -1029,8 +1029,11 @@ module FinancialAssistance
       return unless EnrollRegistry.feature_enabled?(:apply_aggregate_to_enrollment) || !previously_renewal_draft?
       return if retro_application
       on_new_determination = ::Operations::Individual::OnNewDetermination.new.call({family: self.family, year: self.effective_date.year})
-
-      Rails.logger.error { "Failed while creating enrollment on_new_determination: #{self.hbx_id}, Error: #{on_new_determination.failure}" } unless on_new_determination.success?
+      if on_new_determination.success?
+        Rails.logger.info { "Successfully created new enrollment on_new_determination: #{self.hbx_id}" }
+      else
+        Rails.logger.error { "Failed while creating enrollment on_new_determination: #{self.hbx_id}, Error: #{on_new_determination.failure}" }
+      end
     rescue StandardError => e
       Rails.logger.error { "Failed while creating enrollment on_new_determination: #{self.hbx_id}, Error: #{e.message}" }
     end

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -1035,7 +1035,7 @@ module FinancialAssistance
         Rails.logger.error { "Failed while creating enrollment on_new_determination: #{self.hbx_id}, Error: #{on_new_determination.failure}" }
       end
     rescue StandardError => e
-      Rails.logger.error { "Failed while creating enrollment on_new_determination: #{self.hbx_id}, Error: #{e.message}" }
+      Rails.logger.error { "Error while creating enrollment on_new_determination: #{self.hbx_id}, Error: #{e.message}" }
     end
 
     def retro_application

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -1032,7 +1032,7 @@ module FinancialAssistance
       if on_new_determination.success?
         Rails.logger.info { "Successfully created new enrollment on_new_determination: #{self.hbx_id}" }
       else
-        Rails.logger.error { "Failed while creating enrollment on_new_determination: #{self.hbx_id}, Error: #{on_new_determination.failure}" }
+        Rails.logger.error { "Failed while creating enrollment on_new_determination: #{self.hbx_id}, Failure Message: #{on_new_determination.failure}" }
       end
     rescue StandardError => e
       Rails.logger.error { "Error while creating enrollment on_new_determination: #{self.hbx_id}, Error: #{e.message}" }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-185563474](https://www.pivotaltracker.com/n/projects/2640060/stories/185563474)

# A brief description of the changes

Current behavior: The on_new_determination operation is triggered after an application is determined and builds a new enrollment. There has been an instance where we are not seeing a new enrollment created, and there are no failures. Adding a success logger will help us determine if the operation is even being called at all in these instances.

New behavior: Add logging if the on_new_determination operation results in a success

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.