### PR TITLE
displays silent flag for enrs on enrollment detail page

### DIFF
--- a/app/helpers/insured/families_helper.rb
+++ b/app/helpers/insured/families_helper.rb
@@ -410,14 +410,14 @@ module Insured::FamiliesHelper
     if enrollment.latest_wfst.present?
       if enrollment.latest_wfst_is_superseded_silent?
         l10n(
-          'enrollment.latest_transition_data',
+          'enrollment.latest_transition_data_with_silent_reason',
           from_state: enrollment.latest_wfst.from_state,
           to_state: enrollment.latest_wfst.to_state,
           created_at: enrollment.latest_wfst.created_at.in_time_zone('Eastern Time (US & Canada)').strftime("%m/%d/%Y %-I:%M%p")
         )
       else
         l10n(
-          'enrollment.latest_transition_data_with_silent_reason',
+          'enrollment.latest_transition_data',
           from_state: enrollment.latest_wfst.from_state,
           to_state: enrollment.latest_wfst.to_state,
           created_at: enrollment.latest_wfst.created_at.in_time_zone('Eastern Time (US & Canada)').strftime("%m/%d/%Y %-I:%M%p")

--- a/app/helpers/insured/families_helper.rb
+++ b/app/helpers/insured/families_helper.rb
@@ -408,10 +408,21 @@ module Insured::FamiliesHelper
 
   def latest_transition(enrollment)
     if enrollment.latest_wfst.present?
-      l10n('enrollment.latest_transition_data',
-           from_state: enrollment.latest_wfst.from_state,
-           to_state: enrollment.latest_wfst.to_state,
-           created_at: enrollment.latest_wfst.created_at.in_time_zone('Eastern Time (US & Canada)').strftime("%m/%d/%Y %-I:%M%p"))
+      if enrollment.latest_wfst_is_superseded_silent?
+        l10n(
+          'enrollment.latest_transition_data',
+          from_state: enrollment.latest_wfst.from_state,
+          to_state: enrollment.latest_wfst.to_state,
+          created_at: enrollment.latest_wfst.created_at.in_time_zone('Eastern Time (US & Canada)').strftime("%m/%d/%Y %-I:%M%p")
+        )
+      else
+        l10n(
+          'enrollment.latest_transition_data_with_silent_reason',
+          from_state: enrollment.latest_wfst.from_state,
+          to_state: enrollment.latest_wfst.to_state,
+          created_at: enrollment.latest_wfst.created_at.in_time_zone('Eastern Time (US & Canada)').strftime("%m/%d/%Y %-I:%M%p")
+        )
+      end
     else
       l10n('not_available')
     end

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2838,7 +2838,7 @@ class HbxEnrollment
   end
 
   def latest_wfst
-    workflow_state_transitions.order(created_at: :desc).first
+    @latest_wfst ||= workflow_state_transitions.order(created_at: :desc).first
   end
 
   def is_eligible_for_osse_grant?(key)
@@ -2958,6 +2958,13 @@ class HbxEnrollment
       terminated_on.present? &&
       new_effective_on.present? &&
       (new_effective_on - 1.day) >= terminated_on
+  end
+
+  # Checks to see if the latest workflow state transition is 'superseded_silent'
+  def latest_wfst_is_superseded_silent?
+    latest_wfst.metadata_has?(
+      { 'reason' => Enrollments::TerminationReasons::SUPERSEDED_SILENT }
+    )
   end
 
   private

--- a/app/models/workflow_state_transition.rb
+++ b/app/models/workflow_state_transition.rb
@@ -31,12 +31,13 @@ class WorkflowStateTransition
   end
 
   def metadata_has?(matching_hash)
-    return false unless metadata.present?
-    matching_hash.each_pair do |k,v|
-      return false unless metadata.key?(k.to_s)
-      return false unless metadata[k.to_s] == v
+    return false if metadata.blank? || !matching_hash.is_a?(Hash)
+
+    compare_hash = metadata.stringify_keys
+
+    matching_hash.all? do |k, v|
+      compare_hash.key?(k.to_s) && compare_hash[k.to_s] == v
     end
-    true
   end
 
 private

--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -424,6 +424,7 @@ How to find the SEVIS ID: On the DS-2019, the number is on the top right hand si
   :'en.enrollment.effective_on' => 'Effective Date: ',
   :'en.enrollment.latest_transition' => 'Latest Transition: ',
   :'en.enrollment.latest_transition_data' => "From %{from_state} to %{to_state} at %{created_at}",
+  :'en.enrollment.latest_transition_data_with_silent_reason' => "From %{from_state} to %{to_state} at %{created_at} (Silent)",
   :'en.product_hios_id' => 'Product HIOS ID: ',
   :'en.rating_area.exchange_provided_code' => 'Rating Area: ',
   :'en.service_area' => 'Service Area',

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -566,6 +566,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.enrollment.effective_on' => 'Effective Date: ',
   :'en.enrollment.latest_transition' => 'Latest Transition: ',
   :'en.enrollment.latest_transition_data' => "From %{from_state} to %{to_state} at %{created_at}",
+  :'en.enrollment.latest_transition_data_with_silent_reason' => "From %{from_state} to %{to_state} at %{created_at} (Silent)",
   :'en.product_hios_id' => 'Product HIOS ID: ',
   :'en.rating_area.exchange_provided_code' => 'Rating Area: ',
   :'en.service_area' => 'Service Area',

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -568,6 +568,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.enrollment.effective_on' => 'Effective Date: ',
   :'en.enrollment.latest_transition' => 'Latest Transition: ',
   :'en.enrollment.latest_transition_data' => "From %{from_state} to %{to_state} at %{created_at}",
+  :'en.enrollment.latest_transition_data_with_silent_reason' => "From %{from_state} to %{to_state} at %{created_at} (Silent)",
   :'en.product_hios_id' => 'Product HIOS ID: ',
   :'en.rating_area.exchange_provided_code' => 'Rating Area: ',
   :'en.service_area' => 'Service Area',

--- a/spec/helpers/insured/families_helper_spec.rb
+++ b/spec/helpers/insured/families_helper_spec.rb
@@ -684,20 +684,38 @@ RSpec.describe Insured::FamiliesHelper, :type => :helper, dbclean: :after_each  
     end
   end
 
-  describe '#fetch_counties_by_zip', dbclean: :after_each do
-    let!(:family) { FactoryBot.create(:family, :with_primary_family_member) }
-    let!(:hbx_enr) { FactoryBot.create(:hbx_enrollment, aasm_state: 'shopping', kind: 'individual', family: family) }
+  describe '#latest_transition', dbclean: :after_each do
+    let(:family) { FactoryBot.create(:family, :with_primary_family_member) }
+    let(:hbx_enr) { FactoryBot.create(:hbx_enrollment, aasm_state: 'shopping', kind: 'individual', family: family) }
 
-    context 'with workflow_state_transition' do
-      before { hbx_enr.renew_enrollment! }
+    context 'with state transitions including transition args' do
+      let(:transition_reason) { { reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT } }
 
-      it 'should return latest_transition_data' do
+      before { hbx_enr.renew_enrollment!(transition_reason) }
+
+      it 'returns latest_transition_data' do
         expect(helper.latest_transition(hbx_enr)).to match(/From shopping to auto_renewing at/)
+      end
+
+      it 'returns transition reason' do
+        expect(helper.latest_transition(hbx_enr)).to match(/Silent/)
       end
     end
 
-    context 'without workflow_state_transition' do
-      it 'should return latest_transition_data' do
+    context 'with state transitions' do
+      before { hbx_enr.renew_enrollment! }
+
+      it 'returns latest_transition_data' do
+        expect(helper.latest_transition(hbx_enr)).to match(/From shopping to auto_renewing at/)
+      end
+
+      it 'does not return transition reason' do
+        expect(helper.latest_transition(hbx_enr)).not_to match(/Silent/)
+      end
+    end
+
+    context 'without state transitions' do
+      it 'does not return latest_transition_data' do
         expect(helper.latest_transition(hbx_enr)).to eq(l10n('not_available'))
       end
     end

--- a/spec/models/hbx_enrollment_transition_argument_spec.rb
+++ b/spec/models/hbx_enrollment_transition_argument_spec.rb
@@ -41,4 +41,45 @@ RSpec.describe HbxEnrollment, "created in the shopping mode, then transitioned w
     ).first
     expect(found_enrollment.id).to eq(enrollment.id)
   end
