### PR TITLE
adds QHP eligibility checks for enrollment renewals

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -345,7 +345,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
 
     @ivl_benefit = benefit_cp.benefit_packages.detect do |bp|
       bp.effective_year == renewal_coverage_start.year && bp.benefit_categories.include?(@enrollment.coverage_kind)
-    end.first
+    end
   end
   # End: Residency Status & Citizenship Member Eligibility Checks
 

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -296,10 +296,58 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   # rubocop:enable Style/RedundantReturn
 
   def eligible_enrollment_members
-    @enrollment.hbx_enrollment_members.reject do |member|
-      member.person.is_disabled || !eligible_to_get_covered?(member)
+    @enrollment.hbx_enrollment_members.select do |member|
+      if member.person.is_consumer_role_active?
+        consumer_role = member.person.consumer_role
+
+        eligible_to_get_covered?(member) &&
+          residency_status_satisfied?(member, consumer_role) &&
+          citizenship_status_satisfied?(consumer_role) &&
+          !member.person.is_disabled &&
+          !member.person.is_incarcerated &&
+          member.person.is_applying_coverage
+      elsif member.person.is_resident_role_active?
+        eligible_to_get_covered?(member) && !member.person.is_disabled && !member.person.is_incarcerated
+      else
+        false
+      end
     end
   end
+
+  # TODO: IndividualMarket
+  #   1. Research on the differences b/w the eligibility checks in the enrollment renewal code and InsuredEligibleForBenefitRule
+  #   2. Point to InsuredEligibleForBenefitRule for all member eligibility checks in the enrollment renewal context
+  # Start: Residency Status & Citizenship Member Eligibility Checks
+  def citizenship_status_satisfied?(role)
+    return true if role.is_a?(ResidentRole)
+    return false if role.citizen_status.blank?
+
+    ConsumerRole::INELIGIBLE_CITIZEN_VERIFICATION.exclude?(role.citizen_status)
+  end
+
+  def residency_status_satisfied?(member, role)
+    return false if ivl_benefit.blank?
+    return true if ivl_benefit.residency_status.include?('any')
+    return false unless ivl_benefit.residency_status.include?('state_resident') && role.present?
+    return true if role.person.is_dc_resident?
+
+    member.hbx_enrollment.family.active_family_members.any? do |family_member|
+      family_member.age_on(renewal_coverage_start) >= 19 && family_member.is_dc_resident?
+    end
+  end
+
+  def ivl_benefit
+    return @ivl_benefit if defined?(@ivl_benefit)
+    benefit_cp = HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.detect do |bcp|
+      bcp.contains?(renewal_coverage_start)
+    end
+    return nil unless benefit_cp
+
+    @ivl_benefit = benefit_cp.benefit_packages.detect do |bp|
+      bp.effective_year == renewal_coverage_start.year && bp.benefit_categories.include?(@enrollment.coverage_kind)
+    end.first
+  end
+  # End: Residency Status & Citizenship Member Eligibility Checks
 
   def clone_enrollment_members
     old_enrollment_members = eligible_enrollment_members

--- a/spec/domain/operations/individual/renew_enrollment_spec.rb
+++ b/spec/domain/operations/individual/renew_enrollment_spec.rb
@@ -307,12 +307,21 @@ RSpec.describe Operations::Individual::RenewEnrollment, type: :model, dbclean: :
                           renewal_product_id: renewal_product.id)
       end
 
+      let(:dental_benefit_package) do
+        hbx_profile.benefit_sponsorship.benefit_coverage_periods.each do |bcp|
+          bcp.benefit_packages.each do |bp|
+            bp.update_attributes!(benefit_categories: ['dental'], title: "individual_dental_benefits_#{effective_on.year}")
+          end
+        end
+      end
+
       before :each do
         enrollment.expire_coverage!
         enrollment.update_attributes!(coverage_kind: 'dental',
                                       elected_aptc_pct: 0.7,
                                       applied_aptc_amount: 100.00,
                                       product_id: product.id)
+        dental_benefit_package
         @result = subject.call(hbx_enrollment: enrollment, effective_on: effective_on)
       end
 

--- a/spec/domain/operations/product_selection_effects/dchbx_product_selection_effects_spec.rb
+++ b/spec/domain/operations/product_selection_effects/dchbx_product_selection_effects_spec.rb
@@ -496,8 +496,12 @@ RSpec.describe Operations::ProductSelectionEffects::DchbxProductSelectionEffects
     context 'new enrollment in prior plan year for dependent add with previous year active coverage' do
       include_context 'family with two members and one enrollment and one predecessor enrollment with two members with previous year active coverage'
 
