### PR TITLE
deactivates financial assistance on member add/drop for prospective year

### DIFF
--- a/app/domain/operations/households/deactivate_financial_assistance_eligibility.rb
+++ b/app/domain/operations/households/deactivate_financial_assistance_eligibility.rb
@@ -30,7 +30,9 @@ module Operations
       # returns Success(nil)
       def execute(values)
         family = Operations::Families::Find.new.call(id: BSON::ObjectId(values[:family_id]))
-        tax_households = family.success.active_household.latest_active_tax_households.tax_household_with_year(values[:date].to_date.year)
+        return family if family.failure?
+
+        tax_households = family.success.active_household.latest_active_tax_households.current_and_prospective_by_year(values[:date].to_date.year)
         return Success('No Active Tax Households to deactivate') unless tax_households.present?
 
         tax_households.each do |thh|

--- a/app/domain/operations/tax_household_groups/deactivate.rb
+++ b/app/domain/operations/tax_household_groups/deactivate.rb
@@ -33,7 +33,7 @@ module Operations
       end
 
       def deactivate(values)
-        tax_household_groups = values[:family].tax_household_groups.active.by_year(values[:new_effective_date].year)
+        tax_household_groups = values[:family].tax_household_groups.active.current_and_prospective_by_year(values[:new_effective_date].year)
         return Success('No Active Tax Household Groups to deactivate') if tax_household_groups.blank?
 
         tax_household_groups.each do |th_group|

--- a/app/models/tax_household.rb
+++ b/app/models/tax_household.rb
@@ -44,6 +44,8 @@ class TaxHousehold
 
   scope :tax_household_with_year, ->(year) { where( effective_starting_on: (Date.new(year)..Date.new(year).end_of_year)) }
   scope :active_tax_household, ->{ where(effective_ending_on: nil) }
+  scope :inactive, ->{ where(:effective_ending_on.ne => nil) }
+  scope :current_and_prospective_by_year, ->(year) { where(:effective_starting_on.gte => Date.new(year)) }
 
   validate :validate_dates
 

--- a/app/models/tax_household_group.rb
+++ b/app/models/tax_household_group.rb
@@ -40,6 +40,7 @@ class TaxHouseholdGroup
   scope :by_year,   ->(year) { where(assistance_year: year) }
   scope :active,    ->{ where(end_on: nil) }
   scope :inactive,  ->{ where(:end_on.ne => nil) }
+  scope :current_and_prospective_by_year, ->(year) { where(:assistance_year.gte => year) }
 
   def latest_active_tax_household_with_year(year)
     tax_households.tax_household_with_year(year).active_tax_household.order_by(:created_at.desc).first

