### PR TITLE
only auto extend eligible applicants for the current date

### DIFF
--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -184,10 +184,10 @@ module Eligibilities
       self.due_on = new_date
     end
 
-    def can_be_extended?
-      return false unless type_unverified?
-      extensions = verification_histories.where(action: "auto_extend_due_date")
-      return true unless extensions.any?
+    def can_be_extended?(date)
+      return false unless due_on == date && ['rejected', 'outstanding'].include?(self.aasm_state)
+      extensions = verification_histories&.where(action: "auto_extend_due_date")
+      return true unless extensions && extensions.any?
       #  want this limitation on due date extensions to reset anytime an evidence no longer requires a due date
       # (is moved to 'verified' or 'attested' state) so that an individual can benefit from the extension again in the future.
       auto_extend_time = extensions.last&.created_at

--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -187,7 +187,7 @@ module Eligibilities
     def can_be_extended?(date)
       return false unless due_on == date && ['rejected', 'outstanding'].include?(self.aasm_state)
       extensions = verification_histories&.where(action: "auto_extend_due_date")
-      return true unless extensions && extensions.any?
+      return true unless extensions&.any?
       #  want this limitation on due date extensions to reset anytime an evidence no longer requires a due date
       # (is moved to 'verified' or 'attested' state) so that an individual can benefit from the extension again in the future.
       auto_extend_time = extensions.last&.created_at

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/auto_extend_income_evidence.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/auto_extend_income_evidence.rb
@@ -37,7 +37,7 @@ module FinancialAssistance
           updated_applicants = []
           applications.each do |application|
             application.applicants.each do |applicant|
-              next unless applicant.income_evidence&.can_be_extended?
+              next unless applicant.income_evidence&.can_be_extended?(params[:current_due_on])
               updated_applicants << applicant.person_hbx_id
               applicant.income_evidence.auto_extend_due_on(params[:extend_by].days, params[:modified_by])
             end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/auto_extend_income_evidence_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/auto_extend_income_evidence_spec.rb
@@ -9,271 +9,185 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AutoExtendIncome
     DatabaseCleaner.clean
   end
 
