### PR TITLE
add feature flag/ settings for non esi mec fdsh payload format

### DIFF
--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -71,7 +71,7 @@ module Eligibilities
       payload = payload.value!
       headers = self.key == :local_mec ? { payload_type: 'application', key: 'local_mec_check' } : { correlation_id: application.id }
 
-      request_event = event(FDSH_EVENTS[self.key], attributes: payload.to_h, headers: headers)
+      request_event = event(FDSH_EVENTS[self.key], attributes: payload.to_h, headers: headers.merge!(payload_format))
       return false unless request_event.success?
       response = request_event.value!.publish
 
@@ -82,6 +82,15 @@ module Eligibilities
       end
       self.save
       response
+    end
+
+    def payload_format
+      case self.key
+      when :non_esi_mec
+        { non_esi_payload_format: EnrollRegistry[:non_esi_h31].setting(:payload_format).item }
+      else
+        {}
+      end
     end
 
     def add_verification_history(action, update_reason, updated_by)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/magi_medicaid_application_determined.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/magi_medicaid_application_determined.rb
@@ -23,7 +23,13 @@ module FinancialAssistance
 
           def build_event(payload, application_id, local_mec_check)
             headers = local_mec_check ? { payload_type: 'application', key: 'local_mec_check' } : { correlation_id: application_id }
-            event('events.iap.applications.magi_medicaid_application_determined', attributes: payload.to_h, headers: headers)
+            event('events.iap.applications.magi_medicaid_application_determined', attributes: payload.to_h, headers: headers.merge!(payload_format))
+          end
+
+          def payload_format
+            {
+              non_esi_payload_format: EnrollRegistry[:non_esi_h31].setting(:payload_format).item
+            }
           end
 
           def publish(event)

--- a/components/financial_assistance/app/models/financial_assistance/evidence.rb
+++ b/components/financial_assistance/app/models/financial_assistance/evidence.rb
@@ -51,7 +51,16 @@ module FinancialAssistance
       application = self.applicant.application
       payload = construct_payload(application)
       headers = self.key == :local_mec ? { payload_type: 'application', key: 'local_mec_check' } : { correlation_id: application.id }
-      event(FDSH_EVENTS[self.key], attributes: payload.to_h, headers: headers)
+      event(FDSH_EVENTS[self.key], attributes: payload.to_h, headers: headers.merge!(payload_format))
+    end
+
+    def payload_format
+      case self.key
+      when :non_esi_mec
+        { non_esi_payload_format: EnrollRegistry[:non_esi_h31].setting(:payload_format).item }
+      else
+        {}
+      end
     end
 
     def construct_payload(application)

--- a/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -14,6 +14,11 @@ registry:
         settings:
         - key: :payload_type
           item:  <%= ENV['SSA_H3_PAYLOAD_TYPE'] || "xml" %>
+      - key: :non_esi_h31
+        is_enabled: true
+        settings:
+        - key: :payload_format
+          item: <%= ENV['NON_ESI_H31_PAYLOAD_FORMAT'] || "xml" %>
       - key: :renewal_eligibility_verification_using_rrv
         item: :renewal_eligibility_verification_using_rrv
         is_enabled: <%= ENV['RENEWAL_ELIGIBILITY_VERIFICATION_USING_RRV_IS_ENABLED'] || false %>

--- a/config/client_config/me/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -14,6 +14,11 @@ registry:
         settings:
         - key: :payload_type
           item:  <%= ENV['SSA_H3_PAYLOAD_TYPE'] || "xml" %>
+      - key: :non_esi_h31
+        is_enabled: true
+        settings:
+        - key: :payload_format
+          item: <%= ENV['NON_ESI_H31_PAYLOAD_FORMAT'] || "xml" %>
       - key: :renewal_eligibility_verification_using_rrv
         item: :renewal_eligibility_verification_using_rrv
         is_enabled: <%= ENV['RENEWAL_ELIGIBILITY_VERIFICATION_USING_RRV_IS_ENABLED'] || true %>

--- a/spec/client_config/default_fdsh_services_configuration_spec.rb
+++ b/spec/client_config/default_fdsh_services_configuration_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'default fdsh service namespace client specific configurations' do
+
+  describe 'non_esi_h31' do
+    context 'for default value' do
+      it 'returns default value xml' do
+        expect(EnrollRegistry.feature_enabled?(:non_esi_h31)).to be_truthy
+        expect(EnrollRegistry[:non_esi_h31].setting(:payload_format).item).to eq('xml')
+      end
+    end
+  end
+end

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -143,6 +143,31 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
       end
     end
 
+    context 'payload_format' do
+      let(:non_esi_evidence) do
+        applicant.create_esi_evidence(
+          key: :non_esi_mec,
+          title: 'Non Esi',
+          aasm_state: 'pending',
+          due_on: nil,
+          verification_outstanding: false,
+          is_satisfied: true
+        )
+      end
+
+      it 'should return payload format as json when it is set' do
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:non_esi_h31).and_return(true)
+        allow(EnrollRegistry[:non_esi_h31].setting(:payload_format)).to receive(:item).and_return('json')
+        expect(non_esi_evidence.payload_format).to eq({:non_esi_payload_format => 'json'})
+      end
+
+      it 'should return payload format as xml when it is set' do
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:non_esi_h31).and_return(true)
+        allow(EnrollRegistry[:non_esi_h31].setting(:payload_format)).to receive(:item).and_return('xml')
+        expect(non_esi_evidence.payload_format).to eq({:non_esi_payload_format => 'xml'})
+      end
+    end
+
     context 'reject' do
       before do
         income_evidence.move_to_rejected!

--- a/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -14,6 +14,11 @@ registry:
         settings:
         - key: :payload_type
           item:  <%= ENV['SSA_H3_PAYLOAD_TYPE'] || "xml" %>
+      - key: :non_esi_h31
+        is_enabled: true
+        settings:
+        - key: :payload_format
+          item: <%= ENV['NON_ESI_H31_PAYLOAD_FORMAT'] || "xml" %>
       - key: :renewal_eligibility_verification_using_rrv
         item: :renewal_eligibility_verification_using_rrv
         is_enabled: <%= ENV['RENEWAL_ELIGIBILITY_VERIFICATION_USING_RRV_IS_ENABLED'] || false %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185700380

# A brief description of the changes

Current behavior: Enroll currently sends non-ESI MEC FDSH payloads in XML format, which CMS plans to deprecate starting March 2024.

New behavior: Add feature flag to determine what kind of payload format that CMS should receive for Non-ESI MEC Fdsh hub call (JSON/XML)

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: non_esi_h31

- [X] DC
- [X] ME

# Additional Context
Added new Env variable

`DC`:
NON_ESI_H31_PAYLOAD_FORMAT="xml"

`ME`:
NON_ESI_H31_PAYLOAD_FORMAT="json"