### PR TITLE
set default status for evidence types when payload failed to publish

### DIFF
--- a/app/domain/operations/fdsh/build_and_validate_application_payload.rb
+++ b/app/domain/operations/fdsh/build_and_validate_application_payload.rb
@@ -25,7 +25,7 @@ module Operations
           begin
             ::FinancialAssistance::Operations::Applications::Transformers::ApplicationTo::Cv3Application.new.call(application)
           rescue StandardError => e
-            Failure("Failed to construct payload: #{e.message}")
+            Failure(e.message)
           end
         else
           Failure("Could not generate CV3 Application -- wrong object type")

--- a/app/domain/operations/fdsh/build_and_validate_person_payload.rb
+++ b/app/domain/operations/fdsh/build_and_validate_person_payload.rb
@@ -23,7 +23,7 @@ module Operations
         if person.is_a?(::Person)
           Operations::Transformers::PersonTo::Cv3Person.new.call(person)
         else
-          Failure("Invalid Person Object #{person}")
+          Failure("Invalid Person Object")
         end
       end
 

--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -119,7 +119,7 @@ module Eligibilities
       enrollments.any? do |enrollment|
         applicant_enrolled?(applicant, enrollment) &&
           enrollment.is_health_enrollment? &&
-          (enrollment.applied_aptc_amount > 0 || ['03', '04', '05', '06'].include?(enrollment.product.csr_variant_id))
+          (enrollment.applied_aptc_amount > 0 || ['02', '04', '05', '06'].include?(enrollment.product.csr_variant_id))
       end
     end
 

--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -82,7 +82,7 @@ module Eligibilities
 
         false
       else
-        response
+        move_to_pending!
       end
     end
 

--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -64,41 +64,64 @@ module Eligibilities
       "events.individual.eligibilities.application.applicant.#{self.key}_evidence_updated"
     end
 
+    # This method requests a determination for the evidence and updates the verification history accordingly.
+    # Returns the response object if successful, false otherwise.
     def request_determination(action_name, update_reason, updated_by = nil)
-      self.add_verification_history(action_name, update_reason, updated_by)
+      add_verification_history(action_name, update_reason, updated_by)
+
       response = Operations::Fdsh::RequestEvidenceDetermination.new.call(self)
 
-      if response.failure? && EnrollRegistry.feature_enabled?(:validate_and_record_publish_application_errors)
-        determine_evidence_aasm_status(self.evidenceable)
+      if response.failure?
+        if EnrollRegistry.feature_enabled?(:validate_and_record_publish_application_errors)
+          method_name = "determine_#{key.to_s.split('_').last}_evidence_aasm_status".to_sym
+          send(method_name, evidenceable)
 
-        update_reason = "#{self.key.capitalize} Evidence Determination Request Failed due to #{response.failure}"
-        self.add_verification_history("Hub Request Failed", update_reason, "system")
-        false
-      elsif response.failure?
+          update_reason = "#{key.capitalize} Evidence Determination Request Failed due to #{response.failure}"
+          add_verification_history("Hub Request Failed", update_reason, "system")
+        end
+
         false
       else
         response
       end
     end
 
-    def determine_evidence_aasm_status(applicant)
+    # This method sets the evidence to the attested state for the following types of evidence:
+    # - esi_mec
+    # - non_esi_mec
+    # - local_mec
+    def determine_mec_evidence_aasm_status(applicant)
+      applicant.set_evidence_attested(self)
+    end
+
+    # This method sets the evidence to the attested state for the following types of evidence:
+    # - income
+    def determine_income_evidence_aasm_status(applicant)
       family_id = applicant.application.family_id
       enrollments = HbxEnrollment.where(:aasm_state.in => HbxEnrollment::ENROLLED_STATUSES, family_id: family_id)
+      aptc_or_csr_used = enrolled_in_any_aptc_csr_enrollments?(applicant, enrollments)
 
