### PR TITLE
toggle effective date when marketplace is switched coverall/shop

### DIFF
--- a/app/assets/javascripts/group_selection.js
+++ b/app/assets/javascripts/group_selection.js
@@ -81,6 +81,8 @@ function setGroupSelectionHandlers(){
       //setPrimaryForIvl();
       enableIvlEligibleForCoverall();
 
+      var ivl_effective_on = $('#ivl_effective_on').val();
+      $("#effective_date_for_display").html(ivl_effective_on);
     });
 
 

--- a/app/assets/javascripts/group_selection.js
+++ b/app/assets/javascripts/group_selection.js
@@ -66,7 +66,7 @@ function setGroupSelectionHandlers(){
       setPrimaryForIvl();
 
       var ivl_effective_on = $('#ivl_effective_on').val();
-      $("#effective_date_for_display").html(ivl_effective_on);
+      $("#effective_date_for_display").text(ivl_effective_on);
     });
 
     $('#market_kind_coverall').on('change', function() {
@@ -103,7 +103,7 @@ function setGroupSelectionHandlers(){
       setPrimaryForShop();
 
       var shop_effective_on = $('#shop_effective_on').val();
-      $("#effective_date_for_display").html(shop_effective_on);
+      $("#effective_date_for_display").text(shop_effective_on);
     });
   }
 

