### PR TITLE
skips unwanted term transition for enrs during non plan shopping cases

### DIFF
--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -26,7 +26,7 @@ module Operations
           enrollment.generate_signature(previous_enrollment)
           if enrollment.same_signatures(previous_enrollment) && !previous_enrollment.is_shop?
             if enrollment.effective_on > previous_enrollment.effective_on && previous_enrollment.may_terminate_coverage?
-              next previous_enrollment if ineligible_for_termination?(previous_enrollment, enrollment)
+              next previous_enrollment if previous_enrollment.ineligible_for_termination?(enrollment.effective_on)
 
               previous_enrollment.terminate_coverage!(enrollment.effective_on - 1.day)
             elsif previous_enrollment.enrollment_superseded_and_eligible_for_cancellation?(enrollment.effective_on)
@@ -36,21 +36,6 @@ module Operations
             end
           end
         end
-      end
-
-      private
-
-      # Checks to see if the previous enrollment is eligible for termination.
-      # Previous enrollment is ineligible for termination if all the below are true
-      #   - The previous enrollment is already in terminated state
-      #   - The previous enrollment has a terminated_on date
-      #   - The new enrollment has an effective_on date
-      #   - The new enrollment's effective_on is same as previous enrollment's terminated_on date
-      def ineligible_for_termination?(previous_enrollment, enrollment)
-        previous_enrollment.coverage_terminated? &&
-          previous_enrollment.terminated_on.present? &&
-          enrollment.effective_on.present? &&
-          (enrollment.effective_on - 1.day) == previous_enrollment.terminated_on
       end
     end
   end

--- a/app/models/enrollments/replicator/reinstatement.rb
+++ b/app/models/enrollments/replicator/reinstatement.rb
@@ -100,8 +100,10 @@ module Enrollments
         reinstated_enrollment.hbx_enrollment_members = clone_hbx_enrollment_members
         unless base_enrollment.coverage_expired?
           if base_enrollment.may_terminate_coverage? && (reinstate_enrollment.effective_on > base_enrollment.effective_on)
-            base_enrollment.terminate_coverage!
-            base_enrollment.update_attributes!(terminated_on: new_effective_date - 1.day)
+            unless base_enrollment.ineligible_for_termination?(new_effective_date)
+              base_enrollment.terminate_coverage!
+              base_enrollment.update_attributes!(terminated_on: new_effective_date - 1.day)
+            end
           elsif base_enrollment.enrollment_superseded_and_eligible_for_cancellation?(new_effective_date)
             base_enrollment.cancel_coverage_for_superseded_term!
           elsif base_enrollment.may_cancel_coverage?

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2920,6 +2920,22 @@ class HbxEnrollment
       may_cancel_coverage_for_superseded_term?
   end
 
+  # Checks to see if the previous enrollment is ineligible for termination.
+  # Previous enrollment is ineligible for termination if all the below are true
+  #   - Checks if the enrollment is of kind individual market
+  #   - Checks if the enrollment is in terminated state
+  #   - Checks if the enrollment has a terminated_on date
+  #   - Checks if the new_effective_on date exists
+  #   - Checks if new effective on is one day after the enrollment's terminated_on
+  #   - The base/previous enrollment must have the same signature as the new enrollment, which is 'given' before calling this method
+  def ineligible_for_termination?(new_effective_on)
+    is_ivl_by_kind? &&
+      coverage_terminated? &&
+      terminated_on.present? &&
+      new_effective_on.present? &&
+      (new_effective_on - 1.day) == terminated_on
+  end
+
   private
 
   # Calculates sum of enrolled aptc member's of TaxHouseholdEnrollment ehb_premiums including Minimum Responsibility.


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 185903649](https://www.pivotaltracker.com/story/show/185903649)

# A brief description of the changes

Current behavior: The existing terminated span creates a latest state transition from terminated to terminated for all enrollments based on criteria even when there is no change in the span for non-PlanShopping scenarios like FAA, Self Service Aptc change.

New behavior: The existing terminated span does not create a latest state transition from terminated to terminated for all enrollments based on criteria even when there is no change in the span for non-PlanShopping scenarios like FAA, Self Service Aptc change. Adds logic to skip unwanted termination for enrollments for non-PlanShopping cases

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.