### PR TITLE
disable prior year's osse selection except last year

### DIFF
--- a/app/models/services/ivl_osse_eligibility_service.rb
+++ b/app/models/services/ivl_osse_eligibility_service.rb
@@ -47,6 +47,11 @@ module Services
       eligibility_result = {}
 
       args[:osse].each do |year, osse_eligibility|
+        current_year = TimeKeeper.date_of_record.year
+        if year.to_i < (current_year - 1)
+          eligibility_result[year] = "Failure"
+          next
+        end
         effective_on = effective_on_for_year(year.to_i)
         eligibility = get_eligibility_by_date(effective_on)
 

--- a/app/views/insured/families/healthcare_for_childcare_program_form.html.erb
+++ b/app/views/insured/families/healthcare_for_childcare_program_form.html.erb
@@ -22,10 +22,11 @@
           <th style='width: 40%'>Details</th>
         </thead>
         <% individual_osse_eligibility_years_for_display.each do |year| %>
+          <% previous_year = TimeKeeper.date_of_record.year - 1 %>
           <tr style='border: 0px solid #d5d5d5; height: 50px; '>
             <td style='padding: 20px'><strong><%= year %></strong></td>
-            <td><%= radio_button_tag "eligibilities[osse][#{year}]", "true", @osse_status_by_year[year][:is_eligible], class: "radio-button",  disabled: !pundit_allow(HbxProfile, :can_edit_osse_eligibility?) %></td>
-            <td><%= radio_button_tag "eligibilities[osse][#{year}]", "false", !@osse_status_by_year[year][:is_eligible], class: "radio-button",  disabled: !pundit_allow(HbxProfile, :can_edit_osse_eligibility?) %></td>
+            <td><%= radio_button_tag "eligibilities[osse][#{year}]", "true", @osse_status_by_year[year][:is_eligible], class: "radio-button",  disabled: !pundit_allow(HbxProfile, :can_edit_osse_eligibility?) || (year < previous_year) %></td>
+            <td><%= radio_button_tag "eligibilities[osse][#{year}]", "false", !@osse_status_by_year[year][:is_eligible], class: "radio-button",  disabled: !pundit_allow(HbxProfile, :can_edit_osse_eligibility?) || (year < previous_year) %></td>
             <% if @osse_status_by_year[year][:start_on].present? %>
               <td><%= "#{@osse_status_by_year[year][:start_on].to_s} - #{@osse_status_by_year[year][:end_on].to_s}" %></td>
             <% end %>

--- a/components/benefit_sponsors/app/models/benefit_sponsors/services/osse_eligibility_service.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/services/osse_eligibility_service.rb
@@ -40,6 +40,11 @@ module BenefitSponsors
         eligibility_result = {}
 
         args[:osse].each do |year, osse_eligibility|
+          current_year = TimeKeeper.date_of_record.year
+          if year.to_i < (current_year - 1)
+            eligibility_result[year] = "Failure"
+            next
+          end
           effective_on = effective_on_for_year(year.to_i)
           active_eligibility = benefit_sponsorship.active_eligibility_on(effective_on)
           current_eligibility_status = active_eligibility.present?

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/osse_eligibilities.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/osse_eligibilities.html.erb
@@ -21,10 +21,11 @@
           <th style='width: 40%'>Details</th>
         </thead>
         <% shop_osse_eligibility_years_for_display.each do |year| %>
+          <% previous_year = TimeKeeper.date_of_record.year - 1 %>
           <tr style='border: 0px solid #d5d5d5; height: 50px; '>
             <td style='padding: 20px'><strong><%= year %></strong></td>
-            <td><%= radio_button_tag "eligibilities[osse][#{year}]", "true", @osse_status_by_year[year][:is_eligible], class: "radio-button",  disabled: !pundit_allow(HbxProfile, :can_edit_osse_eligibility?) %></td>
-            <td><%= radio_button_tag "eligibilities[osse][#{year}]", "false", !@osse_status_by_year[year][:is_eligible], class: "radio-button", disabled: !pundit_allow(HbxProfile, :can_edit_osse_eligibility?) %></td>
+            <td><%= radio_button_tag "eligibilities[osse][#{year}]", "true", @osse_status_by_year[year][:is_eligible], class: "radio-button",  disabled: !pundit_allow(HbxProfile, :can_edit_osse_eligibility?) || (year < previous_year) %></td>
+            <td><%= radio_button_tag "eligibilities[osse][#{year}]", "false", !@osse_status_by_year[year][:is_eligible], class: "radio-button", disabled: !pundit_allow(HbxProfile, :can_edit_osse_eligibility?) || (year < previous_year) %></td>
             <% if @osse_status_by_year[year][:start_on].present? %>
               <td><%= "#{@osse_status_by_year[year][:start_on].to_s} - #{@osse_status_by_year[year][:end_on].to_s}" %></td>
             <% end %>

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/services/osse_eligibility_service_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/services/osse_eligibility_service_spec.rb
@@ -95,6 +95,17 @@ module BenefitSponsors
         result = subject.update_osse_eligibilities_by_year
         expect(result).to eq({ "Success" => [current_date.year.to_s]})
       end
+
+      context "when the year is more than 1 year old" do
+        let(:old_year) { TimeKeeper.date_of_record.year - 2 }
+        let(:params_1) { {osse: { old_year.to_s => "true" } } }
+        let(:subject_1) { described_class.new(employer_profile, params_1) }
+
+        it "should not update osse eligibility" do
+          result = subject_1.update_osse_eligibilities_by_year
+          expect(result).to eq({ "Failure" => [old_year.to_s]})
+        end
+      end
     end
 
     describe "#store_osse_eligibility" do

--- a/spec/data_migrations/reset_due_dates_for_outstanding_consumers_spec.rb
+++ b/spec/data_migrations/reset_due_dates_for_outstanding_consumers_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 require File.join(Rails.root, "app", "data_migrations", "reset_due_dates_for_outstanding_consumers")
-describe ResetDueDatesForOutstandingConsumers, dbclean: :after_each do
+describe ResetDueDatesForOutstandingConsumers, dbclean: :around_each do
 
   let(:given_task_name) { "remove_enrolled_contingent_state" }
   subject { ResetDueDatesForOutstandingConsumers.new(given_task_name, double(:current_scope => nil)) }

--- a/spec/models/services/ivl_osse_eligibility_service_spec.rb
+++ b/spec/models/services/ivl_osse_eligibility_service_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe Services::IvlOsseEligibilityService, type: :model, :dbclean => :a
 
       expect(result).to eq({ "Success" => [current_date.year.to_s]})
     end
+
+    context "when the year is more than 1 year old" do
+      let(:old_year) { TimeKeeper.date_of_record.year - 2 }
+      let(:params_1) { {person_id: person.id, osse: { old_year.to_s => "true" } } }
+      let(:subject_1) { described_class.new(params_1) }
+
+      it "should not update osse eligibility" do
+        result = subject_1.update_osse_eligibilities_by_year
+        expect(result).to eq({ "Failure" => [old_year.to_s]})
+      end
+    end
   end
 
   describe "#store_osse_eligibility" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/story/show/185940090

# A brief description of the changes

Current behavior:
it will allo all previous yers to update

New behavior:
Radio button eligibility years selection will only be available for the immediate proceeding year and preceding year of the current calendar year.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.