### PR TITLE
remove manual update of family level due date logic

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/auto_extend_income_evidence.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/auto_extend_income_evidence.rb
@@ -41,25 +41,11 @@ module FinancialAssistance
               updated_applicants << applicant.person_hbx_id
               applicant.income_evidence.auto_extend_due_on(params[:extend_by].days, params[:modified_by])
             end
-
-            update_family_level_verification_due_date(application)
           end
 
           Success(updated_applicants)
         rescue StandardError => e
           Failure("Failed to auto extend income evidence due on because of #{e.message}")
-        end
-
-        def update_family_level_verification_due_date(application)
-          family = application.family
-          eligibility_determination = family&.eligibility_determination
-          return unless eligibility_determination
-
-          applicants_earliest_due_date = family&.min_verification_due_date_on_family
-          family_earliest_due_date = eligibility_determination&.outstanding_verification_earliest_due_date
-          return unless applicants_earliest_due_date && family_earliest_due_date
-
-          family.eligibility_determination.update(outstanding_verification_earliest_due_date: applicants_earliest_due_date) if applicants_earliest_due_date > family_earliest_due_date
         end
       end
     end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/auto_extend_income_evidence_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/auto_extend_income_evidence_spec.rb
@@ -273,11 +273,6 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AutoExtendIncome
           expect(applicant2.income_evidence.due_on).to eq(applicant_2_due_date) # extensions only happen if evidence due on is the current_due_on
           expect(applicant3.income_evidence.due_on).to eq(applicant_3_due_date) # Extension period not applicable to applicants ineligible for auto-renewal
         end
-
-        it 'should update the family outstanding_verification_earliest_due_date to the earliest income_evidence due_on date' do
-          # applicant2 has the earliest income_evidence due_on date -- meaning the overall earliest due date for the family should also be this date
-          expect(family.eligibility_determination.outstanding_verification_earliest_due_date).to eq(applicant2.income_evidence.due_on)
-        end
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [pivotal_186115651](https://www.pivotaltracker.com/n/projects/2648255/stories/186115651#)

# A brief description of the changes

No change in the family level due date behavior. No change in functionality.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.