### PR TITLE
loud transmit enrollments with different hios_id

### DIFF
--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -53,7 +53,7 @@ module Operations
         return {} if index.zero?
         return {} unless enrollment.product.is_same_plan_by_hios_id_and_active_year?(previous_enrollment.product)
 
-        { reason: 'superseded_silent' }
+        { reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT }
       end
     end
   end

--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -27,7 +27,7 @@ module Operations
         eligible_enrollments = fetch_eligible_enrollments(enrollment, year)
 
         eligible_enrollments.each_with_index do |previous_enrollment, index|
-          transition_args = fetch_transition_args(index)
+          transition_args = fetch_transition_args(enrollment, index, previous_enrollment)
 
           if enrollment.effective_on > previous_enrollment.effective_on && previous_enrollment.may_terminate_coverage?
             next previous_enrollment if previous_enrollment.ineligible_for_termination?(enrollment.effective_on)
@@ -48,9 +48,10 @@ module Operations
         end.sort_by(&:effective_on)
       end
 
-      def fetch_transition_args(index)
+      def fetch_transition_args(enrollment, index, previous_enrollment)
         return {} unless EnrollRegistry.feature_enabled?(:silent_transition_enrollment)
         return {} if index.zero?
+        return {} unless enrollment.product.is_same_plan_by_hios_id_and_active_year?(previous_enrollment.product)
 
         { reason: 'superseded_silent' }
       end

--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -50,7 +50,7 @@ module Operations
         coverage_bins = construct_continous_coverage_bins(impacted_enrollments)
         coverage_bins.each do |bin|
           bin.each_with_index do |previous_enrollment, index|
-            termination_args = index > 0 ? { reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT } : {}
+            termination_args = index > 0 ? { "reason" => Enrollments::TerminationReasons::SUPERSEDED_SILENT } : {}
             process_termination(enrollment, previous_enrollment, termination_args)
           end
         end

--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -23,21 +23,13 @@ module Operations
       private
 
       def cancel_previous(enrollment, year)
+        return process_previous_enrollments_for(enrollment, year) if EnrollRegistry.feature_enabled?(:silent_transition_enrollment)
+
         #Perform cancel/terms of previous enrollments for the same plan year
         eligible_enrollments = fetch_eligible_enrollments(enrollment, year)
 
-        eligible_enrollments.each_with_index do |previous_enrollment, index|
-          transition_args = fetch_transition_args(enrollment, index, previous_enrollment)
-
-          if enrollment.effective_on > previous_enrollment.effective_on && previous_enrollment.may_terminate_coverage?
-            next previous_enrollment if previous_enrollment.ineligible_for_termination?(enrollment.effective_on)
-
-            previous_enrollment.terminate_coverage!(enrollment.effective_on - 1.day, transition_args)
-          elsif previous_enrollment.enrollment_superseded_and_eligible_for_cancellation?(enrollment.effective_on)
-            previous_enrollment.cancel_coverage_for_superseded_term!(transition_args)
-          elsif previous_enrollment.may_cancel_coverage?
-            previous_enrollment.cancel_coverage!(transition_args)
-          end
+        eligible_enrollments.each do |previous_enrollment|
+          process_termination(enrollment, previous_enrollment)
         end
       end
 
@@ -48,12 +40,50 @@ module Operations
         end.sort_by(&:effective_on)
       end
 
-      def fetch_transition_args(enrollment, index, previous_enrollment)
-        return {} unless EnrollRegistry.feature_enabled?(:silent_transition_enrollment)
-        return {} if index.zero?
-        return {} unless enrollment.product.hios_id == previous_enrollment.product.hios_id
+      def process_previous_enrollments_for(enrollment, year)
+        candidate_enrollments = enrollment.previous_enrollments(year).map do |other_enrollment|
+          Enrollments::IndividualMarket::ProductSelectionInteraction.new(enrollment, other_enrollment)
+        end
+        # Discard the enrollments that shouldn't even change each other,
+        # and put the remainder in order
+        impacted_enrollments = candidate_enrollments.select(&:can_interact?).sort_by(&:affected_effective_on)
+        coverage_bins = construct_continous_coverage_bins(impacted_enrollments)
+        coverage_bins.each do |bin|
+          bin.each_with_index do |previous_enrollment, index|
+            termination_args = index > 0 ? { reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT } : {}
+            process_termination(enrollment, previous_enrollment, termination_args)
+          end
+        end
+      end
 
