### PR TITLE
record evidence determination hub requests and failures 

### DIFF
--- a/app/event_source/subscribers/iap/application_determined_subscriber.rb
+++ b/app/event_source/subscribers/iap/application_determined_subscriber.rb
@@ -24,12 +24,6 @@ module Subscribers
 
     private
 
-    # UpdateEvidenceHistories of Application
-    def update_application_evidence_histories(payload)
-      application = FinancialAssistance::Application.by_hbx_id(payload[:hbx_id]).first
-      application.update_evidence_histories
-    end
-
     # Creates tax_household_groups and its accociations for a Family with Financial Assistance Application's Eligibility Determination
     def create_tax_household_group(subscriber_logger, payload)
       result = ::Operations::Families::CreateTaxHouseholdGroupOnFaDetermination.new.call(payload)

--- a/app/event_source/subscribers/iap/application_determined_subscriber.rb
+++ b/app/event_source/subscribers/iap/application_determined_subscriber.rb
@@ -14,7 +14,8 @@ module Subscribers
       # create_tax_household_group(subscriber_logger, payload) if !Rails.env.test? && EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
       # generate_enrollments(subscriber_logger, payload) if !Rails.env.test? && EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
 
-      update_application_evidence_histories(payload)
+      # This method was moved to components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/request_evidence_determination.rb
+      # update_application_evidence_histories(payload)
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/request_evidence_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/request_evidence_determination.rb
@@ -37,75 +37,7 @@ module FinancialAssistance
             payload_entity = ::Operations::Fdsh::BuildAndValidateApplicationPayload.new.call(application)
             return payload_entity unless EnrollRegistry.feature_enabled?(:validate_and_record_publish_application_errors)
 
-            if payload_entity.success?
-              applicant_evidence_validations, invalid_income_evidence_errors_by_id = check_all_applicant_evidences(payload_entity.value!, application)
-              # stop submission of application if all evidence types for every applicant are invalid
-              handle_invalid_income_evidence(application, invalid_income_evidence_errors_by_id) unless invalid_income_evidence_errors_by_id.empty?
-              return Failure('All applicantion evidences invalid') if applicant_evidence_validations.flatten.all?(&:failure?)
-            else
-              # stop submission of application if cv3/aca application build fails
-              error_message = payload_entity.failure
-              update_all_evidences(application, error_message)
-              return Failure(error_message)
-            end
-            payload_entity
-          end
-
-          def check_all_applicant_evidences(payload_entity, application)
-            invalid_income_evidence_errors_by_id = []
-            applicant_evidences = payload_entity.applicants.map do |mma_applicant|
-              # create an array of all evidence types held by the applicant
-              applicant_evidence_keys = EVIDENCE_ALIASES.each_value.map { |evidence_type| mma_applicant.send(evidence_type)&.key }.compact
-              faa_applicant = application.applicants.find_by { |a| a.person_hbx_id == mma_applicant.person_hbx_id }
-
-              # need to run validations against all evidence types for all applicants -- different evidence types _may_ require different validations
-              applicant_evidence_keys.map do |evidence_key|
-                evidence_validation = ::Operations::Fdsh::PayloadEligibility::CheckApplicantEligibilityRules.new.call(mma_applicant, evidence_key)
-                if evidence_validation.failure?
-                  invalid_income_evidence_errors_by_id << "#{mma_applicant.person_hbx_id} - #{evidence_validation.failure}" if evidence_key == :income
-                  handle_invalid_non_income_evidence(faa_applicant, evidence_key, evidence_validation.failure) if evidence_key != :income
-                end
-
-                evidence_validation
-              end
-            end
-
-            [applicant_evidences, invalid_income_evidence_errors_by_id]
-          end
-
-          def handle_invalid_non_income_evidence(faa_applicant, evidence_type, failure_message)
-            evidence_alias = EVIDENCE_ALIASES[evidence_type]
-            evidence = faa_applicant.send(evidence_alias)
-            failure_message = "#{evidence_type.to_s.titleize} Determination Request Failed due to #{failure_message}"
-
-            evidence.determine_mec_evidence_aasm_status
-            evidence.add_verification_history("Hub Request Failed", failure_message, "system")
-          end
-
-          def handle_invalid_income_evidence(financial_assistance_application, invalid_app_ids)
-            failure_message = "Income Evidence Determination Request Failed due to invalid fields on the following applicants: #{invalid_app_ids.join(', ')}"
-
-            financial_assistance_application.applicants.select(&:income_evidence).each do |applicant|
-              applicant.income_evidence.determine_income_evidence_aasm_status
-              applicant.income_evidence.add_verification_history("Hub Request Failed", failure_message, "system")
-            end
-          end
-
-          def update_all_evidences(application, error_message)
-            application.applicants.each do |applicant|
-              EVIDENCE_ALIASES.each_values.each do |evidence_key|
-                evidence = applicant.send(evidence_key)
-                next unless evidence
-
-                if evidence.key == :income
-                  evidence.determine_income_evidence_aasm_status
-                else
-                  evidence.determine_mec_evidence_aasm_status
-                end
-
-                evidence.add_verification_history("Hub Request Failed", error_message, "system")
-              end
-            end
+            FinancialAssistance::Operations::Applications::Verifications::ValidateApplicantAndUpdateEvidence.new.call(payload_entity, application)
           end
 
           def build_event(payload, application)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/request_evidence_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/request_evidence_determination.rb
