### PR TITLE
add hub requested call to verification history

### DIFF
--- a/app/domain/operations/individual/determine_verifications.rb
+++ b/app/domain/operations/individual/determine_verifications.rb
@@ -55,16 +55,20 @@ module Operations
 
       def add_verification_type_history(consumer_role)
         consumer_role.verification_types.where(:type_name.in => ["Citizenship", "Immigration status", "Social Security Number"]).each do |vt|
-          vt.add_type_history_element(action: "Hub Request", modifier: "System", update_reason: "#{vt.type_name} call hub was requested due to demographic update")
+          add_type_history_element(vt)
         end
       end
 
       def trigger_residency(consumer_role)
         if EnrollRegistry.feature_enabled?(:validate_and_record_publish_errors)
           vt = consumer_role.verification_types.where(:type_name => ::VerificationType::LOCATION_RESIDENCY).first
-          vt.add_type_history_element(action: "Hub Request", modifier: "System", update_reason: "#{vt.type_name} call hub was requested due to demographic update")
+          add_type_history_element(vt)
         end
         consumer_role.trigger_residency!
+      end
+
+      def add_type_history_element(verification_type)
+        verification_type.add_type_history_element(action: "Hub Request", modifier: "System", update_reason: "#{verification_type.type_name} call hub request was made due to demographic create/update")
       end
 
       def can_trigger_residency?(person)

--- a/spec/domain/operations/individual/determine_verifications_spec.rb
+++ b/spec/domain/operations/individual/determine_verifications_spec.rb
@@ -126,8 +126,14 @@ RSpec.describe Operations::Individual::DetermineVerifications, dbclean: :after_e
         types = consumer_role.verification_types
         ssn_type_histories = types.ssn_type.first.type_history_elements
         ssn_type_histories.map(&:action).should include('Hub Request')
+        ssn_type_histories.map(&:update_reason).should include('Social Security Number call hub request was made due to demographic create/update')
+      end
+
+      it 'should record history in citizenship_type for requested hub calls' do
+        types = consumer_role.verification_types
         citizenship_type_histories = types.citizenship_type.first.type_history_elements
         citizenship_type_histories.map(&:action).should include('Hub Request')
+        citizenship_type_histories.map(&:update_reason).should include('Citizenship call hub request was made due to demographic create/update')
       end
 
       it 'should set verification_type to pending' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [pivotal-186067402](https://www.pivotaltracker.com/story/show/186067402)

# A brief description of the changes

Current behavior: For Demographic Create/Update, the request action will be logged in history when the hub request is made. 

New behavior: For every DHS/SSA/Residency request action, hub call request is logged in verification history.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.