### PR TITLE
add feature flag/settings for esi mec fdsh payload format

### DIFF
--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -105,6 +105,8 @@ module Eligibilities
       case self.key
       when :non_esi_mec
         { non_esi_payload_format: EnrollRegistry[:non_esi_h31].setting(:payload_format).item }
+      when :esi_mec
+        { esi_mec_payload_format: EnrollRegistry[:esi_mec].setting(:payload_format).item }
       else
         {}
       end

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/magi_medicaid_application_determined.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/magi_medicaid_application_determined.rb
@@ -28,7 +28,8 @@ module FinancialAssistance
 
           def payload_format
             {
-              non_esi_payload_format: EnrollRegistry[:non_esi_h31].setting(:payload_format).item
+              non_esi_payload_format: EnrollRegistry[:non_esi_h31].setting(:payload_format).item,
+              esi_mec_payload_format: EnrollRegistry[:esi_mec].setting(:payload_format).item
             }
           end
 

--- a/components/financial_assistance/app/models/financial_assistance/evidence.rb
+++ b/components/financial_assistance/app/models/financial_assistance/evidence.rb
@@ -58,6 +58,8 @@ module FinancialAssistance
       case self.key
       when :non_esi_mec
         { non_esi_payload_format: EnrollRegistry[:non_esi_h31].setting(:payload_format).item }
+      when :esi_mec
+        { esi_mec_payload_format: EnrollRegistry[:esi_mec].setting(:payload_format).item }
       else
         {}
       end

--- a/components/financial_assistance/spec/dummy/app/models/eligibilities/evidence.rb
+++ b/components/financial_assistance/spec/dummy/app/models/eligibilities/evidence.rb
@@ -106,6 +106,8 @@ module Eligibilities
       case self.key
       when :non_esi_mec
         { non_esi_payload_format: EnrollRegistry[:non_esi_h31].setting(:payload_format).item }
+      when :esi_mec
+        { esi_mec_payload_format: EnrollRegistry[:esi_mec].setting(:payload_format).item }
       else
         {}
       end

--- a/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -19,6 +19,11 @@ registry:
         settings:
         - key: :payload_format
           item: <%= ENV['NON_ESI_H31_PAYLOAD_FORMAT'] || "xml" %>
+      - key: :esi_mec
+        is_enabled: true
+        settings:
+          - key: :payload_format
+            item: <%= ENV['ESI_MEC_PAYLOAD_FORMAT'] || "xml" %>
       - key: :renewal_eligibility_verification_using_rrv
         item: :renewal_eligibility_verification_using_rrv
         is_enabled: <%= ENV['RENEWAL_ELIGIBILITY_VERIFICATION_USING_RRV_IS_ENABLED'] || false %>

--- a/config/client_config/me/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -19,6 +19,11 @@ registry:
         settings:
         - key: :payload_format
           item: <%= ENV['NON_ESI_H31_PAYLOAD_FORMAT'] || "xml" %>
+      - key: :esi_mec
+        is_enabled: true
+        settings:
+          - key: :payload_format
+            item: <%= ENV['ESI_MEC_PAYLOAD_FORMAT'] || "xml" %>
       - key: :renewal_eligibility_verification_using_rrv
         item: :renewal_eligibility_verification_using_rrv
         is_enabled: <%= ENV['RENEWAL_ELIGIBILITY_VERIFICATION_USING_RRV_IS_ENABLED'] || true %>

--- a/spec/client_config/default_fdsh_services_configuration_spec.rb
+++ b/spec/client_config/default_fdsh_services_configuration_spec.rb
@@ -12,4 +12,13 @@ RSpec.describe 'default fdsh service namespace client specific configurations' d
       end
     end
   end
+
+  describe 'esi_mec' do
+    context 'for default value' do
+      it 'returns default value xml' do
+        expect(EnrollRegistry.feature_enabled?(:esi_mec)).to be_truthy
+        expect(EnrollRegistry[:esi_mec].setting(:payload_format).item).to eq('xml')
+      end
+    end
+  end
 end

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -230,16 +230,43 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
         )
       end
 
