### PR TITLE
remove unnecessary buttons from final page

### DIFF
--- a/app/views/shared/_individual_progress.html.haml
+++ b/app/views/shared/_individual_progress.html.haml
@@ -67,7 +67,7 @@
   %br
 - elsif step == 5
   = link_to purchase_or_confirm, checkout_insured_plan_shopping_path(@enrollment.id, :plan_id => @plan.id, market_kind: @market_kind, coverage_kind: @coverage_kind), :class => 'btn btn-lg btn-primary  btn-block disabled', id: 'btn-continue', :method => :post, :disabled => !@enrollable
-- unless step == 6 && EnrollRegistry.feature_enabled?(:back_to_account_all_shop)
+- elsif step != 6 && !EnrollRegistry.feature_enabled?(:back_to_account_all_shop)
   %button.btn.btn-lg.btn-primary.btn-block#btn-continue{type: 'submit'}
     CONTINUE
 

--- a/app/views/shared/_individual_progress.html.haml
+++ b/app/views/shared/_individual_progress.html.haml
@@ -67,13 +67,13 @@
   %br
 - elsif step == 5
   = link_to purchase_or_confirm, checkout_insured_plan_shopping_path(@enrollment.id, :plan_id => @plan.id, market_kind: @market_kind, coverage_kind: @coverage_kind), :class => 'btn btn-lg btn-primary  btn-block disabled', id: 'btn-continue', :method => :post, :disabled => !@enrollable
-- else
+- unless step == 6 && EnrollRegistry.feature_enabled?(:back_to_account_all_shop)
   %button.btn.btn-lg.btn-primary.btn-block#btn-continue{type: 'submit'}
     CONTINUE
 
 = render partial: 'shared/shopping_nav_panel',
-  locals: {show_exit_button: !@no_save_button,
-  show_previous_button: !@no_previous_button && step != 1,
+  locals: {show_exit_button: !@no_save_button && step < 6,
+  show_previous_button: !@no_previous_button && ![1,6].include?(step),
   show_account_button: step > 2 && EnrollRegistry.feature_enabled?(:back_to_account_all_shop),
   is_complete: step == 6,
-  show_help_button: step != 1 }
+  show_help_button: step != 1 && step < 6}

--- a/app/views/shared/_sep_progress.html.haml
+++ b/app/views/shared/_sep_progress.html.haml
@@ -56,12 +56,12 @@
     CONTINUE
 - elsif step == 6
   = link_to purchase_or_confirm, checkout_insured_plan_shopping_path(@enrollment.id, :plan_id => @plan.id, market_kind: @market_kind, coverage_kind: @coverage_kind, enrollment_kind: @enrollment_kind), :class => 'btn btn-lg btn-primary  btn-block disabled', id: 'btn-continue', :method => :post, :disabled => !@enrollable
-- else
+- unless step == 7 && EnrollRegistry.feature_enabled?(:back_to_account_all_shop)
   %button.btn.btn-lg.btn-primary.btn-block#btn-continue{type: 'submit'}
     CONTINUE
 
 = render partial: 'shared/shopping_nav_panel',