-        { reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT }
+      # rubocop:disable Style/SelfAssignment
+      def construct_continous_coverage_bins(impacted_enrollments)
+        return [] if impacted_enrollments.empty?
+        first_enrollment, *enrollments_to_bin = impacted_enrollments
+        bins = []
+        current_bin = [first_enrollment]
+        until enrollments_to_bin.empty?
+          next_enrollment, *enrollments_to_bin = enrollments_to_bin
+          if current_bin.last.continous_with?(next_enrollment)
+            current_bin = current_bin + [next_enrollment]
+          else
+            bins = bins + [current_bin.map(&:affected_enrollment)]
+            current_bin = [next_enrollment]
+          end
+        end
+        bins + [current_bin.map(&:affected_enrollment)]
+      end
+      # rubocop:enable Style/SelfAssignment
+
+      def process_termination(enrollment, previous_enrollment, termination_args = {})
+        if enrollment.effective_on > previous_enrollment.effective_on && previous_enrollment.may_terminate_coverage?
+          return if previous_enrollment.ineligible_for_termination?(enrollment.effective_on)
+          previous_enrollment.terminate_coverage!(enrollment.effective_on - 1.day)
+        elsif previous_enrollment.enrollment_superseded_and_eligible_for_cancellation?(enrollment.effective_on)
+          previous_enrollment.cancel_coverage_for_superseded_term!(termination_args)
+        elsif previous_enrollment.may_cancel_coverage?
+          previous_enrollment.cancel_coverage!(termination_args)
+        end
       end
     end
   end

--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -50,8 +50,8 @@ module Operations
         coverage_bins = construct_continous_coverage_bins(impacted_enrollments)
         coverage_bins.each do |bin|
           bin.each_with_index do |previous_enrollment, index|
-            termination_args = index > 0 ? { "reason" => Enrollments::TerminationReasons::SUPERSEDED_SILENT } : {}
-            process_termination(enrollment, previous_enrollment, termination_args)
+            transition_args = index > 0 ? { "reason" => Enrollments::TerminationReasons::SUPERSEDED_SILENT } : {}
+            process_termination(enrollment, previous_enrollment, transition_args)
           end
         end
       end
@@ -75,14 +75,14 @@ module Operations
       end
       # rubocop:enable Style/SelfAssignment
 
-      def process_termination(enrollment, previous_enrollment, termination_args = {})
+      def process_termination(enrollment, previous_enrollment, transition_args = {})
         if enrollment.effective_on > previous_enrollment.effective_on && previous_enrollment.may_terminate_coverage?
           return if previous_enrollment.ineligible_for_termination?(enrollment.effective_on)
-          previous_enrollment.terminate_coverage!(enrollment.effective_on - 1.day)
+          previous_enrollment.terminate_coverage!(enrollment.effective_on - 1.day, transition_args)
         elsif previous_enrollment.enrollment_superseded_and_eligible_for_cancellation?(enrollment.effective_on)
-          previous_enrollment.cancel_coverage_for_superseded_term!(termination_args)
+          previous_enrollment.cancel_coverage_for_superseded_term!(transition_args)
         elsif previous_enrollment.may_cancel_coverage?
-          previous_enrollment.cancel_coverage!(termination_args)
+          previous_enrollment.cancel_coverage!(transition_args)
         end
       end
     end