+
+  describe '#latest_wfst_is_superseded_silent?' do
+    before do
+      enrollment.select_coverage!
+      enrollment.cancel_coverage!(Date.today, transition_args)
+    end
+
+    context 'without transition args during transition' do
+      let(:transition_args) { {} }
+
+      it 'returns false' do
+        expect(enrollment.latest_wfst_is_superseded_silent?).to be_falsey
+      end
+    end
+
+    context 'with non-superseded_silent transition args during transition' do
+      let(:transition_args) { { reason: 'Other than superseded silent' } }
+
+      it 'returns false' do
+        expect(enrollment.latest_wfst_is_superseded_silent?).to be_falsey
+      end
+    end
+
+    context 'with superseded_silent transition args during transition' do
+      context 'with symbolized keys' do
+        let(:transition_args) { { reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT } }
+
+        it 'returns true' do
+          expect(enrollment.latest_wfst_is_superseded_silent?).to be_truthy
+        end
+      end
+
+      context 'with stringified keys' do
+        let(:transition_args) { { 'reason' => Enrollments::TerminationReasons::SUPERSEDED_SILENT } }
+
+        it 'returns true' do
+          expect(enrollment.latest_wfst_is_superseded_silent?).to be_truthy
+        end
+      end
+    end
+  end
 end

--- a/spec/models/hbx_enrollment_transition_argument_spec.rb
+++ b/spec/models/hbx_enrollment_transition_argument_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe HbxEnrollment, "created in the shopping mode, then transitioned w
     hbx_enrollment = HbxEnrollment.new(
       :aasm_state => "shopping",
       :kind => "individual",
+      :effective_on => TimeKeeper.date_of_record.beginning_of_month,
       :enrollment_kind => "open_enrollment",
       :coverage_kind => "health",
       :family => family,


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185903885

# A brief description of the changes

Current behavior:

New behavior: As part of the CR 73 policy rebuild, we are flagging some state transitions as `superseded_silent`, we are displaying the `silent` flag in the UI in the Enrollment Detail section

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

We have the feature flag implemented around the persistence where we will persist the information only when the feature is enabled.

# Additional Context
Include any additional context that may be relevant to the peer review process.


Screenshots from the local environment for ME

1. Enrollment without the silent flag
    * ![image](https://github.com/ideacrew/enroll/assets/22556810/5165fe80-034c-464e-bb3c-1adf2f40d0b2)
2. Enrollment with silent flag
    * ![image](https://github.com/ideacrew/enroll/assets/22556810/d0f8cad3-9cb9-4bec-a044-1191b1a920a8)
