### PR TITLE
adds no ssn reason for SSA call for members without ssn

### DIFF
--- a/app/domain/operations/fdsh/payload_eligibility/check_person_eligibility_rules.rb
+++ b/app/domain/operations/fdsh/payload_eligibility/check_person_eligibility_rules.rb
@@ -15,7 +15,7 @@ module Operations
         end
 
         def validate_ssn(payload)
-          encrypted_ssn = payload.person_demographics.encrypted_ssn || payload.person_identifying_information.encrypted_ssn
+          encrypted_ssn = payload.person_demographics.encrypted_ssn
           return Failure('No SSN for member') if encrypted_ssn.nil? || encrypted_ssn.empty?
           Operations::Fdsh::EncryptedSsnValidator.new.call(encrypted_ssn)
         end

--- a/app/domain/operations/fdsh/payload_eligibility/check_person_eligibility_rules.rb
+++ b/app/domain/operations/fdsh/payload_eligibility/check_person_eligibility_rules.rb
@@ -16,7 +16,7 @@ module Operations
 
         def validate_ssn(payload)
           encrypted_ssn = payload.person_demographics.encrypted_ssn
-          return Failure('No SSN for member') if encrypted_ssn.nil? || encrypted_ssn.empty?
+          return Failure('No SSN') if encrypted_ssn.nil? || encrypted_ssn.empty?
           Operations::Fdsh::EncryptedSsnValidator.new.call(encrypted_ssn)
         end
 

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -112,6 +112,8 @@ class ConsumerRole
   delegate :citizen_status, :citizenship_result,:vlp_verified_date, :vlp_authority, :vlp_document_id, to: :lawful_presence_determination_instance
   delegate :citizen_status=, :citizenship_result=,:vlp_verified_date=, :vlp_authority=, :vlp_document_id=, to: :lawful_presence_determination_instance
 
+  delegate :encrypted_ssn, to: :person
+
   field :is_applicant, type: Boolean  # Consumer is applying for benefits coverage
   field :birth_location, type: String
   field :marital_status, type: String

--- a/app/models/lawful_presence_determination.rb
+++ b/app/models/lawful_presence_determination.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LawfulPresenceDetermination
   SSA_VERIFICATION_REQUEST_EVENT_NAME = "local.enroll.lawful_presence.ssa_verification_request"
   VLP_VERIFICATION_REQUEST_EVENT_NAME = "local.enroll.lawful_presence.vlp_verification_request"
@@ -79,9 +81,7 @@ class LawfulPresenceDetermination
       ssa_verification_type = ivl_role.verification_types.ssn_type.first
 
       if result.failure? && EnrollRegistry.feature_enabled?(:validate_and_record_publish_errors)
-        ssa_verification_type.add_type_history_element(action: "Hub Request Failed", modifier: "System", update_reason: "SSA Verification Request Failed due to #{result.failure}")
-        args = OpenStruct.new(determined_at: Time.now, vlp_authority: 'ssa')
-        ivl_role.ssn_invalid!(args)
+        process_ssa_request_failure(result, ssa_verification_type)
       else
         ssa_verification_type.pending_type
       end
@@ -173,5 +173,28 @@ class LawfulPresenceDetermination
       event: aasm.current_event,
       transition_at: Time.now
     )
+  end
+
+  # Method to process the Failure Response from SSA Verification Request when feature :validate_and_record_publish_errors is enabled
+  def process_ssa_request_failure(failure_request_result, ssa_v_type)
+    args = OpenStruct.new(determined_at: Time.now, vlp_authority: 'ssa')
+
+    type_history_params = {
+      action: 'Hub Request Failed',
+      modifier: 'System',
+      update_reason: "SSA Verification Request Failed due to #{failure_request_result.failure}"
+    }
+
+    # Only handles case where SSN is blank and member is US Citizen
+    if ivl_role.encrypted_ssn.blank? && ivl_role.is_native?
+      citizenship_v_type = ivl_role.verification_types.citizenship_type.first
+      # "SSA Verification Request Failed due to No SSN for member"
+      citizenship_v_type.add_type_history_element(type_history_params)
+      # We are not failing SSN DMI as it is not present and only handling Citizenship DMI
+      ivl_role.fail_lawful_presence(args)
+    else
+      ssa_v_type.add_type_history_element(type_history_params)
+      ivl_role.ssn_invalid!(args)
+    end
   end
 end

