### PR TITLE
Revert "updating maxoccurs in faa xml schema"

### DIFF
--- a/components/financial_assistance/lib/schemas/common.xsd
+++ b/components/financial_assistance/lib/schemas/common.xsd
@@ -3,7 +3,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://openhbx.org/api/terms/1.0" xmlns:altova="http://www.altova.com/xml-schema-extensions" targetNamespace="http://openhbx.org/api/terms/1.0" elementFormDefault="qualified" version="1.0">
 	<xs:complexType name="AddressListType">
 		<xs:sequence>
-			<xs:element name="address" type="AddressType" maxOccurs="10"/>
+			<xs:element name="address" type="AddressType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:simpleType name="nonEmptyString">
@@ -22,7 +22,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="alias_id" maxOccurs="10">
+				<xs:element name="alias_id" maxOccurs="unbounded">
 					<xs:complexType>
 						<xs:sequence>
 							<xs:element name="id" type="xs:anyURI">
@@ -44,7 +44,7 @@
 	<xs:element name="approvals">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="approval" type="ApprovalType" maxOccurs="10"/>
+				<xs:element name="approval" type="ApprovalType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -54,7 +54,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="comment" type="CommentType" maxOccurs="10"/>
+				<xs:element name="comment" type="CommentType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -64,7 +64,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="contact" type="ContactType" maxOccurs="10"/>
+				<xs:element name="contact" type="ContactType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -74,7 +74,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="email" type="EmailType" maxOccurs="10"/>
+				<xs:element name="email" type="EmailType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -89,7 +89,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="phone" type="PhoneType" maxOccurs="10"/>
+				<xs:element name="phone" type="PhoneType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -99,7 +99,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="rate" type="RateType" maxOccurs="10"/>
+				<xs:element name="rate" type="RateType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -544,7 +544,7 @@
 					<xs:documentation>URN(s) for the resource instance that is subject of this event</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element ref="extended_resource_instance_uri" minOccurs="0" maxOccurs="10">
+			<xs:element ref="extended_resource_instance_uri" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>URN(s) for other resource instances assocated with this event</xs:documentation>
 				</xs:annotation>
@@ -2024,7 +2024,7 @@
 	</xs:complexType>
 	<xs:complexType name="OfficeLocationListType">
 		<xs:sequence>
-			<xs:element name="office_location" type="OfficeLocationType" maxOccurs="10"/>
+			<xs:element name="office_location" type="OfficeLocationType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 

--- a/components/financial_assistance/lib/schemas/financial_assistance.xsd
+++ b/components/financial_assistance/lib/schemas/financial_assistance.xsd
@@ -72,21 +72,21 @@
 			<xs:element name="incomes">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="income" type="FinancialAssistanceApplicantIncomeType" minOccurs="0" maxOccurs="10"/>
+						<xs:element name="income" type="FinancialAssistanceApplicantIncomeType" minOccurs="0" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="deductions">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="deduction" type="FinancialAssistanceApplicantDeductionType" minOccurs="0" maxOccurs="10"/>
+						<xs:element name="deduction" type="FinancialAssistanceApplicantDeductionType" minOccurs="0" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="benefits">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="benefit" type="FinancialAssistanceApplicantBenefitType" minOccurs="0" maxOccurs="10"/>
+						<xs:element name="benefit" type="FinancialAssistanceApplicantBenefitType" minOccurs="0" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -125,7 +125,7 @@
 	</xs:complexType>
 	<xs:complexType name="AssistanceTaxHouseholdsListType">
 		<xs:sequence>
-			<xs:element name="assistance_tax_household" type="AssistanceTaxHouseholdType" maxOccurs="10"/>
+			<xs:element name="assistance_tax_household" type="AssistanceTaxHouseholdType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="AssistanceTaxHouseholdType">
@@ -142,7 +142,7 @@
 	</xs:complexType>
 	<xs:complexType name="AssistanceEligibilityDeterminationListType">
 		<xs:sequence>
-			<xs:element name="eligibility_determination" type="AssistanceEligibilityDeterminationType" maxOccurs="10"/>
+			<xs:element name="eligibility_determination" type="AssistanceEligibilityDeterminationType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="AssistanceEligibilityDeterminationType">
@@ -190,7 +190,7 @@
 	</xs:complexType>
 	<xs:complexType name="AssistanceEligibilityDeterminationApplicantListType">
 		<xs:sequence>
