### PR TITLE
set aasm_state to applicant_update_required when missing relationship

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
@@ -58,7 +58,7 @@ module FinancialAssistance
             def renew_application(application, validated_params)
               application = create_renewal_draft_application(application, validated_params)
 
-              return Failure("Unable to create renewal application - #{application.failure} with #{validated_params}") if application.failure?
+              return Failure("Unable to create renewal application - #{application.failure} with params: (#{validated_params})") if application.failure?
 
               application
             end
@@ -83,10 +83,16 @@ module FinancialAssistance
                 renewal_application = copied_result.success
 
                 family_members_changed = renewal_application_factory.family_members_changed
+                relationships_changed = renewal_application_factory.relationships_changed
                 calculated_renewal_base_year = calculate_renewal_base_year(application)
 
                 renewal_application.assign_attributes(
-                  aasm_state: find_aasm_state(application, family_members_changed),
+                  aasm_state: find_aasm_state(
+                    application,
+                    family_members_changed,
+                    renewal_application,
+                    relationships_changed
+                  ),
                   assistance_year: validated_params[:renewal_year],
                   years_to_renew: calculate_years_to_renew(application),
                   renewal_base_year: calculated_renewal_base_year,
@@ -100,7 +106,7 @@ module FinancialAssistance
                 if renewal_application.renewal_draft?
                   Success(renewal_application)
                 else
-                  Failure("Renewal Application Applicants Update or income_verification_extension required - #{renewal_application.hbx_id}")
+                  Failure("Renewal Application: (#{renewal_application.hbx_id}) failed with aasm_state: (#{renewal_application.aasm_state}), because: (#{@failure_reason || "Unknown"})")
                 end
               end.to_result
             end
@@ -110,11 +116,18 @@ module FinancialAssistance
               feature.enabled? && feature.settings(:annual_eligibility_redetermination).item
             end
 
-            def find_aasm_state(application, family_members_changed)
+            def find_aasm_state(application, family_members_changed, renew_application, relationships_changed)
               if application.years_to_renew == 0 || application.years_to_renew.nil?
+                @failure_reason = 'years_to_renew is 0 or nil'
                 'income_verification_extension_required'
+              elsif family_members_changed
+                @failure_reason = 'family_members_changed'
+                'applicants_update_required'
+              elsif relationships_changed && !renew_application.relationships_complete?
+                @failure_reason = 'missing_relationships'
+                'applicants_update_required'
               else
-                family_members_changed ? 'applicants_update_required' : 'renewal_draft'
+                'renewal_draft'
               end
             end
 

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
@@ -123,12 +123,16 @@ module FinancialAssistance
               elsif family_members_changed
                 @failure_reason = 'family_members_changed'
                 'applicants_update_required'
-              elsif relationships_changed && !renew_application.relationships_complete?
+              elsif missing_relationships?(relationships_changed, renew_application)
                 @failure_reason = 'missing_relationships'
                 'applicants_update_required'
               else
                 'renewal_draft'
               end
+            end
+
+            def missing_relationships?(relationships_changed, renew_application)
+              relationships_changed && !renew_application.relationships_complete?
             end
 
             def calculate_years_to_renew(application)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
@@ -106,7 +106,7 @@ module FinancialAssistance
                 if renewal_application.renewal_draft?
                   Success(renewal_application)
                 else
-                  Failure("Renewal Application: (#{renewal_application.hbx_id}) failed with aasm_state: (#{renewal_application.aasm_state}), because: (#{@failure_reason || "Unknown"})")
+                  Failure("Renewal Application: (#{renewal_application.hbx_id}) failed with aasm_state: (#{renewal_application.aasm_state}), because: (#{@failure_reason || 'Unknown'})")
                 end
               end.to_result
             end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credits/renewals/renew_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credits/renewals/renew_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AptcCsrCreditEli
 
         it 'should return failure' do
           expect(@result).to be_failure
-          expect  expect(FinancialAssistance::Application.where(family_id: application.family.id).last.aasm_state).to eq 'applicants_update_required'
+          expect(FinancialAssistance::Application.where(family_id: application.family.id).last.aasm_state).to eq 'applicants_update_required'
         end
       end
     end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credits/renewals/renew_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credits/renewals/renew_spec.rb
@@ -303,6 +303,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AptcCsrCreditEli
         it 'should return failure' do
           expect(@result).to be_failure
           expect(FinancialAssistance::Application.where(family_id: application.family.id).last.aasm_state).to eq 'applicants_update_required'
+          expect(@result.failure).to match(/because: \(missing_relationships\)/)
         end
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185799081

# A brief description of the changes

Current behavior:
renewal applications with changed family member relationships will fail to submit and get stuck in the `renewal_draft` state

New behavior:
Renewal applications with changed family member relationships will fail to submit and get marked with aasm_state `applicants_update_required`
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.