### PR TITLE
populates predecessor_enrollment_id for ivl renewal enrollments

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -47,6 +47,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
     renewal_enrollment.hbx_enrollment_members = clone_enrollment_members
     renewal_enrollment.product_id = fetch_product_id(renewal_enrollment)
     renewal_enrollment.is_any_enrollment_member_outstanding = @enrollment.is_any_enrollment_member_outstanding
+    renewal_enrollment.predecessor_enrollment_id = @enrollment.id
 
     renewal_enrollment
   end

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2972,6 +2972,12 @@ class HbxEnrollment
     )
   end
 
+  def predecessor_enrollment_hbx_id
+    return nil unless predecessor_enrollment_id
+
+    HbxEnrollment.where(id: predecessor_enrollment_id).first&.hbx_id
+  end
+
   private
 
   # Calculates sum of enrolled aptc member's of TaxHouseholdEnrollment ehb_premiums including Minimum Responsibility.

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -127,7 +127,12 @@ class HbxEnrollment
   field :external_id, type: String
   field :external_group_identifiers, type: Array
   field :special_enrollment_period_id, type: BSON::ObjectId
+
+  # In Individual Market's context the predecessor_enrollment_id is:
+  #   1. The id of the enrollment that is renewed.
+  #   2. The id of the enrollment that is superseded.(Expand in the future)
   field :predecessor_enrollment_id, type: BSON::ObjectId
+
   field :enrollment_signature, type: String
 
   field :consumer_role_id, type: BSON::ObjectId

--- a/lib/tasks/hbx_reports/enrollment_report.rake
+++ b/lib/tasks/hbx_reports/enrollment_report.rake
@@ -202,7 +202,7 @@ namespace :reports do
                   ethnicity_status(per.ethnicity),
                   per.citizen_status,
                   broker_assisted(enr, primary_person),
-                  en.predecessor_enrollment_hbx_id
+                  enr.predecessor_enrollment_hbx_id
                 ]
               end
             end

--- a/lib/tasks/hbx_reports/enrollment_report.rake
+++ b/lib/tasks/hbx_reports/enrollment_report.rake
@@ -144,7 +144,7 @@ namespace :reports do
               "Purchase Date", "Coverage Start", "Coverage End", "SEP Reason", "Term Reason",
               "Home Address", "Mailing Address","Work Email", "Home Email", "Phone Number","Broker", "Broker NPN",
               "Broker Assignment Date","Race", "Ethnicity", "Citizen Status",
-              "Broker Assisted"]
+              "Broker Assisted", "Predecessor Enrollment HbxID"]
       while offset <= total_count
         enrollments.offset(offset).limit(batch_size).no_timeout.each do |enr|
           count += 1
@@ -201,7 +201,8 @@ namespace :reports do
                   per.ethnicity,
                   ethnicity_status(per.ethnicity),
                   per.citizen_status,
-                  broker_assisted(enr, primary_person)
+                  broker_assisted(enr, primary_person),
+                  en.predecessor_enrollment_hbx_id
                 ]
               end
             end

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -414,6 +414,12 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
                                                 ehb_premium: 1390
                                               })
           end
+
+          it 'populates predecessor_enrollment_id for health enrollments' do
+            expect(
+              subject.renew.predecessor_enrollment_id
+            ).to eq(enrollment.id)
+          end
         end
 
         context 'assisted renewal' do
@@ -628,6 +634,12 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
             renewal = subject.renew
             expect(renewal.is_a?(HbxEnrollment)).to eq true
             expect(subject.aptc_values).to eq({})
+          end
+
+          it 'populates predecessor_enrollment_id for dental enrollments' do
+            expect(
+              subject.renew.predecessor_enrollment_id
+            ).to eq(enrollment.id)
           end
         end
 

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -13,11 +13,13 @@ RSpec.describe HbxEnrollment, type: :model do
   let(:person) { create(:person, :with_consumer_role, :with_active_consumer_role, first_name: 'test1') }
   let(:family) { create(:family, :with_primary_family_member, person: person) }
   let(:aasm_state) { 'coverage_selected' }
+  let(:predecessor_enrollment_id) { nil }
   let(:hbx_enrollment) do
     create(:hbx_enrollment, :individual_aptc, :with_silver_health_product, aasm_state: aasm_state,
                                                                            applied_aptc_amount: applied_aptc_amount,
                                                                            elected_aptc_pct: elected_aptc_pct,
                                                                            family: family,
+                                                                           predecessor_enrollment_id: predecessor_enrollment_id,
                                                                            consumer_role_id: person.consumer_role.id,
                                                                            ehb_premium: enrollment_ehb_premium)
   end
@@ -645,6 +647,33 @@ RSpec.describe HbxEnrollment, type: :model do
           hbx_enrollment.propogate_terminate(terminated_on_date, transition_args)
         end.not_to raise_error(StandardError)
         expect(hbx_enrollment.terminated_on).to eq(terminated_on_date)
+      end
+    end
+  end
+
+  describe '#predecessor_enrollment_hbx_id' do
+    let(:enrollment2) do
+      FactoryBot.create(
+        :hbx_enrollment,
+        :individual_aptc,
+        :with_silver_health_product,
+        aasm_state: aasm_state,
+        family: family,
+        consumer_role_id: person.consumer_role.id
+      )
+    end
+
+    context 'with predecessor_enrollment_id' do
+      let(:predecessor_enrollment_id) { enrollment2.id }
+
+      it 'returns predecessor_enrollment_id' do
+        expect(hbx_enrollment.predecessor_enrollment_hbx_id).to eq(enrollment2.hbx_id)
+      end
+    end
+
+    context 'without predecessor_enrollment_id' do
+      it 'returns nil' do
+        expect(hbx_enrollment.predecessor_enrollment_hbx_id).to be_nil
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Enhancement to the application
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186112909](https://www.pivotaltracker.com/story/show/186112909)

# A brief description of the changes

Current behavior: Cannot find the exact predecessor enrollment of an IVL renewal enrollment

New behavior: By populating `predecessor_enrollment_id` we can find the exact predecessor enrollment of an IVL renewal enrollment

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.