### PR TITLE
add the necessary correlation id when an application determined event is published

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/magi_medicaid_application_determined.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/magi_medicaid_application_determined.rb
@@ -23,7 +23,7 @@ module FinancialAssistance
 
           def build_event(payload, application_id, local_mec_check)
             headers = { correlation_id: application_id }
-            headers = headers.merge!(payload_type: 'application', key: 'local_mec_check') if local_mec_check
+            headers.merge!(payload_type: 'application', key: 'local_mec_check') if local_mec_check
             event('events.iap.applications.magi_medicaid_application_determined', attributes: payload.to_h, headers: headers.merge!(payload_format))
           end
 

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/magi_medicaid_application_determined.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/magi_medicaid_application_determined.rb
@@ -22,7 +22,8 @@ module FinancialAssistance
           private
 
           def build_event(payload, application_id, local_mec_check)
-            headers = local_mec_check ? { payload_type: 'application', key: 'local_mec_check' } : { correlation_id: application_id }
+            headers = { correlation_id: application_id }
+            headers = headers.merge!(payload_type: 'application', key: 'local_mec_check') if local_mec_check
             event('events.iap.applications.magi_medicaid_application_determined', attributes: payload.to_h, headers: headers.merge!(payload_format))
           end
 

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/publish_magi_medicaid_application_determined.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/publish_magi_medicaid_application_determined.rb
@@ -20,7 +20,7 @@ module FinancialAssistance
             valid_application  = yield validate_application(application)
             payload_param      = yield construct_payload(valid_application)
             payload_value      = yield validate_payload(payload_param)
-            payload            = yield publish(payload_value, valid_application.id, application)
+            payload            = yield publish(payload_value, valid_application.hbx_id, application)
 
             Success(payload)
           end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features) See notes below, this is an event source issue

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior: If an application is determined and it is local_mec_checkable it does not include the header of correlation id. This is valid for calls not using the Transmittable framework, but is needed in FDSH for linking jobs and transmissions etc.

New behavior: A correlation_id is always sent in the header of the application determined payload.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
No specs were added as the expected outcome lives only in FDSH