### PR TITLE
correct method in update eligibility script

### DIFF
--- a/script/update_eligibility.rb
+++ b/script/update_eligibility.rb
@@ -7,7 +7,7 @@ def start_date_of_next_year
   @start_date_of_next_year ||= TimeKeeper.date_of_record.next_year.beginning_of_year
 end
 
-report_name = "#{Rails.root}/eligibilities_not_updated_list_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv"
+report_name = "#{Rails.root}/eligibilities_updated_list_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv"
 field_names = %w(
         primary_ssn
         primary_hbx_id

--- a/script/update_eligibility.rb
+++ b/script/update_eligibility.rb
@@ -75,7 +75,7 @@ CSV.open(report_name, "w", force_quotes: true) do |csv|
         csr_int = csr_hash[person_hbx_id]
         csr_int = (csr_int == 'limited' ? '-1' : csr_int)
         person_fm = primary_family.family_members.active.where(person_id: person.id) if person.present?
-        unless person_fm.empty?
+        if person_fm.present?
           person_fm_id = person_fm.first.id
           person_thhm = active_thh.tax_household_members.where(applicant_id: person_fm_id).first
           next if person_thhm.csr_percent_as_integer == csr_int.to_i
@@ -98,8 +98,5 @@ CSV.open(report_name, "w", force_quotes: true) do |csv|
     end
 
   end
-  [ran: ran,
-   not_run: not_run,
-   updated_member_csr: updated_member_csr,
-   created_eligibility: created_eligibility]
+  puts "SUMMARY: #{[ran: ran, not_run: not_run, updated_member_csr: updated_member_csr, created_eligibility: created_eligibility]}"
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior:
Script uses `.empty?` method if person record is not found.  This throws an error becaus this method is not available on `nil`.

New behavior:
Script uses `.present?` which is available on `nil`.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context

The summary of results was not actually being output so a `puts` statement was added at the end of the file as well.
The name of the output csv was misleading (eligibilities_not_updated_list) and has been updated as well.