### PR TITLE
ignore fein field for ivl products and write to output file

### DIFF
--- a/spec/lib/tasks/migrations/plans/glue_load_products_spec.rb
+++ b/spec/lib/tasks/migrations/plans/glue_load_products_spec.rb
@@ -1,20 +1,22 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require 'rake'
 
 describe 'glue_load_products' do
-    after :all do
-        year = TimeKeeper.date_of_record.year
-        json_file_name = Rails.root.join("#{year}_plans.json")
-        error_file_name = Rails.root.join("#{year}_plans_error.txt")
-        File.delete(json_file_name) if File.exist?(json_file_name)
-        File.delete(error_file_name) if File.exist?(error_file_name)
-    end
+  after :all do
+    year = TimeKeeper.date_of_record.year
+    json_file_name = Rails.root.join("#{year}_plans.json")
+    error_file_name = Rails.root.join("#{year}_plans_error.txt")
+    File.delete(json_file_name) if File.exist?(json_file_name)
+    File.delete(error_file_name) if File.exist?(error_file_name)
+  end
 
-    let(:year) { TimeKeeper.date_of_record.year }
-    let(:json_file_name) { Rails.root.join("#{year}_plans.json") }
-    let(:error_file_name) { Rails.root.join("#{year}_plans_error.txt") }
-    let!(:shop_product) { FactoryBot.create(:benefit_markets_products_health_products_health_product) }
-    let!(:ivl_product) { FactoryBot.create(:benefit_markets_products_health_products_health_product, :ivl_product) }
+  let(:year) { TimeKeeper.date_of_record.year }
+  let(:json_file_name) { Rails.root.join("#{year}_plans.json") }
+  let(:error_file_name) { Rails.root.join("#{year}_plans_error.txt") }
+  let!(:shop_product) { FactoryBot.create(:benefit_markets_products_health_products_health_product) }
+  let!(:ivl_product) { FactoryBot.create(:benefit_markets_products_health_products_health_product, :ivl_product) }
 
   before do
     Rails.application.load_tasks
@@ -23,22 +25,26 @@ describe 'glue_load_products' do
 
   describe 'load_products' do
     it 'should write products to the output file' do
-        invoke_rake
-        expect(File.exist?(json_file_name)).to be_truthy
-        expect(File.read(json_file_name)).to include(shop_product.hios_id)
-        expect(File.read(json_file_name)).to include(ivl_product.hios_id)
+      invoke_rake
+      expect(File.exist?(json_file_name)).to be_truthy
+      expect(File.read(json_file_name)).to include(shop_product.hios_id)
+      expect(File.read(json_file_name)).to include(ivl_product.hios_id)
     end
 
+    # Testing specifically with the load method b/c that is what is used to load the data in Glue
+    # rubocop:disable Security/JSONLoad
     it 'should write output that can be loaded as array of json' do
-        file_contents = File.read(json_file_name)
-        loaded_json = JSON.load(file_contents)
-        expect(loaded_json).to be_truthy
-        expect(loaded_json.is_a? Array).to be_truthy
+      file_contents = File.read(json_file_name)
+      loaded_json = JSON.load(file_contents)
+      expect(loaded_json).to be_truthy
+      expect(loaded_json.is_a?(Array)).to be_truthy
     end
+    # rubocop:enable Security/JSONLoad
+
   end
 end
 
 def invoke_rake
-    Rake::Task["seed:load_products"].reenable
-    Rake::Task["seed:load_products"].invoke(TimeKeeper.date_of_record.year)
+  Rake::Task["seed:load_products"].reenable
+  Rake::Task["seed:load_products"].invoke(TimeKeeper.date_of_record.year)
 end

--- a/spec/lib/tasks/migrations/plans/glue_load_products_spec.rb
+++ b/spec/lib/tasks/migrations/plans/glue_load_products_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'glue_load_products' do
+    after :all do
+        year = TimeKeeper.date_of_record.year
+        json_file_name = Rails.root.join("#{year}_plans.json")
+        error_file_name = Rails.root.join("#{year}_plans_error.txt")
+        File.delete(json_file_name) if File.exist?(json_file_name)
+        File.delete(error_file_name) if File.exist?(error_file_name)
+    end
+
+    let(:year) { TimeKeeper.date_of_record.year }
+    let(:json_file_name) { Rails.root.join("#{year}_plans.json") }
+    let(:error_file_name) { Rails.root.join("#{year}_plans_error.txt") }
+    let!(:shop_product) { FactoryBot.create(:benefit_markets_products_health_products_health_product) }
+    let!(:ivl_product) { FactoryBot.create(:benefit_markets_products_health_products_health_product, :ivl_product) }
+
+  before do
+    Rails.application.load_tasks
+    Rake::Task.define_task(:environment)
+  end
+
+  describe 'load_products' do
+    it 'should write products to the output file' do
+        invoke_rake
+        expect(File.exist?(json_file_name)).to be_truthy
+        expect(File.read(json_file_name)).to include(shop_product.hios_id)
+        expect(File.read(json_file_name)).to include(ivl_product.hios_id)
+    end
+
+    it 'should write output that can be loaded as array of json' do
+        file_contents = File.read(json_file_name)
+        loaded_json = JSON.load(file_contents)
+        expect(loaded_json).to be_truthy
+        expect(loaded_json.is_a? Array).to be_truthy
+    end
+  end
+end
+
+def invoke_rake
+    Rake::Task["seed:load_products"].reenable
+    Rake::Task["seed:load_products"].invoke(TimeKeeper.date_of_record.year)
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185933306

# A brief description of the changes

Current behavior:
Rake is run like this:
```
RAILS_ENV=production bundle exec rake seed:load_plans[2024]
```
It looks for the fein field on IVL products which is not relevant.  It prints output that is manually stored as a JSON and loaded into Glue.

New behavior:
Rake is run the same way, but it will ignore the fein field for IVL products and it will write directly a properly named and formatted file that can be copied and loaded directly in to Glue as-is.  It will also write any failures to a separate failure log file.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.