### PR TITLE
fixes a typo to not raise an error

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -251,7 +251,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
 
   def slcsp_feature_enabled?(renewal_year)
     EnrollRegistry.feature_enabled?(:atleast_one_silver_plan_donot_cover_pediatric_dental_cost) &&
-      EnrollRegistry[:atleast_one_silver_plan_donot_cover_pediatric_dental_cost]&.settings(renewal_year)&.item
+      EnrollRegistry[:atleast_one_silver_plan_donot_cover_pediatric_dental_cost]&.settings(renewal_year.to_s.to_sym)&.item
   end
 
   # Check if member turned 19 during renewal and has pediatric only Qualified Dental Plan

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec_1.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec_1.rb
@@ -161,5 +161,35 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
         end
       end
     end
+
+    describe '#slcsp_feature_enabled?' do
+      let(:renewal_year) { TimeKeeper.date_of_record.year }
+
+      before do
+        EnrollRegistry[
+          :atleast_one_silver_plan_donot_cover_pediatric_dental_cost
+        ].feature.stub(:is_enabled).and_return(feature_enabled)
+
+        EnrollRegistry[
+          :atleast_one_silver_plan_donot_cover_pediatric_dental_cost
+        ].settings(renewal_year.to_s.to_sym).stub(:item).and_return(feature_enabled)
+      end
+
+      context 'when feature is enabled' do
+        let(:feature_enabled) { true }
+
+        it 'returns true' do
+          expect(subject.slcsp_feature_enabled?(renewal_year)).to be_truthy
+        end
+      end
+
+      context 'when feature is disabled' do
+        let(:feature_enabled) { false }
+
+        it 'returns false' do
+          expect(subject.slcsp_feature_enabled?(renewal_year)).to be_falsey
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185314908

# A brief description of the changes

Current behavior: Currently, it raises an error when checking for the RR configuration feature.

New behavior: With this change, it will not raise an error when checking for the RR configuration feature.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.