@@ -28,6 +28,7 @@ module FinancialAssistance
 
           private
 
+          # UpdateEvidenceHistories of Application
           def update_application_evidence_histories(application)
             application.update_evidence_histories
             Success()

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/request_evidence_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/request_evidence_determination.rb
@@ -18,6 +18,7 @@ module FinancialAssistance
           }.freeze
 
           def call(application)
+            update_application_evidence_histories(application)
             payload_entity = yield validate_and_construct_application_payload(application)
             event_result = yield build_event(payload_entity, application)
             publish_result = yield publish_event_result(event_result)
@@ -26,6 +27,11 @@ module FinancialAssistance
           end
 
           private
+
+          # UpdateEvidenceHistories of Application
+          def update_application_evidence_histories(application)
+            application.update_evidence_histories
+          end
 
           def validate_and_construct_application_payload(application)
             payload_entity = ::Operations::Fdsh::BuildAndValidateApplicationPayload.new.call(application)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/request_evidence_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/request_evidence_determination.rb
@@ -55,7 +55,7 @@ module FinancialAssistance
             invalid_income_evidence_errors_by_id = []
             applicant_evidences = payload_entity.applicants.map do |mma_applicant|
               # create an array of all evidence types held by the applicant
-              applicant_evidence_keys = EVIDENCE_ALIASES.values.map { |evidence_type| mma_applicant.send(evidence_type)&.key }.compact
+              applicant_evidence_keys = EVIDENCE_ALIASES.each_value.map { |evidence_type| mma_applicant.send(evidence_type)&.key }.compact
               faa_applicant = application.applicants.find_by { |a| a.person_hbx_id == mma_applicant.person_hbx_id }
 
               # need to run validations against all evidence types for all applicants -- different evidence types _may_ require different validations
@@ -93,10 +93,10 @@ module FinancialAssistance
 
           def update_all_evidences(application, error_message)
             application.applicants.each do |applicant|
-              EVIDENCE_ALIASES.values.each do |evidence_key|
+              EVIDENCE_ALIASES.each_values.each do |evidence_key|
                 evidence = applicant.send(evidence_key)
                 next unless evidence
-                
+
                 if evidence.key == :income
                   evidence.determine_income_evidence_aasm_status
                 else

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/validate_applicant_and_update_evidence.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/validate_applicant_and_update_evidence.rb
@@ -4,6 +4,7 @@ module FinancialAssistance
   module Operations
     module Applications
       module Verifications
+        # This class handles the validation of an applicant and updates the evidences as needed
         class ValidateApplicantAndUpdateEvidence
           include Dry::Monads[:result, :do]
 
@@ -76,7 +77,7 @@ module FinancialAssistance
             error_message = payload_entity.failure
             update_all_evidences(application, error_message)
 