-			<xs:element name="eligibility_determination_applicant" type="AssistanceEligibilityDeterminationApplicantType" maxOccurs="10"/>
+			<xs:element name="eligibility_determination_applicant" type="AssistanceEligibilityDeterminationApplicantType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="AssistanceEligibilityDeterminationApplicantType">
@@ -222,7 +222,7 @@
 	</xs:complexType>
 	<xs:complexType name="AssistanceTaxHouseholdMemberListType">
 		<xs:sequence>
-			<xs:element name="assistance_tax_household_member" type="FinancialAssistanceApplicantType" maxOccurs="10"/>
+			<xs:element name="assistance_tax_household_member" type="FinancialAssistanceApplicantType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="AssistedTaxHouseholdIncomesByYearType">
@@ -230,7 +230,7 @@
 			<xs:documentation>Sum of all qualified household income sources, including incomes of person who pays taxes, spouse and dependents, less qualified deductions, by calendar year. Also includes information about verification of the income.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="total_income_by_year" type="VerifiedCurrencyAmountPerAnnumType" maxOccurs="10"/>
+			<xs:element name="total_income_by_year" type="VerifiedCurrencyAmountPerAnnumType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 </xs:schema>

--- a/components/financial_assistance/lib/schemas/financial_assistance_flexible.xsd
+++ b/components/financial_assistance/lib/schemas/financial_assistance_flexible.xsd
@@ -72,21 +72,21 @@
 			<xs:element name="incomes">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="income" type="FinancialAssistanceApplicantIncomeType" minOccurs="0" maxOccurs="10"/>
+						<xs:element name="income" type="FinancialAssistanceApplicantIncomeType" minOccurs="0" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="deductions">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="deduction" type="FinancialAssistanceApplicantDeductionType" minOccurs="0" maxOccurs="10"/>
+						<xs:element name="deduction" type="FinancialAssistanceApplicantDeductionType" minOccurs="0" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="benefits">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="benefit" type="FinancialAssistanceApplicantBenefitType" minOccurs="0" maxOccurs="10"/>
+						<xs:element name="benefit" type="FinancialAssistanceApplicantBenefitType" minOccurs="0" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -125,7 +125,7 @@
 	</xs:complexType>
 	<xs:complexType name="AssistanceTaxHouseholdsListType">
 		<xs:sequence>
-			<xs:element name="assistance_tax_household" type="AssistanceTaxHouseholdType" maxOccurs="10"/>
+			<xs:element name="assistance_tax_household" type="AssistanceTaxHouseholdType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="AssistanceTaxHouseholdType">
@@ -142,7 +142,7 @@
 	</xs:complexType>
 	<xs:complexType name="AssistanceEligibilityDeterminationListType">
 		<xs:sequence>
-			<xs:element name="eligibility_determination" type="AssistanceEligibilityDeterminationType" maxOccurs="10"/>
+			<xs:element name="eligibility_determination" type="AssistanceEligibilityDeterminationType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="AssistanceEligibilityDeterminationType">
@@ -190,7 +190,7 @@
 	</xs:complexType>
 	<xs:complexType name="AssistanceEligibilityDeterminationApplicantListType">
 		<xs:sequence>
-			<xs:element name="eligibility_determination_applicant" type="AssistanceEligibilityDeterminationApplicantType" maxOccurs="10"/>
+			<xs:element name="eligibility_determination_applicant" type="AssistanceEligibilityDeterminationApplicantType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="AssistanceEligibilityDeterminationApplicantType">
@@ -222,7 +222,7 @@
 	</xs:complexType>
 	<xs:complexType name="AssistanceTaxHouseholdMemberListType">
 		<xs:sequence>
-			<xs:element name="assistance_tax_household_member" type="FinancialAssistanceApplicantType" maxOccurs="10"/>
+			<xs:element name="assistance_tax_household_member" type="FinancialAssistanceApplicantType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="AssistedTaxHouseholdIncomesByYearType">
@@ -230,7 +230,7 @@
 			<xs:documentation>Sum of all qualified household income sources, including incomes of person who pays taxes, spouse and dependents, less qualified deductions, by calendar year. Also includes information about verification of the income.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="total_income_by_year" type="VerifiedCurrencyAmountPerAnnumType" maxOccurs="10"/>