-  describe 'extending income evidence verification due date on an individual applicant level' do
-    let!(:person) { FactoryBot.create(:person, :with_consumer_role, hbx_id: '100095') }
-    let!(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
-    let!(:application) do
-      FactoryBot.create(:application,
-                        family_id: family.id,
-                        aasm_state: "determined",
-                        effective_date: TimeKeeper.date_of_record)
-    end
-
-    let!(:applicant) do
-      FactoryBot.create(:applicant,
-                        application: application,
-                        dob: TimeKeeper.date_of_record - 40.years,
-                        is_primary_applicant: true,
-                        family_member_id: family.family_members[0].id,
-                        person_hbx_id: person.hbx_id,
-                        addresses: [FactoryBot.build(:financial_assistance_address)])
-    end
-
-    let!(:income_evidence) do
-      application.applicants.first.create_income_evidence(key: :income,
-                                                          title: 'Income',
-                                                          aasm_state: 'outstanding',
-                                                          due_on: TimeKeeper.date_of_record,
-                                                          verification_outstanding: true,
-                                                          is_satisfied: false)
-    end
-
-    before do
-      allow(FinancialAssistanceRegistry[:auto_update_income_evidence_due_on].setting(:days)).to receive(:item).and_return(65)
-    end
-
-    context 'success' do
-      context 'with no params submitted' do
-        before do
-          @result = subject.call({})
-          applicant.reload
-        end
-
-        it 'should return success' do
-          expect(@result).to be_success
-          expect(@result.value!.length).to eq(1)
-          expect(@result.value!.include?(person.hbx_id)).to be_truthy
-        end
-
-        it 'should update the income evidence due on for the applicant' do
-          expect(applicant.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record)
-          expect(applicant.income_evidence.due_on).to eq(TimeKeeper.date_of_record + 65.days)
-        end
-
-        it 'should add a verification history recording the update' do
-          history = applicant.income_evidence.verification_histories.last
-          expect(history.action).to eq("auto_extend_due_date")
-          expect(history.updated_by).to eq("system")
-        end
-
-      end
-
-      context 'previously auto extended' do
-        before do
-          income_evidence.verification_histories.create(action: 'auto_extend_due_date', update_reason: 'Auto extended due date', updated_by: 'system')
-          @result = subject.call({})
-        end
-
-        it 'should return success' do
-          expect(@result).to be_success
-          expect(@result.value!.length).to eq(0)
-          expect(@result.value!.include?(person.hbx_id)).to be_falsy
-        end
-
-      end
-
-      context 'previously auto extended then transition to attested or verified' do
-        before do
-          income_evidence.verification_histories.create(action: 'auto_extend_due_date', update_reason: 'Auto extended due date', updated_by: 'system')
-          income_evidence.workflow_state_transitions.create(to_state: "verified", transition_at: TimeKeeper.date_of_record, reason: "met minimum criteria", comment: "consumer provided proper documentation",
-                                                            user_id: BSON::ObjectId.from_time(DateTime.now))
-          @result = subject.call({})
-        end
-
-        it 'should return success' do
-          expect(@result).to be_success
-          expect(@result.value!.length).to eq(1)
-          expect(@result.value!.include?(person.hbx_id)).to be_truthy
-        end
-      end
-
-      context 'with params given' do
-        before do
-          @result = subject.call({extend_by: 35, modified_by: 'admin@ideacrew.com'})
-          applicant.reload
-        end
-
-        it 'should return success' do
-          expect(@result).to be_success
-          expect(@result.value!.length).to eq(1)
-          expect(@result.value!.include?(person.hbx_id)).to be_truthy
-        end
-
-        it 'should update the income evidence due on for the applicant' do
-          expect(applicant.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record)
-          expect(applicant.income_evidence.due_on).to eq(TimeKeeper.date_of_record + 35.days)
-        end
-
-        it 'should add a verification history recording the update' do
-          history = applicant.income_evidence.verification_histories.last
-          expect(history.action).to eq("auto_extend_due_date")
-          expect(history.updated_by).to eq("admin@ideacrew.com")
-        end
-      end
-
-    end
-
-    context 'failure' do
-      context 'with invalid current due on' do
-        it 'should fail' do
-          result = subject.call({current_due_on: "08/08/2023"})
-          expect(result).to be_failure
-          expect(result.failure).to eq("Invalid param for key current_due_on, must be a Date")
-        end
-      end
-
-      context 'with invalid extend_by' do
-        it 'should fail' do
-          result = subject.call({extend_by: "08/08/2023"})
-          expect(result).to be_failure
-          expect(result.failure).to eq("Invalid param for key extend_by, must be an Integer")
-        end
-      end
-
-      context 'with invalid modified_by' do
-        it 'should fail' do
-          result = subject.call({modified_by: 345})
-          expect(result).to be_failure
-          expect(result.failure).to eq("Invalid param for key modified_by, must be a String")
-        end
-      end
-    end
+  let!(:family) { FactoryBot.create(:family, :with_primary_family_member_and_dependent)}
+  let!(:person) { family.primary_person }
+  let!(:application) do
+    FactoryBot.create(:application,
+                      family_id: family.id,
+                      aasm_state: "determined",
+                      effective_date: TimeKeeper.date_of_record)
   end
 
-  describe 'extending income evidence verification due date on a family level' do
-    # Test family with
-    # 1 member eligible for income evidence extension (later due date)
-    # 1 member eligible for income evidence extension (earlier due date)
-    # 1 member ineligible for income evidence extension
-    # Maybe add 1 member with complete verified income evidence?
+  let!(:applicant) do
+    FactoryBot.create(:applicant,
+                      application: application,
+                      dob: TimeKeeper.date_of_record - 40.years,
+                      is_primary_applicant: true,
+                      family_member_id: family.family_members[0].id,
+                      person_hbx_id: person.hbx_id,
+                      addresses: [FactoryBot.build(:financial_assistance_address)])
+  end
 
-    let!(:person) { FactoryBot.create(:person, :with_consumer_role, hbx_id: '100095') }
-    # let!(:family) { FactoryBot.create(:family, :with_nuclear_family, person: person) }
-    let!(:family) { FactoryBot.create(:family, :with_primary_family_member_and_spouse_and_child, person: person) }
-    let!(:address) { FactoryBot.build(:financial_assistance_address) }
-    let(:applicant_1_due_date) { TimeKeeper.date_of_record + 10.days }
-    let(:applicant_2_due_date) { TimeKeeper.date_of_record }
-    let(:applicant_3_due_date) { TimeKeeper.date_of_record + 30.days }
+  let!(:applicant2) do
+    FactoryBot.create(:applicant,
+                      application: application,
+                      dob: TimeKeeper.date_of_record - 25.years,
+                      is_primary_applicant: false,
+                      family_member_id: family.family_members[1].id,
+                      person_hbx_id: family.family_members[1].person.hbx_id,
+                      addresses: [FactoryBot.build(:financial_assistance_address)])
+  end
 
-    let!(:application) do
-      FactoryBot.create(:application,
-                        family_id: family.id,
-                        aasm_state: "determined",
-                        effective_date: (TimeKeeper.date_of_record - 2.days))
+  let!(:applicant3) do
+    FactoryBot.create(:applicant,
+                      application: application,
+                      dob: TimeKeeper.date_of_record - 25.years,
+                      is_primary_applicant: false,
+                      family_member_id: family.family_members[2].id,
+                      person_hbx_id: family.family_members[2].person.hbx_id,
+                      addresses: [FactoryBot.build(:financial_assistance_address)])
+  end
+
+  let!(:income_evidence) do
+    applicant.create_income_evidence(key: :income,
+                                     title: 'Income',
+                                     aasm_state: 'outstanding',
+                                     due_on: TimeKeeper.date_of_record,
+                                     verification_outstanding: true,
+                                     is_satisfied: false)
+  end
+
+  let!(:income_evidence2) do
+    applicant2.create_income_evidence(key: :income,
+                                     title: 'Income',
+                                     aasm_state: 'pending',
+                                     due_on: TimeKeeper.date_of_record,
+                                     verification_outstanding: true,
+                                     is_satisfied: false)
+  end
+
+  let!(:income_evidence3) do
+    applicant3.create_income_evidence(key: :income,
+                                     title: 'Income',
+                                     aasm_state: 'outstanding',
+                                     due_on: TimeKeeper.date_of_record + 2.weeks,
+                                     verification_outstanding: true,
+                                     is_satisfied: false)
+  end
+
+  context 'success' do
+    context 'with no params submitted' do
+      before do
+        @result = subject.call({})
+        applicant.reload
+      end
+
+      it 'should return success' do
+        expect(@result).to be_success
+        expect(@result.value!.length).to eq(1)
+        expect(@result.value!.include?(person.hbx_id)).to be_truthy
+      end
+
+      it 'should update the income evidence due on for the applicant' do
+        expect(applicant.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record)
+        expect(applicant.income_evidence.due_on).to eq(TimeKeeper.date_of_record + 65.days)
+      end
+
+      it 'should add a verification history recording the update' do
+        history = applicant.income_evidence.verification_histories.last
+        expect(history.action).to eq("auto_extend_due_date")
+        expect(history.updated_by).to eq("system")
+      end
+
+      it 'should not update the applicant if the evidence is not in outstanding or rejected' do
+        expect(applicant2.income_evidence.due_on).to eq(TimeKeeper.date_of_record)
+        expect(applicant2.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record + 65.days)
+      end
+
+      it 'should not update the applicant if due on is not equal to the provided date' do
+        expect(applicant3.income_evidence.due_on).to eq(TimeKeeper.date_of_record + 2.weeks)
+        expect(applicant3.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record + 65.days)
+      end
+
     end
 
-    let!(:applicant_1) do
-      FactoryBot.create(:applicant,
-                        application: application,
-                        dob: TimeKeeper.date_of_record - 40.years,
-                        is_primary_applicant: true,
-                        family_member_id: family.family_members[0].id,
-                        person_hbx_id: person.hbx_id,
-                        addresses: [address])
+    context 'previously auto extended' do
+      before do
+        income_evidence.verification_histories.create(action: 'auto_extend_due_date', update_reason: 'Auto extended due date', updated_by: 'system')
+        @result = subject.call({})
+      end
+
+      it 'should return success' do
+        expect(@result).to be_success
+        expect(@result.value!.length).to eq(0)
+        expect(@result.value!.include?(person.hbx_id)).to be_falsy
+      end
+
     end
 
-    let!(:applicant_2) do
-      FactoryBot.create(:applicant,
-                        application: application,
-                        dob: TimeKeeper.date_of_record - 42.years,
-                        is_primary_applicant: true,
-                        family_member_id: family.family_members[1].id,
-                        person_hbx_id: family.family_members[1].hbx_id,
-                        addresses: [address])
+    context 'previously auto extended then transistion to attested or verified' do
+      before do
+        income_evidence.verification_histories.create(action: 'auto_extend_due_date', update_reason: 'Auto extended due date', updated_by: 'system')
+        income_evidence.workflow_state_transitions.create(to_state: "verified", transition_at: TimeKeeper.date_of_record, reason: "met minimum criteria", comment: "consumer provided proper documentation",
+                                                          user_id: BSON::ObjectId.from_time(DateTime.now))
+        @result = subject.call({})
+      end
+
+      it 'should return success' do
+        expect(@result).to be_success
+        expect(@result.value!.length).to eq(1)
+        expect(@result.value!.include?(person.hbx_id)).to be_truthy
+      end
     end
 
-    let!(:applicant_3) do
-      FactoryBot.create(:applicant,
-                        application: application,
-                        dob: TimeKeeper.date_of_record - 12.years,
-                        is_primary_applicant: true,
-                        family_member_id: family.family_members[2].id,
-                        person_hbx_id: family.family_members[2].hbx_id,
-                        addresses: [address])
+    context 'with params given' do
+      before do
+        @result = subject.call({extend_by: 35, modified_by: 'admin@ideacrew.com'})
+        applicant.reload
+      end
+
+      it 'should return success' do
+        expect(@result).to be_success
+        expect(@result.value!.length).to eq(1)
+        expect(@result.value!.include?(person.hbx_id)).to be_truthy
+      end
+
+      it 'should update the income evidence due on for the applicant' do
+        expect(applicant.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record)
+        expect(applicant.income_evidence.due_on).to eq(TimeKeeper.date_of_record + 35.days)
+      end
+
+      it 'should add a verification history recording the update' do
+        history = applicant.income_evidence.verification_histories.last
+        expect(history.action).to eq("auto_extend_due_date")
+        expect(history.updated_by).to eq("admin@ideacrew.com")
+      end
     end
 
-    let!(:income_evidence_1) do
-      applicant_1.create_income_evidence(key: :income,
-                                         title: 'Income',
-                                         aasm_state: 'outstanding',
-                                         due_on: applicant_1_due_date,
-                                         verification_outstanding: true,
-                                         is_satisfied: false)
+  end
+
+  context 'failure' do
+    context 'with invalid current due on' do
+      it 'should fail' do
+        result = subject.call({current_due_on: "08/08/2023"})
+        expect(result).to be_failure
+        expect(result.failure).to eq("Invalid param for key current_due_on, must be a Date")
+      end
     end
 
-    let!(:income_evidence_2) do
-      applicant_2.create_income_evidence(key: :income,
-                                         title: 'Income',
-                                         aasm_state: 'outstanding',
-                                         due_on: applicant_2_due_date,
-                                         verification_outstanding: true,
-                                         is_satisfied: false)
+    context 'with invalid extend_by' do
+      it 'should fail' do
+        result = subject.call({extend_by: "08/08/2023"})
+        expect(result).to be_failure
+        expect(result.failure).to eq("Invalid param for key extend_by, must be an Integer")
+      end
     end
 
-    let!(:income_evidence_3) do
-      applicant_3.create_income_evidence(key: :income,
-                                         title: 'Income',
-                                         aasm_state: 'outstanding',
-                                         due_on: applicant_3_due_date,
-                                         verification_outstanding: true,
-                                         is_satisfied: false)
-    end
-
-    before do
-      # Enable to be able to use min_verification_due_date_on_family on family model
-      allow(EnrollRegistry).to receive(:feature_enabled?).with(:crm_update_family_save).and_return(true)
-      allow(EnrollRegistry).to receive(:feature_enabled?).with(:check_for_crm_updates).and_return(true)
-      allow(EnrollRegistry).to receive(:feature_enabled?).with(:include_faa_outstanding_verifications).and_return(true)
-      family.create_eligibility_determination
-      family.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
-                                               outstanding_verification_earliest_due_date: TimeKeeper.date_of_record,
-                                               outstanding_verification_document_status: 'Partially Uploaded')
-
-      income_evidence_3.verification_histories.create(action: 'auto_extend_due_date',
-                                                      update_reason: 'Auto extended due date',
-                                                      updated_by: 'system')
-    end
-
-    context 'success' do
-      context 'with params given' do
-        before do
-          @result = subject.call({extend_by: 35, modified_by: 'admin@ideacrew.com'})
-
-          applicant_1.reload
-          applicant_2.reload
-          applicant_3.reload
-          family.eligibility_determination.reload
-        end
-
-        it 'should return success' do
-          expect(@result).to be_success
-          expect(@result.value!.length).to eq(2)
-
-          expect(@result.value!.include?(family.family_members[0].hbx_id)).to be_truthy
-          expect(@result.value!.include?(family.family_members[1].hbx_id)).to be_truthy
-          expect(@result.value!.include?(family.family_members[2].hbx_id)).to be_falsy
-        end
-
-        it 'should update the income_evidence due_on date for the applicant where applicable' do
-          expect(applicant_1.income_evidence.due_on).to eq(applicant_1_due_date + 35.days)
-          expect(applicant_2.income_evidence.due_on).to eq(applicant_2_due_date + 35.days)
-          expect(applicant_3.income_evidence.due_on).to eq(applicant_3_due_date) # Extension period not applicable to applicants ineligible for auto-renewal
-        end
-
-        it 'should update the family outstanding_verification_earliest_due_date to the earliest income_evidence due_on date' do
-          # applicant_3 has the earliest income_evidence due_on date -- meaning the overall earliest due date for the family should also be this date
-          expect(family.eligibility_determination.outstanding_verification_earliest_due_date).to eq(applicant_3.income_evidence.due_on)
-        end
+    context 'with invalid modified_by' do
+      it 'should fail' do
+        result = subject.call({modified_by: 345})
+        expect(result).to be_failure
+        expect(result.failure).to eq("Invalid param for key modified_by, must be a String")
       end
     end
   end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/auto_extend_income_evidence_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/auto_extend_income_evidence_spec.rb
