### PR TITLE
wip - skips unwanted coverage termination transition for uneffected terminated enrollments

### DIFF
--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -26,7 +26,7 @@ module Operations
           enrollment.generate_signature(previous_enrollment)
           if enrollment.same_signatures(previous_enrollment) && !previous_enrollment.is_shop?
             if enrollment.effective_on > previous_enrollment.effective_on && previous_enrollment.may_terminate_coverage?
-              next previous_enrollment if ineligible_for_termination?(previous_enrollment, enrollment)
+              next previous_enrollment if previous_enrollment.ineligible_for_termination?(enrollment.effective_on)
 
               previous_enrollment.terminate_coverage!(enrollment.effective_on - 1.day)
             elsif previous_enrollment.enrollment_superseded_and_eligible_for_cancellation?(enrollment.effective_on)
@@ -36,21 +36,6 @@ module Operations
             end
           end
         end
-      end
-
-      private
-
-      # Checks to see if the previous enrollment is eligible for termination.
-      # Previous enrollment is ineligible for termination if all the below are true
-      #   - The previous enrollment is already in terminated state
-      #   - The previous enrollment has a terminated_on date
-      #   - The new enrollment has an effective_on date
-      #   - The new enrollment's effective_on is same as previous enrollment's terminated_on date
-      def ineligible_for_termination?(previous_enrollment, enrollment)
-        previous_enrollment.coverage_terminated? &&
-          previous_enrollment.terminated_on.present? &&
-          enrollment.effective_on.present? &&
-          (enrollment.effective_on - 1.day) == previous_enrollment.terminated_on
       end
     end
   end

--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -29,6 +29,8 @@ module Operations
               next previous_enrollment if ineligible_for_termination?(previous_enrollment, enrollment)
 
               previous_enrollment.terminate_coverage!(enrollment.effective_on - 1.day)
+            elsif previous_enrollment.enrollment_superseded_and_eligible_for_cancellation?(enrollment.effective_on)
+              previous_enrollment.cancel_coverage_for_superseded_term!
             elsif previous_enrollment.may_cancel_coverage?
               previous_enrollment.cancel_coverage!
             end

--- a/app/models/enrollments/replicator/reinstatement.rb
+++ b/app/models/enrollments/replicator/reinstatement.rb
@@ -100,8 +100,10 @@ module Enrollments
         reinstated_enrollment.hbx_enrollment_members = clone_hbx_enrollment_members
         unless base_enrollment.coverage_expired?
           if base_enrollment.may_terminate_coverage? && (reinstate_enrollment.effective_on > base_enrollment.effective_on)
-            base_enrollment.terminate_coverage!
-            base_enrollment.update_attributes!(terminated_on: new_effective_date - 1.day)
+            if !base_enrollment.ineligible_for_termination?(new_effective_date)
+              base_enrollment.terminate_coverage!
+              base_enrollment.update_attributes!(terminated_on: new_effective_date - 1.day)
+            end
           elsif base_enrollment.enrollment_superseded_and_eligible_for_cancellation?(new_effective_date)
             base_enrollment.cancel_coverage_for_superseded_term!
           elsif base_enrollment.may_cancel_coverage?

--- a/app/models/enrollments/replicator/reinstatement.rb
+++ b/app/models/enrollments/replicator/reinstatement.rb
@@ -100,7 +100,7 @@ module Enrollments
         reinstated_enrollment.hbx_enrollment_members = clone_hbx_enrollment_members
         unless base_enrollment.coverage_expired?
           if base_enrollment.may_terminate_coverage? && (reinstate_enrollment.effective_on > base_enrollment.effective_on)
-            if !base_enrollment.ineligible_for_termination?(new_effective_date)
+            unless base_enrollment.ineligible_for_termination?(new_effective_date)
               base_enrollment.terminate_coverage!
               base_enrollment.update_attributes!(terminated_on: new_effective_date - 1.day)
             end

--- a/app/models/enrollments/replicator/reinstatement.rb
+++ b/app/models/enrollments/replicator/reinstatement.rb
@@ -102,6 +102,8 @@ module Enrollments
           if base_enrollment.may_terminate_coverage? && (reinstate_enrollment.effective_on > base_enrollment.effective_on)
             base_enrollment.terminate_coverage!
             base_enrollment.update_attributes!(terminated_on: new_effective_date - 1.day)
+          elsif base_enrollment.enrollment_superseded_and_eligible_for_cancellation?(new_effective_date)
+            base_enrollment.cancel_coverage_for_superseded_term!
           elsif base_enrollment.may_cancel_coverage?
             base_enrollment.cancel_coverage!
           end

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2904,6 +2904,22 @@ class HbxEnrollment
     end
   end
 