+			<xs:element name="total_income_by_year" type="VerifiedCurrencyAmountPerAnnumType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 </xs:schema>

--- a/components/financial_assistance/lib/schemas/individual.xsd
+++ b/components/financial_assistance/lib/schemas/individual.xsd
@@ -22,7 +22,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="applicant_link" type="ApplicantLinkType" maxOccurs="10"/>
+				<xs:element name="applicant_link" type="ApplicantLinkType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -32,7 +32,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="applicant" type="ApplicantType" maxOccurs="10"/>
+				<xs:element name="applicant" type="ApplicantType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -47,7 +47,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element ref="application_group" maxOccurs="10"/>
+				<xs:element ref="application_group" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -60,7 +60,7 @@
 	<xs:element name="eligibility_determinations">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="eligibility_determination" type="EligibilityDeterminationType" maxOccurs="10"/>
+				<xs:element name="eligibility_determination" type="EligibilityDeterminationType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -70,14 +70,14 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="eligibility_determination_applicant" type="EligibilityDeterminationApplicantType" maxOccurs="10"/>
+				<xs:element name="eligibility_determination_applicant" type="EligibilityDeterminationApplicantType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="emergency_medicaid_enrollments">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="emergency_medicaid_enrollment" type="EmergencyMedicaidEnrollmentType" maxOccurs="10"/>
+				<xs:element name="emergency_medicaid_enrollment" type="EmergencyMedicaidEnrollmentType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -87,7 +87,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="hbx_enrollment_exemption" type="HbxEnrollmentExemptionType" maxOccurs="10"/>
+				<xs:element name="hbx_enrollment_exemption" type="HbxEnrollmentExemptionType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -97,7 +97,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="financial_statement" type="FinancialStatementType" maxOccurs="10"/>
+				<xs:element name="financial_statement" type="FinancialStatementType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -108,14 +108,14 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="hbx_enrollment" type="HbxEnrollmentType" maxOccurs="10"/>
+				<xs:element name="hbx_enrollment" type="HbxEnrollmentType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="hcr_chip_enrollments">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="hcr_chip_enrollment" type="HcrChipEnrollmentType" maxOccurs="10"/>
+				<xs:element name="hcr_chip_enrollment" type="HcrChipEnrollmentType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -125,7 +125,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="ia_enrollment" type="IaEnrollmentType" maxOccurs="10"/>
+				<xs:element name="ia_enrollment" type="IaEnrollmentType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -150,7 +150,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="irs_group" type="IrsGroupType" maxOccurs="10"/>
+				<xs:element name="irs_group" type="IrsGroupType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -159,7 +159,7 @@
 	<xs:element name="person_relationships">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="person_relationship" type="PersonRelationshipType" minOccurs="0" maxOccurs="10"/>
+				<xs:element name="person_relationship" type="PersonRelationshipType" minOccurs="0" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -172,21 +172,21 @@
 	<xs:element name="responsible_parties">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element ref="responsible_party" maxOccurs="10"/>
+				<xs:element ref="responsible_party" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="shop_enrollments">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="shop_enrollment" type="ShopEnrollmentType" maxOccurs="10"/>
+				<xs:element name="shop_enrollment" type="ShopEnrollmentType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="streamlined_medicaid_enrollments">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="streamlined_medicaid_enrollment" type="StreamlinedMedicaidEnrollmentType" maxOccurs="10"/>
+				<xs:element name="streamlined_medicaid_enrollment" type="StreamlinedMedicaidEnrollmentType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -196,7 +196,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="tax_household_member" type="TaxHouseholdMemberType" maxOccurs="10"/>
+				<xs:element name="tax_household_member" type="TaxHouseholdMemberType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -204,7 +204,7 @@
 	<xs:element name="tax_households">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="tax_household" type="TaxHouseholdType" maxOccurs="10"/>
+				<xs:element name="tax_household" type="TaxHouseholdType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -214,7 +214,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="uqhp_enrollment" type="UQhpEnrollmentType" maxOccurs="10"/>
+				<xs:element name="uqhp_enrollment" type="UQhpEnrollmentType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -462,7 +462,7 @@
 								<xs:element name="application_groups">
 									<xs:complexType>
 										<xs:sequence>
-											<xs:element ref="application_group" minOccurs="0" maxOccurs="10"/>
+											<xs:element ref="application_group" minOccurs="0" maxOccurs="unbounded"/>
 										</xs:sequence>
 									</xs:complexType>
 								</xs:element>
