### PR TITLE
Update due date on Local Mec evidence when bulk call is made

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application.rb
@@ -76,7 +76,7 @@ module FinancialAssistance
           def fetch_evidence_due_date_for_bulk_actions(applicant_local_mec_evidence, response_evidence)
             return applicant_local_mec_evidence.due_on if applicant_local_mec_evidence.due_on.present?
             return unless response_evidence.request_results.any? do |result|
-              FinancialAssistance::Applicant::HUB_CALL_ACTION_TYPES.include?(result.action)
+              FinancialAssistance::Applicant::BULK_REDETERMINATION_ACTION_TYPES.include?(result.action)
             end
 
             TimeKeeper.date_of_record + EnrollRegistry[:bulk_call_verification_due_in_days].item.to_i

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application.rb
@@ -79,7 +79,7 @@ module FinancialAssistance
               FinancialAssistance::Applicant::HUB_CALL_ACTION_TYPES.include?(result.action)
             end
 
-            TimeKeeper.date_of_record + EnrollRegistry[:bulk_call_verification_due_in_days].item
+            TimeKeeper.date_of_record + EnrollRegistry[:bulk_call_verification_due_in_days].item.to_i
           end
 
           def enrolled?(applicant, enrollments)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application.rb
@@ -55,7 +55,8 @@ module FinancialAssistance
             if applicant_local_mec_evidence.present?
               if response_evidence.aasm_state == 'outstanding'
                 if enrolled?(applicant, enrollments)
-                  applicant.set_evidence_outstanding(applicant_local_mec_evidence)
+                  due_date = fetch_evidence_due_date_for_bulk_actions(applicant_local_mec_evidence, response_evidence)
+                  applicant.set_evidence_outstanding(applicant_local_mec_evidence, due_date)
                 else
                   applicant.set_evidence_to_negative_response(applicant_local_mec_evidence)
                 end
@@ -70,6 +71,15 @@ module FinancialAssistance
             end
 
             Success(applicant)
+          end
+
+          def fetch_evidence_due_date_for_bulk_actions(applicant_local_mec_evidence, response_evidence)
+            return applicant_local_mec_evidence.due_on if applicant_local_mec_evidence.due_on.present?
+            return unless response_evidence.request_results.any? do |result|
+              FinancialAssistance::Applicant::HUB_CALL_ACTION_TYPES.include?(result.action)
+            end
+
+            TimeKeeper.date_of_record + EnrollRegistry[:bulk_call_verification_due_in_days].item
           end
 
           def enrolled?(applicant, enrollments)

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1321,11 +1321,11 @@ module FinancialAssistance
       save!
     end
 
-    def set_evidence_outstanding(evidence, due_date = nil)
+    def set_evidence_outstanding(evidence, desired_due_date = nil)
       return unless evidence.may_move_to_outstanding?
 
       evidence.verification_outstanding = true
-      evidence.due_on = due_date if evidence.due_on.blank?
+      evidence.due_on = desired_due_date if desired_due_date.present?
       evidence.is_satisfied = false
       evidence.move_to_outstanding
       save!

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -15,7 +15,7 @@ module FinancialAssistance
     embedded_in :application, class_name: "::FinancialAssistance::Application", inverse_of: :applicants
 
     TAX_FILER_KINDS = %w[tax_filer single joint separate dependent non_filer].freeze