--- a/spec/domain/operations/fdsh/payload_eligibility/check_person_eligibility_rules_spec.rb
+++ b/spec/domain/operations/fdsh/payload_eligibility/check_person_eligibility_rules_spec.rb
@@ -35,6 +35,20 @@ RSpec.describe Operations::Fdsh::PayloadEligibility::CheckPersonEligibilityRules
         expect(result.failure).to eq(["Invalid SSN"])
       end
     end
+
+    context 'person without SSN' do
+      let(:person) do
+        per = FactoryBot.create(:person, :with_consumer_role)
+        per.update_attributes!(encrypted_ssn: nil)
+        per
+      end
+
+      it 'returns a failure result with an error message' do
+        expect(
+          subject.call(payload_entity, request_type).failure
+        ).to include('No SSN')
+      end
+    end
   end
 
   describe 'request_type dhs' do

--- a/spec/factories/lawful_presence_determinations.rb
+++ b/spec/factories/lawful_presence_determinations.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     vlp_verified_at { 2.days.ago }
     citizen_status { "citizen" }
     aasm_state { "verification_successful" }
+
+    trait :us_citizen do
+      citizen_status { 'us_citizen' }
+    end
   end
 end

--- a/spec/models/lawful_presence_determination_spec.rb
+++ b/spec/models/lawful_presence_determination_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require 'aasm/rspec'
 
@@ -140,6 +142,37 @@ describe '#start_ssa_process' do
             expect(ssa_verification_type.validation_status).to eq('outstanding')
           end
         end
+      end
+    end
+
+    context 'when person does not have ssn and is us_citizen' do
+      let(:non_ssn_person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+      let(:ivl_role) { non_ssn_person.consumer_role }
+      let(:lawful_presence) { FactoryBot.create(:lawful_presence_determination, :us_citizen, ivl_role: ivl_role) }
+      let(:citizenship_v_type) { ivl_role.verification_types.citizenship_type.first }
+
+      before { non_ssn_person.update_attributes!(encrypted_ssn: nil) }
+
+      it 'modifies aasm_state of lawful_presence_determination' do
+        expect(lawful_presence.verification_successful?).to be_truthy
+        lawful_presence.start_ssa_process
+        expect(lawful_presence.reload.verification_outstanding?).to be_truthy
+      end
+
+      it 'modifies validation_status of the Citizenship verification type' do
+        expect(citizenship_v_type.validation_status).to eq('unverified')
+        lawful_presence.start_ssa_process
+        expect(citizenship_v_type.reload.validation_status).to eq('negative_response_received')
+      end
+
+      it 'adds type history element to Citizenship verification type' do
+        expect(citizenship_v_type.type_history_elements).to be_empty
+        lawful_presence.start_ssa_process
+        type_history_element = citizenship_v_type.type_history_elements.first.reload
+        expect(type_history_element.action).to eq('Hub Request Failed')
+        expect(type_history_element.modifier).to eq('System')
+        expect(type_history_element.update_reason).to match(/SSA Verification Request/)
+        expect(type_history_element.update_reason).to match(/No SSN for member/)
       end
     end
   end

--- a/spec/models/lawful_presence_determination_spec.rb
+++ b/spec/models/lawful_presence_determination_spec.rb
@@ -172,7 +172,7 @@ describe '#start_ssa_process' do
         expect(type_history_element.action).to eq('Hub Request Failed')
         expect(type_history_element.modifier).to eq('System')
         expect(type_history_element.update_reason).to match(/SSA Verification Request/)
-        expect(type_history_element.update_reason).to match(/No SSN for member/)
+        expect(type_history_element.update_reason).to match(/No SSN/)
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186065995](https://www.pivotaltracker.com/story/show/186065995)

# A brief description of the changes

Current behavior: Error message is not populated for US Citizens who do not have SSNs.

New behavior: Populates error reason when SSA call is made for US Citizens who do not have SSN. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context

When SSA calls are made for US Citizens without SSNs then the below should happen:
- Add a 'No SSN' reason when we attempt to make an SSA call to the type history elements of the Citizenship verification type.
- Changes Lawful Presence Determination's aasm state to `verification_outstanding`.
- Changes the validation status of the Citizenship verification type to `negative_response_received`.
