### PR TITLE
move event attribute to before create callback

### DIFF
--- a/spec/factories/eligible_state_histories.rb
+++ b/spec/factories/eligible_state_histories.rb
@@ -7,8 +7,11 @@ FactoryBot.define do
     from_state { :draft }
     to_state { :eligible }
     transition_at { TimeKeeper.date_of_record }
-    event { :mark_eligible }
     reason { 'met minimum criteria' }
     comment { 'consumer provided proper documentation' }
+
+    before(:create) do |instance|
+      instance.event = :mark_eligible
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186042263

# A brief description of the changes

Current behavior:
translations script is failing, because it is assuming the attribute in factory as event source event.

New behavior:
Translations should run successfully

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.