-    HUB_CALL_ACTION_TYPES = ["Bulk Call"].freeze
+    BULK_REDETERMINATION_ACTION_TYPES = ["Bulk Call"].freeze
     STUDENT_KINDS = %w[
       dropped_out
       elementary

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -15,6 +15,7 @@ module FinancialAssistance
     embedded_in :application, class_name: "::FinancialAssistance::Application", inverse_of: :applicants
 
     TAX_FILER_KINDS = %w[tax_filer single joint separate dependent non_filer].freeze
+    HUB_CALL_ACTION_TYPES = ["Bulk Call"].freeze
     STUDENT_KINDS = %w[
       dropped_out
       elementary
@@ -1320,10 +1321,11 @@ module FinancialAssistance
       save!
     end
 
-    def set_evidence_outstanding(evidence)
+    def set_evidence_outstanding(evidence, due_date = nil)
       return unless evidence.may_move_to_outstanding?
 
       evidence.verification_outstanding = true
+      evidence.due_on = due_date if evidence.due_on.blank?
       evidence.is_satisfied = false
       evidence.move_to_outstanding
       save!

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::MedicaidGateway:
           end
 
           it 'should set due_on on local mec evidence' do
-            due_date = TimeKeeper.date_of_record + EnrollRegistry[:bulk_call_verification_due_in_days].item
+            due_date = TimeKeeper.date_of_record + EnrollRegistry[:bulk_call_verification_due_in_days].item.to_i
             @applicant.reload
             expect(@applicant.local_mec_evidence.aasm_state).to eq "outstanding"
             expect(@applicant.local_mec_evidence.due_on).to eq due_date

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_mec_check_application_spec.rb
@@ -34,11 +34,14 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::MedicaidGateway:
       include_context 'ACES MEC Check sample response'
 
       let(:payload) { response_payload }
+      let(:due_on) { nil }
+      let(:aasm_state) { 'attested' }
 
       before do
         enrollment
         @applicant = application.applicants.first
-        @applicant.build_local_mec_evidence(key: :local_mec, title: "Local MEC")
+        @applicant.build_local_mec_evidence(key: :local_mec, title: "Local MEC", aasm_state: aasm_state,
+                                            due_on: due_on)
         @applicant.save
         @result = subject.call(payload)
 
@@ -96,6 +99,45 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::MedicaidGateway:
           end
         end
 
+        context 'Bulk Local Mec call and not enrolled' do
+          let(:request_result_hash) do
+            {
+              :result => "eligible",
+              :source => "MEDC",
+              :code => "7313",
+              :code_description => "Applicant Not Found",
+              :action => 'Bulk Call'
+            }
+          end
+
+
+          it 'should return success' do
+            expect(@result).to be_success
+          end
+
+          it 'should not set due_on on local mec evidence' do
+            @applicant.reload
+            expect(@applicant.local_mec_evidence.aasm_state).to eq "negative_response_received"
+            expect(@applicant.local_mec_evidence.due_on).to eq nil
+          end
+        end
+
+        context 'Bulk Local Mec call, enrolled and due date already exists on evidence' do
+          let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members, family: family, enrollment_members: family.family_members) }
+          let(:due_on) { TimeKeeper.date_of_record }
+          let(:aasm_state) { 'outstanding' }
+
+          it 'should return success' do
+            expect(@result).to be_success
+          end
+
+          it 'should not update due_on on local mec evidence' do
+            @applicant.reload
+            expect(@applicant.local_mec_evidence.aasm_state).to eq "outstanding"
+            expect(@applicant.local_mec_evidence.due_on).to eq TimeKeeper.date_of_record
+          end
+        end
+
         context 'when enrolled' do
           let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members, family: family, enrollment_members: family.family_members) }
 
@@ -107,7 +149,32 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::MedicaidGateway:
             @applicant.reload
             expect(@applicant.local_mec_evidence.aasm_state).to eq "outstanding"
             expect(@applicant.local_mec_evidence.request_results.present?).to eq true
+            expect(@applicant.local_mec_evidence.due_on).to eq nil
             expect(@result.success).to eq('Successfully updated Applicant with evidences and verifications')
