### PR TITLE
add DR2_DUE_DATE_OFFSET env variable in dc config

### DIFF
--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -179,7 +179,7 @@ registry:
         is_enabled: true
         settings:
           - key: :offset_prior_to_due_date
-            item: 70
+            item: <%= ENV['DR2_DUE_DATE_OFFSET'] || 70 %>
           - key: :units
             item: :days
           - key: :event_name

--- a/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -179,7 +179,7 @@ registry:
         is_enabled: true
         settings:
           - key: :offset_prior_to_due_date
-            item: 70
+            item: <%= ENV['DR2_DUE_DATE_OFFSET'] || 70 %>
           - key: :units
             item: :days
           - key: :event_name


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185491655

# A brief description of the changes

Current behavior: `DR2_DUE_DATE_OFFSET` env variable is only set in ME config

New behavior: Set `DR2_DUE_DATE_OFFSET` env variable in DC config as well

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.