--- a/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
+++ b/app/domain/operations/product_selection_effects/terminate_previous_selections.rb
@@ -51,7 +51,7 @@ module Operations
       def fetch_transition_args(enrollment, index, previous_enrollment)
         return {} unless EnrollRegistry.feature_enabled?(:silent_transition_enrollment)
         return {} if index.zero?
-        return {} unless enrollment.product.is_same_plan_by_hios_id_and_active_year?(previous_enrollment.product)
+        return {} unless enrollment.product.hios_id == previous_enrollment.product.hios_id
 
         { reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT }
       end

--- a/app/models/enrollments/individual_market/product_selection_interaction.rb
+++ b/app/models/enrollments/individual_market/product_selection_interaction.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Enrollments
+  module IndividualMarket
+    # Helps encapsulate the complexity of the interaction between an
+    # HbxEnrollment for which coverage was just selected and another
+    # enrollment that may experience a change because of that selection.
+    #
+    # Note that only enrollments in the same plan year should be compared.
+    class ProductSelectionInteraction
+
+      attr_reader :selected_enrollment, :affected_enrollment
+
+      def initialize(s_enrollment, a_enrollment)
+        @selected_enrollment = s_enrollment
+        @affected_enrollment = a_enrollment
+      end
+
+      def affected_effective_on
+        @affected_enrollment.effective_on
+      end
+
+      def affected_terminated_on
+        @affected_enrollment.terminated_on
+      end
+
+      # Determines if it is even possible for the enrollments to interact
+      # as a result of a purchase.  Used early in the process to eliminate
+      # enrollments that should not be affected.
+      def can_interact?
+        return false if HbxEnrollment::CANCELED_STATUSES.include?(@affected_enrollment.aasm_state)
+        return false unless @selected_enrollment.coverage_kind == @affected_enrollment.coverage_kind
+        return false unless @selected_enrollment.subscriber.applicant_id == @affected_enrollment.subscriber.applicant_id
+
+        return true if @affected_enrollment.effective_on >= @selected_enrollment.effective_on
+        return true if @affected_enrollment.effective_on <= @selected_enrollment.effective_on && @affected_enrollment.terminated_on.blank?
+        (@affected_enrollment.effective_on <= @selected_enrollment.effective_on) && (@affected_enrollment.terminated_on >= @selected_enrollment.effective_on)
+      end
+
+      # Is the affected enrollment continous, coverage wise, with another,
+      # specified enrollment?
+      def continous_with?(next_enrollment)
+        return false unless @affected_enrollment.product_id == next_enrollment.affected_enrollment.product_id
+        return false if @affected_enrollment.terminated_on.blank?
+        @affected_enrollment.terminated_on == (next_enrollment.affected_effective_on - 1.day)
+      end
+    end
+  end
+end

--- a/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
+++ b/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
@@ -19,6 +19,15 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
       )
     end
 
+    let(:silver_product_with_variant02) do
+      FactoryBot.create(
+        :benefit_markets_products_health_products_health_product,
+        metal_level_kind: :silver,
+        hios_id: '012345ME01234567-02',
+        hios_base_id: '012345ME01234567'
+      )
+    end
+
     let(:silver_product2) do
       FactoryBot.create(
         :benefit_markets_products_health_products_health_product,
@@ -229,7 +238,7 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
         - enrollments exists with same enrollment signature
         - enrollments exists with same coverage_kind
         - enrollments exists with same plan_year effective dates
-        - enrollment's product has same hios_base_id as all previous enrollments
+        - enrollment's product has same hios_id as all previous enrollments
         " do
 
         let(:new_enrollment_effective_on) { Date.new(coverage_year, 1) }
@@ -269,7 +278,7 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
         - enrollments exists with same enrollment signature
         - enrollments exists with same coverage_kind
         - enrollments exists with same plan_year effective dates
-        - enrollment's product has same hios_base_id as all previous enrollments
+        - enrollment's product has same hios_id as all previous enrollments
         " do
 
         let(:new_enrollment_effective_on) { Date.new(coverage_year, 2) }
@@ -308,7 +317,7 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
         - enrollments exists with same enrollment signature
         - enrollments exists with same coverage_kind
         - enrollments exists with same plan_year effective dates
-        - enrollment's product does not havw same hios_base_id as all previous enrollments
+        - enrollment's product does not havw same hios_id as all previous enrollments
         " do
 
         let(:new_enr_silver_product) { silver_product2 }
@@ -322,19 +331,19 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
           ).to be_falsey
         end
 
