### PR TITLE
record failure if no vlp documents exist for a consumer when making dhs call

### DIFF
--- a/app/domain/operations/fdsh/payload_eligibility/check_person_eligibility_rules.rb
+++ b/app/domain/operations/fdsh/payload_eligibility/check_person_eligibility_rules.rb
@@ -21,7 +21,10 @@ module Operations
         end
 
         def validate_vlp_documents(person_entity)
-          errors = person_entity.consumer_role.vlp_documents.collect do |vlp_document_entity|
+          vlp_documents = person_entity.consumer_role.vlp_documents
+          return Failure("No VLP Documents") if vlp_documents.empty?
+
+          errors = vlp_documents.collect do |vlp_document_entity|
             next if vlp_document_entity.subject.nil?
             vlp_errors = ::Validators::VlpV37Contract.new.call(JSON.parse(vlp_document_entity.to_json).compact).errors.to_h
             vlp_errors if vlp_errors.present?

--- a/spec/domain/operations/fdsh/payload_eligibility/check_person_eligibility_rules_spec.rb
+++ b/spec/domain/operations/fdsh/payload_eligibility/check_person_eligibility_rules_spec.rb
@@ -77,6 +77,18 @@ RSpec.describe Operations::Fdsh::PayloadEligibility::CheckPersonEligibilityRules
       end
     end
 
+    context 'when a no vlp documents exists for a consumer' do
+      let!(:person_entity) do
+        person_payload.to_h[:consumer_role].merge!(vlp_documents: [])
+        AcaEntities::People::Person.new(person_payload.to_h)
+      end
+
+      it 'returns a Success' do
+        result = described_class.new.call(person_entity, request_type)
+        expect(result.failure).to include('No VLP Documents')
+      end
+    end
+
     context 'when document type I-327 (Reentry Permit) has missing alien_number' do
       let!(:person_entity) do
         person_payload.to_h[:consumer_role][:vlp_documents][0].merge!(alien_number: nil)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/n/projects/2640059/stories/186113466#

# A brief description of the changes

Current behavior: Failure message is not recorded when a Hub call is made but no VLP documents exist for a consumer

New behavior: Record failure message when a hub call is made but no VLP documents exist for a consumer

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.