+  # Checks to see if the new enrollment superseded the previous enrollment and is eligible for cancellation.
+  #   - Checks if RR configuration is enabled
+  #   - Checks if the enrollment is of kind individual market
+  #   - Checks if the previous enrollment is in terminated state
+  #   - Checks if the new enrollment has an effective_on date
+  #   - Checks if the new enrollment's effective_on is same as the current year
+  #   - Checks if the previous enrollment can be canceled via event 'cancel_coverage_for_superseded_term'
+  #   - The base/previous enrollment must have the same signature as the new enrollment, which is checked before calling this method
+  def enrollment_superseded_and_eligible_for_cancellation?(new_effective_on)
+    EnrollRegistry.feature_enabled?(:cancel_superseded_terminated_enrollments) &&
+      coverage_terminated? &&
+      new_effective_on.present? &&
+      new_effective_on.year == TimeKeeper.date_of_record.year &&
+      may_cancel_coverage_for_superseded_term?
+  end
+
   private
 
   # Calculates sum of enrolled aptc member's of TaxHouseholdEnrollment ehb_premiums including Minimum Responsibility.

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2920,6 +2920,22 @@ class HbxEnrollment
       may_cancel_coverage_for_superseded_term?
   end
 
+  # Checks to see if the previous enrollment is ineligible for termination.
+  # Previous enrollment is ineligible for termination if all the below are true
+  #   - Checks if the enrollment is of kind individual market
+  #   - Checks if the enrollment is in terminated state
+  #   - Checks if the enrollment has a terminated_on date
+  #   - Checks if the new_effective_on date exists
+  #   - Checks if new effective on is one day after the enrollment's terminated_on
+  #   - The base/previous enrollment must have the same signature as the new enrollment, which is 'given' before calling this method
+  def ineligible_for_termination?(new_effective_on)
+    is_ivl_by_kind? &&
+      coverage_terminated? &&
+      terminated_on.present? &&
+      new_effective_on.present? &&
+      (new_effective_on - 1.day) == terminated_on
+  end
+
   private
 
   # Calculates sum of enrolled aptc member's of TaxHouseholdEnrollment ehb_premiums including Minimum Responsibility.

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2227,6 +2227,16 @@ class HbxEnrollment
                   guard: :prior_plan_year_coverage?
     end
 
+    # This event is used to cancel coverage for superseded terminated enrollments
+    # This is specific to Individual Market enrollments
+    # Example:
+    #   When enrollments are purchased with a retroactive effective date,
+    #   and there are terminated enrollments in the current year with the same enrollment signature,
+    #   then the terminated enrollments should be canceled.
+    event :cancel_coverage_for_superseded_term, after: :record_transition do
+      transitions from: :coverage_terminated, to: :coverage_canceled, guard: :is_ivl_by_kind?
+    end
+
     event :cancel_for_non_payment, :after => :record_transition do
       transitions from: [:coverage_termination_pending, :auto_renewing, :renewing_coverage_selected,
                          :renewing_transmitted_to_carrier, :renewing_coverage_enrolled, :coverage_selected,

--- a/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
+++ b/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
@@ -20,7 +20,11 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
                         effective_on: new_enrollment_effective_on,
                         family: family)
     end
+
     let(:previous_enrollment_effective_on) { Date.new(coverage_year, 2) }
+
+    let(:previous_enrollment_terminated_on) { previous_enrollment_effective_on.end_of_month }
+
     let(:previous_enrollment) do
       FactoryBot.create(:hbx_enrollment,
                         :individual_unassisted,
@@ -52,21 +56,29 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
       ).first
     end
 
+    let(:prev_enr_term_to_cancel_superseded_transition) do
+      previous_enrollment.reload.workflow_state_transitions.where(
+        event: 'cancel_coverage_for_superseded_term!',
+        from_state: 'coverage_terminated',
+        to_state: 'coverage_canceled'
+      ).first
+    end
+
     before do
       previous_enrollment.generate_hbx_signature
       new_enrollment.generate_hbx_signature
-      subject
     end
 
+    # For event terminate_coverage
     context "when:
       - previous_enrollment is terminated
       - previous_enrollment has terminated_on
       - new_enrollment has effective_on
       - previous_enrollment's terminated_on is same as previous day of new_enrollment's effective_on
       " do
-      let(:previous_enrollment_terminated_on) { previous_enrollment_effective_on.end_of_month }
 
       it 'does not transition the previous_enrollment' do