@@ -59,20 +59,20 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AutoExtendIncome
 
   let!(:income_evidence2) do
     applicant2.create_income_evidence(key: :income,
-                                     title: 'Income',
-                                     aasm_state: 'pending',
-                                     due_on: TimeKeeper.date_of_record,
-                                     verification_outstanding: true,
-                                     is_satisfied: false)
+                                      title: 'Income',
+                                      aasm_state: 'pending',
+                                      due_on: TimeKeeper.date_of_record,
+                                      verification_outstanding: true,
+                                      is_satisfied: false)
   end
 
   let!(:income_evidence3) do
     applicant3.create_income_evidence(key: :income,
-                                     title: 'Income',
-                                     aasm_state: 'outstanding',
-                                     due_on: TimeKeeper.date_of_record + 2.weeks,
-                                     verification_outstanding: true,
-                                     is_satisfied: false)
+                                      title: 'Income',
+                                      aasm_state: 'outstanding',
+                                      due_on: TimeKeeper.date_of_record + 2.weeks,
+                                      verification_outstanding: true,
+                                      is_satisfied: false)
   end
 
   context 'success' do

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/auto_extend_income_evidence_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/auto_extend_income_evidence_spec.rb
@@ -51,11 +51,11 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AutoExtendIncome
   describe 'extending income evidence verification due date on an individual applicant level' do
     let!(:income_evidence) do
       applicant.create_income_evidence(key: :income,
-                                        title: 'Income',
-                                        aasm_state: 'outstanding',
-                                        due_on: TimeKeeper.date_of_record,
-                                        verification_outstanding: true,
-                                        is_satisfied: false)
+                                       title: 'Income',
+                                       aasm_state: 'outstanding',
+                                       due_on: TimeKeeper.date_of_record,
+                                       verification_outstanding: true,
+                                       is_satisfied: false)
     end
 
     let!(:income_evidence2) do