@@ -579,7 +579,7 @@
 	</xs:complexType>
 	<xs:complexType name="EmergencyMedicaidEnrollmentType">
 		<xs:sequence>
-			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="10"/>
+			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="EmployeeRoleType">
@@ -601,7 +601,7 @@
 			<xs:documentation>A list of employee roles for an individual.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="employee_role" type="EmployeeRoleType" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="employee_role" type="EmployeeRoleType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="BrokerRolesListType">
@@ -609,7 +609,7 @@
 			<xs:documentation>A list of employee roles for an individual.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="broker_role" type="BrokerRoleType" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="broker_role" type="BrokerRoleType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="FinancialAssistanceApplicantIndivdualType">
@@ -766,16 +766,16 @@
 			<xs:element name="incomes" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="total_income_by_year" type="CurrencyAmountPerAnnumType" minOccurs="0" maxOccurs="10"/>
-						<xs:element name="income" type="IndividualIncomeType" maxOccurs="10"/>
+						<xs:element name="total_income_by_year" type="CurrencyAmountPerAnnumType" minOccurs="0" maxOccurs="unbounded"/>
+						<xs:element name="income" type="IndividualIncomeType" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="deductions" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="total_deductions_by_year" type="CurrencyAmountPerAnnumType" minOccurs="0" maxOccurs="10"/>
-						<xs:element name="deduction" type="IndividualDeductionType" maxOccurs="10"/>
+						<xs:element name="total_deductions_by_year" type="CurrencyAmountPerAnnumType" minOccurs="0" maxOccurs="unbounded"/>
+						<xs:element name="deduction" type="IndividualDeductionType" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -785,7 +785,7 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="alternative_benefit" type="AlternateBenefitType" maxOccurs="10"/>
+						<xs:element name="alternative_benefit" type="AlternateBenefitType" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -840,7 +840,7 @@
 	</xs:complexType>
 	<xs:complexType name="HcrChipEnrollmentType">
 		<xs:sequence>
-			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="10"/>
+			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="IaEnrollmentType">
@@ -1145,7 +1145,7 @@
 								<xs:element name="individuals">
 									<xs:complexType>
 										<xs:sequence>
-											<xs:element ref="individual" minOccurs="0" maxOccurs="10"/>
+											<xs:element ref="individual" minOccurs="0" maxOccurs="unbounded"/>
 										</xs:sequence>
 									</xs:complexType>
 								</xs:element>
@@ -1158,7 +1158,7 @@
 	</xs:complexType>
 	<xs:complexType name="IndividualUpdateType">
 		<xs:sequence>
-			<xs:element name="change_type" type="IndividualUpdateNameType" maxOccurs="10"/>
+			<xs:element name="change_type" type="IndividualUpdateNameType" maxOccurs="unbounded"/>
 			<xs:element ref="individual"/>
 			<xs:element name="previous_information" type="PreviousIndividualType"/>
 		</xs:sequence>
@@ -1224,14 +1224,14 @@
 			<xs:element name="tax_household_ids">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="tax_household_id" type="IdentifierSimpleType" maxOccurs="10"/>
+						<xs:element name="tax_household_id" type="IdentifierSimpleType" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="hbx_enrollment_ids">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="hbx_enrollment_id" type="IdentifierSimpleType" maxOccurs="10"/>
+						<xs:element name="hbx_enrollment_id" type="IdentifierSimpleType" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -1282,7 +1282,7 @@
 					</xs:restriction>
 				</xs:simpleType>
 			</xs:element>
-			<xs:element name="race" type="RaceNameType" minOccurs="0" maxOccurs="10">
+			<xs:element name="race" type="RaceNameType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>Individual's race - optional selections - can select all that apply</xs:documentation>
 				</xs:annotation>
@@ -1345,7 +1345,7 @@
 			<xs:element name="name_last" type="xs:string"/>
 			<xs:element name="name_suffix" type="xs:string" minOccurs="0"/>
 			<xs:element name="name_full" type="xs:string" minOccurs="0"/>
-			<xs:element name="member_change" type="PreviousMemberType" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="member_change" type="PreviousMemberType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="PreviousMemberType">
@@ -1466,7 +1466,7 @@
 	</xs:complexType>
 	<xs:complexType name="AllocatedAptcsType">
 		<xs:sequence>
