### PR TITLE
Exclude Broadcasting of "Silent" Transitions

### DIFF
--- a/app/models/enrollments.rb
+++ b/app/models/enrollments.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Enrollments
+  # Describes various reasons for enrollment termination.
+  module TerminationReasons
+    # The following reason indicates an enrollment was canceled via by
+    # coverage which replaces it 'as if it has never happened'.
+    # Downstream systems, such as GlueDB, should not be notified of this
+    # transition.
+    SUPERSEDED_SILENT = "superseded_silent"
+  end
+
+  # Stores the AASM states as hard values.
+  #
+  # While these values are present as the name of the AASM states, there are a
+  # number of areas where we need to do string comparisons, so we centralize
+  # those values here.
+  module WorkflowStates
+    COVERAGE_SELECTED = "coverage_selected"
+    COVERAGE_CANCELED = "coverage_canceled"
+    COVERAGE_TERMINATED = "coverage_terminated"
+  end
+end

--- a/app/models/queries/ivl_sep_events.rb
+++ b/app/models/queries/ivl_sep_events.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Queries
+  # Query various events during the lifetime of an IVL enrollment, based on
+  # type of transition and the reasons for that transition.
+  class IvlSepEvents
+    attr_reader :start_time, :end_time, :excluded_enrollment_kinds
+
+    def initialize(s_time, e_time)
+      @start_time = s_time
+      @end_time = e_time
+      @excluded_enrollment_kinds = ["employer_sponsored", "employer_sponsored_cobra"]
+    end
+
+    def terminations_during_window
+      HbxEnrollment.collection.aggregate([
+      {"$match" => {
+        "workflow_state_transitions" => {
+          "$elemMatch" => {
+            "to_state" => {"$in" => [Enrollments::WorkflowStates::COVERAGE_TERMINATED, Enrollments::WorkflowStates::COVERAGE_CANCELED]},
+            "transition_at" => {
+              "$gte" => start_time,
+              "$lt" => end_time
+            }
+          }
+        },
+        "rating_area_id" => {"$ne" => nil},
+        "kind" => {"$nin" => excluded_enrollment_kinds}
+      }},
+      {"$group" => {
+        "_id" => "$hbx_id",
+        "created_at" => { "$last" => "$created_at" }
+      }},
+      { "$sort" => { "created_at" => 1 } }
+      ])
+    end
+
+    def selections_during_window
+      active_statuses = ["coverage_selected", "auto_renewing", "renewing_coverage_selected"]
+      HbxEnrollment.collection.aggregate([
+        {"$match" => {
+          "workflow_state_transitions" => {
+            "$elemMatch" => {
+              "to_state" => {"$in" => active_statuses},
+              "transition_at" => {
+                "$gte" => start_time,
+                "$lt" => end_time
+              }
+            }
+          },
+          "rating_area_id" => {"$ne" => nil},
+          "kind" => {"$nin" => excluded_enrollment_kinds}
+        }},
+        {"$group" => {
+          "_id" => "$hbx_id",
+          "created_at" => { "$last" => "$created_at" },
+          "enrollment_state" => {"$last" => "$aasm_state"}
+        }},
+        {"$project" => {
+          "_id" => 1,
+          "created_at" => 1,
+          "enrollment_state" => "$enrollment_state"
+        }},
+        { "$sort" => { "created_at" => 1 } }
+      ])
+    end
+
+    def has_silent_cancel?(enrollment)
+      return false unless EnrollRegistry.feature_enabled?(:silent_transition_enrollment)
+
+      enrollment.workflow_state_transitions.any? do |wst|
+        (wst.to_state == 'coverage_canceled') &&
+          (wst.transition_at < end_time) && (wst.transition_at >= start_time) &&
+          wst.metadata_has?({"reason" => Enrollments::TerminationReasons::SUPERSEDED_SILENT})
+      end
+    end
+
+    def purchase_and_cancel_in_same_window?(enrollment)
+      return false unless EnrollRegistry.feature_enabled?(:silent_transition_enrollment)
+
+      matching_cancel = enrollment.workflow_state_transitions.any? do |wst|
+        (wst.to_state == Enrollments::WorkflowStates::COVERAGE_CANCELED) &&
+          (wst.transition_at < end_time) && (wst.transition_at >= start_time)
+      end
+
+      matching_selection = enrollment.workflow_state_transitions.any? do |wst|
+        (wst.to_state == Enrollments::WorkflowStates::COVERAGE_SELECTED) &&
+          (wst.transition_at < end_time) && (wst.transition_at >= start_time)
+      end
+
+      matching_cancel && matching_selection
+    end
+  end
+end