@@ -212,29 +212,29 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AutoExtendIncome
 
     let!(:income_evidence_1) do
       applicant.create_income_evidence(key: :income,
-                                         title: 'Income',
-                                         aasm_state: 'outstanding',
-                                         due_on: applicant_1_due_date,
-                                         verification_outstanding: true,
-                                         is_satisfied: false)
+                                       title: 'Income',
+                                       aasm_state: 'outstanding',
+                                       due_on: applicant_1_due_date,
+                                       verification_outstanding: true,
+                                       is_satisfied: false)
     end
 
     let!(:income_evidence_2) do
       applicant2.create_income_evidence(key: :income,
-                                         title: 'Income',
-                                         aasm_state: 'outstanding',
-                                         due_on: applicant_2_due_date,
-                                         verification_outstanding: true,
-                                         is_satisfied: false)
+                                        title: 'Income',
+                                        aasm_state: 'outstanding',
+                                        due_on: applicant_2_due_date,
+                                        verification_outstanding: true,
+                                        is_satisfied: false)
     end
 
     let!(:income_evidence_3) do
       applicant3.create_income_evidence(key: :income,
-                                         title: 'Income',
-                                         aasm_state: 'outstanding',
-                                         due_on: applicant_3_due_date,
-                                         verification_outstanding: true,
-                                         is_satisfied: false)
+                                        title: 'Income',
+                                        aasm_state: 'outstanding',
+                                        due_on: applicant_3_due_date,
+                                        verification_outstanding: true,
+                                        is_satisfied: false)
     end
 
     before do
