### PR TITLE
add validation for child of domestic partner

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -620,13 +620,14 @@ module FinancialAssistance
     end
 
     def valid_child_relationship?
-      child_relationship = self.relationships.where(kind: 'child').first
-      if child_relationship.present?
-        parent = child_relationship.relative
-        domestic_partner_relationship = parent.relationships.where(kind: 'domestic_partner').first
-        return false if domestic_partner_relationship.present? && ['domestic_partners_child', 'child'].exclude?(self.relationships.where(relative_id: domestic_partner_relationship.relative.id).first.kind)
-      end
-      true
+      child_relationship = relationships.where(kind: 'child').first
+      return true if child_relationship.blank?
+
+      parent = child_relationship.relative
+      domestic_partner_relationship = parent.relationships.where(kind: 'domestic_partner').first
+      return true if domestic_partner_relationship.blank?
+
+     ['domestic_partners_child', 'child'].include?(relationships.where(relative_id: domestic_partner_relationship.relative.id).first.kind)
     end
 
     # Checks to see if there is a relationship for Application where current applicant is spouse to PrimaryApplicant.

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -603,6 +603,10 @@ module FinancialAssistance
       spouse_relationship.present?
     end
 
+    def valid_family_relationships?
+      valid_spousal_relationship? && valid_child_relationship?
+    end
+
     # Checks that an applicant cannot have more than one spousal relationship
     def valid_spousal_relationship?
       partner_relationships = application.relationships.where({
@@ -612,6 +616,16 @@ module FinancialAssistance
                                                                 ]
                                                               })
       return false if partner_relationships.size > 2
+      true
+    end
+
+    def valid_child_relationship?
+      child_relationship = self.relationships.where(kind: 'child').first
+      if child_relationship.present?
+        parent = child_relationship.relative
+        domestic_partner = parent.relationships.where(kind: 'domestic_partner').first
+        return false if domestic_partner.present? && self.relationships.where(relative_id: domestic_partner.relative.id).first.kind != 'domestic_partners_child'
+      end
       true
     end
 

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -627,7 +627,7 @@ module FinancialAssistance
       domestic_partner_relationship = parent.relationships.where(kind: 'domestic_partner').first
       return true if domestic_partner_relationship.blank?
 
-     ['domestic_partners_child', 'child'].include?(relationships.where(relative_id: domestic_partner_relationship.relative.id).first.kind)
+      ['domestic_partners_child', 'child'].include?(relationships.where(relative_id: domestic_partner_relationship.relative.id).first.kind)
     end
 
     # Checks to see if there is a relationship for Application where current applicant is spouse to PrimaryApplicant.

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -623,8 +623,8 @@ module FinancialAssistance
       child_relationship = self.relationships.where(kind: 'child').first
       if child_relationship.present?
         parent = child_relationship.relative
-        domestic_partner = parent.relationships.where(kind: 'domestic_partner').first
-        return false if domestic_partner.present? && self.relationships.where(relative_id: domestic_partner.relative.id).first.kind != 'domestic_partners_child'
+        domestic_partner_relationship = parent.relationships.where(kind: 'domestic_partner').first
+        return false if domestic_partner_relationship.present? && ['domestic_partners_child', 'child'].exclude?(self.relationships.where(relative_id: domestic_partner_relationship.relative.id).first.kind)
       end
       true
     end

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -640,7 +640,7 @@ module FinancialAssistance
 
     def validate_relationships(matrix)
       # validates the child has relationship as parent for 'spouse of the primary'.
-      return false if applicants.any? { |applicant| !applicant.valid_spousal_relationship? }
+      return false if applicants.any? { |applicant| !applicant.valid_family_relationships? }
       all_relationships = find_all_relationships(matrix)
       spouse_relation = all_relationships.select{|hash| hash[:relation] == "spouse"}.first
       return true unless spouse_relation.present?

--- a/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
@@ -1143,7 +1143,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
         end
 
         it "returns true" do
-          expect(applicant.valid_family_relationships).to eql(true)
+          expect(applicant.valid_family_relationships?).to eql(true)
         end
       end
     end

--- a/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
@@ -1038,7 +1038,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
     end
   end
 
-  describe '#valid_spousal_relationship' do
+  describe '#valid_family_relationships' do
     let!(:applicant2) do
       FactoryBot.create(:applicant,
                         application: application,
@@ -1055,46 +1055,96 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
                         family_member_id: BSON::ObjectId.new)
     end
 
-    context "invalid spousal relationships" do
-      let!(:relationship_1) do
-        application.ensure_relationship_with_primary(applicant2, 'spouse')
-        applicant.save!
+    context "spousal relationships" do
+
+      context "invalid spousal relationships" do
+        let!(:relationship_1) do
+          application.ensure_relationship_with_primary(applicant2, 'spouse')
+          applicant.save!
+        end
+
+        let!(:relationship_2) do
+          application.add_or_update_relationships(applicant2, applicant3, 'siblings')
+          applicant2.save!
+        end
+
+        let!(:relationship_3) do
+          application.add_or_update_relationships(applicant3, applicant, 'domestic_partner')
+          applicant3.save!
+        end
+
+        it "returns false" do
+          expect(applicant.valid_spousal_relationship?).to eq false
+        end
       end
 