--- a/app/assets/javascripts/group_selection.js
+++ b/app/assets/javascripts/group_selection.js
@@ -70,7 +70,6 @@ function setGroupSelectionHandlers(){
     });
 
     $('#market_kind_coverall').on('change', function() {
-      //debugger;
       disableEmployerSelection();
 
       $('#dental-radio-button').slideDown();
@@ -82,7 +81,7 @@ function setGroupSelectionHandlers(){
       enableIvlEligibleForCoverall();
 
       var ivl_effective_on = $('#ivl_effective_on').val();
-      $("#effective_date_for_display").html(ivl_effective_on);
+      $("#effective_date_for_display").text(ivl_effective_on);
     });
 
 

--- a/app/controllers/insured/group_selection_controller.rb
+++ b/app/controllers/insured/group_selection_controller.rb
@@ -239,10 +239,10 @@ class Insured::GroupSelectionController < ApplicationController
     return unless person_has_dual_role?
 
     @ivl_effective_on = if @person.has_consumer_role?
-      @adapter.calculate_ivl_effective_on
-    else
-      @adapter.calculate_coverall_effective_on
-    end
+                          @adapter.calculate_ivl_effective_on
+                        else
+                          @adapter.calculate_coverall_effective_on
+                        end
 
     @shop_effective_on = @adapter.calculate_new_effective_on(params)
   end

--- a/app/controllers/insured/group_selection_controller.rb
+++ b/app/controllers/insured/group_selection_controller.rb
@@ -232,7 +232,7 @@ class Insured::GroupSelectionController < ApplicationController
   private
 
   def person_has_dual_role?
-    @person.has_consumer_role? && @person.has_active_employee_role?
+    (@person.has_consumer_role? && @person.has_active_employee_role?) || (@person.has_active_employee_role? && @person.has_resident_role?)
   end
 
   def fetch_effective_dates_for_dual_role

--- a/app/controllers/insured/group_selection_controller.rb
+++ b/app/controllers/insured/group_selection_controller.rb
@@ -238,7 +238,12 @@ class Insured::GroupSelectionController < ApplicationController
   def fetch_effective_dates_for_dual_role
     return unless person_has_dual_role?
 
-    @ivl_effective_on = @adapter.calculate_ivl_effective_on
+    @ivl_effective_on = if @person.has_consumer_role?
+      @adapter.calculate_ivl_effective_on
+    else
+      @adapter.calculate_coverall_effective_on
+    end
+
     @shop_effective_on = @adapter.calculate_new_effective_on(params)
   end
 

--- a/app/models/group_selection_prevarication_adapter.rb
+++ b/app/models/group_selection_prevarication_adapter.rb
@@ -170,6 +170,10 @@ class GroupSelectionPrevaricationAdapter
     calculate_effective_on(market_kind: 'individual', employee_role: nil, benefit_group: nil)
   end
 
+  def calculate_coverall_effective_on
+    calculate_effective_on(market_kind: 'coverall', employee_role: nil, benefit_group: nil)
+  end
+
   def calculate_new_effective_on(params)
     benefit_group = select_benefit_group(params)
     calculate_effective_on(market_kind: select_market(params), employee_role: possible_employee_role, benefit_group: benefit_group)

--- a/features/group_selection/employee_and_coverall_role_plan_shopping.feature
+++ b/features/group_selection/employee_and_coverall_role_plan_shopping.feature
@@ -1,0 +1,25 @@
+Feature: EE with consumer role plan purchase
+
+  # TODO: revisit code for background scenarios
+  Background: Setup permissions, HBX Admin, users, and organizations and employer profiles
+    Given enable change tax credit button is enabled
+    Given the shop market configuration is enabled
+    Given all announcements are enabled for user to select
+    Given a Resident exists
+    Given Resident has a dependent in child relationship with age less than 26
+    Given an employer with initial application
+    Given all products with issuer profile
+    Then  an application provides health and dental packages
+    Then there are sponsored benefit offerings for spouse and child
+    When the user visits the Consumer portal during open enrollment
+
+  Scenario: when user switches market place, effective date should be switched
+    Given a matched Employee exists with consumer role
+    And system date is open enrollment date
+    Then Employee sign in to portal
+    When employee clicked on shop for plans
+    When employee switched for employer-sponsored benefits
+    Then user should see the effective date of employer-sponsored coverage
+    When employee switched for individual benefits
+    Then user should see the effective date of individual coverage
+    And system date is today's date

--- a/features/group_selection/employee_and_coverall_role_plan_shopping.feature
+++ b/features/group_selection/employee_and_coverall_role_plan_shopping.feature
@@ -5,8 +5,7 @@ Feature: EE with consumer role plan purchase
     Given enable change tax credit button is enabled
     Given the shop market configuration is enabled
     Given all announcements are enabled for user to select
-    Given a Resident exists
-    Given Resident has a dependent in child relationship with age less than 26
+    Given a resident role person with family
     Given an employer with initial application
     Given all products with issuer profile
     Then  an application provides health and dental packages
@@ -14,12 +13,12 @@ Feature: EE with consumer role plan purchase
     When the user visits the Consumer portal during open enrollment
 
   Scenario: when user switches market place, effective date should be switched
-    Given a matched Employee exists with consumer role
+    Given a matched Employee exists with resident role
     And system date is open enrollment date
     Then Employee sign in to portal
     When employee clicked on shop for plans
     When employee switched for employer-sponsored benefits
     Then user should see the effective date of employer-sponsored coverage
-    When employee switched for individual benefits
+    When employee switched for coverall benefits
     Then user should see the effective date of individual coverage
     And system date is today's date

--- a/features/group_selection/employee_and_coverall_role_plan_shopping.feature
+++ b/features/group_selection/employee_and_coverall_role_plan_shopping.feature
@@ -1,6 +1,4 @@
 Feature: EE with consumer role plan purchase
-
-  # TODO: revisit code for background scenarios
   Background: Setup permissions, HBX Admin, users, and organizations and employer profiles
     Given enable change tax credit button is enabled
     Given the shop market configuration is enabled

--- a/features/step_definitions/group_selection_steps.rb
+++ b/features/step_definitions/group_selection_steps.rb
@@ -74,7 +74,7 @@ And(/(.*) has a dependent in (.*) relationship with age (.*) than 26/) do |role,
   final_person.save
 end
 
-Given (/a matched Employee exists with resident role/) do
+Given(/a matched Employee exists with resident role/) do
   FactoryBot.create(:employee_role, person: @person, employer_profile: @profile, benefit_sponsors_employer_profile_id: @profile.id)
   ce = FactoryBot.build(
     :benefit_sponsors_census_employee_with_active_assignment,

--- a/features/step_definitions/group_selection_steps.rb
+++ b/features/step_definitions/group_selection_steps.rb
@@ -55,7 +55,6 @@ Given (/a matched Employee exists with consumer role/) do
   FactoryBot.create(:hbx_profile, :open_enrollment_coverage_period)
 end
 
-
 And(/(.*) has a dependent in (.*) relationship with age (.*) than 26/) do |role, kind, var|
   dob = (var == "greater" ? TimeKeeper.date_of_record - 35.years : TimeKeeper.date_of_record - 5.years)
   family = Family.all.first
@@ -73,6 +72,23 @@ And(/(.*) has a dependent in (.*) relationship with age (.*) than 26/) do |role,
   ch.coverage_household_members << CoverageHouseholdMember.new(family_member_id: fm.id)
   ch.save
   final_person.save
+end
+
+Given (/a matched Employee exists with resident role/) do
+  FactoryBot.create(:employee_role, person: @person, employer_profile: @profile, benefit_sponsors_employer_profile_id: @profile.id)
+  ce = FactoryBot.build(
+    :benefit_sponsors_census_employee_with_active_assignment,
+    first_name: @person.first_name,
+    last_name: @person.last_name,
+    dob: @person.dob,
+    ssn: @person.ssn,
+    employer_profile: @profile,
+    employee_role_id: @person.employee_roles.first.id,
+    benefit_sponsorship: @sponsorship
+  )
+  ce.save!
+  @person.employee_roles.first.update_attributes(census_employee_id: ce.id)
+  FactoryBot.create(:hbx_profile, :open_enrollment_coverage_period)
 end
 
 And(/(.*) also has a health enrollment with primary person covered/) do |role|
@@ -482,8 +498,11 @@ When(/employee clicked on shop for plans/) do
 end
 
 When(/employee switched for (.*) benefits/) do |market_kind|
-  if market_kind == "individual"
+  case market_kind
+  when "individual"
     find(EmployeeChooseCoverage.individual_benefits_radiobtn).click
+  when "coverall"
+    find(EmployeeChooseCoverage.coverall_benefits_radiobtn).click
   else
     find(EmployeeChooseCoverage.employer_sponsored_benefits_radio_btn).click
   end

--- a/features/support/object_model_pages/shop/employee/registration/ee_choose_coverage.rb
+++ b/features/support/object_model_pages/shop/employee/registration/ee_choose_coverage.rb
@@ -23,6 +23,10 @@ class EmployeeChooseCoverage
     'label[for="market_kind_individual"] span'
   end
 
+  def self.coverall_benefits_radiobtn
+    'label[for="market_kind_coverall"] span'
+  end
+
   def self.health_radio_btn
     'label[for="coverage_kind_health"] span'
   end

--- a/features/support/worlds/employer_world.rb
+++ b/features/support/worlds/employer_world.rb
@@ -125,6 +125,13 @@ Given(/a consumer role person with family/) do
   FactoryBot.create(:user, person: @person, email: person[:email], password: person[:password], password_confirmation: person[:password])
 end
 
+Given(/a resident role person with family/) do
+  person = people['Patrick Doe']
+  @person = FactoryBot.create(:person, :with_resident_role, first_name: 'Employee', last_name: person[:last_name], dob: person[:dob])
+  FactoryBot.create :family, :with_primary_family_member, person: @person
+  FactoryBot.create(:user, person: @person, email: person[:email], password: person[:password], password_confirmation: person[:password])
+end
+
 Given(/all products with issuer profile/) do
   @issuer_profile = FactoryBot.create :benefit_sponsors_organizations_issuer_profile
   BenefitMarkets::Products::Product.all.each {|product| product.update_attributes(issuer_profile: @issuer_profile)}


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [pivotal-186104483](https://www.pivotaltracker.com/n/projects/2640057/stories/186104483#)

# A brief description of the changes

Current behavior: On "Choose Coverage for your Household" page, effective date of employer sponsored benefit is always displayed for dual role scenario

New behavior: When user switches market place in "Choose Coverage for your Household" page, effective date will be switched

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.