-			<xs:element name="allocated_aptc" type="CurrencyAmountPerAnnumType" maxOccurs="10"/>
+			<xs:element name="allocated_aptc" type="CurrencyAmountPerAnnumType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="TotalIncomesByYearType">
@@ -1474,7 +1474,7 @@
 			<xs:documentation>Sum of all qualified household income sources, including incomes of person who pays taxes, spouse and dependents, less qualified deductions, by calendar year</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="total_income_by_year" type="CurrencyAmountPerAnnumType" maxOccurs="10"/>
+			<xs:element name="total_income_by_year" type="CurrencyAmountPerAnnumType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="EligibilityDeterminationApplicantType">
@@ -1543,7 +1543,7 @@
 	</xs:complexType>
 	<xs:complexType name="StreamlinedMedicaidEnrollmentType">
 		<xs:sequence>
-			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="10"/>
+			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="UQhpEnrollmentType">
@@ -2107,7 +2107,7 @@
 	</xs:simpleType>
 	<xs:complexType name="CoverageHouseholdMembersListType">
 		<xs:sequence>
-			<xs:element name="coverage_household_member" type="PersonLinkType" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="coverage_household_member" type="PersonLinkType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="CoverageHouseholdType">
@@ -2134,12 +2134,12 @@
 	</xs:complexType>
 	<xs:complexType name="CoverageHouseholdBrokerAssignmentsType">
 		<xs:sequence>
-			<xs:element name="broker_assignment" type="CoverageHouseholdBrokerAssignmentType" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="broker_assignment" type="CoverageHouseholdBrokerAssignmentType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="CoverageHouseholdsListType">
 		<xs:sequence>
-			<xs:element name="coverage_household" type="CoverageHouseholdType" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="coverage_household" type="CoverageHouseholdType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="HouseholdType">
@@ -2159,12 +2159,12 @@
 	</xs:complexType>
 	<xs:complexType name="HouseholdsListType">
 		<xs:sequence>
-			<xs:element name="household" type="HouseholdType" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="household" type="HouseholdType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="FamilyMembersListType">
 		<xs:sequence>
-			<xs:element name="family_member" type="ApplicantType" maxOccurs="10"/>
+			<xs:element name="family_member" type="ApplicantType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:element name="renewal_consent_through_year">
@@ -2184,7 +2184,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="qualifying_life_event" type="QualifyingLifeEventType" maxOccurs="10"/>
+				<xs:element name="qualifying_life_event" type="QualifyingLifeEventType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -2202,7 +2202,7 @@
 	</xs:complexType>
 	<xs:complexType name="FamilyBrokerAccountListType">
 		<xs:sequence>
-			<xs:element name="broker_account" type="FamilyBrokerAccountType" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="broker_account" type="FamilyBrokerAccountType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:group name="FamilySharedElementsGroup">
@@ -2409,7 +2409,7 @@
 			<xs:documentation>Sum of all qualified, adjusted individual income sources, by calendar year. Also includes information about verification of the income.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="total_income_by_year" type="VerifiedCurrencyAmountPerAnnumType" maxOccurs="10"/>
+			<xs:element name="total_income_by_year" type="VerifiedCurrencyAmountPerAnnumType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:simpleType name="MagiMedicaidCategoryType">

--- a/components/financial_assistance/lib/schemas/links.xsd
+++ b/components/financial_assistance/lib/schemas/links.xsd
@@ -8,7 +8,7 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="enrollee" type="IdentifierSimpleType" maxOccurs="10"/>
+				<xs:element name="enrollee" type="IdentifierSimpleType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>

--- a/components/financial_assistance/lib/schemas/organization.xsd
+++ b/components/financial_assistance/lib/schemas/organization.xsd
@@ -95,7 +95,7 @@
 	</xs:complexType>
 	<xs:complexType name="BrokerAgencyBrokersListType">
 		<xs:sequence>
-			<xs:element name="broker" type="BrokerType" maxOccurs="20"/>
+			<xs:element name="broker" type="BrokerType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="BrokerType">
@@ -132,7 +132,7 @@
 
 	<xs:complexType name="BrokerPaymentAccountsType">
 		<xs:sequence>