+      let(:second_person) { family.family_members[1].person }
+      let!(:consumer_role) { FactoryBot.create(:consumer_role, person: second_person) }
+      let!(:ivl_transition) { FactoryBot.create(:individual_market_transition, person: second_person) }
+
       before do
-        family.family_members[1].person.update_attributes(dob: predecessor_enrollment.effective_on - 10.years)
+        second_person.update_attributes(dob: predecessor_enrollment.effective_on - 10.years)
         expired_enrollment.generate_hbx_signature
         predecessor_enrollment.update_attributes(enrollment_signature: expired_enrollment.enrollment_signature)
         product_selection = Entities::ProductSelection.new({:enrollment => predecessor_enrollment, :product => predecessor_product, :family => family})

--- a/spec/factories/consumer_roles.rb
+++ b/spec/factories/consumer_roles.rb
@@ -15,7 +15,6 @@ FactoryBot.define do
     gender { 'male' }
     is_state_resident { 'yes' }
     citizen_status { 'us_citizen' }
-    is_incarcerated { 'yes' }
     is_applicant { 'yes' }
     vlp_documents {[FactoryBot.build(:vlp_document)]}
     ridp_documents {[FactoryBot.build(:ridp_document)]}

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -1,180 +1,19 @@
- # frozen_string_literal: true
+# frozen_string_literal: true
 
 require 'rails_helper'
 require "#{Rails.root}/spec/shared_contexts/enrollment.rb"
+require "#{Rails.root}/spec/shared_contexts/family_enrollment_renewal.rb"
 
 if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
   RSpec.describe Enrollments::IndividualMarket::FamilyEnrollmentRenewal, type: :model, :dbclean => :after_each do
     include FloatHelper
+    include_context "setup family initial and renewal enrollments data"
 
-    let(:current_date) { Date.new(calender_year, 11, 1) }
+    let(:ivl_benefit) { double('BenefitPackage', residency_status: ['any']) }
 
-    let(:current_benefit_coverage_period) { OpenStruct.new(start_on: current_date.beginning_of_year, end_on: current_date.end_of_year) }
-    let(:renewal_benefit_coverage_period) { OpenStruct.new(start_on: current_date.next_year.beginning_of_year, end_on: current_date.next_year.end_of_year) }
-
-    let(:aptc_values) {{}}
-    let(:assisted) { nil }
-
-    let!(:family) do
-      primary = FactoryBot.create(:person, :with_consumer_role, dob: primary_dob, is_tobacco_user: 'y')
-      FactoryBot.create(:family, :with_primary_family_member, :person => primary)
+    before do
+      allow(subject).to receive(:ivl_benefit).and_return(ivl_benefit)
     end