--- a/spec/domain/operations/tax_household_groups/deactivate_spec.rb
+++ b/spec/domain/operations/tax_household_groups/deactivate_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Operations::TaxHouseholdGroups::Deactivate, type: :model, dbclean: :after_each do
+  before :all do
+    DatabaseCleaner.clean
+  end
+
+  let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+  let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+  let(:system_date) { TimeKeeper.date_of_record }
+
+  let(:retro_tax_household_group) { FactoryBot.create(:tax_household_group, :active_previous_year, family: family) }
+  let(:current_tax_household_group) { FactoryBot.create(:tax_household_group, :active_current_year, family: family) }
+  let(:prospective_tax_household_group) { FactoryBot.create(:tax_household_group, :active_next_year, family: family) }
+
+  let(:inactive_retro_thhg) { FactoryBot.create(:tax_household_group, :inactive_previous_year, family: family) }
+  let(:inactive_current_thhg) { FactoryBot.create(:tax_household_group, :inactive_current_year, family: family) }
+  let(:inactive_prospective_thhg) { FactoryBot.create(:tax_household_group, :inactive_next_year, family: family) }
+
+  subject { described_class.new.call(input_params) }
+
+  describe '#call' do
+    let(:invalid_params_failure_message) { 'Invalid params. family should be an instance of Family and new_effective_date should be an instance of Date' }
+    let(:no_active_thhgs_message) { 'No Active Tax Household Groups to deactivate' }
+    let(:deactivated_thhgs_message) { "Deactivated all the Active tax_household_groups for given family with hbx_id: #{family.hbx_assigned_id}" }
+
+    context 'invalid input params' do
+      context 'invalid family' do
+        let(:input_params) { { family: nil, new_effective_date: system_date } }
+
+        it 'returns a failure with a message' do
+          expect(subject.failure).to eq(invalid_params_failure_message)
+        end
+      end
+
+      context 'invalid new_effective_date' do
+        let(:input_params) { { family: family, new_effective_date: nil } }
+
+        it 'returns a failure with a message' do
+          expect(subject.failure).to eq(invalid_params_failure_message)
+        end
+      end
+
+      context 'invalid family, new_effective_date' do
+        let(:input_params) { { family: nil, new_effective_date: nil } }
+
+        it 'returns a failure with a message' do
+          expect(subject.failure).to eq(invalid_params_failure_message)
+        end
+      end
+    end
+
+    context 'without tax household groups' do
+      let(:input_params) { { family: family, new_effective_date: system_date } }
+
+      it 'returns a success with a message' do
+        expect(subject.success).to eq(no_active_thhgs_message)
+      end
+    end
+
+    context 'without active tax household groups' do
+      let(:input_params) { { family: family, new_effective_date: system_date } }
+
+      before do
+        inactive_retro_thhg
+        inactive_current_thhg
+        inactive_prospective_thhg
+      end
+
+      it 'returns a success with a message' do
+        expect(subject.success).to eq(no_active_thhgs_message)
+      end
+    end
+
+    context 'with active tax household groups' do
+      let(:input_params) { { family: family, new_effective_date: system_date } }
+
+      before do
+        retro_tax_household_group
+        current_tax_household_group
+        prospective_tax_household_group
+
+        inactive_retro_thhg
+        inactive_current_thhg
+        inactive_prospective_thhg
+      end
+
+      it 'returns a success with a message' do
+        expect(subject.success).to eq(deactivated_thhgs_message)
+      end
+
+      it 'deactivates current and prospective year active thhgs' do
+        expect(family.reload.tax_household_groups.active.pluck(:id)).to include(
+          current_tax_household_group.id,
+          prospective_tax_household_group.id
+        )
+
+        subject
+
+        expect(family.reload.tax_household_groups.active.pluck(:id)).to include(retro_tax_household_group.id)
+
+        expect(family.reload.tax_household_groups.inactive.pluck(:id)).to include(
+          current_tax_household_group.id,
+          prospective_tax_household_group.id
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/tax_household_groups.rb
+++ b/spec/factories/tax_household_groups.rb
@@ -7,5 +7,41 @@ FactoryBot.define do
     source { 'Faa' }
     start_on   { TimeKeeper.date_of_record.beginning_of_month }
     assistance_year { TimeKeeper.date_of_record.year }
+
+    trait :active_previous_year do
+      assistance_year { TimeKeeper.datetime_of_record.prev_year.year }
+      start_on        { TimeKeeper.date_of_record.beginning_of_year.prev_year }
+      end_on          { nil }
+    end
+
+    trait :active_current_year do
+      assistance_year { TimeKeeper.datetime_of_record.year }
+      start_on        { TimeKeeper.date_of_record.beginning_of_year }
+      end_on          { nil }
+    end
+
+    trait :active_next_year do
+      assistance_year { TimeKeeper.datetime_of_record.next_year.year }
+      start_on        { TimeKeeper.date_of_record.beginning_of_year.next_year }
+      end_on          { nil }
+    end
+
+    trait :inactive_previous_year do
+      assistance_year { TimeKeeper.datetime_of_record.prev_year.year }
+      start_on        { TimeKeeper.date_of_record.beginning_of_year.prev_year }
+      end_on          { TimeKeeper.date_of_record.end_of_year.prev_year }
+    end
+
+    trait :inactive_current_year do
+      assistance_year { TimeKeeper.datetime_of_record.year }
+      start_on        { TimeKeeper.date_of_record.beginning_of_year }
+      end_on          { TimeKeeper.date_of_record.end_of_year }
+    end
+
+    trait :inactive_next_year do
+      assistance_year { TimeKeeper.datetime_of_record.next_year.year }
+      start_on        { TimeKeeper.date_of_record.beginning_of_year.next_year }
+      end_on          { TimeKeeper.date_of_record.end_of_year.next_year }
+    end
   end
 end

--- a/spec/factories/tax_households.rb
+++ b/spec/factories/tax_households.rb
@@ -11,5 +11,26 @@ FactoryBot.define do
       effective_ending_on     { TimeKeeper.date_of_record.next_year.end_of_year }
       submitted_at     { TimeKeeper.date_of_record.next_year.end_of_year }
     end
+
+    trait :active_previous_year do
+      effective_starting_on     { TimeKeeper.date_of_record.beginning_of_year.prev_year }
+      effective_ending_on       { nil }
+      is_eligibility_determined { true }
+      submitted_at              { TimeKeeper.datetime_of_record.prev_year }
+    end
+
+    trait :active_current_year do
+      effective_starting_on     { TimeKeeper.date_of_record.beginning_of_year }
+      effective_ending_on       { nil }
+      is_eligibility_determined { true }
+      submitted_at              { TimeKeeper.datetime_of_record }
+    end
+
+    trait :active_next_year do
+      effective_starting_on     { TimeKeeper.date_of_record.beginning_of_year.next_year }
+      effective_ending_on       { nil }
+      is_eligibility_determined { true }
+      submitted_at              { TimeKeeper.datetime_of_record.next_year }
+    end
   end
 end

--- a/spec/lib/tasks/migrations/plans/glue_load_products_spec.rb
+++ b/spec/lib/tasks/migrations/plans/glue_load_products_spec.rb
@@ -13,7 +13,8 @@ describe 'glue_load_products' do
   let!(:issuer_profile) { FactoryBot.create(:benefit_sponsors_organizations_issuer_profile, :kaiser_profile, fein: '123456789') }
 
   before :all do
-    Rails.application.load_tasks
+    DatabaseCleaner.clean
+    Rake.application.rake_require 'tasks/migrations/plans/glue_load_products'
     Rake::Task.define_task(:environment)
   end
 
@@ -21,8 +22,8 @@ describe 'glue_load_products' do
     year = TimeKeeper.date_of_record.year
     json_file_name = Rails.root.join("#{year}_plans.json")
     error_file_name = Rails.root.join("#{year}_plans_error.txt")
-    File.delete(json_file_name)
-    File.delete(error_file_name)
+    File.delete(json_file_name) if File.file?(json_file_name)
+    File.delete(error_file_name) if File.file?(error_file_name)
   end
 
   describe 'load_products' do

--- a/spec/models/tax_household_group_spec.rb
+++ b/spec/models/tax_household_group_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TaxHouseholdGroup, type: :model do
+  before :all do
+    DatabaseCleaner.clean
+  end
+
+  let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+  let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+  let(:system_date) { TimeKeeper.date_of_record }
+  let(:retro_tax_household_group) { FactoryBot.create(:tax_household_group, :active_previous_year, family: family) }
+  let(:current_tax_household_group) { FactoryBot.create(:tax_household_group, :active_current_year, family: family) }
+  let(:prospective_tax_household_group) { FactoryBot.create(:tax_household_group, :active_next_year, family: family) }
+
+  describe '.current_and_prospective_by_year' do
+    context 'with retro, current and prospective year thhgs' do
+      before do
+        retro_tax_household_group
+        current_tax_household_group
+        prospective_tax_household_group
+      end
+
+      it 'returns current and prospective tax household groups' do
+        result_thhg_ids = family.tax_household_groups.current_and_prospective_by_year(system_date.year).pluck(:id)
+        expect(result_thhg_ids).to include(current_tax_household_group.id, prospective_tax_household_group.id)
+        expect(result_thhg_ids).not_to include(retro_tax_household_group.id)
+      end
+    end
+  end
+end

--- a/spec/models/tax_household_scopes_spec.rb
+++ b/spec/models/tax_household_scopes_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TaxHousehold, type: :model do
+  before :all do
+    DatabaseCleaner.clean
+  end
+
+  let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+  let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+  let(:household) { family.active_household }
+  let(:system_date) { TimeKeeper.date_of_record }
+  let(:retro_tax_household) { FactoryBot.create(:tax_household, :active_previous_year, household: household) }
+  let(:current_tax_household) { FactoryBot.create(:tax_household, :active_current_year, household: household) }
+  let(:prospective_tax_household) { FactoryBot.create(:tax_household, :active_next_year, household: household) }
+
+  describe '.current_and_prospective_by_year' do
+    context 'with retro, current and prospective year thhs' do
+      before do
+        retro_tax_household
+        current_tax_household
+        prospective_tax_household
+      end
+
+      it 'returns current and prospective tax households' do
+        result_thhg_ids = household.tax_households.current_and_prospective_by_year(system_date.year).pluck(:id)
+        expect(result_thhg_ids).to include(current_tax_household.id, prospective_tax_household.id)
+        expect(result_thhg_ids).not_to include(retro_tax_household.id)
+      end
+    end
+  end
+end

--- a/spec/script/final_eligibility_notice_script_spec.rb
+++ b/spec/script/final_eligibility_notice_script_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe "FinalEligibilityNoticeScript", :dbclean => :after_each do
 
   after :all do
     FileUtils.rm_rf(Dir.glob(File.join(Rails.root, 'spec/test_data/notices/final_eligibility_notice_aqhp_report_*.csv')))
+    DatabaseCleaner.clean
   end
 end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 185958087](https://www.pivotaltracker.com/story/show/185958087)

# A brief description of the changes

Current behavior: Currently, when a member is added/dropped, only the system year's financial assistance determination is deactivated.

New behavior: When a member is added/dropped, both the system year's and prospective year's financial assistance determination is deactivated.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.