-      if enrolled?(applicant, enrollments)
-        enrollments.each do |enrollment|
-          applicant.enrolled_with(enrollment)
-        end
+      if aptc_or_csr_used
+        applicant.set_evidence_outstanding(self)
       else
         applicant.set_evidence_to_negative_response(self)
       end
     end
 
-    def enrolled?(applicant, enrollments)
-      return false if enrollments.blank?
+    # This method checks if the applicant is enrolled in any APTC or CSR enrollments.
+    # returns Boolean
+    def enrolled_in_any_aptc_csr_enrollments?(applicant, enrollments)
+      enrollments.any? do |enrollment|
+        applicant_enrolled?(applicant, enrollment) &&
+          enrollment.is_health_enrollment? &&
+          (enrollment.applied_aptc_amount > 0 || ['03', '04', '05', '06'].include?(enrollment.product.csr_variant_id))
+      end
+    end
 
-      family_member_ids = enrollments.flat_map(&:hbx_enrollment_members).flat_map(&:applicant_id).uniq
-      family_member_ids.map(&:to_s).include?(applicant.family_member_id.to_s)
+    # This method checks if the applicant is enrolled in the given enrollment.
+    # returns Boolean
+    def applicant_enrolled?(applicant, enrollment)
+      enrollment.hbx_enrollment_members.any? { |member| member.applicant_id.to_s == applicant.family_member_id.to_s }
     end
 
     def payload_format

--- a/components/financial_assistance/app/controllers/financial_assistance/evidences_controller.rb
+++ b/components/financial_assistance/app/controllers/financial_assistance/evidences_controller.rb
@@ -29,7 +29,6 @@ module FinancialAssistance
       result = @evidence.request_determination(params[:admin_action], "Requested Hub for verification", current_user.oim_id)
 
       if result
-        @evidence.move_to_pending!
         key = :success
         message = "request submited successfully"
       else

--- a/components/financial_assistance/app/views/financial_assistance/applications/verifications/_verification_card.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/verifications/_verification_card.html.erb
@@ -1,5 +1,5 @@
 <% evidence_type = evidence.title %>
-<div class="row">
+<div class="row" data-cuke="<%=evidence_kind%>_for_<%=applicant.full_name.parameterize.underscore%>">
   <div class="v-type col-md-12">
     <div class="v-type-name col-md-2" id="evidence_kind_<%= evidence_kind %>">
       <%= l10n(display_evidence_type(evidence_type)) %>