-
-    let!(:coverall_family) do
-      primary = FactoryBot.create(:person, :with_resident_role, dob: primary_dob)
-      FactoryBot.create(:family, :with_primary_family_member, :person => primary)
-    end
-
-    let!(:spouse_rec) do
-      FactoryBot.create(:person, dob: spouse_dob, is_tobacco_user: 'y')
-    end
-
-    let!(:spouse) do
-      FactoryBot.create(:family_member, person: spouse_rec, family: family)
-    end
-
-    let!(:child1) do
-      child = FactoryBot.create(:person, dob: child1_dob)
-      FactoryBot.create(:family_member, person: child, family: family)
-    end
-
-    let!(:child2) do
-      child = FactoryBot.create(:person, dob: child2_dob)
-      FactoryBot.create(:family_member, person: child, family: family)
-    end
-
-    let!(:child3) do
-      child = FactoryBot.create(:person, dob: child3_dob)
-      FactoryBot.create(:family_member, person: child, family: family)
-    end
-
-    let(:primary_dob){ current_date.next_month - 57.years }
-    let(:spouse_dob) { current_date.next_month - 55.years }
-    let(:child1_dob) { current_date.next_month - 26.years }
-    let(:child2_dob) { current_date.next_month - 20.years }
-    let(:child3_dob) { current_benefit_coverage_period.start_on + 2.months - 25.years}
-
-    let!(:enrollment) do
-      FactoryBot.create(:hbx_enrollment,
-                        :with_enrollment_members,
-                        family: family,
-                        enrollment_members: enrollment_members,
-                        household: family.active_household,
-                        coverage_kind: coverage_kind,
-                        effective_on: current_benefit_coverage_period.start_on,
-                        kind: "individual",
-                        product_id: current_product.id,
-                        rating_area_id: rating_area.id,
-                        consumer_role_id: family.primary_person.consumer_role.id,
-                        aasm_state: 'coverage_selected')
-    end
-
-    let!(:coverall_enrollment) do
-      FactoryBot.create(:hbx_enrollment,
-                        :with_enrollment_members,
-                        family: coverall_family,
-                        enrollment_members: coverall_enrollment_members,
-                        household: coverall_family.active_household,
-                        coverage_kind: coverage_kind,
-                        rating_area_id: rating_area.id,
-                        resident_role_id: coverall_family.primary_person.resident_role.id,
-                        effective_on: current_benefit_coverage_period.start_on,
-                        kind: "coverall",
-                        product_id: current_product.id,
-                        aasm_state: 'coverage_selected')
-    end
-
-    let!(:catastrophic_enrollment) do
-      FactoryBot.create(:hbx_enrollment,
-                        :with_enrollment_members,
-                        family: family,
-                        enrollment_members: enrollment_members,
-                        household: family.active_household,
-                        coverage_kind: coverage_kind,
-                        rating_area_id: rating_area.id,
-                        resident_role_id: family.primary_person.consumer_role.id,
-                        effective_on: Date.new(Date.current.year,1,1),
-                        kind: "coverall",
-                        product_id: current_cat_product.id,
-                        aasm_state: 'coverage_selected')
-    end
-
-    let(:enrollment_members) { family.family_members }
-    let(:coverall_enrollment_members) { coverall_family.family_members }
-    let(:calender_year) { TimeKeeper.date_of_record.year }
-    let(:coverage_kind) { 'health' }
-    let!(:rating_area) do
-      ::BenefitMarkets::Locations::RatingArea.rating_area_for(address, during: start_on) || FactoryBot.create_default(:benefit_markets_locations_rating_area)
-    end
-    let!(:service_area) do
-      ::BenefitMarkets::Locations::ServiceArea.service_areas_for(address, during: start_on).first || FactoryBot.create_default(:benefit_markets_locations_service_area)
-    end
-    let!(:renewal_rating_area) do
-      ::BenefitMarkets::Locations::RatingArea.rating_area_for(address, during: start_on.next_year) || FactoryBot.create_default(:benefit_markets_locations_rating_area, active_year: start_on.next_year.year)
-    end
-    let!(:renewal_service_area) do
-      ::BenefitMarkets::Locations::ServiceArea.service_areas_for(address, during: start_on.next_year).first || FactoryBot.create_default(:benefit_markets_locations_service_area, active_year: start_on.next_year.year)
-    end
-    let(:start_on) { current_benefit_coverage_period.start_on }
-    let(:address) { family.primary_person.rating_address }
-    let(:application_period) { start_on.beginning_of_year..start_on.end_of_year }
-    let(:renewal_application_period) { start_on.beginning_of_year.next_year..start_on.end_of_year.next_year}
-
-    let!(:current_product) do
-      prod =
-        FactoryBot.create(
-          :benefit_markets_products_health_products_health_product,
-          :with_issuer_profile,
-          benefit_market_kind: :aca_individual,
-          kind: :health,
-          service_area: service_area,
-          csr_variant_id: '01',
-          metal_level_kind: 'silver',
-          hios_id: '11111111122302-01',
-          renewal_product_id: renewal_product.id,
-          application_period: application_period
-        )
-      prod.premium_tables = [premium_table]
-      prod.save
-      prod
-    end
-    let(:premium_table)        { build(:benefit_markets_products_premium_table, effective_period: application_period, rating_area: rating_area) }
-    let!(:renewal_product) do
-      prod =
-        FactoryBot.create(
-          :benefit_markets_products_health_products_health_product,
-          :with_issuer_profile,
-          benefit_market_kind: :aca_individual,
-          kind: :health,
-          service_area: renewal_service_area,
-          csr_variant_id: '01',
-          metal_level_kind: 'silver',
-          hios_id: '11111111122302-01',
-          application_period: renewal_application_period
-        )
-      prod.premium_tables = [renewal_premium_table]
-      prod.save
-      prod
-    end
-    let(:renewal_premium_table)        { build(:benefit_markets_products_premium_table, effective_period: renewal_application_period, rating_area: renewal_rating_area) }
-    let!(:current_cat_product) do
-      prod =
-        FactoryBot.create(
-          :active_ivl_silver_health_product,
-          :with_issuer_profile,
-          benefit_market_kind: :aca_individual,
-          kind: :health,
-          service_area: service_area,
-          csr_variant_id: '01',
-          metal_level_kind: :catastrophic,
-          hios_base_id: "94506DC0390008",
-          application_period: application_period
-        )
-      prod.premium_tables = [cat_premium_table]
-      prod.save
-      prod
-    end
-    let(:cat_premium_table)        { build(:benefit_markets_products_premium_table, effective_period: application_period, rating_area: rating_area) }
 
     subject do
       enrollment_renewal = Enrollments::IndividualMarket::FamilyEnrollmentRenewal.new
