### PR TITLE
removes application eligibility check to fix memory issue

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/request_all.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/request_all.rb
@@ -29,7 +29,11 @@ module FinancialAssistance
             # @return [Array] family_ids
             def renewal_eligible_family_ids(renewal_year)
               family_ids = ::HbxEnrollment.individual_market.enrolled.current_year.distinct(:family_id)
-              eligible_family_ids = ::FinancialAssistance::Application.by_year(renewal_year.pred).determined.where(:family_id.in => family_ids).group_by(&:family_id).select { |_family_id, group| group.max_by(&:created_at).eligible_for_renewal? }.keys
+
+              eligible_family_ids = ::FinancialAssistance::Application.by_year(
+                renewal_year.pred
+              ).determined.where(:family_id.in => family_ids).distinct(:family_id)
+
               Success(eligible_family_ids)
             rescue StandardError => e
               Failure("Failed to find renewal eligible family_ids, error: #{e}")

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/request_all_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/request_all_spec.rb
@@ -166,9 +166,10 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AptcCsrCreditEli
           @result = subject.call(renewal_year: renewal_year)
         end
 
-        it 'should return only family ids with determined applications that are eligible for redetermination' do
-          expect(@result.success.count).to eq 1
-          expect(@result.success.first).to eq family.id
+        it 'returns family ids with all determined apps irrespective of application eligibility' do
+          expect(@result.success.count).to eq 2
+          expect(@result.success).to include(family.id)
+          expect(@result.success).to include(family2.id)
         end
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 185904054](https://www.pivotaltracker.com/story/show/185904054)

# A brief description of the changes

Current behavior: Running the operation causes memory issues.

New behavior: Running the operation does not cause any memory issues.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context

We need not check for application renewal eligibility as this is already handled in the operation 'FinancialAssistance::Operations::Applications::AptcCsrCreditEligibilities::Renewals::Renew'.
