### PR TITLE
use fein from issuer profile if carrier profile missing

### DIFF
--- a/spec/lib/tasks/migrations/plans/glue_load_products_spec.rb
+++ b/spec/lib/tasks/migrations/plans/glue_load_products_spec.rb
@@ -33,14 +33,11 @@ describe 'glue_load_products' do
       expect(@file_contents).to include(ivl_product.hios_id)
     end
 
-    # Testing specifically with the load method b/c that is what is used to load the data in Glue
-    # rubocop:disable Security/JSONLoad
     it 'should write output that can be loaded as array of json' do
       invoke_rake
       expect(@loaded_json).to be_truthy
       expect(@loaded_json.is_a?(Array)).to be_truthy
     end
-    # rubocop:enable Security/JSONLoad
   end
 
   context 'when CarrierProfile does not return fein' do
@@ -62,5 +59,8 @@ def invoke_rake
   Rake::Task["seed:load_products"].reenable
   Rake::Task["seed:load_products"].invoke(year)
   @file_contents = File.read(json_file_name)
+  # Testing specifically with the load method b/c that is what is used to load the data in Glue
+  # rubocop:disable Security/JSONLoad
   @loaded_json = JSON.load(@file_contents)
+  # rubocop:enable Security/JSONLoad
 end

--- a/spec/lib/tasks/migrations/plans/glue_load_products_spec.rb
+++ b/spec/lib/tasks/migrations/plans/glue_load_products_spec.rb
@@ -4,47 +4,63 @@ require 'rails_helper'
 require 'rake'
 
 describe 'glue_load_products' do
-  after :all do
-    year = TimeKeeper.date_of_record.year
-    json_file_name = Rails.root.join("#{year}_plans.json")
-    error_file_name = Rails.root.join("#{year}_plans_error.txt")
-    File.delete(json_file_name) if File.exist?(json_file_name)
-    File.delete(error_file_name) if File.exist?(error_file_name)
-  end
 
   let(:year) { TimeKeeper.date_of_record.year }
   let(:json_file_name) { Rails.root.join("#{year}_plans.json") }
   let(:error_file_name) { Rails.root.join("#{year}_plans_error.txt") }
   let!(:shop_product) { FactoryBot.create(:benefit_markets_products_health_products_health_product) }
-  let!(:ivl_product) { FactoryBot.create(:benefit_markets_products_health_products_health_product, :ivl_product) }
+  let!(:ivl_product) { FactoryBot.create(:benefit_markets_products_health_products_health_product, :ivl_product, issuer_profile: issuer_profile) }
+  let!(:issuer_profile) { FactoryBot.create(:benefit_sponsors_organizations_issuer_profile, :kaiser_profile, fein: '123456789') }
 
-  before do
+  before :all do
     Rails.application.load_tasks
     Rake::Task.define_task(:environment)
+  end
+
+  after :all do
+    year = TimeKeeper.date_of_record.year
+    json_file_name = Rails.root.join("#{year}_plans.json")
+    error_file_name = Rails.root.join("#{year}_plans_error.txt")
+    File.delete(json_file_name)
+    File.delete(error_file_name)
   end
 
   describe 'load_products' do
     it 'should write products to the output file' do
       invoke_rake
       expect(File.exist?(json_file_name)).to be_truthy
-      expect(File.read(json_file_name)).to include(shop_product.hios_id)
-      expect(File.read(json_file_name)).to include(ivl_product.hios_id)
+      expect(@file_contents).to include(shop_product.hios_id)
+      expect(@file_contents).to include(ivl_product.hios_id)
     end
 
     # Testing specifically with the load method b/c that is what is used to load the data in Glue
     # rubocop:disable Security/JSONLoad
     it 'should write output that can be loaded as array of json' do
-      file_contents = File.read(json_file_name)
-      loaded_json = JSON.load(file_contents)
-      expect(loaded_json).to be_truthy
-      expect(loaded_json.is_a?(Array)).to be_truthy
+      invoke_rake
+      expect(@loaded_json).to be_truthy
+      expect(@loaded_json.is_a?(Array)).to be_truthy
     end
     # rubocop:enable Security/JSONLoad
+  end
 
+  context 'when CarrierProfile does not return fein' do
+    it 'should use the fein on the IssuerProfile' do
+      invoke_rake
+      ivl_plan = @loaded_json.detect {|p| p['hios_plan_id'] == ivl_product.hios_id}
+      fein = ivl_product.issuer_profile.organization.fein
+      expect(ivl_plan['fein']).to eq(fein)
+    end
   end
 end
 
 def invoke_rake
+  year = TimeKeeper.date_of_record.year
+  json_file_name = Rails.root.join("#{year}_plans.json")
+  error_file_name = Rails.root.join("#{year}_plans_error.txt")
+  File.delete(json_file_name) if File.exist?(json_file_name)
+  File.delete(error_file_name) if File.exist?(error_file_name)
   Rake::Task["seed:load_products"].reenable
-  Rake::Task["seed:load_products"].invoke(TimeKeeper.date_of_record.year)
+  Rake::Task["seed:load_products"].invoke(year)
+  @file_contents = File.read(json_file_name)
+  @loaded_json = JSON.load(@file_contents)
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-185949753

# A brief description of the changes

Current behavior:
The rake to generate the data dump in Enroll uses CarrierProfile to find the fein number. It also ignores the fein number for IVL products (this is a recent change that needs to be undone).

New behavior:
Enroll rake will set the fein field for IVL and Group products.  If searching by CarrierProfile does not yield a fein number, then the fein stored on the IssuerProfile will be used.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.