### PR TITLE
adds action field to eligibility result response

### DIFF
--- a/app/models/eligibilities/request_result.rb
+++ b/app/models/eligibilities/request_result.rb
@@ -15,6 +15,7 @@ module Eligibilities
     field :code_description, type: Date
     field :raw_payload, type: String
     field :date_of_action, type: DateTime
+    field :action, type: String
 
     after_create :set_date_of_action
 

--- a/components/financial_assistance/app/views/financial_assistance/applications/verifications/_admin_verification_actions.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/verifications/_admin_verification_actions.html.erb
@@ -104,7 +104,7 @@
             <tr>
               <th scope="row"><%= index + 1 %></th>
               <td><%= record&.date_of_action&.in_time_zone('Eastern Time (US & Canada)') %></td>
-              <td><%= record.is_a?(Eligibilities::RequestResult) ? 'Hub Call' : record.action.capitalize %></td>
+              <td><%= (record.is_a?(Eligibilities::RequestResult) && record.action.nil?) ? 'Hub Call' : record.action.capitalize %></td>
               <td><%= record.is_a?(Eligibilities::RequestResult) ? record.source_transaction_id : record.updated_by %></td>
               <td><%= record.is_a?(Eligibilities::RequestResult) ? 'Fdsh Hub Call' : record.update_reason %></td>
               <% if record.is_a?(Eligibilities::RequestResult) %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185837709

# A brief description of the changes

Current behavior: Currently when creating an eligibility request result we do not have the source instead default it to hub call.

New behavior: Adds source action from the response from Medicaid gateway in line with verification histories.

# Feature Flag: No need

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.