-  locals: {show_exit_button: true,
+  locals: {show_exit_button: step < 7,
   show_previous_button: ![1,7].include?(step),
   show_account_button: step > 2 && EnrollRegistry.feature_enabled?(:back_to_account_all_shop),
   show_help_button: step < 7,

--- a/app/views/shared/_sep_progress.html.haml
+++ b/app/views/shared/_sep_progress.html.haml
@@ -56,7 +56,7 @@
     CONTINUE
 - elsif step == 6
   = link_to purchase_or_confirm, checkout_insured_plan_shopping_path(@enrollment.id, :plan_id => @plan.id, market_kind: @market_kind, coverage_kind: @coverage_kind, enrollment_kind: @enrollment_kind), :class => 'btn btn-lg btn-primary  btn-block disabled', id: 'btn-continue', :method => :post, :disabled => !@enrollable
-- unless step == 7 && EnrollRegistry.feature_enabled?(:back_to_account_all_shop)
+- elsif step != 7 && !EnrollRegistry.feature_enabled?(:back_to_account_all_shop)
   %button.btn.btn-lg.btn-primary.btn-block#btn-continue{type: 'submit'}
     CONTINUE
 

--- a/spec/views/shared/_individual_progress.html.erb_spec.rb
+++ b/spec/views/shared/_individual_progress.html.erb_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+# !WARNING! This test file is only a starting point for testing the shared/_individual_progress.html.erb partial.
+# It is in no way exhaustive and should be expanded upon to include all logic in all steps.
+
+describe "shared/_individual_progress.html.erb" do
+  context "last step" do
+    before :each do
+      allow(view).to receive(:policy_helper).and_return(double("FamilyPolicy", updateable?: true))
+      render 'shared/individual_progress', step: '6'
+    end
+
+    it "should only have the continue button; without back_to_account_all_shop" do
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:back_to_account_all_shop).and_return(false)
+      expect(rendered).to have_selector('a#btn-continue', count: 1)
+
+      expect(rendered).not_to have_selector('a', text: l10n("previous_step"))
+      expect(rendered).not_to have_selector('a', text: l10n("help_sign_up"))
+      expect(rendered).not_to have_selector('a', text: l10n("save_and_exit"))
+    end
+
+    it "should only have the continue button; with back_to_account_all_shop" do
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:back_to_account_all_shop).and_return(true)
+      expect(rendered).to have_selector('a#btn-continue', count: 1)
+
+      expect(rendered).not_to have_selector('a', text: l10n("previous_step"))
+      expect(rendered).not_to have_selector('a', text: l10n("help_sign_up"))
+      expect(rendered).not_to have_selector('a', text: l10n("save_and_exit"))
+    end
+  end
+end

--- a/spec/views/shared/_individual_progress.html.erb_spec.rb
+++ b/spec/views/shared/_individual_progress.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 # !WARNING! This test file is only a starting point for testing the shared/_individual_progress.html.erb partial.

--- a/spec/views/shared/_sep_progress.html.erb_spec.rb
+++ b/spec/views/shared/_sep_progress.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+# !WARNING! This test file is only a starting point for testing the shared/_sep_progress.html.erb partial.
+# It is in no way exhaustive and should be expanded upon to include all logic in all steps.
+
+describe "shared/_sep_progress.html.erb" do
+  context "last step" do
+    before :each do
+      render 'shared/sep_progress', step: '7'
+    end
+
+    it "should only have the continue button; without back_to_account_all_shop" do
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:back_to_account_all_shop).and_return(false)
+      expect(rendered).to have_selector('a#btn-continue', count: 1)
+
+      expect(rendered).not_to have_selector('a', text: l10n("previous_step"))
+      expect(rendered).not_to have_selector('a', text: l10n("help_sign_up"))
+      expect(rendered).not_to have_selector('a', text: l10n("save_and_exit"))
+    end
+
+    it "should only have the continue button; with back_to_account_all_shop" do
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:back_to_account_all_shop).and_return(true)
+      expect(rendered).to have_selector('a#btn-continue', count: 1)
+
+      expect(rendered).not_to have_selector('a', text: l10n("previous_step"))
+      expect(rendered).not_to have_selector('a', text: l10n("help_sign_up"))
+      expect(rendered).not_to have_selector('a', text: l10n("save_and_exit"))
+    end
+  end
+end

--- a/spec/views/shared/_sep_progress.html.erb_spec.rb
+++ b/spec/views/shared/_sep_progress.html.erb_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 # !WARNING! This test file is only a starting point for testing the shared/_sep_progress.html.erb partial.


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?
Ticket: 
TT6-185821043

# A brief description of the changes

Current behavior:
During the open enrollment flow the final page had Continue, Continue to my account, Previous Step, Help Me Sign Up, and Log Out buttons displayed.

New behavior:
Only the Continue to my account is displayed

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:
BACK_TO_ACCOUNT_ALL_SHOP_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.