### PR TITLE
adds eligibility check for DHS hub call for consumers

### DIFF
--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -703,10 +703,14 @@ class ConsumerRole
     invoke_verification! if [:dhs_pending, :ssa_pending].include?(aasm.current_state)
   end
 
+  def eligible_for_invoking_dhs?
+    [NATURALIZED_CITIZEN_STATUS, ALIEN_LAWFULLY_PRESENT_STATUS].include?(citizen_status)
+  end
+
   def invoke_verification!(*args)
     return if skip_residency_verification == true
     invoke_ssa if person.ssn.present? || is_native?
-    invoke_dhs
+    invoke_dhs if eligible_for_invoking_dhs?
   end
 
   def verify_ivl_by_admin(*args)

--- a/spec/models/consumer_role_invoke_hub_call_spec.rb
+++ b/spec/models/consumer_role_invoke_hub_call_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ConsumerRole, dbclean: :around_each do
+  before { DatabaseCleaner.clean }
+
+  let(:person) { FactoryBot.create(:person, :with_ssn) }
+  let(:consumer_role) { FactoryBot.create(:consumer_role, person: person, lawful_presence_determination: lawful_presence_determination) }
+  let(:lawful_presence_determination) { FactoryBot.build(:lawful_presence_determination, citizen_status: citizen_status) }
+
+  describe '#eligible_for_invoking_dhs?' do
+    shared_examples_for 'eligibility of invoking dhs call' do |citizen_status, eligible|
+      let(:citizen_status) { citizen_status }
+
+      it "returns #{eligible} for citizen_status: #{citizen_status}" do
+        expect(consumer_role.eligible_for_invoking_dhs?).to eq(eligible)
+      end
+    end
+
+    context "native validation doesn't exist" do
+      it_behaves_like 'eligibility of invoking dhs call', 'alien_lawfully_present', true
+      it_behaves_like 'eligibility of invoking dhs call', 'lawful_permanent_resident', false
+      it_behaves_like 'eligibility of invoking dhs call', 'naturalized_citizen', true
+      it_behaves_like 'eligibility of invoking dhs call', 'non_native_not_lawfully_present_in_us', false
+      it_behaves_like 'eligibility of invoking dhs call', 'not_lawfully_present_in_us', false
+      it_behaves_like 'eligibility of invoking dhs call', 'us_citizen', false
+    end
+  end
+end

--- a/spec/models/consumer_role_spec.rb
+++ b/spec/models/consumer_role_spec.rb
@@ -505,12 +505,22 @@ context 'Verification process and notices' do
         end
       end
 
-      context 'coverage_purchased_no_residency' do
+      # DHS calls will not made for people who are 'us_citizen'
+      context 'coverage_purchased_no_residency with us_citizen' do
         it_behaves_like 'IVL state machine transitions and verification_types validation_status', '999001234', 'us_citizen', :unverified, :verification_outstanding, 'coverage_purchased_no_residency!', ["Social Security Number"],
                         "negative_response_received"
-        it_behaves_like 'IVL state machine transitions and verification_types validation_status', '999001234', 'us_citizen', :unverified, :verification_outstanding, 'coverage_purchased_no_residency!', ["Citizenship"], "pending"
+        it_behaves_like 'IVL state machine transitions and verification_types validation_status', '999001234', 'us_citizen', :unverified, :verification_outstanding, 'coverage_purchased_no_residency!', ["Citizenship"], "negative_response_received"
         it_behaves_like 'IVL state machine transitions and verification_types validation_status', '111111111', 'us_citizen', :unverified, :ssa_pending, 'coverage_purchased_no_residency!', ["Social Security Number"], "pending"
-        it_behaves_like 'IVL state machine transitions and verification_types validation_status', '111111111', 'us_citizen', :unverified, :ssa_pending, 'coverage_purchased_no_residency!', ["Citizenship"], "pending"
+        it_behaves_like 'IVL state machine transitions and verification_types validation_status', '111111111', 'us_citizen', :unverified, :ssa_pending, 'coverage_purchased_no_residency!', ["Citizenship"], "unverified"
+      end
+
+      # DHS calls will be made for people who are 'naturalized_citizen'
+      context 'coverage_purchased_no_residency with naturalized_citizen' do
+        it_behaves_like 'IVL state machine transitions and verification_types validation_status', '999001234', 'naturalized_citizen', :unverified, :verification_outstanding, 'coverage_purchased_no_residency!', ["Social Security Number"],
+                        "negative_response_received"
+        it_behaves_like 'IVL state machine transitions and verification_types validation_status', '999001234', 'naturalized_citizen', :unverified, :verification_outstanding, 'coverage_purchased_no_residency!', ["Citizenship"], "pending"
+        it_behaves_like 'IVL state machine transitions and verification_types validation_status', '111111111', 'naturalized_citizen', :unverified, :ssa_pending, 'coverage_purchased_no_residency!', ["Social Security Number"], "pending"
+        it_behaves_like 'IVL state machine transitions and verification_types validation_status', '111111111', 'naturalized_citizen', :unverified, :ssa_pending, 'coverage_purchased_no_residency!', ["Citizenship"], "pending"
       end
     end
 
@@ -652,6 +662,9 @@ context 'Verification process and notices' do
           consumer.verification_types.each do |verif|
             if verif.type_name == 'American Indian Status'
               expect(verif.validation_status).to eq('negative_response_received')
+            elsif verif.type_name == 'Citizenship'
+              # Validation Status stays same as we will not make DHS call for people who are 'us_citizen'
+              expect(verif.validation_status).to eq('unverified')
             else
               expect(verif.validation_status).to eq('pending')
             end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186062363](https://www.pivotaltracker.com/story/show/186062363)

# A brief description of the changes

Current behavior: DHS calls are being made for all consumers irrespective of their citizen status.

New behavior: DHS will be made irrespective of whether an SSN exists if the member attested as a Naturalized Citizen or has Eligible Immigrant Status.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.