@@ -402,9 +241,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
       # Don't we need this for all the dependents
       # Are we using is_disabled flag in the system
       context "When a child person record is disabled" do
-        let!(:spouse_rec) do
-          FactoryBot.create(:person, dob: spouse_dob, is_disabled: true)
-        end
+        let(:spouse_person) { FactoryBot.create(:person, dob: spouse_dob, is_disabled: true) }
 
         it "should not include child person record" do
           applicant_ids = subject.clone_enrollment_members.collect(&:applicant_id)
@@ -1134,16 +971,16 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
             enrollment_renewal.assisted = true
             enrollment_renewal.aptc_values = {:applied_percentage => 1, :applied_aptc => 730.0, :max_aptc => 730.0, :csr_amt => 73}
             enrollment_renewal.renewal_coverage_start = Date.new(Date.current.year + 1,1,1)
-            enrollment_renewal.renew
+            enrollment_renewal
           end
           let(:child1_dob) { current_date.next_month - 30.years }
 
           it "should return new renewal product with applied aptc" do
-            expect(subject.applied_aptc_amount.to_f > 0.0).to be_truthy
+            expect(subject.renew.applied_aptc_amount.to_f > 0.0).to be_truthy
           end
 
           it "should return new renewal enrollment without catastrophic product" do
-            expect(subject.product.metal_level_kind).not_to be :catastrophic
+            expect(subject.renew.product.metal_level_kind).not_to be :catastrophic
           end
         end
 
@@ -1154,16 +991,16 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
             enrollment_renewal.assisted = true
             enrollment_renewal.aptc_values = {:applied_percentage => 1, :applied_aptc => 0, :max_aptc => 0, :csr_amt => 73}
             enrollment_renewal.renewal_coverage_start = Date.new(Date.current.year + 1,1,1)
-            enrollment_renewal.renew
+            enrollment_renewal
           end
           let(:child1_dob) { current_date.next_month - 30.years }
 
           it "should return new renewal product without applied aptc" do
-            expect(subject.applied_aptc_amount.to_f).to eq 0.0
+            expect(subject.renew.applied_aptc_amount.to_f).to eq 0.0
           end
 
           it "should return new renewal enrollment without catastrophic product" do
-            expect(subject.product.metal_level_kind).not_to be :catastrophic
+            expect(subject.renew.product.metal_level_kind).not_to be :catastrophic
           end
         end
       end

--- a/spec/shared_contexts/dchbx_product_selection.rb
+++ b/spec/shared_contexts/dchbx_product_selection.rb
@@ -23,7 +23,7 @@ RSpec.shared_context 'family with one member and one enrollment', :shared_contex
 
   let(:person2) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
 
-  let!(:family) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person) }
+  let!(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
   let!(:family_member) { family.primary_applicant }
   let!(:family_member1) { FactoryBot.create(:family_member, family: family, person: person2) }
   let!(:renewal_product) do

--- a/spec/shared_contexts/dchbx_product_selection.rb
+++ b/spec/shared_contexts/dchbx_product_selection.rb
@@ -21,9 +21,11 @@ RSpec.shared_context 'family with one member and one enrollment', :shared_contex
                       dob: (start_of_year - 22.years))
   end
 
+  let(:person2) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+
   let!(:family) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person) }
   let!(:family_member) { family.primary_applicant }
-  let!(:family_member1) {family.family_members[1]}
+  let!(:family_member1) { FactoryBot.create(:family_member, family: family, person: person2) }
   let!(:renewal_product) do
     FactoryBot.create(:benefit_markets_products_health_products_health_product,
                       :ivl_product,

--- a/spec/shared_contexts/dchbx_product_selection.rb
+++ b/spec/shared_contexts/dchbx_product_selection.rb
@@ -21,11 +21,9 @@ RSpec.shared_context 'family with one member and one enrollment', :shared_contex
                       dob: (start_of_year - 22.years))
   end
 