--- a/app/models/workflow_state_transition.rb
+++ b/app/models/workflow_state_transition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class WorkflowStateTransition
   include Mongoid::Document
   include Mongoid::Timestamps
@@ -26,6 +28,15 @@ class WorkflowStateTransition
     else
       "<div>#{transition_at.strftime("%m/%d/%Y %H:%M UTC")} - State changed from <b>#{from_state.camelcase}</b> to <b>#{to_state.camelcase}</b>.</div>".html_safe
     end
+  end
+
+  def metadata_has?(matching_hash)
+    return false unless metadata.present?
+    matching_hash.each_pair do |k,v|
+      return false unless metadata.key?(k.to_s)
+      return false unless metadata[k.to_s] == v
+    end
+    true
   end
 
 private

--- a/spec/models/hbx_enrollment_transition_argument_spec.rb
+++ b/spec/models/hbx_enrollment_transition_argument_spec.rb
@@ -25,19 +25,19 @@ RSpec.describe HbxEnrollment, "created in the shopping mode, then transitioned w
     hbx_enrollment
   end
 
-  it "can be found using the reason when coverage is canceled" do
-    enrollment.select_coverage!({:reason => "because"})
+  it "can be found using the reason when coverage is selected" do
+    enrollment.select_coverage!({:reason => "aptc_update"})
     found_enrollment = HbxEnrollment.where(
-      "workflow_state_transitions.metadata.reason" => "because"
+      "workflow_state_transitions.metadata.reason" => "aptc_update"
     ).first
     expect(found_enrollment.id).to eq(enrollment.id)
   end
 
   it "can be found using the reason when coverage is canceled" do
     enrollment.select_coverage!
-    enrollment.cancel_coverage!(Date.today, {:reason => "because"})
+    enrollment.cancel_coverage!(Date.today, {:reason => Enrollments::TerminationReasons::SUPERSEDED_SILENT})
     found_enrollment = HbxEnrollment.where(
-      "workflow_state_transitions.metadata.reason" => "because"
+      "workflow_state_transitions.metadata.reason" => Enrollments::TerminationReasons::SUPERSEDED_SILENT
     ).first
     expect(found_enrollment.id).to eq(enrollment.id)
   end