@@ -244,7 +244,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AutoExtendIncome
       allow(EnrollRegistry).to receive(:feature_enabled?).with(:include_faa_outstanding_verifications).and_return(true)
       family.create_eligibility_determination
       family.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
-                                               outstanding_verification_earliest_due_date: (TimeKeeper.date_of_record),
+                                               outstanding_verification_earliest_due_date: TimeKeeper.date_of_record,
                                                outstanding_verification_document_status: 'Partially Uploaded')
     end
 

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/auto_extend_income_evidence_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/auto_extend_income_evidence_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AutoExtendIncome
     FactoryBot.create(:application,
                       family_id: family.id,
                       aasm_state: "determined",
-                      effective_date: TimeKeeper.date_of_record)
+                      effective_date: (TimeKeeper.date_of_record - 12.days))
   end
 
   let!(:applicant) do
@@ -48,146 +48,236 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AutoExtendIncome
                       addresses: [FactoryBot.build(:financial_assistance_address)])
   end
 
-  let!(:income_evidence) do
-    applicant.create_income_evidence(key: :income,
-                                     title: 'Income',
-                                     aasm_state: 'outstanding',
-                                     due_on: TimeKeeper.date_of_record,
-                                     verification_outstanding: true,
-                                     is_satisfied: false)
+  describe 'extending income evidence verification due date on an individual applicant level' do
+    let!(:income_evidence) do
+      applicant.create_income_evidence(key: :income,
+                                        title: 'Income',
+                                        aasm_state: 'outstanding',
+                                        due_on: TimeKeeper.date_of_record,
+                                        verification_outstanding: true,
+                                        is_satisfied: false)
+    end
+
+    let!(:income_evidence2) do
+      applicant2.create_income_evidence(key: :income,
+                                        title: 'Income',
+                                        aasm_state: 'pending',
+                                        due_on: TimeKeeper.date_of_record,
+                                        verification_outstanding: true,
+                                        is_satisfied: false)
+    end
+
+    let!(:income_evidence3) do
+      applicant3.create_income_evidence(key: :income,
+                                        title: 'Income',
+                                        aasm_state: 'outstanding',
+                                        due_on: TimeKeeper.date_of_record + 2.weeks,
+                                        verification_outstanding: true,
+                                        is_satisfied: false)
+    end
+
+    before do
+      allow(FinancialAssistanceRegistry[:auto_update_income_evidence_due_on].setting(:days)).to receive(:item).and_return(65)
+    end
+
+    context 'success' do
+      context 'with no params submitted' do
+        before do
+          @result = subject.call({})
+          applicant.reload
+        end
+
+        it 'should return success' do
+          expect(@result).to be_success
+          expect(@result.value!.length).to eq(1)
+          expect(@result.value!.include?(person.hbx_id)).to be_truthy
+        end
+
+        it 'should update the income evidence due on for the applicant' do
+          expect(applicant.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record)
+          expect(applicant.income_evidence.due_on).to eq(TimeKeeper.date_of_record + 65.days)
+        end
+
+        it 'should add a verification history recording the update' do
+          history = applicant.income_evidence.verification_histories.last
+          expect(history.action).to eq("auto_extend_due_date")
+          expect(history.updated_by).to eq("system")
+        end
+
+      end
+
+      context 'previously auto extended' do
+        before do
+          income_evidence.verification_histories.create(action: 'auto_extend_due_date', update_reason: 'Auto extended due date', updated_by: 'system')
+          @result = subject.call({})
+        end
+
+        it 'should return success' do
+          expect(@result).to be_success
+          expect(@result.value!.length).to eq(0)
+          expect(@result.value!.include?(person.hbx_id)).to be_falsy
+        end
+
+      end
+
+      context 'previously auto extended then transition to attested or verified' do
+        before do
+          income_evidence.verification_histories.create(action: 'auto_extend_due_date', update_reason: 'Auto extended due date', updated_by: 'system')
+          income_evidence.workflow_state_transitions.create(to_state: "verified", transition_at: TimeKeeper.date_of_record, reason: "met minimum criteria", comment: "consumer provided proper documentation",
+                                                            user_id: BSON::ObjectId.from_time(DateTime.now))
+          @result = subject.call({})
+        end
+
+        it 'should return success' do
+          expect(@result).to be_success
+          expect(@result.value!.length).to eq(1)
+          expect(@result.value!.include?(person.hbx_id)).to be_truthy
+        end
+      end
+
+      context 'with params given' do
+        before do
+          @result = subject.call({extend_by: 35, modified_by: 'admin@ideacrew.com'})
+          applicant.reload
+        end
+
+        it 'should return success' do
+          expect(@result).to be_success
+          expect(@result.value!.length).to eq(1)
+          expect(@result.value!.include?(person.hbx_id)).to be_truthy
+        end
+
+        it 'should update the income evidence due on for the applicant' do
+          expect(applicant.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record)
+          expect(applicant.income_evidence.due_on).to eq(TimeKeeper.date_of_record + 35.days)
+        end
+
+        it 'should add a verification history recording the update' do
+          history = applicant.income_evidence.verification_histories.last
+          expect(history.action).to eq("auto_extend_due_date")
+          expect(history.updated_by).to eq("admin@ideacrew.com")
+        end
+
+        it 'should not update the applicant if the evidence is not in outstanding or rejected' do
+          expect(applicant2.income_evidence.due_on).to eq(TimeKeeper.date_of_record)
+          expect(applicant2.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record + 65.days)
+        end
+
+        it 'should not update the applicant if due on is not equal to the provided date' do
+          expect(applicant3.income_evidence.due_on).to eq(TimeKeeper.date_of_record + 2.weeks)
+          expect(applicant3.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record + 65.days)
+        end
+      end
+
+    end
+
+    context 'failure' do
+      context 'with invalid current due on' do
+        it 'should fail' do
+          result = subject.call({current_due_on: "08/08/2023"})
+          expect(result).to be_failure
+          expect(result.failure).to eq("Invalid param for key current_due_on, must be a Date")
+        end
+      end
+
+      context 'with invalid extend_by' do
+        it 'should fail' do
+          result = subject.call({extend_by: "08/08/2023"})
+          expect(result).to be_failure
+          expect(result.failure).to eq("Invalid param for key extend_by, must be an Integer")
+        end
+      end
+
+      context 'with invalid modified_by' do
+        it 'should fail' do
+          result = subject.call({modified_by: 345})
+          expect(result).to be_failure
+          expect(result.failure).to eq("Invalid param for key modified_by, must be a String")
+        end
+      end
+    end
   end
 
