### PR TITLE
fixes bug to create prospective year benefit coverage period

### DIFF
--- a/app/models/benefit_sponsorship.rb
+++ b/app/models/benefit_sponsorship.rb
@@ -121,10 +121,11 @@ class BenefitSponsorship
       oe_begin.process_renewals
     end
 
+    # Creates BCP for the prospective year
     def create_prospective_year_benefit_coverage_period(new_date)
       return unless eligible_for_new_benefit_coverage_period?(new_date)
 
-      HbxProfile.current_hbx.benefit_sponsorship.create_benefit_coverage_period(new_date.year)
+      HbxProfile.current_hbx.benefit_sponsorship.create_benefit_coverage_period(new_date.year.next)
     rescue StandardError => e
       Rails.logger.error { "Couldn't create prospective year benefit coverage period due to #{e.inspect}" }
     end

--- a/spec/models/benefit_sponsorship_spec.rb
+++ b/spec/models/benefit_sponsorship_spec.rb
@@ -167,6 +167,69 @@ RSpec.describe BenefitSponsorship, :type => :model do
     end
   end
 
+  describe '.create_prospective_year_benefit_coverage_period' do
+    let(:hbx_profile) { FactoryBot.create(:hbx_profile) }
+
+    let(:benefit_sponsorship) { FactoryBot.create(:benefit_sponsorship, hbx_profile: hbx_profile) }
+    let(:system_date) { TimeKeeper.date_of_record }
+    let(:current_year) { system_date.year }
+    let(:prospective_year) { current_year.next }
+    let(:benefit_coverage_period) do
+      FactoryBot.create(:benefit_coverage_period, benefit_sponsorship: benefit_sponsorship, coverage_year: current_year)
+    end
+    let(:renewal_benefit_coverage_period) do
+      FactoryBot.create(:benefit_coverage_period, benefit_sponsorship: benefit_sponsorship, coverage_year: prospective_year)
+    end
+
+    before do
+      benefit_coverage_period
+      renewal_benefit_coverage_period
+      allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:create_bcp_on_date_change).and_return(feature_enabled)
+
+      allow(
+        FinancialAssistanceRegistry[:create_bcp_on_date_change].settings(:bcp_creation_month)
+      ).to receive(:item).and_return(system_date.month)
+
+      allow(
+        FinancialAssistanceRegistry[:create_bcp_on_date_change].settings(:bcp_creation_day)
+      ).to receive(:item).and_return(system_date.day)
+    end
+
+    context 'when:
+      - with a prospective year bcp
+      - feature :create_bcp_on_date_change is enabled
+      - both :bcp_creation_month and :bcp_creation_day match with the system month and day
+      ' do
+
+      let(:feature_enabled) { true }
+
+      it 'returns the existing prospective year bcp' do
+        BenefitSponsorship.create_prospective_year_benefit_coverage_period(system_date)
+        expect(
+          benefit_sponsorship.reload.benefit_coverage_periods.by_year(prospective_year).count
+        ).to eq(1)
+        expect(
+          benefit_sponsorship.reload.benefit_coverage_periods.by_year(prospective_year).first
+        ).to eq(renewal_benefit_coverage_period)
+      end
+    end
+
+    context 'when:
+      - with a prospective year bcp
+      - feature :create_bcp_on_date_change is disabled
+      - both :bcp_creation_month and :bcp_creation_day match with the system month and day
+      ' do
+
+      let(:feature_enabled) { false }
+
+      it 'returns the nil' do
+        expect(
+          BenefitSponsorship.create_prospective_year_benefit_coverage_period(system_date)
+        ).to be_nil
+      end
+    end
+  end
+
   describe '#create_benefit_coverage_period' do
     let(:hbx_profile) { FactoryBot.create(:hbx_profile) }
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185855874

# A brief description of the changes

Current behavior: Currently, the auto job creates the current year's benefit coverage period instead of the prospective year's benefit coverage period.

New behavior: The auto job creates the prospective year's benefit coverage period.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.