-			<xs:element name="broker_payment_account" type="BrokerPaymentAccountType" minOccurs="1" maxOccurs="20"/>
+			<xs:element name="broker_payment_account" type="BrokerPaymentAccountType" minOccurs="1" maxOccurs="unbounded"/>
 	        </xs:sequence>
 	</xs:complexType>
 
@@ -178,10 +178,10 @@
 		<xs:sequence>
 			<xs:element name="entity_identifier" type="EntityNameType"/>
 			<xs:element name="organization" type="OrganizationType" minOccurs="0"/>
-			<xs:element name="policies" maxOccurs="20">
+			<xs:element name="policies" maxOccurs="unbounded">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="policy" type="PolicyLinkType" maxOccurs="20"/>
+						<xs:element name="policy" type="PolicyLinkType" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -218,7 +218,7 @@
 	</xs:complexType>
 	<xs:complexType name="GAAssignmentListType">
 		<xs:sequence>
-			<xs:element name="ga_assignment" type="GAAssignmentType" minOccurs="1" maxOccurs="20"/>
+			<xs:element name="ga_assignment" type="GAAssignmentType" minOccurs="1" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="BrokerAccountType">
@@ -249,7 +249,7 @@
 	</xs:complexType>
 	<xs:complexType name="BrokerAccountListType">
 		<xs:sequence>
-			<xs:element name="broker_account" type="BrokerAccountType" minOccurs="0" maxOccurs="20"/>
+			<xs:element name="broker_account" type="BrokerAccountType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="BrokerAgencyProfileType">
@@ -262,7 +262,7 @@
 	</xs:complexType>
 	<xs:complexType name="PlanYearListType">
 		<xs:sequence>
-			<xs:element name="plan_year" type="PlanYearType" maxOccurs="20"/>
+			<xs:element name="plan_year" type="PlanYearType" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="EmployerPlanListType">
@@ -314,7 +314,7 @@
 
 	<xs:complexType name="RelationshipBenefitsListType">
 		<xs:sequence>
-			<xs:element name="relationship_benefit" type="RelationshipBenefitType" minOccurs="0" maxOccurs="20"/>
+			<xs:element name="relationship_benefit" type="RelationshipBenefitType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="BenefitGroupType">
@@ -331,7 +331,7 @@
 			<xs:element name="elected_plans">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="elected_plan" type="PlanLinkType" minOccurs="0" maxOccurs="20"/>
+						<xs:element name="elected_plan" type="PlanLinkType" minOccurs="0" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -399,7 +399,7 @@
 			<xs:element name="benefit_groups" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="benefit_group" type="BenefitGroupType" maxOccurs="20"/>
+						<xs:element name="benefit_group" type="BenefitGroupType" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -524,7 +524,7 @@
 			<xs:element name="dependents" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="dependent" type="EmployerCensusFamilyDependentType" maxOccurs="20"/>
+						<xs:element name="dependent" type="EmployerCensusFamilyDependentType" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -533,7 +533,7 @@
 	<xs:element name="employer_census_families">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="employer_census_family" type="EmployerCensusFamilyType" maxOccurs="20"/>
+				<xs:element name="employer_census_family" type="EmployerCensusFamilyType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -786,7 +786,7 @@
 			<xs:element name="benefit_groups">
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="benefit_group" type="BenefitGroupLinkType" minOccurs="1" maxOccurs="20"/>
+						<xs:element name="benefit_group" type="BenefitGroupLinkType" minOccurs="1" maxOccurs="unbounded"/>
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
@@ -849,7 +849,7 @@
 							<xs:documentation>URN(s) for the employer instance that is subject of this event</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element ref="extended_resource_instance_uri" minOccurs="0" maxOccurs="20">
+					<xs:element ref="extended_resource_instance_uri" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>URN(s) for additional uris which may be used to reference the subject of this event.</xs:documentation>
 						</xs:annotation>
@@ -872,7 +872,7 @@
 					<xs:documentation>The start and end timestamps for events listed in this digest instance</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="employer_event" type="EmployerEventType" minOccurs="0" maxOccurs="20"/>
+			<xs:element name="employer_event" type="EmployerEventType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="EmployerDigestServiceEventBodyType">
@@ -1155,7 +1155,7 @@
 
 	<xs:complexType name="CompositeRatingTierListType">
 		<xs:sequence>
