### PR TITLE
return success monad in tax household transform

### DIFF
--- a/app/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment.rb
+++ b/app/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment.rb
@@ -72,7 +72,7 @@ module Operations
           end
           return Failure("Could not transform tax household enrollment(s): #{transformed_th_enrs.select(&:failure?).map(&:failure)}") unless transformed_th_enrs.all?(&:success?)
 
-          transformed_th_enrs.map(&:value!)
+          Success(transformed_th_enrs.map(&:value!))
         end
 
         def transform_tax_household_enr(tax_household_enr)

--- a/spec/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment_spec.rb
+++ b/spec/domain/operations/transformers/hbx_enrollment_to/cv3_hbx_enrollment_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe ::Operations::Transformers::HbxEnrollmentTo::Cv3HbxEnrollment, db
     end
   end
 
+  context 'when tax household enrollment is present' do
+    let(:tax_household_enrollment) { FactoryBot.create(:tax_household_enrollment, enrollment_id: enrollment.id)}
+
+    before do
+      allow(Operations::Transformers::TaxHouseholdEnrollmentTo::Cv3TaxHouseholdEnrollment).to receive_message_chain(:new, :call).with(tax_household_enrollment).and_return(Dry::Monads::Result::Success.new(double))
+    end
+
+    it 'should return success with tax household enrollment' do
+      result = subject.call(enrollment)
+      expect(result.success?).to be_truthy
+      expect(result.value!.keys.include?(:tax_households_references)).to be_truthy
+    end
+  end
+
   context 'slcsp' do
     before do
       transformed_payload = subject.call(enrollment).success


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186003991

# A brief description of the changes

Current behavior:
Throws an error when tax household enrollments are present in the CV3 HbxEnrollment transform.

New behavior:
Result of the transform_enr_tax_households method returns the data wrapped in a Success monad so no error is thrown.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.