### PR TITLE
restore continue button on help paying for coverage page

### DIFF
--- a/app/views/shared/_individual_progress.html.haml
+++ b/app/views/shared/_individual_progress.html.haml
@@ -67,7 +67,7 @@
   %br
 - elsif step == 5
   = link_to purchase_or_confirm, checkout_insured_plan_shopping_path(@enrollment.id, :plan_id => @plan.id, market_kind: @market_kind, coverage_kind: @coverage_kind), :class => 'btn btn-lg btn-primary  btn-block disabled', id: 'btn-continue', :method => :post, :disabled => !@enrollable
-- elsif step != 6 && !EnrollRegistry.feature_enabled?(:back_to_account_all_shop)
+- elsif step == 6 ? !EnrollRegistry.feature_enabled?(:back_to_account_all_shop) : true
   %button.btn.btn-lg.btn-primary.btn-block#btn-continue{type: 'submit'}
     CONTINUE
 

--- a/app/views/shared/_individual_progress.html.haml
+++ b/app/views/shared/_individual_progress.html.haml
@@ -67,7 +67,7 @@
   %br
 - elsif step == 5
   = link_to purchase_or_confirm, checkout_insured_plan_shopping_path(@enrollment.id, :plan_id => @plan.id, market_kind: @market_kind, coverage_kind: @coverage_kind), :class => 'btn btn-lg btn-primary  btn-block disabled', id: 'btn-continue', :method => :post, :disabled => !@enrollable
-- elsif step == 6 ? !EnrollRegistry.feature_enabled?(:back_to_account_all_shop) : true
+- elsif step != 6 # The final step is handled in the shopping_nav_panel partial
   %button.btn.btn-lg.btn-primary.btn-block#btn-continue{type: 'submit'}
     CONTINUE
 

--- a/app/views/shared/_sep_progress.html.haml
+++ b/app/views/shared/_sep_progress.html.haml
@@ -56,10 +56,9 @@
     CONTINUE
 - elsif step == 6
   = link_to purchase_or_confirm, checkout_insured_plan_shopping_path(@enrollment.id, :plan_id => @plan.id, market_kind: @market_kind, coverage_kind: @coverage_kind, enrollment_kind: @enrollment_kind), :class => 'btn btn-lg btn-primary  btn-block disabled', id: 'btn-continue', :method => :post, :disabled => !@enrollable
-- elsif step == 7 ? !EnrollRegistry.feature_enabled?(:back_to_account_all_shop) : true
+- elsif step != 7  # The final step is handled in the shopping_nav_panel partial
   %button.btn.btn-lg.btn-primary.btn-block#btn-continue{type: 'submit'}
     CONTINUE
