### PR TITLE
handling retro relationships while comparing

### DIFF
--- a/components/benefit_sponsors/app/models/benefit_sponsors/pricing_calculators/shop_simple_list_bill_pricing_calculator.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/pricing_calculators/shop_simple_list_bill_pricing_calculator.rb
@@ -95,7 +95,7 @@ module BenefitSponsors
             puts(exception_message)
             log(exception_message)
           end
-          [pricing_model.map_relationship_for(rm.relationship, coverage_age, rm.is_disabled?), rm.dob]
+          [pricing_model.map_relationship_for(rm.relationship, coverage_age, rm.is_disabled?).to_s, rm.dob]
         end
         calc_state = CalculatorState.new(age_calculator, roster_coverage.product, pricing_model, pricing_unit_map, roster_coverage, coverage_eligibility_dates)
         calc_results = sorted_members.inject(calc_state) do |calc, mem|


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186063639

# A brief description of the changes

Current behavior: it's erroring when trying to compare nil with string when family members with relationships like parent, unrelated exists on enrollment

New behavior: handling this error

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.