### PR TITLE
check tribe codes when enabling AI/AN verif_type

### DIFF
--- a/app/controllers/concerns/vlp_doc.rb
+++ b/app/controllers/concerns/vlp_doc.rb
@@ -106,15 +106,15 @@ module VlpDoc
       tribal_id = params.dig("person", "tribal_id")
 
       if tribal_state == EnrollRegistry[:enroll_app].setting(:state_abbreviation).item
-        role.person.send("tribe_codes") != tribe_codes
+        role.person.tribe_codes != tribe_codes
       elsif tribal_id.present?
-        role.person.send("tribal_id") != tribal_id
+        role.person.tribal_id != tribal_id
       else
-        role.person.send("tribal_name") != tribal_name
+        role.person.tribal_name != tribal_name
       end
     else
       params_hash = params.permit("tribal_id").to_h
-      role.person.send("tribal_id") != params_hash["tribal_id"]
+      role.person.tribal_id != params_hash["tribal_id"]
     end
   end
 end

--- a/app/controllers/concerns/vlp_doc.rb
+++ b/app/controllers/concerns/vlp_doc.rb
@@ -100,11 +100,10 @@ module VlpDoc
     return unless role
 
     if EnrollRegistry.feature_enabled?(:indian_alaskan_tribe_codes)
-      person_params = params[:person]
-      tribal_state = person_params[:tribal_state]
-      tribe_codes =  person_params[:tribe_codes]
-      tribal_name = person_params[:tribal_name]
-      tribal_id = person_params[:tribal_id]
+      tribal_state = params.dig("person", "tribal_state")
+      tribe_codes =  params.dig("person", "tribe_codes")
+      tribal_name = params.dig("person", "tribal_name")
+      tribal_id = params.dig("person", "tribal_id")
 
       if tribal_state == EnrollRegistry[:enroll_app].setting(:state_abbreviation).item
         role.person.send("tribe_codes") != tribe_codes

--- a/app/controllers/concerns/vlp_doc.rb
+++ b/app/controllers/concerns/vlp_doc.rb
@@ -104,9 +104,12 @@ module VlpDoc
       tribal_state = person_params[:tribal_state]
       tribe_codes =  person_params[:tribe_codes]
       tribal_name = person_params[:tribal_name]
+      tribal_id = person_params[:tribal_id]
 
       if tribal_state == EnrollRegistry[:enroll_app].setting(:state_abbreviation).item
         role.person.send("tribe_codes") != tribe_codes
+      elsif tribal_id.present?
+        role.person.send("tribal_id") != tribal_id
       else
         role.person.send("tribal_name") != tribal_name
       end

--- a/app/controllers/concerns/vlp_doc.rb
+++ b/app/controllers/concerns/vlp_doc.rb
@@ -98,7 +98,7 @@ module VlpDoc
 
   def native_status_changed?(role)
     return unless role
-    
+
     if EnrollRegistry.feature_enabled?(:indian_alaskan_tribe_codes)
       person_params = params[:person]
       tribal_state = person_params[:tribal_state]

--- a/app/controllers/concerns/vlp_doc.rb
+++ b/app/controllers/concerns/vlp_doc.rb
@@ -98,7 +98,21 @@ module VlpDoc
 
   def native_status_changed?(role)
     return unless role
-    params_hash = params.permit("tribal_id").to_h
-    role.person.send("tribal_id") != params_hash["tribal_id"]
+    
+    if EnrollRegistry.feature_enabled?(:indian_alaskan_tribe_codes)
+      person_params = params[:person]
+      tribal_state = person_params[:tribal_state]
+      tribe_codes =  person_params[:tribe_codes]
+      tribal_name = person_params[:tribal_name]
+
+      if tribal_state == EnrollRegistry[:enroll_app].setting(:state_abbreviation).item
+        role.person.send("tribe_codes") != tribe_codes
+      else
+        role.person.send("tribal_name") != tribal_name
+      end
+    else
+      params_hash = params.permit("tribal_id").to_h
+      role.person.send("tribal_id") != params_hash["tribal_id"]
+    end
   end
 end

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -1267,7 +1267,6 @@ class ConsumerRole
   end
 
   def ensure_native_validation
