### PR TITLE
verifying whether product is osse_eligible before renewing ivl enrollment

### DIFF
--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2847,6 +2847,7 @@ class HbxEnrollment
       osse_childcare_subsidy = osse_subsidy_for_member(primary_hbx_enrollment_member)
     else
       return unless ivl_osse_eligible?
+      return unless product.is_hc4cc_plan?
 
       cost_calculator = build_plan_premium(qhp_plan: product, elected_aptc: applied_aptc_amount, apply_aptc: applied_aptc_amount > 0)
       osse_childcare_subsidy = cost_calculator.total_childcare_subsidy_amount

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2847,7 +2847,7 @@ class HbxEnrollment
       osse_childcare_subsidy = osse_subsidy_for_member(primary_hbx_enrollment_member)
     else
       return unless ivl_osse_eligible?
-      return unless product.is_hc4cc_plan?
+      return unless product.is_hc4cc_plan
 
       cost_calculator = build_plan_premium(qhp_plan: product, elected_aptc: applied_aptc_amount, apply_aptc: applied_aptc_amount > 0)
       osse_childcare_subsidy = cost_calculator.total_childcare_subsidy_amount

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -949,10 +949,12 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
             allow_any_instance_of(HbxEnrollment).to receive(:ivl_osse_eligible?).and_return(true)
             allow_any_instance_of(HbxEnrollment).to receive(:is_eligible_for_osse_grant?).and_return(true)
             enrollment.update_osse_childcare_subsidy
+            expect(enrollment.product.is_hc4cc_plan).to be_truthy
             expect(enrollment.eligible_child_care_subsidy.to_f).to be > 0
 
             renewal = subject.renew
             expect(renewal.auto_renewing?).to be_truthy
+            expect(renewal.product.is_hc4cc_plan).to be_truthy
             expect(renewal.eligible_child_care_subsidy.to_f).to be > 0
             expect(renewal.eligible_child_care_subsidy.to_f).to eq(renewal.total_premium.to_f)
           end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640061/stories/185911762

# A brief description of the changes

Current behavior:
OSSE eligible consumers who are enrolled in a non-OSSE 2023 plan get renewed into the correct 2024 plan, but incorrectly have the OSSE subsidy applied to their 2024 non-OSSE plan.

New behavior:
Renewed non-OSSE plans should not have the OSSE subsidy applied, even for consumers who are OSSE eligible.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [x] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.