-  let!(:income_evidence2) do
-    applicant2.create_income_evidence(key: :income,
-                                      title: 'Income',
-                                      aasm_state: 'pending',
-                                      due_on: TimeKeeper.date_of_record,
-                                      verification_outstanding: true,
-                                      is_satisfied: false)
-  end
+  describe 'extending income evidence verification due date on a family level' do
+    # Test family with
+    # 1 member eligible for income evidence extension (later due date)
+    # 1 member eligible for income evidence extension (earlier due date)
+    # 1 member ineligible for income evidence extension
+    # Maybe add 1 member with complete verified income evidence?
 
-  let!(:income_evidence3) do
-    applicant3.create_income_evidence(key: :income,
-                                      title: 'Income',
-                                      aasm_state: 'outstanding',
-                                      due_on: TimeKeeper.date_of_record + 2.weeks,
-                                      verification_outstanding: true,
-                                      is_satisfied: false)
-  end
+    let!(:address) { FactoryBot.build(:financial_assistance_address) }
+    let(:applicant_1_due_date) { TimeKeeper.date_of_record }
+    let(:applicant_2_due_date) { TimeKeeper.date_of_record + 5.days }
+    let(:applicant_3_due_date) { TimeKeeper.date_of_record + 30.days }
 
-  context 'success' do
-    context 'with no params submitted' do
-      before do
-        @result = subject.call({})
-        applicant.reload
-      end
-
-      it 'should return success' do
-        expect(@result).to be_success
-        expect(@result.value!.length).to eq(1)
-        expect(@result.value!.include?(person.hbx_id)).to be_truthy
-      end
-
-      it 'should update the income evidence due on for the applicant' do
-        expect(applicant.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record)
-        expect(applicant.income_evidence.due_on).to eq(TimeKeeper.date_of_record + 65.days)
-      end
-
-      it 'should add a verification history recording the update' do
-        history = applicant.income_evidence.verification_histories.last
-        expect(history.action).to eq("auto_extend_due_date")
-        expect(history.updated_by).to eq("system")
-      end
-
-      it 'should not update the applicant if the evidence is not in outstanding or rejected' do
-        expect(applicant2.income_evidence.due_on).to eq(TimeKeeper.date_of_record)
-        expect(applicant2.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record + 65.days)
-      end
-
-      it 'should not update the applicant if due on is not equal to the provided date' do
-        expect(applicant3.income_evidence.due_on).to eq(TimeKeeper.date_of_record + 2.weeks)
-        expect(applicant3.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record + 65.days)
-      end
-
+    let!(:income_evidence_1) do
+      applicant.create_income_evidence(key: :income,
+                                         title: 'Income',
+                                         aasm_state: 'outstanding',
+                                         due_on: applicant_1_due_date,
+                                         verification_outstanding: true,
+                                         is_satisfied: false)
     end
 