-      it 'should return payload format as json when it is set' do
-        allow(EnrollRegistry).to receive(:feature_enabled?).with(:non_esi_h31).and_return(true)
-        allow(EnrollRegistry[:non_esi_h31].setting(:payload_format)).to receive(:item).and_return('json')
-        expect(non_esi_evidence.payload_format).to eq({:non_esi_payload_format => 'json'})
+      let(:esi_evidence) do
+        applicant.create_esi_evidence(
+          key: :esi_mec,
+          title: 'Esi',
+          aasm_state: 'pending',
+          due_on: nil,
+          verification_outstanding: false,
+          is_satisfied: true
+        )
       end
 
-      it 'should return payload format as xml when it is set' do
-        allow(EnrollRegistry).to receive(:feature_enabled?).with(:non_esi_h31).and_return(true)
-        allow(EnrollRegistry[:non_esi_h31].setting(:payload_format)).to receive(:item).and_return('xml')
-        expect(non_esi_evidence.payload_format).to eq({:non_esi_payload_format => 'xml'})
+      context 'non_esi_mec' do
+        it 'should return payload format as json when it is set' do
+          allow(EnrollRegistry).to receive(:feature_enabled?).with(:non_esi_h31).and_return(true)
+          allow(EnrollRegistry[:non_esi_h31].setting(:payload_format)).to receive(:item).and_return('json')
+          expect(non_esi_evidence.payload_format).to eq({:non_esi_payload_format => 'json'})
+        end
+
+        it 'should return payload format as xml when it is set' do
+          allow(EnrollRegistry).to receive(:feature_enabled?).with(:non_esi_h31).and_return(true)
+          allow(EnrollRegistry[:non_esi_h31].setting(:payload_format)).to receive(:item).and_return('xml')
+          expect(non_esi_evidence.payload_format).to eq({:non_esi_payload_format => 'xml'})
+        end
+      end
+
+      context 'esi_mec' do
+        it 'should return payload format as json when it is set' do
+          allow(EnrollRegistry).to receive(:feature_enabled?).with(:esi_mec).and_return(true)
+          allow(EnrollRegistry[:esi_mec].setting(:payload_format)).to receive(:item).and_return('json')
+          expect(esi_evidence.payload_format).to eq({:esi_mec_payload_format => 'json'})
+        end
+
+        it 'should return payload format as xml when it is set' do
+          allow(EnrollRegistry).to receive(:feature_enabled?).with(:esi_mec).and_return(true)
+          allow(EnrollRegistry[:esi_mec].setting(:payload_format)).to receive(:item).and_return('xml')
+          expect(esi_evidence.payload_format).to eq({:esi_mec_payload_format => 'xml'})
+        end
       end
     end
 

--- a/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -19,6 +19,11 @@ registry:
         settings:
         - key: :payload_format
           item: <%= ENV['NON_ESI_H31_PAYLOAD_FORMAT'] || "xml" %>
+      - key: :esi_mec
+        is_enabled: true
+        settings:
+          - key: :payload_format
+            item: <%= ENV['ESI_MEC_PAYLOAD_FORMAT'] || "xml" %>
       - key: :renewal_eligibility_verification_using_rrv
         item: :renewal_eligibility_verification_using_rrv
         is_enabled: <%= ENV['RENEWAL_ELIGIBILITY_VERIFICATION_USING_RRV_IS_ENABLED'] || false %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185698172

# A brief description of the changes

Current behavior: Enroll currently sends ESI MEC FDSH payloads in XML format, which CMS plans to deprecate starting March 2024.

New behavior: Add feature flag to determine what kind of payload format that CMS should receive for ESI MEC Fdsh hub call (JSON/XML)

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [X] DC
- [X] ME

# Additional Context
Added new Env variable

`DC:`
ESI_MEC_PAYLOAD_FORMAT="xml"

`ME:`
ESI_MEC_PAYLOAD_FORMAT="json"