-  
     self.native_validation = "na" if EnrollRegistry[:indian_alaskan_tribe_details].enabled? && (tribal_state.nil? || tribal_state.empty? || check_tribal_name.nil? || check_tribal_name.empty?)
 
     if tribal_id.nil? || tribal_id.empty?

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -785,7 +785,7 @@ class ConsumerRole
         live_types << 'Immigration status' if us_citizen != nil
       end
       inactive = verification_types.map(&:type_name) - live_types
-      new_types = live_types - person.verification_types.active.map(&:type_name)
+      new_types = live_types - verification_types.active.map(&:type_name)
       person.deactivate_types(inactive)
       new_types.each do |new_type|
         person.add_new_verification_type(new_type)

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -914,3 +914,6 @@ registry:
       - key: :back_to_account_all_shop
         item: :back_to_account_all_shop
         is_enabled: <%= ENV['BACK_TO_ACCOUNT_ALL_SHOP_IS_ENABLED'] || false %>
+      - key: :indian_alaskan_tribe_codes
+        item: :indian_alaskan_tribe_codes
+        is_enabled: <%= ENV['INDIAN_ALASKAN_TRIBE_CODES_IS_ENABLED'] || false %>

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -901,3 +901,6 @@ registry:
       - key: :back_to_account_all_shop
         item: :back_to_account_all_shop
         is_enabled: <%= ENV['BACK_TO_ACCOUNT_ALL_SHOP_IS_ENABLED'] || false %>
+      - key: :indian_alaskan_tribe_codes
+        item: :indian_alaskan_tribe_codes
+        is_enabled: <%= ENV['INDIAN_ALASKAN_TRIBE_CODES_IS_ENABLED'] || false %>

--- a/spec/controllers/concerns/vlp_doc_spec.rb
+++ b/spec/controllers/concerns/vlp_doc_spec.rb
@@ -323,4 +323,93 @@ describe FakesController do
       end
     end
   end
+
+  describe "#native_status_changed?" do
+
+    let(:consumer_role) { FactoryBot.build(:consumer_role, tribal_state: 'ME', tribe_codes: ["PR"], tribal_name: "Tribe1") }
+
+    before :each do
+      EnrollRegistry[:indian_alaskan_tribe_codes].feature.stub(:is_enabled).and_return(true)
+      allow(subject).to receive(:params).and_return params.deep_symbolize_keys
+      allow(EnrollRegistry[:enroll_app].setting(:state_abbreviation)).to receive(:item).and_return('ME')
+    end
+
+    context "tribe located inside ME" do
+
+      context "tribe codes have changed" do
+
+        let(:params) do
+          {
+            'person' => {
+              "tribal_state" => "ME",
+              "tribal_name" => "",
+              "tribe_codes" => ["LA"],
+            }
+          }
+        end
+
+        it "returns true if tribe codes have changed" do
+          expect(subject.native_status_changed?(consumer_role)).to eql(true)
+        end
+      end
+
+      context "tribe codes have not changed"  do
+
+        let(:params) do
+          {
+            'person' => {
+              "tribal_state" => "ME",
+              "tribal_name" => "",
+              "tribe_codes" => ["PR"],
+            }
+          }
+        end
+  
+        it "returns false if tribe codes have not changed" do
+          expect(subject.native_status_changed?(consumer_role)).to eql(false)
+        end
+      end
+    end
+
+    context "tribe located outside ME" do
+
+      context "tribe name has changed" do
+
+        let(:params) do
+          {
+            'person' => {
+              "tribal_state" => "CA",
+              "tribal_name" => "Tribe2",
+              "tribe_codes" => "",
+            }
+          }
+        end
+  
+        it "returns true if tribal name has changed" do
+          expect(subject.native_status_changed?(consumer_role)).to eql(true)
+        end
+      end
+
+      context "tribe name has not changed" do
+
+        let(:params) do
+          {
+            'person' => {
+              "tribal_state" => "CA",
+              "tribal_name" => "Tribe1",
+              "tribe_codes" => "",
+            }
+          }
+        end
+  
+        it "returns false if tribal name has not changed" do
+          expect(subject.native_status_changed?(consumer_role)).to eql(false)
+        end
+
+      end
+
+      
+    end
+
+  end
 end