-            return Failure(error_message)
+            Failure(error_message)
           end
 
           def update_all_evidences(application, error_message)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/validate_applicant_and_update_evidence.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/verifications/validate_applicant_and_update_evidence.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module FinancialAssistance
+  module Operations
+    module Applications
+      module Verifications
+        class ValidateApplicantAndUpdateEvidence
+          include Dry::Monads[:result, :do]
+
+          EVIDENCE_ALIASES = {
+            income: :income_evidence,
+            esi_mec: :esi_evidence,
+            non_esi_mec: :non_esi_evidence,
+            local_mec: :local_mec_evidence
+          }.freeze
+
+          def call(payload_entity, application)
+            return handle_malformed_payload_entity(payload_entity, application) if payload_entity.failure?
+
+            evidence_validations, income_evidence_errors = check_all_applicant_evidences(payload_entity.value!, application)
+            handle_invalid_income_evidence(application, income_evidence_errors) unless income_evidence_errors.empty?
+
+            return Failure('All applicantion evidences invalid') if evidence_validations.flatten.all?(&:failure?)
+            payload_entity
+          end
+
+          private
+
+          def check_all_applicant_evidences(payload_entity, application)
+            income_evidence_errors = []
+            evidences = payload_entity.applicants.map do |mma_applicant|
+              evidence_keys, faa_applicant = get_applicant_info(application, mma_applicant)
+
+              # need to run validations against all evidence types for all applicants -- different evidence types _may_ require different validations
+              evidence_keys.map do |evidence_key|
+                evidence_validation = ::Operations::Fdsh::PayloadEligibility::CheckApplicantEligibilityRules.new.call(mma_applicant, evidence_key)
+                if evidence_validation.failure?
+                  income_evidence_errors << "#{mma_applicant.person_hbx_id} - #{evidence_validation.failure}" if evidence_key == :income
+                  handle_invalid_non_income_evidence(faa_applicant, evidence_key, evidence_validation.failure) if evidence_key != :income
+                end
+
+                evidence_validation
+              end
+            end
+
+            [evidences, income_evidence_errors]
+          end
+
+          def get_applicant_info(application, mma_applicant)
+            # create an array of all evidence types held by the applicant
+            evidence_keys = EVIDENCE_ALIASES.each_value.map { |evidence_type| mma_applicant.send(evidence_type)&.key }.compact
+            faa_applicant = application.applicants.find_by { |a| a.person_hbx_id == mma_applicant.person_hbx_id }
+
+            [evidence_keys, faa_applicant]
+          end
+
+          def handle_invalid_non_income_evidence(faa_applicant, evidence_type, failure_message)
+            evidence_alias = EVIDENCE_ALIASES[evidence_type]
+            evidence = faa_applicant.send(evidence_alias)
+            failure_message = "#{evidence_type.to_s.titleize} Determination Request Failed due to #{failure_message}"
+
+            evidence.determine_mec_evidence_aasm_status
+            evidence.add_verification_history("Hub Request Failed", failure_message, "system")
+          end
+
+          def handle_invalid_income_evidence(financial_assistance_application, invalid_app_ids)
+            failure_message = "Income Evidence Determination Request Failed due to invalid fields on the following applicants: #{invalid_app_ids.join(', ')}"
+
+            financial_assistance_application.applicants.select(&:income_evidence).each do |applicant|
+              applicant.income_evidence.determine_income_evidence_aasm_status
+              applicant.income_evidence.add_verification_history("Hub Request Failed", failure_message, "system")
+            end
+          end
+
+          def handle_malformed_payload_entity(payload_entity, application)
+            error_message = payload_entity.failure
+            update_all_evidences(application, error_message)
+
+            return Failure(error_message)
+          end
+
+          def update_all_evidences(application, error_message)
+            application.applicants.each do |applicant|
+              EVIDENCE_ALIASES.each_values.each do |evidence_key|
+                evidence = applicant.send(evidence_key)
+                next unless evidence
+
+                method = "determine_#{evidence.key.split('_').last}_evidence_aasm_status"
+                evidence.send(method)
+
+                evidence.add_verification_history("Hub Request Failed", error_message, "system")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/verifications/request_evidence_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/verifications/request_evidence_determination_spec.rb
@@ -146,11 +146,25 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Verifications::R
     it 'should return success with message' do
       expect(@result.success).to eq('Event published successfully')
     end
