### PR TITLE
disable download_tax_documents_button in dc

### DIFF
--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -699,7 +699,7 @@ registry:
         is_enabled: false
       - key: :show_download_tax_documents
         item: :show_download_tax_documents
-        is_enabled: true
+        is_enabled: <%= ENV['SHOW_DOWNLOAD_TAX_DOCUMENTS_IS_ENABLED'] || false %>
       - key: :tobacco_user_field
         item: :tobacco_user_field
         is_enabled: false

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -710,7 +710,7 @@ registry:
         is_enabled: false
       - key: :show_download_tax_documents
         item: :show_download_tax_documents
-        is_enabled: false
+        is_enabled: <%= ENV['SHOW_DOWNLOAD_TAX_DOCUMENTS_IS_ENABLED'] || false %>
       - key: :show_upload_notices
         item: :show_upload_notices
         is_enabled: false

--- a/spec/helpers/insured/families_helper_spec.rb
+++ b/spec/helpers/insured/families_helper_spec.rb
@@ -488,6 +488,7 @@ RSpec.describe Insured::FamiliesHelper, :type => :helper, dbclean: :after_each  
       let(:consumer_role) {FactoryBot.build(:consumer_role)}
       context "had a SSN" do
         before do
+          EnrollRegistry[:show_download_tax_documents].feature.stub(:is_enabled).and_return(true)
           person.consumer_role = consumer_role
             person.ssn = '123456789'
         end

--- a/spec/views/insured/families/inbox.html.erb_spec.rb
+++ b/spec/views/insured/families/inbox.html.erb_spec.rb
@@ -17,6 +17,7 @@ describe "insured/families/inbox.html.erb", dbclean: :after_each do
 
   context "as admin" do
     before :each do
+      EnrollRegistry[:show_download_tax_documents].feature.stub(:is_enabled).and_return(true)
       allow(view).to receive_message_chain("current_user.has_hbx_staff_role?").and_return(true)
     end
 
@@ -76,6 +77,7 @@ describe "insured/families/inbox.html.erb", dbclean: :after_each do
     
     context "as consumer" do
       before do
+        EnrollRegistry[:show_download_tax_documents].feature.stub(:is_enabled).and_return(true)
         allow(view).to receive_message_chain("current_user.has_hbx_staff_role?").and_return(false)
         allow(view).to receive(:individual_market_is_enabled?).and_return(true)
         allow(person).to receive(:consumer_role).and_return consumer_role

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -699,7 +699,7 @@ registry:
         is_enabled: false
       - key: :show_download_tax_documents
         item: :show_download_tax_documents
-        is_enabled: true
+        is_enabled: <%= ENV['SHOW_DOWNLOAD_TAX_DOCUMENTS_IS_ENABLED'] || false %>
       - key: :tobacco_user_field
         item: :tobacco_user_field
         is_enabled: false


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/186027210#

# A brief description of the changes

Current behavior: 

New behavior: Added environment variable

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.