### PR TITLE
check osse eligibility by quote

### DIFF
--- a/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_proposals_controller.rb
+++ b/components/sponsored_benefits/app/controllers/sponsored_benefits/organizations/plan_design_proposals_controller.rb
@@ -32,7 +32,7 @@ module SponsoredBenefits
       unless claim_code_status == "invalid"
         osse_quote = quote.osse_eligibility&.present? && EnrollRegistry.feature_enabled?(:broker_quote_osse_eligibility)
         effective_on = quote.profile.benefit_application.effective_period.min
-        employer_osse_eligible = employer_profile.active_benefit_sponsorship&.eligibility_on(effective_on).present?
+        employer_osse_eligible = employer_profile.active_benefit_sponsorship&.active_eligibility_on(effective_on).present?
 
         error_message = quote.present? && aca_state_abbreviation == "MA" ? check_if_county_zip_are_same(quote, employer_profile) : " "
       end

--- a/components/sponsored_benefits/app/models/sponsored_benefits/benefit_applications/plan_design_proposal_builder.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/benefit_applications/plan_design_proposal_builder.rb
@@ -10,7 +10,7 @@ module SponsoredBenefits
         @plan_design_organization = plan_design_organization
         @effective_date = effective_date
         @osse_eligibility ||= 'false'
-        @plan_design_proposal = plan_design_organization.plan_design_proposals.build(title: "Plan Design #{@effective_date.year}")
+        @plan_design_proposal = plan_design_organization.plan_design_proposals.find_or_initialize_by(title: "Plan Design #{@effective_date.year}")
       end
 
       def add_plan_design_profile

--- a/components/sponsored_benefits/app/models/sponsored_benefits/forms/plan_design_proposal.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/forms/plan_design_proposal.rb
@@ -82,8 +82,7 @@ module SponsoredBenefits
           .strftime('%Y-%m-%d')
         @quote_date = @proposal.updated_at.strftime('%m/%d/%Y')
         sponsorship = @proposal.profile.benefit_sponsorships.first
-        @osse_eligibility ||= 'true' if sponsorship &&
-                                        osse_eligibility_with(sponsorship)&.is_eligible_on?(TimeKeeper.date_of_record)
+        @osse_eligibility ||= 'true' if osse_eligibility_with(sponsorship)&.is_eligible_on?(TimeKeeper.date_of_record)
       end
 
       def ensure_proposal
@@ -236,7 +235,7 @@ module SponsoredBenefits
       end
 
       def osse_eligibility_with(benefit_sponsorship)
-        benefit_sponsorship.eligibility_on(effective_date)
+        benefit_sponsorship&.eligibility_on(effective_date)
       end
 
       def create_or_term_osse_eligibility(benefit_sponsorship)

--- a/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/organizations/plan_design_proposal.rb
@@ -54,12 +54,7 @@ module SponsoredBenefits
       end
 
       def osse_eligibility
-        pdo_eligibilities = benefit_sponsorship.eligibility_on(effective_date)
-        return pdo_eligibilities if pdo_eligibilities.present?
-
-        return nil unless plan_design_organization.fein.present?
-        org = BenefitSponsors::Organizations::Organization.where(fein: plan_design_organization.fein)&.first
-        org&.active_benefit_sponsorship&.eligibility_on(effective_date)
+        benefit_sponsorship.active_eligibility_on(effective_date)
       end
 
       def metal_level_products_restricted?

--- a/components/sponsored_benefits/spec/models/sponsored_benefits/forms/plan_design_proposal_form_spec.rb
+++ b/components/sponsored_benefits/spec/models/sponsored_benefits/forms/plan_design_proposal_form_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe SponsoredBenefits::Forms::PlanDesignProposal, type: :model, dbcle
         osse_eligibility = benefit_sponsorship.reload.eligibility_on(plan_design_proposal.effective_date)
         expect(osse_eligibility).to be_present
         expect(osse_eligibility.is_eligible_on?(plan_design_proposal.effective_date)).to be_truthy
+        expect(plan_design_proposal.osse_eligibility.present?).to eq true
       end
     end
 
@@ -93,6 +94,7 @@ RSpec.describe SponsoredBenefits::Forms::PlanDesignProposal, type: :model, dbcle
           plan_design_proposal.effective_date
         )
         expect(osse_eligibility.is_eligible_on?(plan_design_proposal.effective_date)).to be_falsey
+        expect(plan_design_proposal.osse_eligibility.present?).to eq false
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/story/show/185924681

# A brief description of the changes
checking quote status individually

Current behavior:
When selecting “no” on “Is this a HC4CC quote?“, the quote is being created is storing as “yes” and enforcing OSSE minimum eligibility rules are applying
Duplicate quotes are being created

New behavior:
When selecting “no” on “Is this a HC4CC quote?“, the quote will store “no” and not enforce the OSSE minimum eligibility rules regardless if the group is actively OSSE eligible or ineligible
When selecting “yes” on “Is this a HC4CC quote?“, the quote will store “yes” and will enforce the OSSE minimum eligibility rules regardless if the group is actively OSSE eligible or ineligible

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.