### PR TITLE
record error message under citizenship DMI when invalid ssn is entered

### DIFF
--- a/app/models/lawful_presence_determination.rb
+++ b/app/models/lawful_presence_determination.rb
@@ -192,7 +192,7 @@ class LawfulPresenceDetermination
       ivl_role.fail_lawful_presence(args)
     else
       ssa_v_type.add_type_history_element(type_history_params)
-      citizenship_v_type.add_type_history_element(type_history_params)
+      citizenship_v_type.add_type_history_element(type_history_params) if ivl_role.is_native?
       ivl_role.ssn_invalid!(args)
     end
   end

--- a/app/models/lawful_presence_determination.rb
+++ b/app/models/lawful_presence_determination.rb
@@ -185,15 +185,14 @@ class LawfulPresenceDetermination
       update_reason: "SSA Verification Request Failed due to #{failure_request_result.failure}"
     }
 
+    citizenship_v_type = ivl_role.verification_types.citizenship_type.first
     # Only handles case where SSN is blank and member is US Citizen
     if ivl_role.encrypted_ssn.blank? && ivl_role.is_native?
-      citizenship_v_type = ivl_role.verification_types.citizenship_type.first
-      # "SSA Verification Request Failed due to No SSN for member"
       citizenship_v_type.add_type_history_element(type_history_params)
-      # We are not failing SSN DMI as it is not present and only handling Citizenship DMI
       ivl_role.fail_lawful_presence(args)
     else
       ssa_v_type.add_type_history_element(type_history_params)
+      citizenship_v_type.add_type_history_element(type_history_params)
       ivl_role.ssn_invalid!(args)
     end
   end

--- a/spec/models/lawful_presence_determination_spec.rb
+++ b/spec/models/lawful_presence_determination_spec.rb
@@ -176,7 +176,7 @@ describe '#start_ssa_process' do
       end
     end
 
-    context 'when person does not have ssn and is us_citizen' do
+    context 'when person have invalid ssn and is us_citizen' do
       let(:invalid_ssn_person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
       let(:ivl_role) { invalid_ssn_person.consumer_role }
       let(:lawful_presence) { FactoryBot.create(:lawful_presence_determination, :us_citizen, ivl_role: ivl_role) }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/n/projects/2640059/stories/186113330

# A brief description of the changes

Current behavior: Error message is not being recorded under citizenship DMI when hub call is made for person with invalid ssn

New behavior: Record error message under citizenship DMI when hub call is made for person with invalid ssn

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.