-        it 'does not add metadata as hios_base_id is different' do
+        it 'does not add metadata as hios_id is different' do
           expect(
             enrollment3.reload.workflow_state_transitions.where(metadata_query).first
           ).to be_falsey
         end
 
-        it 'does not add metadata as hios_base_id is different' do
+        it 'does not add metadata as hios_id is different' do
           expect(
             enrollment4.reload.workflow_state_transitions.where(metadata_query).first
           ).to be_falsey
         end
 
-        it 'does not add metadata as hios_base_id is different' do
+        it 'does not add metadata as hios_id is different' do
           expect(
             enrollment5.reload.workflow_state_transitions.where(metadata_query).first
           ).to be_falsey
@@ -348,11 +357,11 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
         - enrollments exists with same enrollment signature
         - enrollments exists with same coverage_kind
         - enrollments exists with same plan_year effective dates
-        - some of the in-between enrollment does not have same hios_base_id as new_enrollment
+        - some of the in-between enrollment does not have same hios_id as new_enrollment
         " do
 
         let(:enrollment3_silver_product) { silver_product2 }
-        let(:enrollment4_silver_product) { silver_product2 }
+        let(:enrollment4_silver_product) { silver_product_with_variant02 }
         let(:new_enrollment_effective_on) { Date.new(coverage_year, 2) }
         let(:previous_enrollment_effective_on) { Date.new(coverage_year, 1) }
         let(:previous_enrollment_terminated_on) { new_enrollment_effective_on.end_of_month }
@@ -363,19 +372,19 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
           ).to be_falsey
         end
 
-        it 'does not add metadata as hios_base_id is different' do
+        it 'does not add metadata as hios_id is different' do
           expect(
             enrollment3.reload.workflow_state_transitions.where(metadata_query).first
           ).to be_falsey
         end
 
-        it 'does not add metadata as hios_base_id is different' do
+        it 'does not add metadata as csr_variant_id is different' do
           expect(
             enrollment4.reload.workflow_state_transitions.where(metadata_query).first
           ).to be_falsey
         end
 
-        it 'adds metadata as hios_base_id is same' do
+        it 'adds metadata as hios_id is same' do
           expect(
             enrollment5.reload.workflow_state_transitions.where(metadata_query).first
           ).to be_truthy

--- a/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
+++ b/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
@@ -9,12 +9,33 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
     let(:coverage_year) { Date.today.year }
     let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
     let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+