--- a/spec/controllers/concerns/vlp_doc_spec.rb
+++ b/spec/controllers/concerns/vlp_doc_spec.rb
@@ -343,7 +343,7 @@ describe FakesController do
             'person' => {
               "tribal_state" => "ME",
               "tribal_name" => "",
-              "tribe_codes" => ["LA"],
+              "tribe_codes" => ["LA"]
             }
           }
         end
@@ -360,11 +360,11 @@ describe FakesController do
             'person' => {
               "tribal_state" => "ME",
               "tribal_name" => "",
-              "tribe_codes" => ["PR"],
+              "tribe_codes" => ["PR"]
             }
           }
         end
-  
+
         it "returns false if tribe codes have not changed" do
           expect(subject.native_status_changed?(consumer_role)).to eql(false)
         end
@@ -380,11 +380,11 @@ describe FakesController do
             'person' => {
               "tribal_state" => "CA",
               "tribal_name" => "Tribe2",
-              "tribe_codes" => "",
+              "tribe_codes" => ""
             }
           }
         end
-  
+
         it "returns true if tribal name has changed" do
           expect(subject.native_status_changed?(consumer_role)).to eql(true)
         end
@@ -397,19 +397,15 @@ describe FakesController do
             'person' => {
               "tribal_state" => "CA",
               "tribal_name" => "Tribe1",
-              "tribe_codes" => "",
+              "tribe_codes" => ""
             }
           }
         end
-  
+
         it "returns false if tribal name has not changed" do
           expect(subject.native_status_changed?(consumer_role)).to eql(false)
         end
-
       end
-
-      
     end
-
   end
 end

--- a/spec/controllers/concerns/vlp_doc_spec.rb
+++ b/spec/controllers/concerns/vlp_doc_spec.rb
@@ -330,13 +330,16 @@ describe FakesController do
 
     before :each do
       EnrollRegistry[:indian_alaskan_tribe_codes].feature.stub(:is_enabled).and_return(true)
-      allow(subject).to receive(:params).and_return params.deep_symbolize_keys
       allow(EnrollRegistry[:enroll_app].setting(:state_abbreviation)).to receive(:item).and_return('ME')
     end
 
     context "tribe located inside ME" do
 
       context "tribe codes have changed" do
