### PR TITLE
return false if osse subsidy feature is disabled

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1011,6 +1011,7 @@ module ApplicationHelper
   end
 
   def plan_childcare_subsidy_eligible(plan)
+    return false unless EnrollRegistry.feature_enabled?(:aca_ivl_osse_subsidy)
     return true unless EnrollRegistry.feature_enabled?("individual_osse_plan_filter")
 
     plan.ivl_osse_eligible? && plan.is_hc4cc_plan

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -894,6 +894,24 @@ describe "Enabled/Disabled IVL market" do
     it_behaves_like 'float_fix', (0.57 * 100), 57
   end
 
+  describe "#plan_childcare_subsidy_eligible" do
+
+    let(:plan) {double("Plan")}
+
+    context "when aca_ivl_osse_subsidy feature is disabled" do
+
+      before do
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:aca_ivl_osse_subsidy).and_return(false)
+      end
+
+      it "returns false" do
+        expect(helper.plan_childcare_subsidy_eligible(plan)).to eq(false)
+      end
+    end
+
+    
+  end
+
   describe 'round_down_float_two_decimals' do
 
     shared_examples_for 'rounding float number' do |input, output|

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -908,8 +908,6 @@ describe "Enabled/Disabled IVL market" do
         expect(helper.plan_childcare_subsidy_eligible(plan)).to eq(false)
       end
     end
-
-    
   end
 
   describe 'round_down_float_two_decimals' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/185944193

# A brief description of the changes

Current behavior: When plan shopping for a family with aptc, the plan premiums display $0

New behavior: The plan premium displays the correct amount

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.