+    let(:silver_product) do
+      FactoryBot.create(
+        :benefit_markets_products_health_products_health_product,
+        metal_level_kind: :silver,
+        hios_id: '012345ME01234567-01',
+        hios_base_id: '012345ME01234567'
+      )
+    end
+
+    let(:silver_product2) do
+      FactoryBot.create(
+        :benefit_markets_products_health_products_health_product,
+        metal_level_kind: :silver,
+        hios_id: '012345ME76543210-01',
+        hios_base_id: '012345ME76543210'
+      )
+    end
+
+    let(:new_enr_silver_product) { silver_product }
+
     let(:new_enrollment_effective_on) { Date.new(coverage_year, 3) }
     let(:new_enrollment) do
       FactoryBot.create(:hbx_enrollment,
                         :individual_unassisted,
-                        :with_silver_health_product,
                         :with_enrollment_members,
+                        product_id: new_enr_silver_product.id,
                         enrollment_members: family.family_members,
                         household: family.active_household,
                         effective_on: new_enrollment_effective_on,
@@ -27,11 +48,13 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
 
     let(:previous_enrollment_aasm_state) { 'coverage_terminated' }
 
+    let(:previous_enr_silver_product) { silver_product }
+
     let(:previous_enrollment) do
       FactoryBot.create(:hbx_enrollment,
                         :individual_unassisted,
-                        :with_silver_health_product,
                         :with_enrollment_members,
+                        product_id: previous_enr_silver_product.id,
                         enrollment_members: family.family_members,
                         aasm_state: previous_enrollment_aasm_state,
                         household: family.active_household,
@@ -132,25 +155,55 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
     end
 
     context 'for silent superseded enrollments' do
+      let(:enrollment3_silver_product) { silver_product }
+
       let(:enrollment3) do
-        FactoryBot.create(:hbx_enrollment, :individual_unassisted, :with_silver_health_product, :with_enrollment_members,
-                          enrollment_members: family.family_members, aasm_state: 'coverage_terminated',
-                          household: family.active_household, effective_on: Date.new(coverage_year, 3), family: family,
-                          terminated_on: previous_enrollment_terminated_on)
+        FactoryBot.create(
+          :hbx_enrollment,
+          :individual_unassisted,
+          :with_enrollment_members,
+          product_id: enrollment3_silver_product.id,
+          enrollment_members: family.family_members,
+          aasm_state: 'coverage_terminated',
+          household: family.active_household,
+          effective_on: Date.new(coverage_year, 3),
+          family: family,
+          terminated_on: previous_enrollment_terminated_on
+        )
       end
+
+      let(:enrollment4_silver_product) { silver_product }
 
       let(:enrollment4) do
-        FactoryBot.create(:hbx_enrollment, :individual_unassisted, :with_silver_health_product, :with_enrollment_members,
-                          enrollment_members: family.family_members, aasm_state: 'coverage_selected',
-                          household: family.active_household, effective_on: Date.new(coverage_year, 4), family: family,
-                          terminated_on: previous_enrollment_terminated_on)
+        FactoryBot.create(
+          :hbx_enrollment,
+          :individual_unassisted,
+          :with_enrollment_members,
+          product_id: enrollment4_silver_product.id,
+          enrollment_members: family.family_members,
+          aasm_state: 'coverage_selected',
+          household: family.active_household,
+          effective_on: Date.new(coverage_year, 4),
+          family: family,
+          terminated_on: previous_enrollment_terminated_on
+        )
       end
 
+      let(:enrollment5_silver_product) { silver_product }
+
       let(:enrollment5) do
-        FactoryBot.create(:hbx_enrollment, :individual_unassisted, :with_silver_health_product, :with_enrollment_members,
-                          enrollment_members: family.family_members, aasm_state: 'coverage_terminated',
-                          household: family.active_household, effective_on: Date.new(coverage_year, 5), family: family,
-                          terminated_on: previous_enrollment_terminated_on)
+        FactoryBot.create(
+          :hbx_enrollment,
+          :individual_unassisted,
+          :with_enrollment_members,
+          product_id: enrollment5_silver_product.id,
+          enrollment_members: family.family_members,
+          aasm_state: 'coverage_terminated',
+          household: family.active_household,
+          effective_on: Date.new(coverage_year, 5),
+          family: family,
+          terminated_on: previous_enrollment_terminated_on
+        )
       end
 
       let(:metadata_query) { { 'metadata.reason' => 'superseded_silent' } }
@@ -174,8 +227,9 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
         - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
         - RR configuration feature :silent_transition_enrollment is enabled
         - enrollments exists with same enrollment signature
-        - enrollemnts exists with same coverage_kind
+        - enrollments exists with same coverage_kind
         - enrollments exists with same plan_year effective dates
+        - enrollment's product has same hios_base_id as all previous enrollments
         " do
 
         let(:new_enrollment_effective_on) { Date.new(coverage_year, 1) }
@@ -213,8 +267,9 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
         - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
         - RR configuration feature :silent_transition_enrollment is enabled
         - enrollments exists with same enrollment signature
-        - enrollemnts exists with same coverage_kind
+        - enrollments exists with same coverage_kind
         - enrollments exists with same plan_year effective dates
+        - enrollment's product has same hios_base_id as all previous enrollments
         " do
 
         let(:new_enrollment_effective_on) { Date.new(coverage_year, 2) }
@@ -240,6 +295,87 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
         end
 
         it 'adds metadata as this is not first enrollment' do
+          expect(
+            enrollment5.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_truthy
+        end
+      end
+
+      context "when:
+        - previous_enrollment is coverage_terminated
+        - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
+        - RR configuration feature :silent_transition_enrollment is enabled
+        - enrollments exists with same enrollment signature
+        - enrollments exists with same coverage_kind
+        - enrollments exists with same plan_year effective dates
+        - enrollment's product does not havw same hios_base_id as all previous enrollments
+        " do
+
+        let(:new_enr_silver_product) { silver_product2 }
+        let(:new_enrollment_effective_on) { Date.new(coverage_year, 2) }
+        let(:previous_enrollment_effective_on) { Date.new(coverage_year, 1) }
+        let(:previous_enrollment_terminated_on) { new_enrollment_effective_on.end_of_month }
+
+        it 'does not add metadata as this is first enrollment' do
+          expect(
+            previous_enrollment.workflow_state_transitions.where(metadata_query).first
+          ).to be_falsey
+        end
+
+        it 'does not add metadata as hios_base_id is different' do
+          expect(
+            enrollment3.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_falsey
+        end
+
+        it 'does not add metadata as hios_base_id is different' do
+          expect(
+            enrollment4.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_falsey
+        end
+
+        it 'does not add metadata as hios_base_id is different' do
+          expect(
+            enrollment5.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_falsey
+        end
+      end
+
+      context "when:
+        - previous_enrollment is coverage_terminated
+        - RR configuration feature :cancel_superseded_terminated_enrollments is enabled
+        - RR configuration feature :silent_transition_enrollment is enabled
+        - enrollments exists with same enrollment signature
+        - enrollments exists with same coverage_kind
+        - enrollments exists with same plan_year effective dates
+        - some of the in-between enrollment does not have same hios_base_id as new_enrollment
+        " do
+
+        let(:enrollment3_silver_product) { silver_product2 }
+        let(:enrollment4_silver_product) { silver_product2 }
+        let(:new_enrollment_effective_on) { Date.new(coverage_year, 2) }
+        let(:previous_enrollment_effective_on) { Date.new(coverage_year, 1) }
+        let(:previous_enrollment_terminated_on) { new_enrollment_effective_on.end_of_month }
+
+        it 'does not add metadata as this is first enrollment' do
+          expect(
+            previous_enrollment.workflow_state_transitions.where(metadata_query).first
+          ).to be_falsey
+        end
+
+        it 'does not add metadata as hios_base_id is different' do
+          expect(
+            enrollment3.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_falsey
+        end
+
+        it 'does not add metadata as hios_base_id is different' do
+          expect(
+            enrollment4.reload.workflow_state_transitions.where(metadata_query).first
+          ).to be_falsey
+        end
+
+        it 'adds metadata as hios_base_id is same' do
           expect(
             enrollment5.reload.workflow_state_transitions.where(metadata_query).first
           ).to be_truthy

--- a/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
+++ b/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
@@ -206,7 +206,7 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
         )
       end
 
-      let(:metadata_query) { { 'metadata.reason' => 'superseded_silent' } }
+      let(:metadata_query) { { 'metadata.reason' => Enrollments::TerminationReasons::SUPERSEDED_SILENT } }
 
       before do
         allow(

--- a/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
+++ b/spec/domain/operations/product_selection_effects/terminate_previous_selections_spec.rb
@@ -177,9 +177,11 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
           household: family.active_household,
           effective_on: Date.new(coverage_year, 3),
           family: family,
-          terminated_on: previous_enrollment_terminated_on
+          terminated_on: enrollment_3_termination_date
         )
       end
+
+      let(:enrollment_3_termination_date) { Date.new(coverage_year, 4) - 1.day }
 
       let(:enrollment4_silver_product) { silver_product }
 
@@ -194,9 +196,11 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
           household: family.active_household,
           effective_on: Date.new(coverage_year, 4),
           family: family,
-          terminated_on: previous_enrollment_terminated_on
+          terminated_on: enrollment_4_termination_date
         )
       end
+
+      let(:enrollment_4_termination_date) { Date.new(coverage_year, 5) - 1.day }
 
       let(:enrollment5_silver_product) { silver_product }
 
@@ -252,10 +256,10 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
           ).to be_falsey
         end
 
-        it 'adds metadata as this is not first enrollment' do
+        it 'does not add metadata as there is a gap in coverage' do
           expect(
             enrollment3.reload.workflow_state_transitions.where(metadata_query).first
-          ).to be_truthy
+          ).to be_falsey
         end
 
         it 'adds metadata as this is not first enrollment' do
@@ -317,7 +321,7 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
         - enrollments exists with same enrollment signature
         - enrollments exists with same coverage_kind
         - enrollments exists with same plan_year effective dates
-        - enrollment's product does not havw same hios_id as all previous enrollments
+        - enrollment's product does not have same hios_id as all previous enrollments
         " do
 
         let(:new_enr_silver_product) { silver_product2 }
@@ -331,22 +335,22 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
           ).to be_falsey
         end
 
-        it 'does not add metadata as hios_id is different' do
+        it 'adds metadata as previous coverage was continguous' do
           expect(
             enrollment3.reload.workflow_state_transitions.where(metadata_query).first
-          ).to be_falsey
+          ).to be_truthy
         end
 
-        it 'does not add metadata as hios_id is different' do
+        it 'adds metadata as previous coverage was continguous' do
           expect(
             enrollment4.reload.workflow_state_transitions.where(metadata_query).first
-          ).to be_falsey
+          ).to be_truthy
         end
 