+
+    it 'should add verification histories to all evidences' do
+      evidence_1 = applicant_1.esi_evidence
+      evidence_2 = applicant_2.esi_evidence
+      evidence_3 = applicant_3.esi_evidence
+
+      expect(evidence_1.verification_histories.length).to eq 1
+      expect(evidence_2.verification_histories.length).to eq 1
+      expect(evidence_3.verification_histories.length).to eq 1
+
+      expect(evidence_1.verification_histories.last.action).to eq 'application_determined'
+    end
   end
 
   context 'with invalid application' do
     before do
-      @result = subject.call("application_id")
+      application.applicants.destroy_all
+
+      @result = subject.call(application)
     end
 
     it 'should return a failure with error message' do
@@ -171,22 +185,30 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Verifications::R
           expect(@result).to be_success
         end
 
-        it "should update invalid applicants' verification history" do
+        it "should update invalid applicants' verification history with additional error history" do
           evidence = applicant_1.esi_evidence
-          expect(evidence.verification_histories.length).to eq 1
-          expect(evidence.verification_histories.first.update_reason).to include "Invalid SSN"
+          expect(evidence.verification_histories.length).to eq 2
+          expect(evidence.verification_histories.last.update_reason).to include 'Invalid SSN'
         end
 
-        it "should NOT modify valid applicants' verification histories" do
+        it "should NOT add an error to valid applicants' verification histories" do
           evidence_2 = applicant_2.esi_evidence
           evidence_3 = applicant_3.esi_evidence
-          expect(evidence_2.verification_histories.length).to eq 0
-          expect(evidence_3.verification_histories.length).to eq 0
+          expect(evidence_2.verification_histories.length).to eq 1
+          expect(evidence_3.verification_histories.length).to eq 1
+        end
+
+        it 'should not affect the valid applicants evidence aasm_states' do
+          evidence_2 = applicant_2.esi_evidence
+          evidence_3 = applicant_3.esi_evidence
+
+          expect(evidence_2.aasm_state).to eq 'pending'
+          expect(evidence_3.aasm_state).to eq 'pending'
         end
 
         it 'should update the invalid applicants aasm_states to attested' do
           evidence = applicant_1.esi_evidence
-          expect(evidence.aasm_state).to eq "attested"
+          expect(evidence.aasm_state).to eq 'attested'
         end
       end
 
@@ -212,18 +234,18 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Verifications::R
           evidence_1 = applicant_1.income_evidence
           evidence_2 = applicant_2.income_evidence
           evidence_3 = applicant_3.income_evidence
-          expect(evidence_1.verification_histories.length).to eq 1
-          expect(evidence_2.verification_histories.length).to eq 1
-          expect(evidence_3.verification_histories.length).to eq 1
+          expect(evidence_1.verification_histories.length).to eq 2
+          expect(evidence_2.verification_histories.length).to eq 2
+          expect(evidence_3.verification_histories.length).to eq 2
         end
 
         it 'should update the aasm_states to negative_response_received' do
           evidence_1 = applicant_1.income_evidence
           evidence_2 = applicant_2.income_evidence
           evidence_3 = applicant_3.income_evidence
-          expect(evidence_1.aasm_state).to eq "negative_response_received"
-          expect(evidence_2.aasm_state).to eq "negative_response_received"
-          expect(evidence_3.aasm_state).to eq "negative_response_received"
+          expect(evidence_1.aasm_state).to eq 'negative_response_received'
+          expect(evidence_2.aasm_state).to eq 'negative_response_received'
+          expect(evidence_3.aasm_state).to eq 'negative_response_received'
         end
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [185760505](https://www.pivotaltracker.com/story/show/185760505)

# A brief description of the changes

Current behavior: Does not log `application_determined` message to evidence verification histories when publishing magi medical application

New behavior: Will log `application_determined` during the publish magi medical application process

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: `VALIDATE_AND_RECORD_PUBLISH_APPLICATION_ERRORS_IS_ENABLED`

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.