### PR TITLE
fetching info from plan design organization

### DIFF
--- a/app/helpers/insured/families_helper.rb
+++ b/app/helpers/insured/families_helper.rb
@@ -439,13 +439,16 @@ module Insured::FamiliesHelper
   end
 
   def is_general_agency_authorized?(current_user, family)
-    logged_user_ga_roles = current_user.person&.general_agency_staff_roles
+    logged_user_ga_roles = current_user.person&.active_general_agency_staff_roles
     return false if logged_user_ga_roles.blank? # logged in user is not a ga
 
-    family_broker_role_id = family.current_broker_agency&.writing_agent_id
-    return false if family_broker_role_id.blank? # family has no broker, hence no ga
+    family_broker_profile_id = family.current_broker_agency&.benefit_sponsors_broker_agency_profile_id
+    return false if family_broker_profile_id.blank? # family has no broker, hence no ga
 
-    logged_user_ga_roles.map(&:general_agency_profile).map(&:primary_broker_role_id).include?(family_broker_role_id)
+    ::SponsoredBenefits::Organizations::PlanDesignOrganization.where(
+      :owner_profile_id => family_broker_profile_id,
+      :general_agency_accounts => {:"$elemMatch" => {aasm_state: :active, :benefit_sponsrship_general_agency_profile_id.in => logged_user_ga_roles.map(&:benefit_sponsors_general_agency_profile_id)}}
+    ).present?
   end
 
   def is_family_authorized?(current_user, family)

--- a/spec/controllers/insured/group_selection_controller_spec.rb
+++ b/spec/controllers/insured/group_selection_controller_spec.rb
@@ -881,7 +881,7 @@ RSpec.describe Insured::GroupSelectionController, :type => :controller, dbclean:
       end
 
       before do
-        general_agency_profile.update_attributes(primary_broker_role_id: broker_role.id)
+        allow(::SponsoredBenefits::Organizations::PlanDesignOrganization).to receive(:where).and_return([double('PlanDesignOrganization')])
       end
 
       it "should be able to terminate coverage if user is valid and has active ga staff role" do

--- a/spec/helpers/insured/families_helper_spec.rb
+++ b/spec/helpers/insured/families_helper_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
+require "#{SponsoredBenefits::Engine.root}/spec/shared_contexts/sponsored_benefits"
 
 RSpec.describe Insured::FamiliesHelper, :type => :helper, dbclean: :after_each  do
+  include_context "set up broker agency profile for BQT, by using configuration settings"
 
   describe "#plan_shopping_dependent_text", dbclean: :after_each  do
     let(:person) { FactoryBot.build_stubbed(:person)}
@@ -755,4 +757,60 @@ RSpec.describe Insured::FamiliesHelper, :type => :helper, dbclean: :after_each  
     end
   end
 
+  describe '#is_general_agency_authorized' do
+    context 'when current user is not a ga staff' do
+      let(:user) { FactoryBot.create(:user, :with_consumer_role) }
+      let(:family) { FactoryBot.create(:person, :with_family) }
+
+      it 'return false' do
+        expect(helper.is_general_agency_authorized?(user, family)).to eq false
+      end
+    end
+
+    context 'when family does not have an assigned broker' do
+      let(:user) { FactoryBot.create(:user, :with_consumer_role) }
+      let(:family) { FactoryBot.create(:person, :with_family).primary_family }
+
+      before do
+        allow(user).to receive_message_chain(:person, :active_general_agency_staff_roles).and_return [double('GeneralAgencyStaffRole')]
+      end
+
+      it 'return false' do
+        expect(helper.is_general_agency_authorized?(user, family)).to eq false
+      end
+    end
+
+    context 'when family an assigned broker & current user has ga staff role' do
+      context 'when current user ga does not belong to family broker' do
+        let(:user) { FactoryBot.create(:user, :with_consumer_role) }
+        let(:family) { FactoryBot.create(:person, :with_family).primary_family }
+
+        before do
+          allow(user).to receive_message_chain(:person, :active_general_agency_staff_roles).and_return [double('GeneralAgencyStaffRole', benefit_sponsors_general_agency_profile_id: general_agency_profile.id)]
+          allow(family).to receive(:current_broker_agency).and_return double('BrokerAgencyAccount', benefit_sponsors_broker_agency_profile_id: BSON::ObjectId.new)
+          plan_design_organization_with_assigned_ga
+        end
+
+        it 'return false' do
+          expect(helper.is_general_agency_authorized?(user, family)).to eq false
+        end
+      end
+
+      context 'when current user ga belongs to family broker' do
+        let(:user) { FactoryBot.create(:user, :with_consumer_role) }
+        let(:family) { FactoryBot.create(:person, :with_family).primary_family }
+
+        before do
+          allow(user).to receive_message_chain(:person, :active_general_agency_staff_roles).and_return [double('GeneralAgencyStaffRole', benefit_sponsors_general_agency_profile_id: general_agency_profile.id)]
+          allow(family).to receive(:current_broker_agency).and_return double('BrokerAgencyAccount', benefit_sponsors_broker_agency_profile_id: owner_profile.id)
+          plan_design_organization_with_assigned_ga
+        end
+
+        it 'return true' do
+          expect(helper.is_general_agency_authorized?(user, family)).to eq true
+        end
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185673402

# A brief description of the changes

Current behavior: ga check for auth is relying on primary broker role

New behavior: Above check relies on plan design organization, as we're not setting primary broker role.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.