+          end
+        end
+
+        context "Bulk Local Mec call and enrolled" do
+          let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members, family: family, enrollment_members: family.family_members) }
+          let(:request_result_hash) do
+            {
+              :result => "eligible",
+              :source => "MEDC",
+              :code => "7313",
+              :code_description => "Applicant Not Found",
+              :action => 'Bulk Call'
+            }
+          end
+
+          it 'should return success' do
+            expect(@result).to be_success
+          end
+
+          it 'should set due_on on local mec evidence' do
+            due_date = TimeKeeper.date_of_record + EnrollRegistry[:bulk_call_verification_due_in_days].item
+            @applicant.reload
+            expect(@applicant.local_mec_evidence.aasm_state).to eq "outstanding"
+            expect(@applicant.local_mec_evidence.due_on).to eq due_date
           end
         end
       end

--- a/components/financial_assistance/spec/shared_examples/medicaid_gateway/test_aces_mec_response.rb
+++ b/components/financial_assistance/spec/shared_examples/medicaid_gateway/test_aces_mec_response.rb
@@ -183,20 +183,7 @@ RSpec.shared_context 'ACES MEC Check sample response', :shared_context => :metad
             :tution_and_fees => 0,
             :other_magi_eligible_income => 0
           },
-          :local_mec_evidence => {
-            :key => :local_mec,
-            :title => "Local MEC",
-            :description => nil,
-            :aasm_state => "verified",
-            :due_on => nil,
-            :updated_by => nil,
-            :request_results => [{
-              :result => "eligible",
-              :source => "MEDC",
-              :code => "7313",
-              :code_description => "Applicant Not Found"
-            }]
-          },
+          :local_mec_evidence => local_mec_evidence,
           :mitc_relationships => [],
           :mitc_is_required_to_file_taxes => false
         }
@@ -258,6 +245,27 @@ RSpec.shared_context 'ACES MEC Check sample response', :shared_context => :metad
           :dependents => []
         }
       ]
+    }
+  end
+
+  let(:local_mec_evidence) do
+    {
+      :key => :local_mec,
+      :title => "Local MEC",
+      :description => nil,
+      :aasm_state => "verified",
+      :due_on => nil,
+      :updated_by => nil,
+      :request_results => [request_result_hash]
+    }
+  end
+
+  let(:request_result_hash) do
+    {
+      :result => "eligible",
+      :source => "MEDC",
+      :code => "7313",
+      :code_description => "Applicant Not Found"
     }
   end
 end

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -17,6 +17,9 @@ registry:
       - key: :verification_document_due_in_days
         item: 96
         is_enabled: true
+      - key: :bulk_call_verification_due_in_days
+        item: <%= ENV['BULK_CALL_VERIFICATION_DUE_IN_DAYS'] || 35 %>
+        is_enabled: true
       - key: :ivl_eligibility_notices
         is_enabled: true
         settings:

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -17,6 +17,9 @@ registry:
       - key: :verification_document_due_in_days
         item: 96
         is_enabled: true
+      - key: :bulk_call_verification_due_in_days
+        item: <%= ENV['BULK_CALL_VERIFICATION_DUE_IN_DAYS'] || 35 %>
+        is_enabled: true
       - key: :ivl_eligibility_notices
         is_enabled: true
         settings:

--- a/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -17,6 +17,9 @@ registry:
       - key: :verification_document_due_in_days
         item: 96
         is_enabled: true
+      - key: :bulk_call_verification_due_in_days
+        item: <%= ENV['BULK_CALL_VERIFICATION_DUE_IN_DAYS'] || 35 %>
+        is_enabled: true
       - key: :ivl_eligibility_notices
         is_enabled: true
         settings:


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186061790

# A brief description of the changes

Current behavior: Due date is not set when a bulk call is made for local mec service and the response comes back as outstanding

New behavior: Set due date on Local MEC evidence to System_date + 35.days when a bulk call is made, and response is outstanding. Only set due if the application is enrolled in an APTC or CSR-eligible plan

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [X] DC
- [X] ME

# Additional Context
Added environment variables to for number of due in days to be set on evidence
BULK_CALL_VERIFICATION_DUE_IN_DAYS=35