### PR TITLE
remove timestamps from redeterminations custom logs

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/determine_all.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/determine_all.rb
@@ -36,7 +36,7 @@ module FinancialAssistance
 
             # rubocop:disable Style/MultilineBlockChain
             def generate_determination_submission_events(renewal_year, app_ids)
-              logger = Logger.new("#{Rails.root}/log/aptc_credit_eligibilities_determine_all_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+              logger = Logger.new("#{Rails.root}/log/aptc_credit_eligibilities_determine_all.log")
               logger.info "Total number of applications with assistance_year: #{renewal_year.pred} are #{app_ids.count}"
               logger.info 'Started publishing renewal_events'
 

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/request_all.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/request_all.rb
@@ -35,7 +35,7 @@ module FinancialAssistance
 
             # rubocop:disable Style/MultilineBlockChain
             def generate_renewal_events(renewal_year, family_ids)
-              logger = Logger.new("#{Rails.root}/log/aptc_credit_eligibilities_request_all_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+              logger = Logger.new("#{Rails.root}/log/aptc_credit_eligibilities_request_all.log")
 
               logger.info 'Started publish_generate_draft_renewals process'
               logger.info "Total number of applications with assistance_year: #{renewal_year.pred} are #{family_ids.count}"


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185790360

# A brief description of the changes

Current behavior:
The operations below are called during the annual redeterminations process.
```
FinancialAssistance::Operations::Applications::AptcCsrCreditEligibilities::Renewals::RequestAll
FinancialAssistance::Operations::Applications::AptcCsrCreditEligibilities::Renewals::DetermineAll
```

They create custom log files with this format:
```
"#{Rails.root}/log/aptc_credit_eligibilities_request_all_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
"#{Rails.root}/log/aptc_credit_eligibilities_determine_all_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
```
New behavior:
The custom log files di not have a timestamp:
```
"#{Rails.root}/log/aptc_credit_eligibilities_request_all.log"
"#{Rails.root}/log/aptc_credit_eligibilities_determine_all.log"
```

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

Removing the timestamps from the log file names allows dev ops to flush the contents of the logs to standard out so that the logs are accessible in Graylog.