### PR TITLE
set due_date to system_date + 35 days if the response pvc call is outstanding

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -15,7 +15,7 @@ module FinancialAssistance
     embedded_in :application, class_name: "::FinancialAssistance::Application", inverse_of: :applicants
 
     TAX_FILER_KINDS = %w[tax_filer single joint separate dependent non_filer].freeze
-    BULK_REDETERMINATION_ACTION_TYPES = ["Bulk Call"].freeze
+    BULK_REDETERMINATION_ACTION_TYPES = ["Bulk Call", "pvc_bulk_call"].freeze
     STUDENT_KINDS = %w[
       dropped_out
       elementary

--- a/components/financial_assistance/spec/shared_examples/pvc/medicare/test_pvc_medicare_response.rb
+++ b/components/financial_assistance/spec/shared_examples/pvc/medicare/test_pvc_medicare_response.rb
@@ -248,7 +248,7 @@ RSpec.shared_context 'FDSH PVC Medicare sample response', :shared_context => :me
             :tution_and_fees => 0,
             :other_magi_eligible_income => 0
           },
-          :non_esi_evidence => {:key => :non_esi_mec, :title => "NON ESI MEC", :aasm_state => "outstanding"},
+          :non_esi_evidence => non_esi_mec_evidence_1,
           :mitc_relationships => [],
           :mitc_is_required_to_file_taxes => false
         }
@@ -557,7 +557,7 @@ RSpec.shared_context 'FDSH PVC Medicare sample response', :shared_context => :me
             :tution_and_fees => 0,
             :other_magi_eligible_income => 0
           },
-          :non_esi_evidence => {:key => :non_esi_mec, :title => "NON ESI MEC", aasm_state: "attested"},
+          :non_esi_evidence => non_esi_mec_evidence_2,
           :mitc_relationships => [],
           :mitc_is_required_to_file_taxes => false
         }
@@ -619,6 +619,39 @@ RSpec.shared_context 'FDSH PVC Medicare sample response', :shared_context => :me
           :dependents => []
         }
     ]
+    }
+  end
+
+  let(:non_esi_mec_evidence_1) do
+    {
+      :key => :non_esi_mec,
+      :title => 'Non ESI MEC',
+      :description => nil,
+      :aasm_state => 'outstanding',
+      :due_on => nil,
+      :updated_by => nil,
+      :request_results => [request_result_hash]
+    }
+  end
+
+  let(:non_esi_mec_evidence_2) do
+    {
+      :key => :non_esi_mec,
+      :title => 'Non ESI MEC',
+      :description => nil,
+      :aasm_state => 'attested',
+      :due_on => nil,
+      :updated_by => nil,
+      :request_results => [request_result_hash]
+    }
+  end
+
+  let(:request_result_hash) do
+    {
+      :result => 'eligible',
+      :source => 'MEDC',
+      :code => '7313',
+      :code_description => 'Applicant Not Found'
     }
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186077237](https://www.pivotaltracker.com/story/show/186077237)

# A brief description of the changes

Current behavior: Due date is not set when a bulk call is made for pvc service and the response comes back as outstanding

New behavior: Set due date on non esi evidence to System_date + 35.days when a bulk pvc call is made, and response is outstanding. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.