### PR TITLE
extend active support callbacks and process default eligibilities without callbacks

### DIFF
--- a/app/domain/operations/ivl_osse_eligibilities/create_ivl_osse_eligibility.rb
+++ b/app/domain/operations/ivl_osse_eligibilities/create_ivl_osse_eligibility.rb
@@ -37,13 +37,9 @@ module Operations
         errors = []
         errors << "evidence key missing" unless params[:evidence_key]
         errors << "evidence value missing" unless params[:evidence_value]
-        unless params[:effective_date].is_a?(::Date)
-          errors << "effective date missing or it should be a date"
-        end
+        errors << "effective date missing or it should be a date" unless params[:effective_date].is_a?(::Date)
         @subject = GlobalID::Locator.locate(params[:subject])
-        unless subject.present?
-          errors << "subject missing or not found for #{params[:subject]}"
-        end
+        errors << "subject missing or not found for #{params[:subject]}" unless subject.present?
 
         errors.empty? ? Success(params) : Failure(errors)
       end
@@ -53,11 +49,11 @@ module Operations
       def find_eligibility(values)
         eligibility =
           subject
-            .eligibilities
-            .by_key(
-              "aca_ivl_osse_eligibility_#{values[:effective_date].year}".to_sym
-            )
-            .last
+          .eligibilities
+          .by_key(
+            "aca_ivl_osse_eligibility_#{values[:effective_date].year}".to_sym
+          )
+          .last
 
         Success(eligibility)
       end
@@ -98,12 +94,12 @@ module Operations
         end
 
         save_proc = proc do
-            if subject.save
-              Success(eligibility_record)
-            else
-              Failure(subject.errors.full_messages)
-            end
+          if subject.save
+            Success(eligibility_record)
+          else
+            Failure(subject.errors.full_messages)
           end
+        end
 
         if default_eligibility
           Person.without_callbacks(callbacks_to_skip, &save_proc)

--- a/app/event_source/subscribers/eligible/eligibility_subscriber.rb
+++ b/app/event_source/subscribers/eligible/eligibility_subscriber.rb
@@ -12,7 +12,7 @@ module Subscribers
         :on_create_default_eligibility
       ) do |delivery_info, _metadata, response|
         logger_name =
-          "on_create_default_eligibility_#{TimeKeeper.date_of_record.strftime("%Y_%m_%d")}"
+          "on_create_default_eligibility_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}"
         subscriber_logger = Logger.new("#{Rails.root}/log/#{logger_name}.log")
         subscriber_logger.info "-" * 100 unless Rails.env.test?
 
@@ -36,9 +36,7 @@ module Subscribers
               }
             )
 
-          unless result.success?
-            subscriber_logger.error "EligibilitySubscriber, payload: #{payload}. Failed due to #{result.failure}"
-          end
+          subscriber_logger.error "EligibilitySubscriber, payload: #{payload}. Failed due to #{result.failure}" unless result.success?
         end
         ack(delivery_info.delivery_tag)
       rescue StandardError, SystemStackError => e
@@ -48,7 +46,7 @@ module Subscribers
 
       subscribe(:on_renew_eligibility) do |delivery_info, _metadata, response|
         logger_name =
-          "on_renew_eligibility_#{TimeKeeper.date_of_record.strftime("%Y_%m_%d")}"
+          "on_renew_eligibility_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}"
         subscriber_logger = Logger.new("#{Rails.root}/log/#{logger_name}.log")
         subscriber_logger.info "-" * 100 unless Rails.env.test?
 
@@ -75,9 +73,7 @@ module Subscribers
               }
             )
 
-          unless result.success?
-            subscriber_logger.error "EligibilitySubscriber, payload: #{payload}. Failed due to #{result.failure}"
-          end
+          subscriber_logger.error "EligibilitySubscriber, payload: #{payload}. Failed due to #{result.failure}" unless result.success?
         end
 
         ack(delivery_info.delivery_tag)
@@ -99,9 +95,7 @@ module Subscribers
 
       def create_eligibility(options)
         operation = eligibility_operation_for(options[:subject]).new
-        if options[:evidence_value] == "false"
-          operation.default_eligibility = true
-        end
+        operation.default_eligibility = true if options[:evidence_value] == "false"
 
         operation.call(
           {

--- a/components/benefit_sponsors/app/domain/benefit_sponsors/operations/benefit_sponsorships/shop_osse_eligibilities/create_shop_osse_eligibility.rb
+++ b/components/benefit_sponsors/app/domain/benefit_sponsors/operations/benefit_sponsorships/shop_osse_eligibilities/create_shop_osse_eligibility.rb
@@ -11,7 +11,7 @@ module BenefitSponsors
         class CreateShopOsseEligibility
           send(:include, Dry::Monads[:result, :do])
 
-          attr_reader :subject
+          attr_accessor :subject, :default_eligibility
 
           # @param [Hash] opts Options to build eligibility
           # @option opts [<GlobalId>] :subject required

--- a/config/initializers/without_callback.rb
+++ b/config/initializers/without_callback.rb
@@ -1,15 +1,22 @@
-module ActiveSupport::Callbacks::ClassMethods
-  def without_callback(*args, &block)
-    skip_callback(*args)
-    result = yield
-    set_callback(*args)
-    result
-  end
+# frozen_string_literal: true
 
-  def without_callbacks(args, &block)
-    args.each { |args| skip_callback(*args) }
-    result = yield
-    args.each { |args| set_callback(*args) }
-    result
+module ActiveSupport
+  module Callbacks
+    # Enhance Active Support callbacks with the following methods that enable us to modify records without invoking callbacks.
+    module ClassMethods
+      def without_callback(*args)
+        skip_callback(*args)
+        result = yield
+        set_callback(*args)
+        result
+      end
+
+      def without_callbacks(callback_options)
+        callback_options.each { |args| skip_callback(*args) }
+        result = yield
+        callback_options.each { |args| set_callback(*args) }
+        result
+      end
+    end
   end
 end

--- a/config/initializers/without_callback.rb
+++ b/config/initializers/without_callback.rb
@@ -1,0 +1,15 @@
+module ActiveSupport::Callbacks::ClassMethods
+  def without_callback(*args, &block)
+    skip_callback(*args)
+    result = yield
+    set_callback(*args)
+    result
+  end
+
+  def without_callbacks(args, &block)
+    args.each { |args| skip_callback(*args) }
+    result = yield
+    args.each { |args| set_callback(*args) }
+    result
+  end
+end


### PR DESCRIPTION

Added new methods to support saving without callbacks Update default eligibility creation logic to store eligib

# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185956977

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.