--- a/spec/models/queries/ivl_sep_events_spec.rb
+++ b/spec/models/queries/ivl_sep_events_spec.rb
@@ -1,0 +1,369 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Queries::IvlSepEvents, "searching for terminations, with :silent_transition_enrollment ON", dbclean: :after_each do
+  # We're going to be playing some games with start and end times here -
+  # It's crucial for us that we don't have the events we want to match in the
+  # same time span as the cancel.  Pay close attention below to when we first
+  # reference start_time and end_time in each spec, as first reference is the
+  # moment when RSpec 'initializes' the variable.
+  let(:start_time) { Time.now }
+  let(:end_time) { Time.now }
+
+  let(:product) do
+    FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health)
+  end
+
+  let(:family) do
+    FactoryBot.create(:individual_market_family)
+  end
+
+  let(:enrollment) do
+    hbx_enrollment = HbxEnrollment.new(
+      :aasm_state => "shopping",
+      :kind => "individual",
+      :enrollment_kind => "open_enrollment",
+      :coverage_kind => "health",
+      :family => family,
+      :household => family.households.first,
+      :product => product,
+      :rating_area_id => "ME0"
+    )
+    hbx_enrollment.save!
+    hbx_enrollment.select_coverage!
+    start_time
+    hbx_enrollment
+  end
+
+  let(:same_window_enrollment) do
+    start_time
+    hbx_enrollment = HbxEnrollment.new(
+      :aasm_state => "shopping",
+      :kind => "individual",
+      :enrollment_kind => "open_enrollment",
+      :coverage_kind => "health",
+      :family => family,
+      :household => family.households.first,
+      :product => product,
+      :rating_area_id => "ME0"
+    )
+    hbx_enrollment.save!
+    hbx_enrollment.select_coverage!
+    hbx_enrollment
+  end
+
+  subject do
+    query = described_class.new(start_time, end_time)
+    map_by_hbx_id = query.terminations_during_window.map do |rec|
+      HbxEnrollment.where(hbx_id: rec["_id"]).first
+    end
+    reject_for_reasons = map_by_hbx_id.reject do |en|
+      query.has_silent_cancel?(en) || query.purchase_and_cancel_in_same_window?(en)
+    end
+    reject_for_reasons.map(&:hbx_id)
+  end
+
+  before :each do
+    allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+    allow(EnrollRegistry).to receive(:feature_enabled?).with(:silent_transition_enrollment).and_return(true)
+  end
+
+  # Make sure we don't crash on old records which have no metadata.
+  # Because the ORM will populate it with '{}' by default, we manually whack
+  # it in the database using an update to remove the key from the model.
+  it "matches cancels which have no metadata" do
+    enrollment.cancel_coverage!
+    end_time
+    enrollment.reload
+    wft_index = 0
+    enrollment.workflow_state_transitions.each_with_index do |wft, idx|
+      if wft.to_state == Enrollments::WorkflowStates::COVERAGE_CANCELED
+        wft_index = idx
+        break
+      end
+    end
+    HbxEnrollment.where(hbx_id: enrollment.hbx_id).update_all(
+      {
+        "$unset" => { "workflow_state_transitions.#{wft_index}.metadata" => "" }
+      }
+    )
+    expect(subject).to include(enrollment.hbx_id)
+  end
+
+  it "matches cancels which have metadata with a different reason code" do
+    enrollment.cancel_coverage!({reason: "MAKE SOMETHING UP"})
+    end_time
+    expect(subject).to include(enrollment.hbx_id)
+  end
+
+  it "does not match cancels which have the excluded reason" do
+    enrollment.cancel_coverage!({reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT})
+    end_time
+    expect(subject).not_to include(enrollment.hbx_id)
+  end
+
+  it "does not match a term which was then canceled with the excluded reason" do
+    enrollment.terminate_coverage!(Date.today + 30.days)
+
+    previous_state = enrollment.aasm_state
+    enrollment.update_attributes(aasm_state: Enrollments::WorkflowStates::COVERAGE_CANCELED)
+    enrollment.workflow_state_transitions << WorkflowStateTransition.new(
+      {
+        from_state: previous_state,
+        to_state: Enrollments::WorkflowStates::COVERAGE_CANCELED,
+        metadata: {
+          reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT
+        }
+      }
+    )
+    end_time
+    expect(subject).not_to include(enrollment.hbx_id)
+  end
+
+  it "does not match an enrollment which was purchased and then canceled in the same window" do
+    same_window_enrollment.cancel_coverage!
+    end_time
+    expect(subject).not_to include(same_window_enrollment.hbx_id)
+  end
+end
+
+describe Queries::IvlSepEvents, "searching for terminations, with :silent_transition_enrollment OFF", dbclean: :after_each do
+  # We're going to be playing some games with start and end times here -
+  # It's crucial for us that we don't have the events we want to match in the
+  # same time span as the cancel.  Pay close attention below to when we first
+  # reference start_time and end_time in each spec, as first reference is the
+  # moment when RSpec 'initializes' the variable.
+  let(:start_time) { Time.now }
+  let(:end_time) { Time.now }
+
+  let(:product) do
+    FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health)
+  end
+
+  let(:family) do
+    FactoryBot.create(:individual_market_family)
+  end
+
+  let(:enrollment) do
+    hbx_enrollment = HbxEnrollment.new(
+      :aasm_state => "shopping",
+      :kind => "individual",
+      :enrollment_kind => "open_enrollment",
+      :coverage_kind => "health",
+      :family => family,
+      :household => family.households.first,
+      :product => product,
+      :rating_area_id => "ME0"
+    )
+    hbx_enrollment.save!
+    hbx_enrollment.select_coverage!
+    start_time
+    hbx_enrollment
+  end
+
+  let(:same_window_enrollment) do
+    start_time
+    hbx_enrollment = HbxEnrollment.new(
+      :aasm_state => "shopping",
+      :kind => "individual",
+      :enrollment_kind => "open_enrollment",
+      :coverage_kind => "health",
+      :family => family,
+      :household => family.households.first,
+      :product => product,
+      :rating_area_id => "ME0"
+    )
+    hbx_enrollment.save!
+    hbx_enrollment.select_coverage!
+    hbx_enrollment
+  end
+
+  subject do
+    query = described_class.new(start_time, end_time)
+    map_by_hbx_id = query.terminations_during_window.map do |rec|
+      HbxEnrollment.where(hbx_id: rec["_id"]).first
+    end
+    reject_for_reasons = map_by_hbx_id.reject do |en|
+      query.has_silent_cancel?(en) || query.purchase_and_cancel_in_same_window?(en)
+    end
+    reject_for_reasons.map(&:hbx_id)
+  end
+
+  before :each do
+    allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+    allow(EnrollRegistry).to receive(:feature_enabled?).with(:silent_transition_enrollment).and_return(false)
+  end
+
+  # Make sure we don't crash on old records which have no metadata.
+  # Because the ORM will populate it with '{}' by default, we manually whack
+  # it in the database using an update to remove the key from the model.
+  it "matches cancels which have no metadata" do
+    enrollment.cancel_coverage!
+    end_time
+    enrollment.reload
+    wft_index = 0
+    enrollment.workflow_state_transitions.each_with_index do |wft, idx|
+      if wft.to_state == Enrollments::WorkflowStates::COVERAGE_CANCELED
+        wft_index = idx
+        break
+      end
+    end
+    HbxEnrollment.where(hbx_id: enrollment.hbx_id).update_all(
+      {
+        "$unset" => { "workflow_state_transitions.#{wft_index}.metadata" => "" }
+      }
+    )
+    expect(subject).to include(enrollment.hbx_id)
+  end
+
+  it "matches cancels which have metadata with a different reason code" do
+    enrollment.cancel_coverage!({reason: "MAKE SOMETHING UP"})
+    end_time
+    expect(subject).to include(enrollment.hbx_id)
+  end
+
+  it "matches cancels which have the excluded reason" do
+    enrollment.cancel_coverage!({reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT})
+    end_time
+    expect(subject).to include(enrollment.hbx_id)
+  end
+
+  it "matches a term which was then canceled with the excluded reason" do
+    enrollment.terminate_coverage!(Date.today + 30.days)
+
+    previous_state = enrollment.aasm_state
+    enrollment.update_attributes(aasm_state: Enrollments::WorkflowStates::COVERAGE_CANCELED)
+    enrollment.workflow_state_transitions << WorkflowStateTransition.new(
+      {
+        from_state: previous_state,
+        to_state: Enrollments::WorkflowStates::COVERAGE_CANCELED,
+        metadata: {
+          reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT
+        }
+      }
+    )
+    end_time
+    expect(subject).to include(enrollment.hbx_id)
+  end
+
+  it "matches an enrollment which was purchased and then canceled in the same window" do
+    same_window_enrollment.cancel_coverage!
+    end_time
+    expect(subject).to include(same_window_enrollment.hbx_id)
+  end
+end
+
+describe Queries::IvlSepEvents, "searching for purchases, with :silent_transition_enrollment ON", dbclean: :after_each do
+  # We're going to be playing some games with start and end times here -
+  # It's crucial for us that we don't have the events we want to match in the
+  # same time span as the cancel.  Pay close attention below to when we first
+  # reference start_time and end_time in each spec, as first reference is the
+  # moment when RSpec 'initializes' the variable.
+  let(:start_time) { Time.now }
+  let(:end_time) { Time.now }
+
+  let(:product) do
+    FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health)
+  end
+
+  let(:family) do
+    FactoryBot.create(:individual_market_family)
+  end
+
+  let(:same_window_enrollment) do
+    start_time
+    hbx_enrollment = HbxEnrollment.new(
+      :aasm_state => "shopping",
+      :kind => "individual",
+      :enrollment_kind => "open_enrollment",
+      :coverage_kind => "health",
+      :family => family,
+      :household => family.households.first,
+      :product => product,
+      :rating_area_id => "ME0"
+    )
+    hbx_enrollment.save!
+    hbx_enrollment.select_coverage!
+    hbx_enrollment
+  end
+
+  before :each do
+    allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+    allow(EnrollRegistry).to receive(:feature_enabled?).with(:silent_transition_enrollment).and_return(true)
+  end
+
+  subject do
+    query = described_class.new(start_time, end_time)
+    map_by_hbx_id = query.selections_during_window.map do |rec|
+      HbxEnrollment.where(hbx_id: rec["_id"]).first
+    end
+    reject_for_reasons = map_by_hbx_id.reject do |en|
+      query.purchase_and_cancel_in_same_window?(en)
+    end
+    reject_for_reasons.map(&:hbx_id)
+  end
+
+  it "does not match an enrollment which was purchased and then canceled in the same window" do
+    same_window_enrollment.cancel_coverage!
+    end_time
+    expect(subject).not_to include(same_window_enrollment.hbx_id)
+  end
+end
+
+describe Queries::IvlSepEvents, "searching for purchases, with :silent_transition_enrollment OFF", dbclean: :after_each do
+  # We're going to be playing some games with start and end times here -
+  # It's crucial for us that we don't have the events we want to match in the
+  # same time span as the cancel.  Pay close attention below to when we first
+  # reference start_time and end_time in each spec, as first reference is the
+  # moment when RSpec 'initializes' the variable.
+  let(:start_time) { Time.now }
+  let(:end_time) { Time.now }
+
+  let(:product) do
+    FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health)
+  end
+
+  let(:family) do
+    FactoryBot.create(:individual_market_family)
+  end
+
+  let(:same_window_enrollment) do
+    start_time
+    hbx_enrollment = HbxEnrollment.new(
+      :aasm_state => "shopping",
+      :kind => "individual",
+      :enrollment_kind => "open_enrollment",
+      :coverage_kind => "health",
+      :family => family,
+      :household => family.households.first,
+      :product => product,
+      :rating_area_id => "ME0"
+    )
+    hbx_enrollment.save!
+    hbx_enrollment.select_coverage!
+    hbx_enrollment
+  end
+
+  before :each do
+    allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+    allow(EnrollRegistry).to receive(:feature_enabled?).with(:silent_transition_enrollment).and_return(false)
+  end
+
+  subject do
+    query = described_class.new(start_time, end_time)
+    map_by_hbx_id = query.selections_during_window.map do |rec|
+      HbxEnrollment.where(hbx_id: rec["_id"]).first
+    end
+    reject_for_reasons = map_by_hbx_id.reject do |en|
+      query.purchase_and_cancel_in_same_window?(en)
+    end
+    reject_for_reasons.map(&:hbx_id)
+  end
+
+  it "matches an enrollment which was purchased and then canceled in the same window" do
+    same_window_enrollment.cancel_coverage!
+    end_time
+    expect(subject).to include(same_window_enrollment.hbx_id)
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [X] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/185888825

