### PR TITLE
skips unwanted coverage termination transition for enrollments

### DIFF
--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -26,12 +26,29 @@ module Operations
           enrollment.generate_signature(previous_enrollment)
           if enrollment.same_signatures(previous_enrollment) && !previous_enrollment.is_shop?
             if enrollment.effective_on > previous_enrollment.effective_on && previous_enrollment.may_terminate_coverage?
+              next previous_enrollment if ineligible_for_termination?(previous_enrollment, enrollment)
+
               previous_enrollment.terminate_coverage!(enrollment.effective_on - 1.day)
             elsif previous_enrollment.may_cancel_coverage?
               previous_enrollment.cancel_coverage!
             end
           end
         end
+      end
+
+      private
+
+      # Checks to see if the previous enrollment is eligible for termination.
+      # Previous enrollment is ineligible for termination if all the below are true
+      #   - The previous enrollment is already in terminated state
+      #   - The previous enrollment has a terminated_on date
+      #   - The new enrollment has an effective_on date
+      #   - The new enrollment's effective_on is same as previous enrollment's terminated_on date
+      def ineligible_for_termination?(previous_enrollment, enrollment)
+        previous_enrollment.coverage_terminated? &&
+          previous_enrollment.terminated_on.present? &&
+          enrollment.effective_on.present? &&
+          (enrollment.effective_on - 1.day) == previous_enrollment.terminated_on
       end
     end
   end

--- a/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
+++ b/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbclean: :after_each do
+  subject { described_class.call(product_selection) }
+
+  describe ".call" do
+    let(:coverage_year) { Date.today.year }
+    let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+    let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+    let(:new_enrollment_effective_on) { Date.new(coverage_year, 3) }
+    let(:new_enrollment) do
+      FactoryBot.create(:hbx_enrollment,
+                        :individual_unassisted,
+                        :with_silver_health_product,
+                        :with_enrollment_members,
+                        enrollment_members: family.family_members,
+                        household: family.active_household,
+                        effective_on: new_enrollment_effective_on,
+                        family: family)
+    end
+    let(:previous_enrollment_effective_on) { Date.new(coverage_year, 2) }
+    let(:previous_enrollment) do
+      FactoryBot.create(:hbx_enrollment,
+                        :individual_unassisted,
+                        :with_silver_health_product,
+                        :with_enrollment_members,
+                        enrollment_members: family.family_members,
+                        aasm_state: 'coverage_terminated',
+                        household: family.active_household,
+                        effective_on: previous_enrollment_effective_on,
+                        family: family,
+                        terminated_on: previous_enrollment_terminated_on)
+    end
+
+    let(:product_selection) do
+      Entities::ProductSelection.new(
+        {
+          enrollment: new_enrollment,
+          family: new_enrollment.family,
+          product: new_enrollment.product
+        }
+      )
+    end
+
+    let(:previous_enrollment_terminated_to_terminated_state_transition) do
+      previous_enrollment.reload.workflow_state_transitions.where(
+        event: 'terminate_coverage!',
+        from_state: 'coverage_terminated',
+        to_state: 'coverage_terminated'
+      ).first
+    end
+
+    before do
+      previous_enrollment.generate_hbx_signature
+      new_enrollment.generate_hbx_signature
+      subject
+    end
+
+    context "when:
+      - previous_enrollment is terminated
+      - previous_enrollment has terminated_on
+      - new_enrollment has effective_on
+      - previous_enrollment's terminated_on is same as previous day of new_enrollment's effective_on
+      " do
+      let(:previous_enrollment_terminated_on) { previous_enrollment_effective_on.end_of_month }
+
+      it 'does not transition the previous_enrollment' do
+        expect(previous_enrollment_terminated_to_terminated_state_transition).to be_nil
+      end
+    end
+
+    context "when:
+      - previous_enrollment is terminated
+      - previous_enrollment has terminated_on
+      - new_enrollment has effective_on
+      - previous_enrollment's terminated_on is not same as previous day of new_enrollment's effective_on
+      " do
+      let(:previous_enrollment_terminated_on) { previous_enrollment_effective_on.end_of_year }
+
+      it 'transitions the previous_enrollment' do
+        expect(previous_enrollment_terminated_to_terminated_state_transition).to be_truthy
+      end
+
+      it 'updates terminated_on for previous_enrollment' do
+        expect(previous_enrollment.reload.terminated_on).to eq(new_enrollment_effective_on - 1.day)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 185903649](https://www.pivotaltracker.com/story/show/185903649)

# A brief description of the changes

Current behavior: The existing terminated span creates a latest state transition from terminated to terminated for all enrollments based on criteria even when there is no change in the span.

New behavior: The existing terminated span does not create a latest state transition from terminated to terminated for all enrollments based on criteria even when there is no change in the span.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.