### PR TITLE
disable callback on consumer role while storing osse eligibility

### DIFF
--- a/app/domain/operations/ivl_osse_eligibilities/create_ivl_osse_eligibility.rb
+++ b/app/domain/operations/ivl_osse_eligibilities/create_ivl_osse_eligibility.rb
@@ -93,19 +93,25 @@ module Operations
           subject.eligibilities << eligibility_record
         end
 
-        save_proc = proc do
-          if subject.save
-            Success(eligibility_record)
-          else
-            Failure(subject.errors.full_messages)
+        save_proc =
+          proc do
+            if subject.save
+              Success(eligibility_record)
+            else
+              Failure(subject.errors.full_messages)
+            end
           end
-        end
 
-        if default_eligibility
-          Person.without_callbacks(callbacks_to_skip, &save_proc)
-        else
-          save_proc.call
-        end
+        ConsumerRole.skip_callback(:update, :after, :publish_updated_event) if subject.is_a?(ConsumerRole)
+        output =
+          if default_eligibility
+            Person.without_callbacks(callbacks_to_skip, &save_proc)
+          else
+            save_proc.call
+          end
+        ConsumerRole.set_callback(:update, :after, :publish_updated_event) if subject.is_a?(ConsumerRole)
+
+        output
       end
 
       def callbacks_to_skip


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640061/stories/186053246

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.