-			<xs:element name="composite_rating_tier" type="CompositeRatingTierType" minOccurs="1" maxOccurs="20"/>
+			<xs:element name="composite_rating_tier" type="CompositeRatingTierType" minOccurs="1" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 </xs:schema>

--- a/components/financial_assistance/lib/schemas/plan.xsd
+++ b/components/financial_assistance/lib/schemas/plan.xsd
@@ -4,21 +4,21 @@
 	<xs:element name="coverages">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="coverage" type="CoverageType" maxOccurs="10"/>
+				<xs:element name="coverage" type="CoverageType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="deductables">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="deductables" type="DeductableType" maxOccurs="10"/>
+				<xs:element name="deductables" type="DeductableType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="maximums">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="maximum" type="MaximumType" maxOccurs="10"/>
+				<xs:element name="maximum" type="MaximumType" maxOccurs="unbounded"/>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
@@ -71,7 +71,7 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="custom_scenarios" minOccurs="0" maxOccurs="10">
+			<xs:element name="custom_scenarios" minOccurs="0" maxOccurs="unbounded">
 				<xs:complexType>
 					<xs:sequence>
 						<xs:element name="name">

--- a/components/financial_assistance/lib/schemas/verification_services.xsd
+++ b/components/financial_assistance/lib/schemas/verification_services.xsd
@@ -25,7 +25,7 @@
 
 	<xs:complexType name="verificationQuestionResponseOptionListType">
 		<xs:sequence>
-	          <xs:element name="response_option" type="verificationQuestionResponseOptionType" minOccurs="1" maxOccurs="10"/>
+	          <xs:element name="response_option" type="verificationQuestionResponseOptionType" minOccurs="1" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 
@@ -48,7 +48,7 @@
 		<xs:sequence>
 			<xs:element name="session_id" type="xs:string"/>
 			<xs:element name="transaction_id" type="xs:string"/>
-			<xs:element name="question_response" type="verificationQuestionResponseType" minOccurs="1" maxOccurs="10"/>
+			<xs:element name="question_response" type="verificationQuestionResponseType" minOccurs="1" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 
@@ -85,7 +85,7 @@
 			<xs:element name="response_text" type="xs:string" minOccurs="0"/>
 			<xs:element name="transaction_id" type="xs:string"/>
 			<xs:element name="session_id" type="xs:string" minOccurs="0"/>
-		        <xs:element name="question" type="verificationQuestionPromptType" minOccurs="0" maxOccurs="10"/>
+		        <xs:element name="question" type="verificationQuestionPromptType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 
@@ -108,7 +108,7 @@
 					<xs:element name="response_code" type="interactiveVerificationSessionResponseCodeType"/>
 					<xs:element name="transaction_id" type="xs:string"/>
 					<xs:element name="session_id" type="xs:string"/>
-					<xs:element name="question" type="verificationQuestionPromptType" minOccurs="1" maxOccurs="10"/>
+					<xs:element name="question" type="verificationQuestionPromptType" minOccurs="1" maxOccurs="unbounded"/>
 				</xs:sequence>
 			</xs:restriction>
 		</xs:complexContent>
@@ -549,8 +549,8 @@
 			<xs:element name="interactive_verification_results" type="xs:boolean" minOccurs="0"/>
 			<xs:element name="lawful_presence_verification_results" type="ExternalLawfulPresenceResultType" minOccurs="0"/>
 			<xs:element name="residency_verification_results" type="residencyVerificationResultCodeType" minOccurs="0"/>
-			<xs:element name="income_verification_result" type="IncomeVerificationResultType" minOccurs="0" maxOccurs="10"/>
-			<xs:element name="mec_verification_result" type="MECVerificationResultType" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="income_verification_result" type="IncomeVerificationResultType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="mec_verification_result" type="MECVerificationResultType" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="ExternalVerificationsType">
@@ -625,7 +625,7 @@
 
 	<xs:complexType name="VerifiedFamilyMembersListType">
 		<xs:sequence>
-			<xs:element name="family_member" type="VerifiedFamilyMemberType" minOccurs="1" maxOccurs="10"/>
+			<xs:element name="family_member" type="VerifiedFamilyMemberType" minOccurs="1" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 


### PR DESCRIPTION
This reverts commit 7f33aab90aebf0c77e5271875f975e318eed421a.

# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185895421

# A brief description of the changes

Current behavior: having a definite number of maxOccurs instead of unlimited

New behavior: reverting above back to unlimited

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.