# A brief description of the changes

**NOTE**: builds and relies upon https://github.com/ideacrew/enroll/pull/3125

Current behavior:

When an enrollment is superseded it will be send downstream.

New behavior:

When feature is enabled, do not broadcast enrollments which were canceled in the specified 'silent' manner.  Additionally, do not broadcast enrollment events for enrollments which were purchased and then subsequently canceled immediately.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [X] DC
- [X] ME

Resource Registry configurations

Environment Variable: SILENT_TRANSITION_ENROLLMENT_IS_ENABLED
RR config name: :silent_transition_enrollment

# AppScan CodeSweep Failure

This PR is being flagged as a failure by AppScan codesweep - and it is a false positive.

The code in question is `app/models/queries/ivl_sep_events.rb:17` which reads:
```ruby
      HbxEnrollment.collection.aggregate([
      {"$match" => {
        "workflow_state_transitions" => {
          "$elemMatch" => {
            "to_state" => {"$in" => [Enrollments::WorkflowStates::COVERAGE_TERMINATED, Enrollments::WorkflowStates::COVERAGE_CANCELED]},
            "transition_at" => {
              "$gte" => start_time,
              "$lt" => end_time
            }
          }
        },
```

(It's tagging `app/models/queries/ivl_sep_events.rb:41` for the same reason)

The reason AppScan is flagging this is:
1. The AppScan heuristic for flagging default, insecure routing settings looks for expressions of the form `match =>`.
2. It seems to be unaware or not configured for the fact that the code of the form `$match =>` is frequently used in MongoDB queries.
3. It doesn't verify that the expression in question is in a file or code block that actually controls rails routing settings, such as `config/routes.rb`.  The code it is flagging isn't in a routing configuration file and has nothing to do with routing.

We should most likely try to contact AppScan and inform them of the false positive, but I don't know if it would be fixed in time to prevent a blockage of this feature.
