### PR TITLE
adds metadata to workflow state transitions of eligible enrs

### DIFF
--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -20,21 +20,39 @@ module Operations
         cancel_previous(enrollment, product.active_year)
       end
 
+      private
+
       def cancel_previous(enrollment, year)
         #Perform cancel/terms of previous enrollments for the same plan year
-        enrollment.previous_enrollments(year).each do |previous_enrollment|
-          enrollment.generate_signature(previous_enrollment)
-          if enrollment.same_signatures(previous_enrollment) && !previous_enrollment.is_shop?
-            if enrollment.effective_on > previous_enrollment.effective_on && previous_enrollment.may_terminate_coverage?
-              next previous_enrollment if previous_enrollment.ineligible_for_termination?(enrollment.effective_on)
+        eligible_enrollments = fetch_eligible_enrollments(enrollment, year)
 
-              previous_enrollment.terminate_coverage!(enrollment.effective_on - 1.day)
-            elsif previous_enrollment.enrollment_superseded_and_eligible_for_cancellation?(enrollment.effective_on)
-              previous_enrollment.cancel_coverage_for_superseded_term!
-            elsif previous_enrollment.may_cancel_coverage?
-              previous_enrollment.cancel_coverage!
-            end
+        eligible_enrollments.each_with_index do |previous_enrollment, index|
+          transition_args = fetch_transition_args(index)
+
+          if enrollment.effective_on > previous_enrollment.effective_on && previous_enrollment.may_terminate_coverage?
+            next previous_enrollment if previous_enrollment.ineligible_for_termination?(enrollment.effective_on)
+
+            previous_enrollment.terminate_coverage!(enrollment.effective_on - 1.day, transition_args)
+          elsif previous_enrollment.enrollment_superseded_and_eligible_for_cancellation?(enrollment.effective_on)
+            previous_enrollment.cancel_coverage_for_superseded_term!(transition_args)
+          elsif previous_enrollment.may_cancel_coverage?
+            previous_enrollment.cancel_coverage!(transition_args)
           end
+        end
+      end
+
+      def fetch_eligible_enrollments(enrollment, year)
+        enrollment.previous_enrollments(year).select do |previous_enrollment|
+          enrollment.generate_signature(previous_enrollment)
+          enrollment.same_signatures(previous_enrollment) && !previous_enrollment.is_shop?
+        end.sort_by(&:effective_on)
+      end
+
+      def fetch_transition_args(index)
+        if index.zero? || !EnrollRegistry.feature_enabled?(:silent_transition_enrollment)
+          {}
+        else
+          { reason: 'SILENT_SUPERSEDE' }
         end
       end
     end

--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -49,11 +49,10 @@ module Operations
       end
 
       def fetch_transition_args(index)
-        if index.zero? || !EnrollRegistry.feature_enabled?(:silent_transition_enrollment)
-          {}
-        else
-          { reason: 'SILENT_SUPERSEDE' }
-        end
+        return {} unless EnrollRegistry.feature_enabled?(:silent_transition_enrollment)
+        return {} if index.zero?
+
+        { reason: 'superseded_silent' }
       end
     end
   end

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -868,7 +868,13 @@ class HbxEnrollment
     ::EnrollRegistry[:cancel_renewals_for_term] { {hbx_enrollment: self} }
   end
 
-  def propogate_terminate(term_date = TimeKeeper.date_of_record.end_of_month)
+  def propogate_terminate(*args)
+    term_date = if args.present? && args.first.respond_to?(:to_date)
+                  args.first
+                else
+                  TimeKeeper.date_of_record.end_of_month
+                end
+
     if terminated_on.present? && term_date < terminated_on
       self.terminated_on = term_date
     else

--- a/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
+++ b/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
@@ -153,7 +153,7 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
                           terminated_on: previous_enrollment_terminated_on)
       end
 
