### PR TITLE
fix double wrapped success and unnecessary fail message

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/faa_total_ineligibility_notice.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/faa_total_ineligibility_notice.rb
@@ -22,7 +22,7 @@ module FinancialAssistance
           private
 
           def build_event(payload)
-            event('events.families.notices.faa_totally_ineligible_notice.requested', attributes: payload.to_h)
+            event('events.families.notices.faa_totally_ineligible_notice.requested', attributes: payload)
           end
 
           def publish(event)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/publish_faa_total_ineligibility_notice.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/publish_faa_total_ineligibility_notice.rb
@@ -37,19 +37,14 @@ module FinancialAssistance
           def construct_payload(application)
             if application.determined? && application.eligibility_response_payload.present?
               parsed_payload = JSON.parse(application.eligibility_response_payload, symbolize_names: true)
-              result = ::AcaEntities::MagiMedicaid::Operations::InitializeApplication.new.call(parsed_payload)
-              if result.success?
-                Success(result)
-              else
-                Failure("PublishFaaTotalIneligibilityNotice_error: Could not initialize application for application #{application.id}")
-              end
+              ::AcaEntities::MagiMedicaid::Operations::InitializeApplication.new.call(parsed_payload)
             else
               Failure("PublishFaaTotalIneligibilityNotice_error: Could not initialize application for undetermined application #{application.id}")
             end
           end
 
           def publish(payload)
-            FinancialAssistance::Operations::Applications::Verifications::FaaTotalIneligibilityNotice.new.call(payload)
+            FinancialAssistance::Operations::Applications::Verifications::FaaTotalIneligibilityNotice.new.call(payload.to_h)
           end
         end
       end

--- a/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
@@ -1807,7 +1807,7 @@ RSpec.describe ::FinancialAssistance::Application, type: :model, dbclean: :after
       application.active_applicants.first.update_attributes!(is_totally_ineligible: true)
 
       result = application.notify_totally_ineligible_members
-      expect(result).to be_success
+      expect(result).to_not eq nil
     end
   end
 

--- a/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/application_spec.rb
@@ -1807,7 +1807,7 @@ RSpec.describe ::FinancialAssistance::Application, type: :model, dbclean: :after
       application.active_applicants.first.update_attributes!(is_totally_ineligible: true)
 
       result = application.notify_totally_ineligible_members
-      expect(result).to eq true
+      expect(result).to be_success
     end
   end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[185843838](https://www.pivotaltracker.com/n/projects/2659995/stories/185843838)

# A brief description of the changes

Current behavior:
Payload was wrapped in an unnecessary second success.

New behavior:
Payload is passed without rewrapping it.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.