+        subject
         expect(previous_enrollment_terminated_to_terminated_state_transition).to be_nil
       end
     end
@@ -80,11 +92,41 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
       let(:previous_enrollment_terminated_on) { previous_enrollment_effective_on.end_of_year }
 
       it 'transitions the previous_enrollment' do
+        subject
         expect(previous_enrollment_terminated_to_terminated_state_transition).to be_truthy
       end
 
       it 'updates terminated_on for previous_enrollment' do
+        subject
         expect(previous_enrollment.reload.terminated_on).to eq(new_enrollment_effective_on - 1.day)
+      end
+    end
+
+
+    # For event cancel_coverage_for_superseded_term
+    context "when:
+      - previous_enrollment is terminated
+      - new_enrollment has effective_on
+      - previous_enrollment's effective_on greater than or equal to new_enrollment's effective_on
+      - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
+      " do
+
+      before do
+        allow(
+          EnrollRegistry[:cancel_superseded_terminated_enrollments].feature
+        ).to receive(:is_enabled).and_return(true)
+      end
+
+      let(:previous_enrollment_effective_on) { new_enrollment_effective_on }
+
+      it 'transitions enrollment to canceled state' do
+        subject
+        expect(previous_enrollment.reload.coverage_canceled?).to be_truthy
+      end
+
+      it 'transitions enrollment via cancel_coverage_for_superseded_term' do
+        subject
+        expect(prev_enr_term_to_cancel_superseded_transition).to be_truthy
       end
     end
   end

--- a/spec/models/enrollments/replicator/reinstatement_spec.rb
+++ b/spec/models/enrollments/replicator/reinstatement_spec.rb
@@ -507,4 +507,59 @@ RSpec.describe Enrollments::Replicator::Reinstatement, :type => :model, dbclean:
       end
     end
   end
+
+  describe '#build' do
+    subject { described_class.new(base_enrollment, new_enrollment_effective_on) }
+
+    let(:coverage_year) { Date.today.year }
+    let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+    let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+    let(:new_enrollment_effective_on) { Date.new(coverage_year, 3) }
+    let(:base_enrollment_effective_on) { new_enrollment_effective_on }
+    let(:base_enrollment_terminated_on) { base_enrollment_effective_on.end_of_month }
+    let(:base_enrollment) do
+      FactoryBot.create(:hbx_enrollment,
+                        :individual_unassisted,
+                        :with_silver_health_product,
+                        :with_enrollment_members,
+                        aasm_state: 'coverage_terminated',
+                        consumer_role_id: person.consumer_role.id,
+                        effective_on: base_enrollment_effective_on,
+                        enrollment_members: family.family_members,
+                        family: family,
+                        household: family.active_household,
+                        terminated_on: base_enrollment_terminated_on)
+    end
+
+    let(:prev_enr_term_to_cancel_superseded_transition) do
+      base_enrollment.workflow_state_transitions.where(
+        event: 'cancel_coverage_for_superseded_term!',
+        from_state: 'coverage_terminated',
+        to_state: 'coverage_canceled'
+      ).first
+    end
+
+    context "when:
+      - base_enrollment is terminated
+      - base_enrollment's effective_on greater than or equal to new_effective_on
+      - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
+      " do
+
+      before do
+        allow(
+          EnrollRegistry[:cancel_superseded_terminated_enrollments].feature
+        ).to receive(:is_enabled).and_return(true)
+
+        subject.build
+      end
+
+      it 'transitions enrollment to canceled state' do
+        expect(base_enrollment.reload.coverage_canceled?).to be_truthy
+      end
+
+      it 'transitions enrollment via cancel_coverage_for_superseded_term' do
+        expect(prev_enr_term_to_cancel_superseded_transition).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -316,4 +316,49 @@ RSpec.describe HbxEnrollment, type: :model do
       end
     end
   end
