### PR TITLE
Fix duplicate translation warnings

### DIFF
--- a/db/seedfiles/translations/en/dc/broker_agencies.rb
+++ b/db/seedfiles/translations/en/dc/broker_agencies.rb
@@ -24,7 +24,6 @@ BROKER_AGENCIES_TRANSLATIONS = {
 	"en.broker_agencies.profiles.broker_agency_message" => "Broker Agency Message",
 	"en.broker_agencies.profiles.send_secure_message" => "Send Secure Message to %{site_short_name}",
 	"en.assign" => "Assign",
-  "en.broker_agency" => "Broker Agency",
   "en.add_broker_staff_role" => "Add Broker Staff Role",
   "en.broker_agency_staff" => "Broker Agency Staff",
 	"en.general_agencies" => "General Agencies",

--- a/db/seedfiles/translations/en/dc/employer.rb
+++ b/db/seedfiles/translations/en/dc/employer.rb
@@ -35,7 +35,6 @@ EMPLOYER_TRANSLATIONS = {
   :'en.osse_eligibility_question' => 'Does this business qualify for HC4CC subsidies?',
   :'en.osse_bqt_eligibility_question' => 'Are you creating a quote for a business participating in HC4CC?',
   :'en.osse_eligibility_ivl_question' => 'Does this consumer qualify for HC4CC?',
-  :'en.eligibility_history' => 'View eligibility history',
   :'en.osse_subsidy_title' => 'HealthCare4ChildCare (HC4CC) Program',
   :'en.ivl_osse_subsidy_title_line_1' => 'HealthCare4ChildCare Through DC Health Link:',
   :'en.ivl_osse_subsidy_title_line_2' => 'Affordable health coverage for early childhood providers and their teams',


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/story/show/185958090
# A brief description of the changes

Current behavior:

We observe below warnings:
/home/runner/work/enroll/enroll/db/seedfiles/translations/en/dc/broker_agencies.rb:27: warning: key "en.broker_agency" is duplicated and overwritten on line 90
/home/runner/work/enroll/enroll/db/seedfiles/translations/en/dc/employer.rb:38: warning: key :"en.eligibility_history" is duplicated and overwritten on line 42

New behavior:

Fixes the warnings and cleans up duplicate translation keys.
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.