-        it 'does not add metadata as hios_id is different' do
+        it 'adds metadata as previous coverage was continguous' do
           expect(
             enrollment5.reload.workflow_state_transitions.where(metadata_query).first
-          ).to be_falsey
+          ).to be_truthy
         end
       end
 
@@ -384,10 +388,10 @@ describe Operations::ProductSelectionEffects::TerminatePreviousSelections, dbcle
           ).to be_falsey
         end
 
-        it 'adds metadata as hios_id is same' do
+        it 'does not add metadata to enrollment 5 as coverage is not contiguous' do
           expect(
             enrollment5.reload.workflow_state_transitions.where(metadata_query).first
-          ).to be_truthy
+          ).to be_falsey
         end
       end
     end

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -638,7 +638,7 @@ RSpec.describe HbxEnrollment, type: :model do
 
     context 'with terminated_on and additional transition args' do
       let(:terminated_on_date) { hbx_enrollment.effective_on.end_of_month }
-      let(:transition_args) { { reason: 'superseded_silent' } }
+      let(:transition_args) { { reason: Enrollments::TerminationReasons::SUPERSEDED_SILENT } }
 
       it 'assigns terminated_on without raising any error' do
         expect do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186053895](https://www.pivotaltracker.com/story/show/186053895)

# A brief description of the changes

Current behavior: Currently, enroll does not transmit in-between enrollments if they have different product hios_base_id

New behavior: In-between enrollments that have different product hios_base_id will flagged as loud transitions.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.