--- a/features/financial_assistance/step_definitions/financial_assistance_steps.rb
+++ b/features/financial_assistance/step_definitions/financial_assistance_steps.rb
@@ -676,6 +676,10 @@ Then(/^a family with financial application and applicants in (.*) state exists w
   create_family_faa_application_with_applicants_and_evidences(state)
 end
 
+Then(/^a family with financial application and applicants in (.*) state exists with unverified evidences$/) do |state|
+  create_family_faa_application_with_applicants_and_unverified_evidences(state)
+end
+
 When(/^an applicant with other income exists for a (.*) financial application$/) do |state|
   create_application_applicant_with_incomes(state)
 end

--- a/features/insured/individual_call_hub_by_admin.feature
+++ b/features/insured/individual_call_hub_by_admin.feature
@@ -1,6 +1,6 @@
 Feature: Consumer verification process
 
-  Scenario: Consumer has determined Financial Assistance application
+  Scenario: Failed consumer esi evidence determination request
     Given the FAA feature configuration is enabled
     And FAA display_medicaid_question feature is enabled
     And FAA mec_check feature is enabled
@@ -16,3 +16,6 @@ Feature: Consumer verification process
     When evidence determination payload is failed to publish
     Then Admin should see the error message unable to submited request
     And Admin should see the esi evidence state as attested
+    And Admin clicks on esi evidence action dropdown
+    Then Admin navigates to view history section
+    Then Admin should see the failed request recorded in the view history table

--- a/features/insured/individual_call_hub_by_admin.feature
+++ b/features/insured/individual_call_hub_by_admin.feature
@@ -1,0 +1,17 @@
+Feature: Consumer verification process
+
+  Scenario: Consumer has determined Financial Assistance application
+    Given the FAA feature configuration is enabled
+    And FAA display_medicaid_question feature is enabled
+    And FAA mec_check feature is enabled
+    And a family with financial application and applicants in determined state exists with unverified evidences
+    And the user with hbx_staff role is logged in
+    When admin visits home page
+    And Individual clicks on Documents link
+    Then Individual should see cost saving documents for evidences
+    When validate_and_record_publish_application_errors is enabled
+    And Admin clicks on esi evidence action dropdown
+    Then Admin should see and click Call HUB option
+    And Admin clicks confirm
+    Then Admin should see the error message unable to submited request
+    And Admin should see the esi evidence state as attested

--- a/features/insured/individual_call_hub_by_admin.feature
+++ b/features/insured/individual_call_hub_by_admin.feature
@@ -4,14 +4,15 @@ Feature: Consumer verification process
     Given the FAA feature configuration is enabled
     And FAA display_medicaid_question feature is enabled
     And FAA mec_check feature is enabled
+    And validate_and_record_publish_application_errors feature is enabled
     And a family with financial application and applicants in determined state exists with unverified evidences
     And the user with hbx_staff role is logged in
     When admin visits home page
     And Individual clicks on Documents link
     Then Individual should see cost saving documents for evidences
-    When validate_and_record_publish_application_errors is enabled
     And Admin clicks on esi evidence action dropdown
     Then Admin should see and click Call HUB option
     And Admin clicks confirm
+    When evidence determination payload is failed to publish
     Then Admin should see the error message unable to submited request
     And Admin should see the esi evidence state as attested

--- a/features/step_definitions/verification_process_steps.rb
+++ b/features/step_definitions/verification_process_steps.rb
@@ -138,8 +138,8 @@ Then /^Admin should see the error message ([^"]*)$/ do |error_message|
 end
 
 Then /^Admin should see the esi evidence state as attested$/ do
-  txt = "//*[@id='home']/div/div/div[2]/div[2]/div[5]/div/div/div/div[2]/div[8]"
-  page.all(:xpath, txt).each do |element|
+  txt = IvlDocumentsPage.esi_evidence_row_for(@applicant.full_name)
+  page.all(:css, txt).each do |element|
     expect(element).to have_selector('.label', text: 'Attested')
   end
 end

--- a/features/step_definitions/verification_process_steps.rb
+++ b/features/step_definitions/verification_process_steps.rb
@@ -151,6 +151,15 @@ Then(/^Individual should see view history option/) do
   expect(page).to have_content('View History')
 end
 
+Then(/^Admin navigates to view history section/) do
+  expect(page).to have_content('View History')
+  find(:xpath, IvlDocumentsPage.view_history_option).click
+end
+
+Then(/^Admin should see the failed request recorded in the view history table/) do
+  expect(page).to have_content("Hub request failed")
+end
+
 And(/^Individual clicks on verify/) do
   find(:xpath, IvlDocumentsPage.verify_option).click
 end

--- a/features/step_definitions/verification_process_steps.rb
+++ b/features/step_definitions/verification_process_steps.rb
@@ -109,8 +109,39 @@ Then(/^Individual should see cost saving documents for evidences$/) do
   expect(page).to have_content(l10n('faa.evidence_type_aces'))
 end
 
+Then(/^validate_and_record_publish_application_errors is enabled$/) do
+  EnrollRegistry[:validate_and_record_publish_application_errors].feature.stub(:is_enabled).and_return(true)
+  evidence_verification_request = instance_double(Operations::Fdsh::RequestEvidenceDetermination)
+  allow(evidence_verification_request).to receive(:call).and_return(Dry::Monads::Failure("test"))
+  allow(Operations::Fdsh::RequestEvidenceDetermination).to receive(:new).and_return(evidence_verification_request)
+end
+
 And(/^Individual clicks on Actions dropdown$/) do
   find_all('.v-type-actions')[-1].click
+end
+
+And(/^Admin clicks on esi evidence action dropdown$/) do
+  find_all('.v-type-actions')[-3].click
+end
+
+And(/^Admin should see and click (.*) option$/) do |option|
+  expect(page).to have_content(option)
+  find(:xpath, IvlDocumentsPage.send("#{option.parameterize.underscore}_option".to_sym)).click
+end
+
+And(/^Admin clicks confirm$/) do
+  find('.v-type-confirm-button').click
+end
+
+Then /^Admin should see the error message ([^"]*)$/ do |error_message|
+  expect(page).to have_content(error_message)
+end
+
+Then /^Admin should see the esi evidence state as attested$/ do
+  txt = "//*[@id='home']/div/div/div[2]/div[2]/div[5]/div/div/div/div[2]/div[8]"
+  page.all(:xpath, txt).each do |element|
+    expect(element).to have_selector('.label', text: 'Attested')
+  end
 end
 
 Then(/^Individual should see view history option/) do

--- a/features/step_definitions/verification_process_steps.rb
+++ b/features/step_definitions/verification_process_steps.rb
@@ -136,11 +136,11 @@ And(/^Admin clicks confirm$/) do
   find('.v-type-confirm-button').click
 end
 
-Then /^Admin should see the error message ([^"]*)$/ do |error_message|
+Then(/^Admin should see the error message ([^"]*)$/) do |error_message|
   expect(page).to have_content(error_message)
 end
 
-Then /^Admin should see the esi evidence state as attested$/ do
+Then(/^Admin should see the esi evidence state as attested$/) do
   txt = IvlDocumentsPage.esi_evidence_row_for(@applicant.full_name)
   page.all(:css, txt).each do |element|
     expect(element).to have_selector('.label', text: 'Attested')

--- a/features/step_definitions/verification_process_steps.rb
+++ b/features/step_definitions/verification_process_steps.rb
@@ -109,8 +109,11 @@ Then(/^Individual should see cost saving documents for evidences$/) do
   expect(page).to have_content(l10n('faa.evidence_type_aces'))
 end
 
-Then(/^validate_and_record_publish_application_errors is enabled$/) do
-  EnrollRegistry[:validate_and_record_publish_application_errors].feature.stub(:is_enabled).and_return(true)
+Then(/^validate_and_record_publish_application_errors feature is (.*)$/) do |config|
+  EnrollRegistry[:validate_and_record_publish_application_errors].feature.stub(:is_enabled).and_return(config == 'enabled')
+end
+
+When(/^evidence determination payload is failed to publish$/) do
   evidence_verification_request = instance_double(Operations::Fdsh::RequestEvidenceDetermination)
   allow(evidence_verification_request).to receive(:call).and_return(Dry::Monads::Failure("test"))
   allow(Operations::Fdsh::RequestEvidenceDetermination).to receive(:new).and_return(evidence_verification_request)

--- a/features/support/object_model_pages/ivl/homepage/ivl_documents_page.rb
+++ b/features/support/object_model_pages/ivl/homepage/ivl_documents_page.rb
@@ -23,6 +23,10 @@ class IvlDocumentsPage
     "//div[@class='selectric-scroll']/ul/li[contains(text(), 'View History')]"
   end
 
+  def self.call_hub_option
+    "//div[@class='selectric-scroll']/ul/li[contains(text(), 'Call HUB')]"
+  end
+
   def self.verify_option
     "//div[@class='selectric-scroll']/ul/li[contains(text(), 'Verify')]"
   end

--- a/features/support/object_model_pages/ivl/homepage/ivl_documents_page.rb
+++ b/features/support/object_model_pages/ivl/homepage/ivl_documents_page.rb
@@ -15,6 +15,14 @@ class IvlDocumentsPage
     '#evidence_kind_income_evidence'
   end
 
+  def self.income_evidence_row_for(name)
+    "[data-cuke='income_evidence_for_#{name.parameterize.underscore}']"
+  end
+
+  def self.esi_evidence_row_for(name)
+    "[data-cuke='esi_evidence_for_#{name.parameterize.underscore}']"
+  end
+
   def self.local_mec_evidence_actions
     "#v-action-#{@applicant.id}-local-mec"
   end

--- a/features/support/worlds/ivl_assistance_world.rb
+++ b/features/support/worlds/ivl_assistance_world.rb
@@ -237,6 +237,18 @@ module IvlAssistanceWorld
     end
   end
 
+  def create_family_faa_application_with_applicants_and_unverified_evidences(state)
+    create_family_faa_application_with_applicants(state)
+
+    @application.applicants.each do |applicant|
+      applicant.income_evidence = FactoryBot.build(:evidence, :with_request_results, :with_verification_histories, key: :income, title: 'Income', aasm_state: 'unverified', is_satisfied: false)
+      applicant.esi_evidence = FactoryBot.build(:evidence, :with_request_results, :with_verification_histories, key: :esi_mec, title: 'ESI MEC', aasm_state: 'unverified', is_satisfied: false)
+      applicant.non_esi_evidence = FactoryBot.build(:evidence, :with_request_results, :with_verification_histories, key: :non_esi_mec, title: 'Non ESI MEC', aasm_state: 'unverified', is_satisfied: false)
+      applicant.local_mec_evidence = FactoryBot.build(:evidence, :with_request_results, :with_verification_histories, key: :local_mec, title: 'Local MEC', aasm_state: 'unverified', is_satisfied: false)
+      applicant.save
+    end
+  end
+
   def create_enrollment_for_family(family, carrier_name = nil)
     case carrier_name
     when 'Kaiser Permanente', 'Kaiser'

--- a/spec/domain/operations/fdsh/build_and_validate_application_payload_spec.rb
+++ b/spec/domain/operations/fdsh/build_and_validate_application_payload_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe Operations::Fdsh::BuildAndValidateApplicationPayload, dbclean: :a
             result = described_class.new.call(application, request_type)
 
             expect(result).to be_failure
-            expect(result.failure).to include('Failed to construct payload:')
           end
         end
 

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'aasm/rspec'
 
 RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
   let!(:application) do
@@ -51,6 +52,10 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
       )
     end
 
+    let(:updated_by) { 'admin' }
+    let(:update_reason) { "Requested Hub for verification" }
+    let(:action) { 'request_hub' }
+
     context '.extend_due_on' do
       let(:new_due_date) do
         applicant.schedule_verification_due_on + 30.days
@@ -78,11 +83,7 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
       end
     end
 
-    let(:updated_by) { 'admin' }
-    let(:update_reason) { "Requested Hub for verification" }
-    let(:action) { 'request_hub' }
-
-    context '.request_determination' do
+    context '.request_determination for income evidence' do
       before do
         allow(EnrollRegistry).to receive(:feature_enabled?).and_return(false)
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:validate_and_record_publish_application_errors).and_return(true)
@@ -240,6 +241,159 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:non_esi_h31).and_return(true)
         allow(EnrollRegistry[:non_esi_h31].setting(:payload_format)).to receive(:item).and_return('xml')
         expect(non_esi_evidence.payload_format).to eq({:non_esi_payload_format => 'xml'})
+      end
+    end
+
+    context '.request_determination for esi mec evidence' do
+      before do
+        allow(EnrollRegistry).to receive(:feature_enabled?).and_return(false)
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:validate_and_record_publish_application_errors).and_return(true)
+      end
+
+      let(:evidence_verification_request) { instance_double(Operations::Fdsh::RequestEvidenceDetermination) }
+
+      context 'with no errors' do
+        before do
+          allow(evidence_verification_request).to receive(:call).and_return(Dry::Monads::Success({}))
+          allow(Operations::Fdsh::RequestEvidenceDetermination).to receive(:new).and_return(evidence_verification_request)
+          esi_evidence.update_attributes!(aasm_state: 'unverified')
+          @result = esi_evidence.request_determination(action, update_reason, updated_by)
+          esi_evidence.reload
+        end
+
+        it 'should return true' do
+          expect(@result).to be_truthy
+        end
+
+        it 'should change evidence aasm_state to pending' do
+          expect(esi_evidence).to have_state(:pending)
+        end
+
+        it 'should create verification history for the requested call' do
+          history = esi_evidence.verification_histories.first
+          expect(history.action).to eq action
+          expect(history.update_reason).to eq update_reason
+          expect(history.updated_by).to eq updated_by
+        end
+      end
+
+      context 'builds and publishes with errors' do
+        let(:failed_action) { 'Hub Request Failed' }
+        let(:failed_updated_by) { 'system' }
+        let(:failed_update_reason) { "Invalid SSN" }
+
+        let(:person) { FactoryBot.create(:person, :with_consumer_role) }
+        let!(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+
+        before do
+          allow(evidence_verification_request).to receive(:call).and_return(Dry::Monads::Failure(failed_update_reason))
+          allow(Operations::Fdsh::RequestEvidenceDetermination).to receive(:new).and_return(evidence_verification_request)
+
+          family_member_id = family.family_members[0].id
+          applicant.update(family_member_id: family_member_id)
+          application.update(family_id: family.id)
+        end
+
+        context 'with an applicant without an active enrollment' do
+          before do
+            esi_evidence.update_attributes!(aasm_state: 'unverified')
+            @result = esi_evidence.request_determination(action, update_reason, updated_by)
+            esi_evidence.reload
+          end
+
+          it 'should return false' do
+            expect(@result).to be_falsey
+          end
+
+          it 'should change evidence aasm_state to attested' do
+            expect(esi_evidence).to have_state(:attested)
+          end
+
+          it 'should create history for requested call' do
+            admin_call_history = esi_evidence.verification_histories.first
+            expect(admin_call_history.action).to eq action
+            expect(admin_call_history.update_reason).to eq update_reason
+            expect(admin_call_history.updated_by).to eq updated_by
+          end
+
+          it 'should create history for failed publish' do
+            failure_history = esi_evidence.verification_histories.last
+            expect(failure_history.action).to eq failed_action
+            expect(failure_history.update_reason).to include(failed_update_reason)
+            expect(failure_history.updated_by).to eq(failed_updated_by)
+          end
+        end
+
+        context 'with an applicant who has an active enrollment' do
+          let!(:hbx_enrollment) do
+            FactoryBot.create(:hbx_enrollment, :with_enrollment_members, :with_health_product,
+                              family: family, enrollment_members: [family.primary_applicant],
+                              aasm_state: 'coverage_selected', kind: 'individual')
+          end
+
+          context 'and not using aptc or valid csr' do
+            before do
+              # csr_variant_id "01" is not one of the valid csr codes to change aasm_state
+              hbx_enrollment.product.update(csr_variant_id: '01')
+              esi_evidence.update_attributes!(aasm_state: 'unverified')
+              @result = esi_evidence.request_determination(action, update_reason, updated_by)
+              esi_evidence.reload
+            end
+
+            it 'should return false' do
+              expect(@result).to be_falsey
+            end
+
+            it 'should change evidence aasm_state to attested' do
+              expect(esi_evidence).to have_state(:attested)
+            end
+
+            it 'should create history for requested call' do
+              admin_call_history = esi_evidence.verification_histories.first
+              expect(admin_call_history.action).to eq action
+              expect(admin_call_history.update_reason).to eq update_reason
+              expect(admin_call_history.updated_by).to eq updated_by
+            end
+
+            it 'should create history for failed publish' do
+              failure_history = esi_evidence.verification_histories.last
+              expect(failure_history.action).to eq failed_action
+              expect(failure_history.update_reason).to include(failed_update_reason)
+              expect(failure_history.updated_by).to eq(failed_updated_by)
+            end
+          end
+
+          context 'and using aptc' do
+            before do
+              hbx_enrollment.update(applied_aptc_amount: 720)
+              esi_evidence.update_attributes!(aasm_state: 'unverified')
+              @result = esi_evidence.request_determination(action, update_reason, updated_by)
+              esi_evidence.reload
+            end
+
+            it 'should return false' do
+              expect(@result).to be_falsey
+            end
+
+            it 'should change evidence aasm_state to attested' do
+              expect(esi_evidence).to have_state(:attested)
+            end
+
+            it 'should create history for requested call' do
+              admin_call_history = esi_evidence.verification_histories.first
+              expect(admin_call_history.action).to eq action
+              expect(admin_call_history.update_reason).to eq update_reason
+              expect(admin_call_history.updated_by).to eq updated_by
+            end
+
+            it 'should create history for failed publish' do
+              failure_history = esi_evidence.verification_histories.last
+              expect(failure_history.action).to eq failed_action
+              expect(failure_history.update_reason).to include(failed_update_reason)
+              expect(failure_history.updated_by).to eq(failed_updated_by)
+            end
+          end
+        end
       end
     end
 

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -270,8 +270,8 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
           expect(esi_evidence).to have_state(:pending)
         end
 
-        it 'should not change income evidence aasm_state to pending' do
-          expect(income_evidence).not_to have_state(:pending)
+        it 'should not change income evidence aasm_state to unverified' do
+          expect(income_evidence).to have_state(:unverified)
         end
 
         it 'should create verification history for the requested call' do

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
           result = income_evidence.request_determination(action, update_reason, updated_by)
           income_evidence.reload
 
-          expect(result).to be_success
+          expect(result).to be_truthy
           expect(income_evidence.verification_histories).to be_present
 
           history = income_evidence.verification_histories.first
@@ -257,6 +257,7 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
           allow(evidence_verification_request).to receive(:call).and_return(Dry::Monads::Success({}))
           allow(Operations::Fdsh::RequestEvidenceDetermination).to receive(:new).and_return(evidence_verification_request)
           esi_evidence.update_attributes!(aasm_state: 'unverified')
+          income_evidence.update_attributes!(aasm_state: 'unverified')
           @result = esi_evidence.request_determination(action, update_reason, updated_by)
           esi_evidence.reload
         end
@@ -265,8 +266,12 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
           expect(@result).to be_truthy
         end
 
-        it 'should change evidence aasm_state to pending' do
+        it 'should change esi evidence aasm_state to pending' do
           expect(esi_evidence).to have_state(:pending)
+        end
+
+        it 'should not change income evidence aasm_state to pending' do
+          expect(income_evidence).not_to have_state(:pending)
         end
 
         it 'should create verification history for the requested call' do
@@ -297,6 +302,7 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
         context 'with an applicant without an active enrollment' do
           before do
             esi_evidence.update_attributes!(aasm_state: 'unverified')
+            income_evidence.update_attributes!(aasm_state: 'unverified')
             @result = esi_evidence.request_determination(action, update_reason, updated_by)
             esi_evidence.reload
           end
@@ -305,8 +311,12 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
             expect(@result).to be_falsey
           end
 
-          it 'should change evidence aasm_state to attested' do
+          it 'should change esi evidence aasm_state to attested' do
             expect(esi_evidence).to have_state(:attested)
+          end
+
+          it 'should not change income evidence aasm_state to attested' do
+            expect(income_evidence).not_to have_state(:attested)
           end
 
           it 'should create history for requested call' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [pivotal-185760688](https://www.pivotaltracker.com/story/show/185760688)

# A brief description of the changes

Current behavior: For MEC evidence types when request failed to publish, the evidence state remains in pending and failed request is not recorded in hisrtory.

New behavior: New changes will default the state when the request fails and also will record the reason for failure in history

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.