-
 = render partial: 'shared/shopping_nav_panel',
   locals: {show_exit_button: step < 7,
   show_previous_button: ![1,7].include?(step),

--- a/app/views/shared/_sep_progress.html.haml
+++ b/app/views/shared/_sep_progress.html.haml
@@ -56,7 +56,7 @@
     CONTINUE
 - elsif step == 6
   = link_to purchase_or_confirm, checkout_insured_plan_shopping_path(@enrollment.id, :plan_id => @plan.id, market_kind: @market_kind, coverage_kind: @coverage_kind, enrollment_kind: @enrollment_kind), :class => 'btn btn-lg btn-primary  btn-block disabled', id: 'btn-continue', :method => :post, :disabled => !@enrollable
-- elsif step != 7 && !EnrollRegistry.feature_enabled?(:back_to_account_all_shop)
+- elsif step == 7 ? !EnrollRegistry.feature_enabled?(:back_to_account_all_shop) : true
   %button.btn.btn-lg.btn-primary.btn-block#btn-continue{type: 'submit'}
     CONTINUE
 

--- a/spec/views/shared/_individual_progress.html.erb_spec.rb
+++ b/spec/views/shared/_individual_progress.html.erb_spec.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 # NOTE: The current tests provide a baseline coverage for the shared/_individual_progress.html.erb partial.
-# As the logic in the view evolves, it's crucial to expand upon these tests to ensure comprehensive coverage.
+# As the logic in the view is complex, it's crucial to expand upon these tests to ensure comprehensive coverage.
 # These tests are not exhaustive and should be considered a starting point. As features or functionalities
 # are added to or modified in the view, corresponding tests should be updated or added accordingly to
 # maintain a robust test suite.
 require 'rails_helper'
 
 describe "shared/_individual_progress.html.erb" do
+  # Define the steps to test.
+  tested_steps = %w[0 6].freeze
+
   let(:person_user) { FactoryBot.create(:person) }
   let(:current_user) { FactoryBot.create(:user, person: person_user) }
 
@@ -15,31 +18,43 @@ describe "shared/_individual_progress.html.erb" do
     sign_in current_user
     allow(view).to receive(:policy_helper).and_return(double("FamilyPolicy", updateable?: true))
   end
-
-  def validate_continue_button
+  # Helper to assert the presence of the continue button.
+  def assert_continue_button_present
     expect(rendered).to have_selector('#btn-continue', count: 1)
   end
 
-  def validate_link_visibility(should_be_visible)
-    %w[previous_step help_sign_up save_and_exit].each do |link_name|
+  # Helper to assert the visibility of specific links.
+  def assert_links_visibility(should_be_visible, skip_links: [])
+    links = %w[previous_step help_sign_up save_and_exit] - skip_links
+
+    links.each do |link_name|
       action = should_be_visible ? :to : :not_to
       expect(rendered).send(action, have_selector('a', text: l10n(link_name)))
     end
   end
 
-  # Currently testing for steps 0 and 6, where 6 is the last step. You can add more steps
-  # to the array if you want to test for more steps and update the test accordingly (e.g. the validate_link_visibility parameter)
-  %w[0 6].each do |step|
-    context "on step #{step}" do
-      before { render 'shared/individual_progress', step: step }
+  # Mocks the feature enabled state, defaulting all to false.
+  def mock_feature_state(feature, state)
+    allow(EnrollRegistry).to receive(:feature_enabled?).and_return(false)
+    allow(EnrollRegistry).to receive(:feature_enabled?).with(feature).and_return(state)
+  end
 
+  # Tests for specific steps. Extend tested_steps to test additional ones.
+  tested_steps.each do |step|
+    context "on step #{step}" do
       [true, false].each do |feature_state|
         context "with back_to_account_all_shop feature #{feature_state ? 'enabled' : 'disabled'}" do
-          before { allow(EnrollRegistry).to receive(:feature_enabled?).with(:back_to_account_all_shop).and_return(feature_state) }
+          before do
+            mock_feature_state(:back_to_account_all_shop, feature_state)
+            render 'shared/individual_progress', step: step
+          end
 
           it "validates button and link visibility" do
-            validate_continue_button
-            validate_link_visibility(step == '0')
+            assert_continue_button_present
+            #  # Help sign up is inconsistent when back_to_account_all_shop is disabled.
+            skip_links = feature_state ? [] : ['help_sign_up']
+            # Validate links based on the current step and feature state.
+            assert_links_visibility(step == '0', skip_links: skip_links)
           end
         end
       end

--- a/spec/views/shared/_sep_progress.html.erb_spec.rb
+++ b/spec/views/shared/_sep_progress.html.erb_spec.rb
@@ -1,44 +1,58 @@
 # frozen_string_literal: true
 
 # NOTE: The current tests provide a baseline coverage for the shared/_sep_progress.html.erb partial.
-# As the logic in the view evolves, it's crucial to expand upon these tests to ensure comprehensive coverage.
+# As the logic in the view is complex, it's crucial to expand upon these tests to ensure comprehensive coverage.
 # These tests are not exhaustive and should be considered a starting point. As features or functionalities
 # are added to or modified in the view, corresponding tests should be updated or added accordingly to
 # maintain a robust test suite.
 require 'rails_helper'
 
 describe "shared/_sep_progress.html.erb" do
+  # Define the steps to test.
+  tested_steps = %w[0 7].freeze
+
   let(:person_user) { FactoryBot.create(:person) }
   let(:current_user) { FactoryBot.create(:user, person: person_user) }
 
-  before do
-    sign_in current_user
-  end
+  before { sign_in current_user }
 
-  def validate_continue_button
+  # Helper to assert the presence of the continue button.
+  def assert_continue_button_present
     expect(rendered).to have_selector('#btn-continue', count: 1)
   end
 
-  def validate_link_visibility(should_be_visible)
-    %w[previous_step help_sign_up save_and_exit].each do |link_name|
+  # Helper to assert the visibility of specific links.
+  def assert_links_visibility(should_be_visible, skip_links: [])
+    links = %w[previous_step help_sign_up save_and_exit] - skip_links
+
+    links.each do |link_name|
       action = should_be_visible ? :to : :not_to
       expect(rendered).send(action, have_selector('a', text: l10n(link_name)))
     end
   end
 
-  # Currently testing for steps 0 and 7, where 7 is the last step. You can add more steps
-  # to the array if you want to test for more steps and update the test accordingly (e.g. the validate_link_visibility parameter)
-  %w[0 7].each do |step|
-    context "on step #{step}" do
-      before { render 'shared/sep_progress', step: step }
+  # Mocks the feature enabled state, defaulting all to false.
+  def mock_feature_state(feature, state)
+    allow(EnrollRegistry).to receive(:feature_enabled?).and_return(false)
+    allow(EnrollRegistry).to receive(:feature_enabled?).with(feature).and_return(state)
+  end
 
+  # Tests for specific steps. Extend tested_steps to test additional ones.
+  tested_steps.each do |step|
+    context "on step #{step}" do
       [true, false].each do |feature_state|
         context "with back_to_account_all_shop feature #{feature_state ? 'enabled' : 'disabled'}" do
-          before { allow(EnrollRegistry).to receive(:feature_enabled?).with(:back_to_account_all_shop).and_return(feature_state) }
+          before do
+            mock_feature_state(:back_to_account_all_shop, feature_state)
+            render 'shared/sep_progress', step: step
+          end
 
           it "validates button and link visibility" do
-            validate_continue_button
-            validate_link_visibility(step == '0')
+            assert_continue_button_present
+            #  # Help sign up is inconsistent when back_to_account_all_shop is disabled.
+            skip_links = feature_state ? [] : ['help_sign_up']
+            # Validate links based on the current step and feature state.
+            assert_links_visibility(step == '0', skip_links: skip_links)
           end
         end
       end

--- a/spec/views/shared/_sep_progress.html.erb_spec.rb
+++ b/spec/views/shared/_sep_progress.html.erb_spec.rb
@@ -1,32 +1,47 @@
 # frozen_string_literal: true
 
+# NOTE: The current tests provide a baseline coverage for the shared/_sep_progress.html.erb partial.
+# As the logic in the view evolves, it's crucial to expand upon these tests to ensure comprehensive coverage.
+# These tests are not exhaustive and should be considered a starting point. As features or functionalities
+# are added to or modified in the view, corresponding tests should be updated or added accordingly to
+# maintain a robust test suite.
 require 'rails_helper'
 
-# !WARNING! This test file is only a starting point for testing the shared/_sep_progress.html.erb partial.
-# It is in no way exhaustive and should be expanded upon to include all logic in all steps.
-
 describe "shared/_sep_progress.html.erb" do
-  context "last step" do
-    before :each do
-      render 'shared/sep_progress', step: '7'
+  let(:person_user) { FactoryBot.create(:person) }
+  let(:current_user) { FactoryBot.create(:user, person: person_user) }
+
+  before do
+    sign_in current_user
+  end
+
+  def validate_continue_button
+    expect(rendered).to have_selector('#btn-continue', count: 1)
+  end
+
+  def validate_link_visibility(should_be_visible)
+    %w[previous_step help_sign_up save_and_exit].each do |link_name|
+      action = should_be_visible ? :to : :not_to
+      expect(rendered).send(action, have_selector('a', text: l10n(link_name)))
     end
+  end
 
-    it "should only have the continue button; without back_to_account_all_shop" do
-      allow(EnrollRegistry).to receive(:feature_enabled?).with(:back_to_account_all_shop).and_return(false)
-      expect(rendered).to have_selector('a#btn-continue', count: 1)
+  # Currently testing for steps 0 and 7, where 7 is the last step. You can add more steps
+  # to the array if you want to test for more steps and update the test accordingly (e.g. the validate_link_visibility parameter)
+  %w[0 7].each do |step|
+    context "on step #{step}" do
+      before { render 'shared/sep_progress', step: step }
 
-      expect(rendered).not_to have_selector('a', text: l10n("previous_step"))
-      expect(rendered).not_to have_selector('a', text: l10n("help_sign_up"))
-      expect(rendered).not_to have_selector('a', text: l10n("save_and_exit"))
-    end
+      [true, false].each do |feature_state|
+        context "with back_to_account_all_shop feature #{feature_state ? 'enabled' : 'disabled'}" do
+          before { allow(EnrollRegistry).to receive(:feature_enabled?).with(:back_to_account_all_shop).and_return(feature_state) }
 
-    it "should only have the continue button; with back_to_account_all_shop" do
-      allow(EnrollRegistry).to receive(:feature_enabled?).with(:back_to_account_all_shop).and_return(true)
-      expect(rendered).to have_selector('a#btn-continue', count: 1)
-
-      expect(rendered).not_to have_selector('a', text: l10n("previous_step"))
-      expect(rendered).not_to have_selector('a', text: l10n("help_sign_up"))
-      expect(rendered).not_to have_selector('a', text: l10n("save_and_exit"))
+          it "validates button and link visibility" do
+            validate_continue_button
+            validate_link_visibility(step == '0')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[TT6-185821043](https://www.pivotaltracker.com/n/projects/2640057/stories/185821043)

# A brief description of the changes

Current behavior:
The buttons and links are not always valid on the pre (step 0) and last steps
New behavior:
The buttons and links are tested to be accurate
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:
BACK_TO_ACCOUNT_ALL_SHOP_IS_ENABLED
- [x] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

The specs are written to encourage adding more tests for other steps and ideally testing all like partials similarly.