-      let!(:relationship_2) do
-        application.add_or_update_relationships(applicant2, applicant3, 'siblings')
-        applicant2.save!
-      end
+      context "valid spousal relationships" do
 
-      let!(:relationship_3) do
-        application.add_or_update_relationships(applicant3, applicant, 'domestic_partner')
-        applicant3.save!
-      end
+        let!(:relationship_1) do
+          application.ensure_relationship_with_primary(applicant2, 'spouse')
+          application.reload
+        end
 
-      it "returns false" do
-        expect(applicant.valid_spousal_relationship?).to eq false
+        let!(:relationship_2) do
+          application.add_or_update_relationships(applicant2, applicant3, 'parent')
+          applicant2.save!
+        end
+
+        let!(:relationship_3) do
+          application.add_or_update_relationships(applicant3, applicant, 'child')
+          applicant3.save!
+        end
+
+        it "returns true" do
+          expect(applicant.valid_spousal_relationship?).to eq true
+        end
       end
     end
 
-    context "valid spousal relationships" do
+    context "child relationships" do
 
-      let!(:relationship_1) do
-        application.ensure_relationship_with_primary(applicant2, 'spouse')
-        application.reload
+      context "invalid child relationships" do
+
+        let!(:relationship_1) do
+          application.ensure_relationship_with_primary(applicant2, 'domestic_partner')
+          application.reload
+        end
+
+        let!(:relationship_2) do
+          application.add_or_update_relationships(applicant2, applicant3, 'parent')
+          applicant2.save!
+        end
+
+        let!(:relationship_3) do
+          application.add_or_update_relationships(applicant3, applicant, 'unrelated')
+          applicant3.save!
+        end
+
+        it "returns false" do
+          expect(applicant3.valid_family_relationships?).to eql(false)
+        end
       end
 
-      let!(:relationship_2) do
-        application.add_or_update_relationships(applicant2, applicant3, 'parent')
-        applicant2.save!
-      end
+      context "valid child relationships" do
 
-      let!(:relationship_3) do
-        application.add_or_update_relationships(applicant3, applicant, 'child')
-        applicant3.save!
-      end
+        let!(:relationship_1) do
+          application.ensure_relationship_with_primary(applicant2, 'domestic_partner')
+          application.reload
+        end
 
-      it "returns true" do
-        expect(applicant.valid_spousal_relationship?).to eq true
+        let!(:relationship_2) do
+          application.add_or_update_relationships(applicant2, applicant3, 'parent')
+          applicant2.save!
+        end
+
+        let!(:relationship_3) do
+          application.add_or_update_relationships(applicant3, applicant, 'child_of_domestic_partner')
+          applicant3.save!
+        end
+
+        it "returns true" do
+          expect(applicant.valid_family_relationships).to eql(true)
+        end
       end
     end
   end
@@ -1156,6 +1206,7 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
         expect(applicant2.is_spouse_of_primary).to eq(false)
       end
     end
+
 
     context 'when is_spouse_of_primary id called for primary_applicant' do
       it 'should return false' do

--- a/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
@@ -1907,6 +1907,26 @@ RSpec.describe ::FinancialAssistance::Application, type: :model, dbclean: :after
       end
     end
 
+    context "when an applicant is unrelated to the domestic partner of their parent" do
+      let!(:applicant1) { FactoryBot.create(:financial_assistance_applicant, application: relationship_application, family_member_id: BSON::ObjectId.new) }
+      let!(:applicant2) { FactoryBot.create(:financial_assistance_applicant, application: relationship_application, family_member_id: BSON::ObjectId.new) }
+      let(:set_up_relationships) do
+        relationship_application.ensure_relationship_with_primary(applicant1, 'child')
+        relationship_application.ensure_relationship_with_primary(applicant2, 'domestic_partner')
+        relationship_application.add_or_update_relationships(applicant1, applicant2, 'unrelated')
+        relationship_application.build_relationship_matrix
+        relationship_application.save(validate: false)
+      end
+
+      before do
+        set_up_relationships
+      end
+
+      it "returns false" do
+        expect(relationship_application.valid_relations?).to eq(false)
+      end
+    end
+
     context "when there are two applicants with spouse relationship" do
       let!(:applicant1) { FactoryBot.create(:financial_assistance_applicant, application: relationship_application, family_member_id: BSON::ObjectId.new) }
       let(:set_up_relationships) do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/185698165

# A brief description of the changes

Current behavior: If an applicant is a child and their parent has a domestic partner, there is no validation preventing application submission if that child's relationship to the domestic partner is something other than child of domestic partner.

New behavior: We add a validation to prevent application submission if there is an incorrect relationship between a child and a domestic partner.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: **EnrollRegistry.feature_enabled?(:mitc_relationships)**
 
- [x] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.