-      let(:metadata_query) { { 'metadata.reason' => 'SILENT_SUPERSEDE' } }
+      let(:metadata_query) { { 'metadata.reason' => 'superseded_silent' } }
 
       before do
         allow(

--- a/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
+++ b/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
@@ -25,13 +25,15 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
 
     let(:previous_enrollment_terminated_on) { previous_enrollment_effective_on.end_of_month }
 
+    let(:previous_enrollment_aasm_state) { 'coverage_terminated' }
+
     let(:previous_enrollment) do
       FactoryBot.create(:hbx_enrollment,
                         :individual_unassisted,
                         :with_silver_health_product,
                         :with_enrollment_members,
                         enrollment_members: family.family_members,
-                        aasm_state: 'coverage_terminated',
+                        aasm_state: previous_enrollment_aasm_state,
                         household: family.active_household,
                         effective_on: previous_enrollment_effective_on,
                         family: family,
@@ -102,7 +104,6 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
       end
     end
 
-
     # For event cancel_coverage_for_superseded_term
     context "when:
       - previous_enrollment is terminated
@@ -127,6 +128,122 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
       it 'transitions enrollment via cancel_coverage_for_superseded_term' do
         subject
         expect(prev_enr_term_to_cancel_superseded_transition).to be_truthy
+      end
+    end
+
+    context 'for silent superseded enrollments' do
+      let(:enrollment3) do
+        FactoryBot.create(:hbx_enrollment, :individual_unassisted, :with_silver_health_product, :with_enrollment_members,
+                          enrollment_members: family.family_members, aasm_state: 'coverage_terminated',
+                          household: family.active_household, effective_on: Date.new(coverage_year, 3), family: family,
+                          terminated_on: previous_enrollment_terminated_on)
+      end
+
+      let(:enrollment4) do
+        FactoryBot.create(:hbx_enrollment, :individual_unassisted, :with_silver_health_product, :with_enrollment_members,
+                          enrollment_members: family.family_members, aasm_state: 'coverage_selected',
+                          household: family.active_household, effective_on: Date.new(coverage_year, 4), family: family,
+                          terminated_on: previous_enrollment_terminated_on)
+      end
+
+      let(:enrollment5) do
+        FactoryBot.create(:hbx_enrollment, :individual_unassisted, :with_silver_health_product, :with_enrollment_members,
+                          enrollment_members: family.family_members, aasm_state: 'coverage_terminated',
+                          household: family.active_household, effective_on: Date.new(coverage_year, 5), family: family,
+                          terminated_on: previous_enrollment_terminated_on)
+      end
+
+      let(:metadata_query) { { 'metadata.reason' => 'SILENT_SUPERSEDE' } }
+
+      before do
+        allow(
+          EnrollRegistry[:cancel_superseded_terminated_enrollments].feature
+        ).to receive(:is_enabled).and_return(true)
+
+        allow(
+          EnrollRegistry[:silent_transition_enrollment].feature
+        ).to receive(:is_enabled).and_return(true)
+
+        [enrollment5, enrollment3, enrollment4].each(&:generate_hbx_signature)
+
+        subject
+      end
+
+      context "when:
+        - previous_enrollment is coverage_selected
+        - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
+        - RR configuration feature :silent_transition_enrollment is enabled
+        - enrollments exists with same enrollment signature
+        - enrollemnts exists with same coverage_kind
+        - enrollments exists with same plan_year effective dates
+        " do
+
+        let(:new_enrollment_effective_on) { Date.new(coverage_year, 1) }
+        let(:previous_enrollment_effective_on) { Date.new(coverage_year, 1) }
+        let(:previous_enrollment_aasm_state) { 'coverage_selected' }
+        let(:previous_enrollment_terminated_on) { new_enrollment_effective_on.end_of_month }
+
+        it 'does not add metadata as this is first enrollment' do
+          expect(
+            previous_enrollment.workflow_state_transitions.where(metadata_query).first
+          ).to be_falsey
+        end
+
+        it 'adds metadata as this is not first enrollment' do
+          expect(
+            enrollment3.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_truthy
+        end
+
+        it 'adds metadata as this is not first enrollment' do
+          expect(
+            enrollment4.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_truthy
+        end
+
+        it 'adds metadata as this is not first enrollment' do
+          expect(
+            enrollment5.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_truthy
+        end
+      end
+
+      context "when:
+        - previous_enrollment is coverage_terminated
+        - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
+        - RR configuration feature :silent_transition_enrollment is enabled
+        - enrollments exists with same enrollment signature
+        - enrollemnts exists with same coverage_kind
+        - enrollments exists with same plan_year effective dates
+        " do
+
+        let(:new_enrollment_effective_on) { Date.new(coverage_year, 2) }
+        let(:previous_enrollment_effective_on) { Date.new(coverage_year, 1) }
+        let(:previous_enrollment_terminated_on) { new_enrollment_effective_on.end_of_month }
+
+        it 'does not add metadata as this is first enrollment' do
+          expect(
+            previous_enrollment.workflow_state_transitions.where(metadata_query).first
+          ).to be_falsey
+        end
+
+        it 'adds metadata as this is not first enrollment' do
+          expect(
+            enrollment3.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_truthy
+        end
+
+        it 'adds metadata as this is not first enrollment' do
+          expect(
+            enrollment4.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_truthy
+        end
+
+        it 'adds metadata as this is not first enrollment' do
+          expect(
+            enrollment5.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_truthy
+        end
       end
     end
   end

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -623,7 +623,7 @@ RSpec.describe HbxEnrollment, type: :model do
 
     context 'with terminated_on and additional transition args' do
       let(:terminated_on_date) { hbx_enrollment.effective_on.end_of_month }
-      let(:transition_args) { { reason: 'SILENT_SUPERSEDE' } }
+      let(:transition_args) { { reason: 'superseded_silent' } }
 
       it 'assigns terminated_on without raising any error' do
         expect do

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -599,4 +599,38 @@ RSpec.describe HbxEnrollment, type: :model do
       end
     end
   end
+
+  describe '#propogate_terminate' do
+    let(:aasm_state) { 'coverage_terminated' }
+
+    context 'without arguments' do
+      it 'assigns terminated_on without raising any error' do
+        expect { hbx_enrollment.propogate_terminate }.not_to raise_error(StandardError)
+        expect(hbx_enrollment.terminated_on).to be_truthy
+      end
+    end
+
+    context 'with only terminated_on' do
+      let(:terminated_on_date) { hbx_enrollment.effective_on.end_of_month }
+
+      it 'assigns terminated_on without raising any error' do
+        expect do
+          hbx_enrollment.propogate_terminate(terminated_on_date)
+        end.not_to raise_error(StandardError)
+        expect(hbx_enrollment.terminated_on).to eq(terminated_on_date)
+      end
+    end
+
+    context 'with terminated_on and additional transition args' do
+      let(:terminated_on_date) { hbx_enrollment.effective_on.end_of_month }
+      let(:transition_args) { { reason: 'SILENT_SUPERSEDE' } }
+
+      it 'assigns terminated_on without raising any error' do
+        expect do
+          hbx_enrollment.propogate_terminate(terminated_on_date, transition_args)
+        end.not_to raise_error(StandardError)
+        expect(hbx_enrollment.terminated_on).to eq(terminated_on_date)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 185888812](https://www.pivotaltracker.com/story/show/185888812)

# A brief description of the changes

Current behavior: Currently, we do not populate metadata to workflow state transitions of eligible enrollments to skip transition of in-between enrollments from Enroll to Glue.

New behavior: We will populate metadata to workflow state transitions of eligible enrollments to skip the transition of in-between enrollments from Enroll to Glue

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

Resource Registry configurations
- Environment Variable: **SILENT_TRANSITION_ENROLLMENT_IS_ENABLED**
- RR config name: **:silent_transition_enrollment**

# Additional Context
Include any additional context that may be relevant to the peer review process.