### PR TITLE
skips DHS calls for non-applicants

### DIFF
--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -704,7 +704,7 @@ class ConsumerRole
   end
 
   def eligible_for_invoking_dhs?
-    [NATURALIZED_CITIZEN_STATUS, ALIEN_LAWFULLY_PRESENT_STATUS].include?(citizen_status)
+    is_applying_coverage && [NATURALIZED_CITIZEN_STATUS, ALIEN_LAWFULLY_PRESENT_STATUS].include?(citizen_status)
   end
 
   def invoke_verification!(*args)

--- a/spec/domain/operations/individual/determine_verifications_spec.rb
+++ b/spec/domain/operations/individual/determine_verifications_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Operations::Individual::DetermineVerifications, dbclean: :after_e
       context 'when validate_and_record_publish_errors feature is enabled' do
         let!(:person) {FactoryBot.create(:person, ssn: '999001234')}
         let!(:consumer_role) do
-          consumer = ConsumerRole.new(person: person, is_applicant: true, citizen_status: "us_citizen")
+          consumer = ConsumerRole.new(person: person, is_applicant: true, citizen_status: 'naturalized_citizen')
           consumer.ensure_verification_types
           consumer.save!
           consumer
@@ -185,7 +185,7 @@ RSpec.describe Operations::Individual::DetermineVerifications, dbclean: :after_e
       context 'when validate_and_record_publish_errors feature is disabled' do
         let!(:person) {FactoryBot.create(:person, ssn: '999001234')}
         let!(:consumer_role) do
-          consumer = ConsumerRole.new(person: person, is_applicant: true, citizen_status: "us_citizen")
+          consumer = ConsumerRole.new(person: person, is_applicant: true, citizen_status: 'naturalized_citizen')
           consumer.ensure_verification_types
           consumer.save!
           consumer

--- a/spec/models/consumer_role_invoke_hub_call_spec.rb
+++ b/spec/models/consumer_role_invoke_hub_call_spec.rb
@@ -6,25 +6,42 @@ describe ConsumerRole, dbclean: :around_each do
   before { DatabaseCleaner.clean }
 
   let(:person) { FactoryBot.create(:person, :with_ssn) }
-  let(:consumer_role) { FactoryBot.create(:consumer_role, person: person, lawful_presence_determination: lawful_presence_determination) }
+  let(:consumer_role) do
+    FactoryBot.create(
+      :consumer_role,
+      is_applying_coverage: is_applying_coverage,
+      person: person,
+      lawful_presence_determination: lawful_presence_determination
+    )
+  end
   let(:lawful_presence_determination) { FactoryBot.build(:lawful_presence_determination, citizen_status: citizen_status) }
 
   describe '#eligible_for_invoking_dhs?' do
-    shared_examples_for 'eligibility of invoking dhs call' do |citizen_status, eligible|
+    shared_examples_for 'eligibility of invoking dhs call' do |citizen_status, is_applying_coverage, eligible|
       let(:citizen_status) { citizen_status }
+      let(:is_applying_coverage) { is_applying_coverage }
 
-      it "returns #{eligible} for citizen_status: #{citizen_status}" do
+      it "returns #{eligible} for citizen_status: #{citizen_status} and member attestation #{is_applying_coverage} to coverage required" do
         expect(consumer_role.eligible_for_invoking_dhs?).to eq(eligible)
       end
     end
 
-    context "native validation doesn't exist" do
-      it_behaves_like 'eligibility of invoking dhs call', 'alien_lawfully_present', true
-      it_behaves_like 'eligibility of invoking dhs call', 'lawful_permanent_resident', false
-      it_behaves_like 'eligibility of invoking dhs call', 'naturalized_citizen', true
-      it_behaves_like 'eligibility of invoking dhs call', 'non_native_not_lawfully_present_in_us', false
-      it_behaves_like 'eligibility of invoking dhs call', 'not_lawfully_present_in_us', false
-      it_behaves_like 'eligibility of invoking dhs call', 'us_citizen', false
+    context 'with different citizen status and consumer applying for coverage' do
+      it_behaves_like 'eligibility of invoking dhs call', 'alien_lawfully_present', true, true
+      it_behaves_like 'eligibility of invoking dhs call', 'lawful_permanent_resident', true, false
+      it_behaves_like 'eligibility of invoking dhs call', 'naturalized_citizen', true, true
+      it_behaves_like 'eligibility of invoking dhs call', 'non_native_not_lawfully_present_in_us', true, false
+      it_behaves_like 'eligibility of invoking dhs call', 'not_lawfully_present_in_us', true, false
+      it_behaves_like 'eligibility of invoking dhs call', 'us_citizen', true, false
+    end
+
+    context 'with different citizen status and consumer not applying for coverage' do
+      it_behaves_like 'eligibility of invoking dhs call', 'alien_lawfully_present', false, false
+      it_behaves_like 'eligibility of invoking dhs call', 'lawful_permanent_resident', false, false
+      it_behaves_like 'eligibility of invoking dhs call', 'naturalized_citizen', false, false
+      it_behaves_like 'eligibility of invoking dhs call', 'non_native_not_lawfully_present_in_us', false, false
+      it_behaves_like 'eligibility of invoking dhs call', 'not_lawfully_present_in_us', false, false
+      it_behaves_like 'eligibility of invoking dhs call', 'us_citizen', false, false
     end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186065996](https://www.pivotaltracker.com/story/show/186065996)

# A brief description of the changes

Current behavior: Currently, DHS calls are made for non-applicants

New behavior: DHS calls will not be made for non-applicants

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.