### PR TITLE
allow member for calculating due date irrespective of income values

### DIFF
--- a/app/models/eligibilities/visitors/aptc_csr_credit_visitor.rb
+++ b/app/models/eligibilities/visitors/aptc_csr_credit_visitor.rb
@@ -19,7 +19,7 @@ module Eligibilities
 
       def visit(applicant)
         return unless applicant.family_member_id == subject.id
-        return if evidence_item[:key].to_s == "income_evidence" # && applicant.incomes.blank? commenting out this as per pivotal-186104816
+        # return if evidence_item[:key].to_s == "income_evidence" && applicant.incomes.blank? comment this as per pivotal-186104816
 
         current_record = applicant.send(evidence_item[:key])
         unless current_record

--- a/app/models/eligibilities/visitors/aptc_csr_credit_visitor.rb
+++ b/app/models/eligibilities/visitors/aptc_csr_credit_visitor.rb
@@ -19,7 +19,7 @@ module Eligibilities
 
       def visit(applicant)
         return unless applicant.family_member_id == subject.id
-        return if evidence_item[:key].to_s == "income_evidence" && applicant.incomes.blank?
+        return if evidence_item[:key].to_s == "income_evidence" # && applicant.incomes.blank? commenting out this as per pivotal-186104816
 
         current_record = applicant.send(evidence_item[:key])
         unless current_record

--- a/spec/domain/operations/eligibilities/build_eligibility_state_spec.rb
+++ b/spec/domain/operations/eligibilities/build_eligibility_state_spec.rb
@@ -160,6 +160,27 @@ RSpec.describe ::Operations::Eligibilities::BuildEligibilityState,
     end
   end
 
+  context 'when there is no income for the applicant' do
+    before do
+      application.applicants[1].update_attributes(incomes: [])
+      @result = subject.call(required_params)
+    end
+
+    it 'should return success' do
+      expect(@result.success?).to be_truthy
+    end
+
+    it 'should have evidence states built' do
+      eligibility_state = @result.success
+      expect(eligibility_state.key?(:determined_at)).to be_truthy
+      expect(eligibility_state.key?(:evidence_states)).to be_truthy
+      expect(eligibility_state[:evidence_states].keys).to eq eligibility_item
+        .evidence_items
+        .map(&:key)
+        .map(&:to_sym)
+    end
+  end
+
   context '.fetch_document_status' do
 
     context 'fully uploaded' do

--- a/spec/domain/operations/eligibilities/build_evidence_state_spec.rb
+++ b/spec/domain/operations/eligibilities/build_evidence_state_spec.rb
@@ -159,4 +159,20 @@ RSpec.describe ::Operations::Eligibilities::BuildEvidenceState,
       expect(result.success.key?(evidence_item.key.to_sym)).to be_truthy
     end
   end
+
+  context 'when there is no income for the applicant' do
+    before do
+      application.applicants[1].update_attributes(incomes: [])
+      @result = subject.call(required_params)
+    end
+
+    it 'should return success' do
+      expect(@result.success?).to be_truthy
+    end
+
+    it 'should build with evidence details' do
+      expect(@result.success).to be_a(Hash)
+      expect(@result.success.key?(evidence_item.key.to_sym)).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [pivotal-186104816](https://www.pivotaltracker.com/n/projects/2648255/stories/186104816)

# A brief description of the changes

Current behavior: Family Level due date update operations that are triggered after evidence update is fetching the applicants with income evidence and also check if the income is present for the respective evidence. Due to this the respective dependent is not considered in calculating the family level due date.

New behavior: Allow all members with outstanding income evidence for calculating due date irrespective of income values.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.