+
+        before do 
+          allow(subject).to receive(:params).and_return params
+        end
 
         let(:params) do
           {
@@ -354,6 +357,10 @@ describe FakesController do
       end
 
       context "tribe codes have not changed"  do
+
+        before do 
+          allow(subject).to receive(:params).and_return params
+        end
 
         let(:params) do
           {
@@ -375,6 +382,10 @@ describe FakesController do
 
       context "tribe name has changed" do
 
+        before do 
+          allow(subject).to receive(:params).and_return params
+        end
+
         let(:params) do
           {
             'person' => {
@@ -391,6 +402,10 @@ describe FakesController do
       end
 
       context "tribe name has not changed" do
+
+        before do 
+          allow(subject).to receive(:params).and_return params
+        end
 
         let(:params) do
           {

--- a/spec/controllers/concerns/vlp_doc_spec.rb
+++ b/spec/controllers/concerns/vlp_doc_spec.rb
@@ -337,7 +337,7 @@ describe FakesController do
 
       context "tribe codes have changed" do
 
-        before do 
+        before do
           allow(subject).to receive(:params).and_return params
         end
 
@@ -358,7 +358,7 @@ describe FakesController do
 
       context "tribe codes have not changed"  do
 
-        before do 
+        before do
           allow(subject).to receive(:params).and_return params
         end
 
@@ -382,7 +382,7 @@ describe FakesController do
 
       context "tribe name has changed" do
 
-        before do 
+        before do
           allow(subject).to receive(:params).and_return params
         end
 
@@ -403,7 +403,7 @@ describe FakesController do
 
       context "tribe name has not changed" do
 
-        before do 
+        before do
           allow(subject).to receive(:params).and_return params
         end
 

--- a/spec/models/consumer_role_spec.rb
+++ b/spec/models/consumer_role_spec.rb
@@ -375,7 +375,7 @@ context 'Verification process and notices' do
         EnrollRegistry[:indian_alaskan_tribe_details].feature.stub(:is_enabled).and_return(true)
         EnrollRegistry[:indian_alaskan_tribe_codes].feature.stub(:is_enabled).and_return(true)
         allow(EnrollRegistry[:enroll_app].setting(:state_abbreviation)).to receive(:item).and_return('ME')
-        person.update_attributes!(tribal_state: "ME", tribe_codes: ["", "PE"]) 
+        person.update_attributes!(tribal_state: "ME", tribe_codes: ["", "PE"])
         v_type = VerificationType.new(type_name: "American Indian Status", validation_status: 'outstanding', inactive: false)
         person1.verification_types << v_type
         person1.save!
@@ -388,7 +388,7 @@ context 'Verification process and notices' do
         expect(ai_an_type.inactive).to eql(false)
       end
     end
-  
+
     context "native validation doesn't exist" do
       it_behaves_like 'ensures native american field value', 'assigns', 'na', 'NON native american consumer', nil, nil
 
@@ -407,13 +407,13 @@ context 'Verification process and notices' do
       EnrollRegistry[:indian_alaskan_tribe_details].feature.stub(:is_enabled).and_return(true)
       EnrollRegistry[:indian_alaskan_tribe_codes].feature.stub(:is_enabled).and_return(true)
       allow(EnrollRegistry[:enroll_app].setting(:state_abbreviation)).to receive(:item).and_return('ME')
-      
+
     end
 
     context "tribal state is ME" do
 
       before do
-        person.update_attributes!(tribal_state: "ME", tribe_codes: ["", "PE"]) 
+        person.update_attributes!(tribal_state: "ME", tribe_codes: ["", "PE"])
       end
 
       it "returns tribal codes" do
@@ -422,10 +422,10 @@ context 'Verification process and notices' do
     end
 
     context "tribal state is outside ME" do
-      before do 
-        person.update_attributes!(tribal_state: "CA", tribe_codes: [], tribal_name: 'tribal name1') 
+      before do
+        person.update_attributes!(tribal_state: "CA", tribe_codes: [], tribal_name: 'tribal name1')
       end
-     
+
       it "returns tribal name" do
         expect(person.consumer_role.check_tribal_name).to eq("tribal name1")
       end

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -914,3 +914,6 @@ registry:
       - key: :back_to_account_all_shop
         item: :back_to_account_all_shop
         is_enabled: <%= ENV['BACK_TO_ACCOUNT_ALL_SHOP_IS_ENABLED'] || false %>
+      - key: :indian_alaskan_tribe_codes
+        item: :indian_alaskan_tribe_codes
+        is_enabled: <%= ENV['INDIAN_ALASKAN_TRIBE_CODES_IS_ENABLED'] || false %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-186050736](https://www.pivotaltracker.com/n/projects/2640060/stories/186050736)

# A brief description of the changes

Current behavior: If a consumer has AI/AN status and their tribe is located in Maine their AI/AN verification type becomes deactivated every time the consumer role is saved. 

New behavior: The consumer's AI/AN status will not be deactivated and checks to see if the consumer's AI/AN status will be consistent.

# Feature Flag: INDIAN_ALASKAN_TRIBE_CODES_IS_ENABLED

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.