-  let(:person2) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
-
-  let!(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+  let!(:family) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person) }
   let!(:family_member) { family.primary_applicant }
-  let!(:family_member1) { FactoryBot.create(:family_member, family: family, person: person2) }
+  let!(:family_member1) {family.family_members[1]}
   let!(:renewal_product) do
     FactoryBot.create(:benefit_markets_products_health_products_health_product,
                       :ivl_product,

--- a/spec/shared_contexts/family_enrollment_renewal.rb
+++ b/spec/shared_contexts/family_enrollment_renewal.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "setup family initial and renewal enrollments data", :shared_context => :metadata do
+  let(:current_date) { Date.new(calender_year, 11, 1) }
+  let(:current_benefit_coverage_period) { OpenStruct.new(start_on: current_date.beginning_of_year, end_on: current_date.end_of_year) }
+  let(:renewal_benefit_coverage_period) { OpenStruct.new(start_on: current_date.next_year.beginning_of_year, end_on: current_date.next_year.end_of_year) }
+  let(:aptc_values) {{}}
+  let(:assisted) { nil }
+  let(:primary) { FactoryBot.create(:person, :with_consumer_role, dob: primary_dob, is_tobacco_user: 'y') }
+
+  let!(:family) do
+    FactoryBot.create(:family, :with_primary_family_member, :person => primary)
+  end
+
+  let(:coverall_primary) { FactoryBot.create(:person, :with_resident_role, dob: primary_dob) }
+
+  let!(:coverall_family) do
+    FactoryBot.create(:family, :with_primary_family_member, :person => coverall_primary)
+  end
+
+  let(:spouse_person) { FactoryBot.create(:person, :with_consumer_role, dob: spouse_dob, is_tobacco_user: 'y') }
+
+  let!(:spouse) { FactoryBot.create(:family_member, person: spouse_person, family: family) }
+
+  let(:person_child1) { FactoryBot.create(:person, :with_consumer_role, dob: child1_dob) }
+
+  let!(:child1) { FactoryBot.create(:family_member, person: person_child1, family: family) }
+
+  let(:person_child2) { FactoryBot.create(:person, :with_consumer_role, dob: child2_dob) }
+
+  let!(:child2) { FactoryBot.create(:family_member, person: person_child2, family: family) }
+
+  let(:person_child3) { FactoryBot.create(:person, :with_consumer_role, dob: child3_dob) }
+
+  let!(:child3) { FactoryBot.create(:family_member, person: person_child3, family: family) }
+
+  let(:primary_dob){ current_date.next_month - 57.years }
+  let(:spouse_dob) { current_date.next_month - 55.years }
+  let(:child1_dob) { current_date.next_month - 26.years }
+  let(:child2_dob) { current_date.next_month - 20.years }
+  let(:child3_dob) { current_benefit_coverage_period.start_on + 2.months - 25.years}
+
+  let!(:enrollment) do
+    FactoryBot.create(:hbx_enrollment,
+                      :with_enrollment_members,
+                      family: family,
+                      enrollment_members: enrollment_members,
+                      household: family.active_household,
+                      coverage_kind: coverage_kind,
+                      effective_on: current_benefit_coverage_period.start_on,
+                      kind: "individual",
+                      product_id: current_product.id,
+                      rating_area_id: rating_area.id,
+                      consumer_role_id: family.primary_person.consumer_role.id,
+                      aasm_state: 'coverage_selected')
+  end
+
+  let!(:coverall_enrollment) do
+    FactoryBot.create(:hbx_enrollment,
+                      :with_enrollment_members,
+                      family: coverall_family,
+                      enrollment_members: coverall_enrollment_members,
+                      household: coverall_family.active_household,
+                      coverage_kind: coverage_kind,
+                      rating_area_id: rating_area.id,
+                      resident_role_id: coverall_family.primary_person.resident_role.id,
+                      effective_on: current_benefit_coverage_period.start_on,
+                      kind: "coverall",
+                      product_id: current_product.id,
+                      aasm_state: 'coverage_selected')
+  end
+
+  let!(:catastrophic_enrollment) do
+    FactoryBot.create(:hbx_enrollment,
+                      :with_enrollment_members,
+                      family: family,
+                      enrollment_members: enrollment_members,
+                      household: family.active_household,
+                      coverage_kind: coverage_kind,
+                      rating_area_id: rating_area.id,
+                      resident_role_id: family.primary_person.consumer_role.id,
+                      effective_on: Date.new(Date.current.year,1,1),
+                      kind: "coverall",
+                      product_id: current_cat_product.id,
+                      aasm_state: 'coverage_selected')
+  end
+
+  let(:enrollment_members) { family.family_members }
+  let(:coverall_enrollment_members) { coverall_family.family_members }
+  let(:calender_year) { TimeKeeper.date_of_record.year }
+  let(:coverage_kind) { 'health' }
+  let!(:rating_area) do
+    ::BenefitMarkets::Locations::RatingArea.rating_area_for(address, during: start_on) || FactoryBot.create_default(:benefit_markets_locations_rating_area)
+  end
+
+  let!(:service_area) do
+    ::BenefitMarkets::Locations::ServiceArea.service_areas_for(address, during: start_on).first || FactoryBot.create_default(:benefit_markets_locations_service_area)
+  end
+
+  let!(:renewal_rating_area) do
+    ::BenefitMarkets::Locations::RatingArea.rating_area_for(address, during: start_on.next_year) || FactoryBot.create_default(:benefit_markets_locations_rating_area, active_year: start_on.next_year.year)
+  end
+
+  let!(:renewal_service_area) do
+    ::BenefitMarkets::Locations::ServiceArea.service_areas_for(address, during: start_on.next_year).first || FactoryBot.create_default(:benefit_markets_locations_service_area, active_year: start_on.next_year.year)
+  end
+
+  let(:start_on) { current_benefit_coverage_period.start_on }
+  let(:address) { family.primary_person.rating_address }
+  let(:application_period) { start_on.beginning_of_year..start_on.end_of_year }
+  let(:renewal_application_period) { start_on.beginning_of_year.next_year..start_on.end_of_year.next_year}
+
+  let!(:current_product) do
+    prod =
+      FactoryBot.create(
+        :benefit_markets_products_health_products_health_product,
+        :with_issuer_profile,
+        benefit_market_kind: :aca_individual,
+        kind: :health,
+        service_area: service_area,
+        csr_variant_id: '01',
+        metal_level_kind: 'silver',
+        hios_id: '11111111122302-01',
+        renewal_product_id: renewal_product.id,
+        application_period: application_period
+      )
+    prod.premium_tables = [premium_table]
+    prod.save
+    prod
+  end
+
+  let(:premium_table)        { build(:benefit_markets_products_premium_table, effective_period: application_period, rating_area: rating_area) }
+
+  let!(:renewal_product) do
+    prod =
+      FactoryBot.create(
+        :benefit_markets_products_health_products_health_product,
+        :with_issuer_profile,
+        benefit_market_kind: :aca_individual,
+        kind: :health,
+        service_area: renewal_service_area,
+        csr_variant_id: '01',
+        metal_level_kind: 'silver',
+        hios_id: '11111111122302-01',
+        application_period: renewal_application_period
+      )
+    prod.premium_tables = [renewal_premium_table]
+    prod.save
+    prod
+  end
+
+  let(:renewal_premium_table)        { build(:benefit_markets_products_premium_table, effective_period: renewal_application_period, rating_area: renewal_rating_area) }
+
+  let!(:current_cat_product) do
+    prod =
+      FactoryBot.create(
+        :active_ivl_silver_health_product,
+        :with_issuer_profile,
+        benefit_market_kind: :aca_individual,
+        kind: :health,
+        service_area: service_area,
+        csr_variant_id: '01',
+        metal_level_kind: :catastrophic,
+        hios_base_id: "94506DC0390008",
+        application_period: application_period
+      )
+    prod.premium_tables = [cat_premium_table]
+    prod.save
+    prod
+  end
+
+  let(:cat_premium_table)        { build(:benefit_markets_products_premium_table, effective_period: application_period, rating_area: rating_area) }
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 185314911](https://www.pivotaltracker.com/story/show/185314911)

# A brief description of the changes

Current behavior: As part of the individual market enrollment renewals the following are **not** being checked:
- Non-applicant
- Not lawfully present
- Incarcerated
- Not a state resident

New behavior:  As part of the individual market enrollment renewals the following are being checked:
- Non-applicant
- Not lawfully present
- Incarcerated
- Not a state resident

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.