-    context 'previously auto extended' do
-      before do
-        income_evidence.verification_histories.create(action: 'auto_extend_due_date', update_reason: 'Auto extended due date', updated_by: 'system')
-        @result = subject.call({})
-      end
-
-      it 'should return success' do
-        expect(@result).to be_success
-        expect(@result.value!.length).to eq(0)
-        expect(@result.value!.include?(person.hbx_id)).to be_falsy
-      end
-
+    let!(:income_evidence_2) do
+      applicant2.create_income_evidence(key: :income,
+                                         title: 'Income',
+                                         aasm_state: 'outstanding',
+                                         due_on: applicant_2_due_date,
+                                         verification_outstanding: true,
+                                         is_satisfied: false)
     end
 
-    context 'previously auto extended then transistion to attested or verified' do
-      before do
-        income_evidence.verification_histories.create(action: 'auto_extend_due_date', update_reason: 'Auto extended due date', updated_by: 'system')
-        income_evidence.workflow_state_transitions.create(to_state: "verified", transition_at: TimeKeeper.date_of_record, reason: "met minimum criteria", comment: "consumer provided proper documentation",
-                                                          user_id: BSON::ObjectId.from_time(DateTime.now))
-        @result = subject.call({})
-      end
-
-      it 'should return success' do
-        expect(@result).to be_success
-        expect(@result.value!.length).to eq(1)
-        expect(@result.value!.include?(person.hbx_id)).to be_truthy
-      end
+    let!(:income_evidence_3) do
+      applicant3.create_income_evidence(key: :income,
+                                         title: 'Income',
+                                         aasm_state: 'outstanding',
+                                         due_on: applicant_3_due_date,
+                                         verification_outstanding: true,
+                                         is_satisfied: false)
     end
 
-    context 'with params given' do
-      before do
-        @result = subject.call({extend_by: 35, modified_by: 'admin@ideacrew.com'})
-        applicant.reload
-      end
-
-      it 'should return success' do
-        expect(@result).to be_success
-        expect(@result.value!.length).to eq(1)
-        expect(@result.value!.include?(person.hbx_id)).to be_truthy
-      end
-
-      it 'should update the income evidence due on for the applicant' do
-        expect(applicant.income_evidence.due_on).not_to eq(TimeKeeper.date_of_record)
-        expect(applicant.income_evidence.due_on).to eq(TimeKeeper.date_of_record + 35.days)
-      end
-
-      it 'should add a verification history recording the update' do
-        history = applicant.income_evidence.verification_histories.last
-        expect(history.action).to eq("auto_extend_due_date")
-        expect(history.updated_by).to eq("admin@ideacrew.com")
-      end
+    before do
+      # Enable to be able to use min_verification_due_date_on_family on family model
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:crm_update_family_save).and_return(true)
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:check_for_crm_updates).and_return(true)
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:include_faa_outstanding_verifications).and_return(true)
+      family.create_eligibility_determination
+      family.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
+                                               outstanding_verification_earliest_due_date: (TimeKeeper.date_of_record),
+                                               outstanding_verification_document_status: 'Partially Uploaded')
     end
 