+
+  describe '#cancel_coverage_for_superseded_term' do
+    context "when:
+      - enrollment is of kind 'individual'
+      - enrollment is in 'coverage_terminated' state
+      " do
+
+      let(:aasm_state) { 'coverage_terminated' }
+
+      it 'transitions enrollment to canceled' do
+        expect(hbx_enrollment.may_cancel_coverage_for_superseded_term?).to be_truthy
+        hbx_enrollment.cancel_coverage_for_superseded_term!
+        expect(hbx_enrollment.reload.coverage_canceled?).to be_truthy
+      end
+    end
+
+    context "when:
+      - enrollment is of kind 'individual'
+      - enrollment is not in 'coverage_terminated' state
+      " do
+
+      it 'returns false for transition check' do
+        expect(hbx_enrollment.may_cancel_coverage_for_superseded_term?).to be_falsey
+        expect do
+          hbx_enrollment.cancel_coverage_for_superseded_term!
+        end.to raise_error(AASM::InvalidTransition)
+      end
+    end
+
+    context "when:
+      - enrollment is not of kind 'individual'
+      - enrollment is in 'coverage_terminated' state
+      " do
+
+      let(:aasm_state) { 'coverage_terminated' }
+
+      it 'returns false for transition check' do
+        allow(hbx_enrollment).to receive(:is_ivl_by_kind?).and_return(false)
+        expect(hbx_enrollment.may_cancel_coverage_for_superseded_term?).to be_falsey
+        expect do
+          hbx_enrollment.cancel_coverage_for_superseded_term!
+        end.to raise_error(AASM::InvalidTransition)
+      end
+    end
+  end
 end

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -361,4 +361,131 @@ RSpec.describe HbxEnrollment, type: :model do
       end
     end
   end
+
+  describe '#enrollment_superseded_and_eligible_for_cancellation?' do
+    let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+    let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+    let(:new_effective_on) { TimeKeeper.date_of_record }
+    let(:aasm_state) { 'coverage_terminated' }
+    let(:kind) { 'individual' }
+
+    let(:prev_enrollment) do
+      FactoryBot.create(:hbx_enrollment,
+                        :with_silver_health_product,
+                        :with_enrollment_members,
+                        kind: kind,
+                        enrollment_members: family.family_members,
+                        aasm_state: aasm_state,
+                        household: family.active_household,
+                        effective_on: TimeKeeper.date_of_record,
+                        family: family)
+    end
+
+    let(:feature_enabled) { true }
+
+    before do
+      allow(
+        EnrollRegistry[:cancel_superseded_terminated_enrollments].feature
+      ).to receive(:is_enabled).and_return(feature_enabled)
+    end
+
+    context "when:
+      - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
+      - enrollment is of kind individual market
+      - enrollment is terminated
+      - new effective exists
+      - new effective on's year is same as system year
+      " do
+
+      it 'returns true' do
+        expect(
+          prev_enrollment.enrollment_superseded_and_eligible_for_cancellation?(new_effective_on)
+        ).to be_truthy
+      end
+    end
+
+    context "when:
+      - RR configuration feature :cancel_superseded_terminated_enrollments is disabled
+      - enrollment is of kind individual market
+      - enrollment is terminated
+      - new effective exists
+      - new effective on's year is same as system year
+      " do
+
+      let(:feature_enabled) { false }
+
+      it 'returns false' do
+        expect(
+          prev_enrollment.enrollment_superseded_and_eligible_for_cancellation?(new_effective_on)
+        ).to be_falsey
+      end
+    end
+
+    context "when:
+      - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
+      - enrollment is not of kind individual market
+      - enrollment is terminated
+      - new effective exists
+      - new effective on's year is same as system year
+      " do
+
+      let(:kind) { 'employer_sponsored' }
+
+      it 'returns false' do
+        expect(
+          prev_enrollment.enrollment_superseded_and_eligible_for_cancellation?(new_effective_on)
+        ).to be_falsey
+      end
+    end
+
+    context "when:
+      - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
+      - enrollment is of kind individual market
+      - enrollment is not terminated
+      - new effective exists
+      - new effective on's year is same as system year
+      " do
+
+      let(:aasm_state) { 'coverage_selected' }
+
+      it 'returns false' do
+        expect(
+          prev_enrollment.enrollment_superseded_and_eligible_for_cancellation?(new_effective_on)
+        ).to be_falsey
+      end
+    end
+
+    context "when:
+      - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
+      - enrollment is of kind individual market
+      - enrollment is terminated
+      - new effective does not exists
+      " do
+
+      let(:new_effective_on) { nil }
+
+      it 'returns false' do
+        expect(
+          prev_enrollment.enrollment_superseded_and_eligible_for_cancellation?(new_effective_on)
+        ).to be_falsey
+      end
+    end
+
+    context "when:
+      - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
+      - enrollment is of kind individual market
+      - enrollment is not terminated
+      - new effective exists
+      - new effective on's year is not same as system year
+      " do
+
+      let(:new_effective_on) { TimeKeeper.date_of_record.next_year }
+
+      it 'returns false' do
+        expect(
+          prev_enrollment.enrollment_superseded_and_eligible_for_cancellation?(new_effective_on)
+        ).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
# TODOs:
- [ ] Update base after code merge
- [ ] Fix failing specs
- [ ] Reconstruct commit history
- [ ] Update PR with correct description

# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.