### PR TITLE
set due date on evedinces on moving to outstanding state

### DIFF
--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -372,7 +372,8 @@ module Eligibilities
     def record_transition
       self.workflow_state_transitions << WorkflowStateTransition.new(
         from_state: aasm.from_state,
-        to_state: aasm.to_state
+        to_state: aasm.to_state,
+        event: aasm.current_event
       )
     end
 

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1326,7 +1326,7 @@ module FinancialAssistance
       evidence.verification_outstanding = true
       evidence.due_on = desired_due_date if desired_due_date.present?
       evidence.is_satisfied = false
-      evidence.due_on = schedule_verification_due_on if evidence.due_on.blank?
+      evidence.due_on = (desired_due_date || schedule_verification_due_on) if evidence.due_on.blank?
       evidence.move_to_outstanding
       save!
     end

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1283,7 +1283,6 @@ module FinancialAssistance
         aptc_or_csr_used = enrollment.applied_aptc_amount > 0 || ['02', '04', '05', '06'].include?(enrollment.product.csr_variant_id)
 
         if aptc_or_csr_used && ['pending', 'negative_response_received'].include?(evidence.aasm_state)
-          evidence.due_on = schedule_verification_due_on if evidence.due_on.blank?
           set_evidence_outstanding(evidence)
         elsif !aptc_or_csr_used
           set_evidence_to_negative_response(evidence)
@@ -1325,6 +1324,7 @@ module FinancialAssistance
 
       evidence.verification_outstanding = true
       evidence.is_satisfied = false
+      evidence.due_on = schedule_verification_due_on if evidence.due_on.blank?
       evidence.move_to_outstanding
       save!
     end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::MedicaidGateway:
             @applicant.reload
             expect(@applicant.local_mec_evidence.aasm_state).to eq "outstanding"
             expect(@applicant.local_mec_evidence.request_results.present?).to eq true
-            expect(@applicant.local_mec_evidence.due_on).to eq nil
+            expect(@applicant.local_mec_evidence.due_on).not_to eq nil
             expect(@result.success).to eq('Successfully updated Applicant with evidences and verifications')
           end
         end

--- a/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
@@ -1464,11 +1464,13 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
 
         let(:current_evidence) { applicant.income_evidence }
 
-        it 'should set evidence verified' do
+        it 'should move evidence to outstanding and set due date' do
           expect(current_evidence.pending?).to be_truthy
+          expect(current_evidence.due_on).to eq nil
           applicant.set_evidence_outstanding(current_evidence)
           current_evidence.reload
           expect(current_evidence.verification_outstanding).to be_truthy
+          expect(current_evidence.due_on).not_to eq nil
         end
 
         it 'should set is_satisfied and verification_outstanding' do

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -699,6 +699,11 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
         it 'should transition to rejected' do
           expect(income_evidence.aasm_state).to eq 'rejected'
         end
+
+        it 'should have event on workflow state transistions' do
+          workflow_st = income_evidence.workflow_state_transitions.last
+          expect(workflow_st.event).to eq 'move_to_rejected!'
+        end
       end
 
       it_behaves_like "transition to rejected", 'pending'


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/n/projects/2640059/stories/186061798

https://www.pivotaltracker.com/n/projects/2640059/stories/186071774

# A brief description of the changes

Current behavior:
due_on is not setting on moving to outstanding state
event name is missing on evidence workflow state transitions

New behavior:
setting due_on when we are moving evidence to outstanding state
setting event name on evidence workflow state transitions


# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.