-  end
+    context 'success' do
+      context 'with params given' do
+        before do
+          @result = subject.call({extend_by: 35, modified_by: 'admin@ideacrew.com'})
 
-  context 'failure' do
-    context 'with invalid current due on' do
-      it 'should fail' do
-        result = subject.call({current_due_on: "08/08/2023"})
-        expect(result).to be_failure
-        expect(result.failure).to eq("Invalid param for key current_due_on, must be a Date")
-      end
-    end
+          applicant.reload
+          applicant2.reload
+          applicant3.reload
+          family.eligibility_determination.reload
+        end
 
-    context 'with invalid extend_by' do
-      it 'should fail' do
-        result = subject.call({extend_by: "08/08/2023"})
-        expect(result).to be_failure
-        expect(result.failure).to eq("Invalid param for key extend_by, must be an Integer")
-      end
-    end
+        it 'should return success' do
+          expect(@result).to be_success
+          expect(@result.value!.length).to eq(1)
 
-    context 'with invalid modified_by' do
-      it 'should fail' do
-        result = subject.call({modified_by: 345})
-        expect(result).to be_failure
-        expect(result.failure).to eq("Invalid param for key modified_by, must be a String")
+          expect(@result.value!.include?(family.family_members[0].hbx_id)).to be_truthy
+          expect(@result.value!.include?(family.family_members[1].hbx_id)).to be_falsy
+          expect(@result.value!.include?(family.family_members[2].hbx_id)).to be_falsy
+        end
+
+        it 'should update the income_evidence due_on date for the applicant where applicable' do
+          expect(applicant.income_evidence.due_on).to eq(applicant_1_due_date + 35.days)
+          expect(applicant2.income_evidence.due_on).to eq(applicant_2_due_date) # extensions only happen if evidence due on is the current_due_on
+          expect(applicant3.income_evidence.due_on).to eq(applicant_3_due_date) # Extension period not applicable to applicants ineligible for auto-renewal
+        end
+
+        it 'should update the family outstanding_verification_earliest_due_date to the earliest income_evidence due_on date' do
+          # applicant2 has the earliest income_evidence due_on date -- meaning the overall earliest due date for the family should also be this date
+          expect(family.eligibility_determination.outstanding_verification_earliest_due_date).to eq(applicant2.income_evidence.due_on)
+        end
       end
     end
   end

--- a/components/financial_assistance/spec/dummy/app/models/eligibilities/evidence.rb
+++ b/components/financial_assistance/spec/dummy/app/models/eligibilities/evidence.rb
@@ -140,9 +140,9 @@ module Eligibilities
     end
 
     def can_be_extended?(date)
-      return false unless due_on == date && ['rejected', 'outstanding'].include? aasm_state
+      return false unless due_on == date && ['rejected', 'outstanding'].include?(aasm_state)
       extensions = verification_histories&.where(action: "auto_extend_due_date")
-      return true unless extensions && extensions.any?
+      return true unless extensions&.any?
       #  want this limitation on due date extensions to reset anytime an evidence no longer requires a due date
       # (is moved to 'verified' or 'attested' state) so that an individual can benefit from the extension again in the future.
       auto_extend_time = extensions.last&.created_at

--- a/components/financial_assistance/spec/dummy/app/models/eligibilities/evidence.rb
+++ b/components/financial_assistance/spec/dummy/app/models/eligibilities/evidence.rb
@@ -139,10 +139,10 @@ module Eligibilities
       self.due_on = new_date
     end
 
-    def can_be_extended?
-      return false unless type_unverified?
-      extensions = verification_histories.where(action: "auto_extend_due_date")
-      return true unless extensions.any?
+    def can_be_extended?(date)
+      return false unless due_on == date && ['rejected', 'outstanding'].include? aasm_state
+      extensions = verification_histories&.where(action: "auto_extend_due_date")
+      return true unless extensions && extensions.any?
       #  want this limitation on due date extensions to reset anytime an evidence no longer requires a due date
       # (is moved to 'verified' or 'attested' state) so that an individual can benefit from the extension again in the future.
       auto_extend_time = extensions.last&.created_at


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185728651

# A brief description of the changes

Current behavior: While the query to grab all the families check for current date, it was updating all applicants who were eligible even if their evidence wasn't due that day.

New behavior: Added a check so only the ones with the current due date get auto-extended

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.