### PR TITLE
update error loging on event_source subscribers

### DIFF
--- a/app/event_source/subscribers/applications/aptc_csr_credits/renewals/determination_submission_requested_subscriber.rb
+++ b/app/event_source/subscribers/applications/aptc_csr_credits/renewals/determination_submission_requested_subscriber.rb
@@ -44,8 +44,8 @@ module Subscribers
 
             ack(delivery_info.delivery_tag)
           rescue StandardError, SystemStackError => e
-            subscriber_logger.info "on_enroll_applications_aptc_csr_credits_renewals_determination_submission, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-            logger.info "on_enroll_applications_aptc_csr_credits_renewals_determination_submission: errored & acked. Backtrace: #{e.backtrace}"
+            subscriber_logger.error "on_enroll_applications_aptc_csr_credits_renewals_determination_submission, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+            logger.error "on_enroll_applications_aptc_csr_credits_renewals_determination_submission: errored & acked. error message: #{e.message}, Backtrace: #{e.backtrace}"
             ack(delivery_info.delivery_tag)
           end
         end

--- a/app/event_source/subscribers/applications/aptc_csr_credits/renewals/renewal_determined_subscriber.rb
+++ b/app/event_source/subscribers/applications/aptc_csr_credits/renewals/renewal_determined_subscriber.rb
@@ -40,8 +40,8 @@ module Subscribers
 
             ack(delivery_info.delivery_tag)
           rescue StandardError, SystemStackError => e
-            logger.info "RenewalDeterminedSubscriber error: #{e.backtrace}"
-            subscriber_logger.info "RenewalDeterminedSubscriber error: #{e.backtrace}"
+            logger.error "RenewalDeterminedSubscriber error message: #{e.message}, backtrace: #{e.backtrace}"
+            subscriber_logger.error "RenewalDeterminedSubscriber error message: #{e.message}, backtrace: #{e.backtrace}"
             ack(delivery_info.delivery_tag)
           end
         end

--- a/app/event_source/subscribers/applications/aptc_csr_credits/renewals/renewal_requested_subscriber.rb
+++ b/app/event_source/subscribers/applications/aptc_csr_credits/renewals/renewal_requested_subscriber.rb
@@ -42,9 +42,9 @@ module Subscribers
 
             ack(delivery_info.delivery_tag)
           rescue StandardError, SystemStackError => e
-            subscriber_logger.info "RenewalRequestSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-            logger.info "RenewalRequestSubscriber: errored & acked. Backtrace: #{e.backtrace}"
-            subscriber_logger.info "RenewalRequestSubscriber, ack: #{payload}"
+            subscriber_logger.error "RenewalRequestSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+            logger.error "RenewalRequestSubscriber: errored & acked. error message: #{e.message}, backtrace: #{e.backtrace}"
+            subscriber_logger.error "RenewalRequestSubscriber, ack: #{payload}"
             ack(delivery_info.delivery_tag)
           end
         end

--- a/app/event_source/subscribers/aptc_csr_credit_eligibilities_subscriber.rb
+++ b/app/event_source/subscribers/aptc_csr_credit_eligibilities_subscriber.rb
@@ -56,9 +56,9 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "AptcCsrCreditEligibilitiesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "AptcCsrCreditEligibilitiesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
       # logger.info "AptcCsrCreditEligibilitiesSubscriber: errored & acked. Backtrace: #{e.backtrace}"
-      subscriber_logger.info "AptcCsrCreditEligibilitiesSubscriber, ack: #{payload}"
+      subscriber_logger.error "AptcCsrCreditEligibilitiesSubscriber, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 

--- a/app/event_source/subscribers/atp_subscriber.rb
+++ b/app/event_source/subscribers/atp_subscriber.rb
@@ -36,7 +36,7 @@ module Subscribers
       FinancialAssistance::Operations::Transfers::MedicaidGateway::PublishTransferResponse.new.call(transfer_details)
     rescue StandardError => e
       nack(delivery_info.delivery_tag)
-      logger.info "AtpSubscriber: error: #{e.backtrace}"
+      logger.error "AtpSubscriber: error_message: #{e.message}, backtrace: #{e.backtrace}"
     end
   end
 end

--- a/app/event_source/subscribers/batch_process_subscriber.rb
+++ b/app/event_source/subscribers/batch_process_subscriber.rb
@@ -25,9 +25,9 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "BatchProcessSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      logger.info "BatchProcessSubscriber: errored & acked. Backtrace: #{e.backtrace}"
-      subscriber_logger.info "BatchProcessSubscriber, ack: #{payload}"
+      subscriber_logger.error "BatchProcessSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      logger.error "BatchProcessSubscriber: errored & acked. error message: #{e.message}, Backtrace: #{e.backtrace}"
+      subscriber_logger.error "BatchProcessSubscriber, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 
@@ -51,9 +51,9 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "BatchProcessSubscriber#on_enroll_enterprise_events, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      logger.info "BatchProcessSubscriber#on_enroll_enterprise_events: errored & acked. Backtrace: #{e.backtrace}"
-      subscriber_logger.info "BatchProcessSubscriber#on_enroll_enterprise_events, ack: #{payload}"
+      subscriber_logger.error "BatchProcessSubscriber#on_enroll_enterprise_events, payload: #{payload}, error_message: #{e.message}, backtrace: #{e.backtrace}"
+      logger.error "BatchProcessSubscriber#on_enroll_enterprise_events: errored & acked. error_message: #{e.message}, Backtrace: #{e.backtrace}"
+      subscriber_logger.error "BatchProcessSubscriber#on_enroll_enterprise_events, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
   end

--- a/app/event_source/subscribers/benefit_sponsors/benefit_application_subscriber.rb
+++ b/app/event_source/subscribers/benefit_sponsors/benefit_application_subscriber.rb
@@ -20,8 +20,8 @@ module Subscribers
 
         ack(delivery_info.delivery_tag)
       rescue StandardError, SystemStackError => e
-        subscriber_logger.info "BenefitApplicationsSubscriber, employer fein: #{benefit_sponsorship.fein}, error message: #{e.message}, backtrace: #{e.backtrace}"
-        logger.info "BenefitApplicationsSubscriber: errored & acked. payload: #{payload} Backtrace: #{e.backtrace}"
+        subscriber_logger.error "BenefitApplicationsSubscriber, employer fein: #{benefit_sponsorship.fein}, error message: #{e.message}, backtrace: #{e.backtrace}"
+        logger.error "BenefitApplicationsSubscriber: errored & acked. payload: #{payload} error message: #{e.message}, backtrace: #{e.backtrace}"
         ack(delivery_info.delivery_tag)
       end
 

--- a/app/event_source/subscribers/benefit_sponsors/census_employee_subscriber.rb
+++ b/app/event_source/subscribers/benefit_sponsors/census_employee_subscriber.rb
@@ -19,8 +19,8 @@ module Subscribers
 
         ack(delivery_info.delivery_tag)
       rescue StandardError, SystemStackError => e
-        subscriber_logger.info "CensusEmployeeSubscriber, census_employee: #{census_employee.full_name}, employer: #{employer.legal_name}, error message: #{e.message}, backtrace: #{e.backtrace}"
-        logger.info "CensusEmployeeSubscriber: errored & acked. payload: #{payload} Backtrace: #{e.backtrace}"
+        subscriber_logger.error "CensusEmployeeSubscriber, census_employee: #{census_employee.full_name}, employer: #{employer.legal_name}, error message: #{e.message}, backtrace: #{e.backtrace}"
+        logger.error "CensusEmployeeSubscriber: errored & acked. payload: #{payload}, error message: #{e.message}, Backtrace: #{e.backtrace}"
         ack(delivery_info.delivery_tag)
       end
 
@@ -60,8 +60,8 @@ module Subscribers
         end
         ack(delivery_info.delivery_tag)
       rescue StandardError, SystemStackError => e
-        subscriber_logger.info "CensusEmployeeSubscriber on_census_employee_terminated, census_employee: #{census_employee.full_name}, employer: #{employer.legal_name}, error message: #{e.message}, backtrace: #{e.backtrace}"
-        logger.info "CensusEmployeeSubscriber on_census_employee_terminated: errored & acked. payload: #{payload} Backtrace: #{e.backtrace}"
+        subscriber_logger.error "CensusEmployeeSubscriber on_census_employee_terminated, census_employee: #{census_employee.full_name}, employer: #{employer.legal_name}, error message: #{e.message}, backtrace: #{e.backtrace}"
+        logger.error "CensusEmployeeSubscriber on_census_employee_terminated: errored & acked. payload: #{payload} error message: #{e.message}, backtrace: #{e.backtrace}"
         ack(delivery_info.delivery_tag)
       end
 

--- a/app/event_source/subscribers/benefit_sponsors/employee_role_subscriber.rb
+++ b/app/event_source/subscribers/benefit_sponsors/employee_role_subscriber.rb
@@ -21,8 +21,8 @@ module Subscribers
 
         ack(delivery_info.delivery_tag)
       rescue StandardError, SystemStackError => e
-        subscriber_logger.info "EmployeeRoleSubscriber, employee_role: #{person&.full_name}, employer: #{employer&.legal_name}, error message: #{e.message}, backtrace: #{e.backtrace}"
-        logger.info "EmployeeRoleSubscriber: errored & acked. payload: #{payload} Backtrace: #{e.backtrace}"
+        subscriber_logger.error "EmployeeRoleSubscriber, employee_role: #{person&.full_name}, employer: #{employer&.legal_name}, error message: #{e.message}, backtrace: #{e.backtrace}"
+        logger.error "EmployeeRoleSubscriber: errored & acked. payload: #{payload} error message: #{e.message}, backtrace: #{e.backtrace}"
         ack(delivery_info.delivery_tag)
       end
 

--- a/app/event_source/subscribers/benefit_sponsors/employer_profile_subscriber.rb
+++ b/app/event_source/subscribers/benefit_sponsors/employer_profile_subscriber.rb
@@ -37,13 +37,13 @@ module Subscribers
             logger.info "BulkCeUpload: acked, FailureResult, errors: #{errors}"
           end
         rescue StandardError => e
-          logger.info "EmployerProfileSubscriber: on_bulk_ce_upload error: #{e.backtrace}"
+          logger.error "EmployerProfileSubscriber: on_bulk_ce_upload error_message: #{e.message}, backtrace: #{e.backtrace}"
         ensure
           Aws::S3Storage.delete_file(payload['bucket_name'], payload['s3_reference_key'])
         end
         ack(delivery_info.delivery_tag)
       rescue StandardError, SystemStackError => e
-        logger.info "EmployerProfileSubscriber: on_bulk_ce_upload error: #{e.backtrace}"
+        logger.error "EmployerProfileSubscriber: on_bulk_ce_upload error_message: #{e.message}, backtrace: #{e.backtrace}"
         ack(delivery_info.delivery_tag)
       end
 

--- a/app/event_source/subscribers/benefit_sponsors/non_congressional/dependent_age_off_termination_subscriber.rb
+++ b/app/event_source/subscribers/benefit_sponsors/non_congressional/dependent_age_off_termination_subscriber.rb
@@ -37,8 +37,8 @@ module Subscribers
 
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
-          subscriber_logger.info "on_enroll_benefit_sponsors_non_congressional_dependent_age_off_termination, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-          logger.info "on_enroll_benefit_sponsors_non_congressional_dependent_age_off_termination: errored & acked. Backtrace: #{e.backtrace}"
+          subscriber_logger.error "on_enroll_benefit_sponsors_non_congressional_dependent_age_off_termination, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+          logger.error "on_enroll_benefit_sponsors_non_congressional_dependent_age_off_termination: errored & acked. error_message: #{e.message}, backtrace: #{e.backtrace}"
           ack(delivery_info.delivery_tag)
         end
       end

--- a/app/event_source/subscribers/broker_updates_subscriber.rb
+++ b/app/event_source/subscribers/broker_updates_subscriber.rb
@@ -13,8 +13,8 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "BrokerUpdatesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      subscriber_logger.info "BrokerUpdatesSubscriber, ack: #{payload}"
+      subscriber_logger.error "BrokerUpdatesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "BrokerUpdatesSubscriber, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 
@@ -26,21 +26,21 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "BrokerUpdatesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      subscriber_logger.info "BrokerUpdatesSubscriber, ack: #{payload}"
+      subscriber_logger.error "BrokerUpdatesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "BrokerUpdatesSubscriber, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 
     def hire_broker(payload, subscriber_logger)
       ::Operations::Families::HireBrokerAgency.new.call(payload)
     rescue StandardError => e
-      subscriber_logger.info "Error: BrokerUpdatesSubscriber, response: #{e}"
+      subscriber_logger.error "Error: BrokerUpdatesSubscriber, error message: #{e.message}, backtrace: #{e.backtrace}"
     end
 
     def fire_broker(payload, subscriber_logger)
       ::Operations::Families::TerminateBrokerAgency.new.call(payload)
     rescue StandardError => e
-      subscriber_logger.info "Error: BrokerUpdatesSubscriber, response: #{e}"
+      subscriber_logger.error "Error: BrokerUpdatesSubscriber, error message: #{e.message}, backtrace: #{e.backtrace}"
     end
 
     def subscriber_logger_for(event)

--- a/app/event_source/subscribers/consumer_roles_subscriber.rb
+++ b/app/event_source/subscribers/consumer_roles_subscriber.rb
@@ -13,8 +13,8 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "ConsumerRolesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      subscriber_logger.info "ConsumerRolesSubscriber, ack: #{payload}"
+      subscriber_logger.error "ConsumerRolesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "ConsumerRolesSubscriber, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 
@@ -26,7 +26,7 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "ConsumerRolesSubscriber Update, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "ConsumerRolesSubscriber Update, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
       ack(delivery_info.delivery_tag)
     end
 
@@ -35,7 +35,7 @@ module Subscribers
     def determine_verifications(payload, subscriber_logger)
       ::Operations::Individual::DetermineVerifications.new.call({ id: GlobalID::Locator.locate(payload[:gid]).id })
     rescue StandardError => e
-      subscriber_logger.info "Error: ConsumerRolesSubscriber, response: #{e}"
+      subscriber_logger.error "Error: ConsumerRolesSubscriber, error message: #{e.message}, backtrace: #{e.backtrace}"
     end
 
     def determine_verifications_on_update(payload, subscriber_logger)
@@ -43,7 +43,7 @@ module Subscribers
         { payload: payload, subscriber_logger: subscriber_logger }
       )
     rescue StandardError => e
-      subscriber_logger.info "Error: ConsumerRolesSubscriber OnUpdate, response: #{e}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "Error: ConsumerRolesSubscriber OnUpdate, error message: #{e.message}, backtrace: #{e.backtrace}"
     end
 
     def subscriber_logger_for(event)

--- a/app/event_source/subscribers/determination_subscriber.rb
+++ b/app/event_source/subscribers/determination_subscriber.rb
@@ -50,8 +50,8 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      logger.info "DeterminationSubscriber: error: #{e.backtrace}"
-      subscriber_logger.info "DeterminationSubscriber: error: #{e.backtrace}"
+      logger.error "DeterminationSubscriber: error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "DeterminationSubscriber: error message: #{e.message}, backtrace: #{e.backtrace}"
       ack(delivery_info.delivery_tag)
     end
   end

--- a/app/event_source/subscribers/document_meta_data_subscriber.rb
+++ b/app/event_source/subscribers/document_meta_data_subscriber.rb
@@ -19,7 +19,7 @@ module Subscribers
       end
       ack(delivery_info.delivery_tag)
     rescue StandardError => e
-      logger.error "Enroll: enroll_document_meta_data_subscriber_error: #{e.backtrace} for payload: #{payload}"
+      logger.error "Enroll: enroll_document_meta_data_subscriber_error: error message: #{e.message}, backtrace: #{e.backtrace} for payload: #{payload}"
       ack(delivery_info.delivery_tag)
     end
   end

--- a/app/event_source/subscribers/edi_gateway_cv3_family_requested_subscriber.rb
+++ b/app/event_source/subscribers/edi_gateway_cv3_family_requested_subscriber.rb
@@ -15,7 +15,7 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "Subscribers::EdiGatewayCv3FamilyRequestedSubscriber:: errored & acked. Backtrace: #{e.backtrace}"
+      subscriber_logger.error "Subscribers::EdiGatewayCv3FamilyRequestedSubscriber:: errored & acked. error message: #{e.message}, Backtrace: #{e.backtrace}"
       ack(delivery_info.delivery_tag)
     end
 

--- a/app/event_source/subscribers/eligible/eligibility_subscriber.rb
+++ b/app/event_source/subscribers/eligible/eligibility_subscriber.rb
@@ -40,7 +40,7 @@ module Subscribers
         end
         ack(delivery_info.delivery_tag)
       rescue StandardError, SystemStackError => e
-        subscriber_logger.info "EligibilitySubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+        subscriber_logger.error "EligibilitySubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
         ack(delivery_info.delivery_tag)
       end
 
@@ -78,7 +78,7 @@ module Subscribers
 
         ack(delivery_info.delivery_tag)
       rescue StandardError, SystemStackError => e
-        subscriber_logger.info "EligibilitySubscriber#on_enroll_enterprise_events, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+        subscriber_logger.error "EligibilitySubscriber#on_enroll_enterprise_events, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
         ack(delivery_info.delivery_tag)
       end
 

--- a/app/event_source/subscribers/enrollment_subscriber.rb
+++ b/app/event_source/subscribers/enrollment_subscriber.rb
@@ -15,9 +15,9 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "EnrollmentSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "EnrollmentSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
     #   logger.info "EnrollmentSubscriber: errored & acked. Backtrace: #{e.backtrace}"
-      subscriber_logger.info "EnrollmentSubscriber, ack: #{payload}"
+      subscriber_logger.error "EnrollmentSubscriber, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 
@@ -31,8 +31,8 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "EnrollmentSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      subscriber_logger.info "EnrollmentSubscriber, ack: #{payload}"
+      subscriber_logger.error "EnrollmentSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "EnrollmentSubscriber, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 
@@ -44,8 +44,8 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "EnrollmentSubscriber#on_enroll_individual_enrollments, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      subscriber_logger.info "EnrollmentSubscriber#on_enroll_individual_enrollments, ack: #{payload}"
+      subscriber_logger.error "EnrollmentSubscriber#on_enroll_individual_enrollments, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "EnrollmentSubscriber#on_enroll_individual_enrollments, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 

--- a/app/event_source/subscribers/enterprise_subscriber.rb
+++ b/app/event_source/subscribers/enterprise_subscriber.rb
@@ -28,9 +28,9 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "EnterpriseSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      logger.info "EnterpriseSubscriber: errored & acked. Backtrace: #{e.backtrace}"
-      subscriber_logger.info "EnterpriseSubscriber, ack: #{payload}"
+      subscriber_logger.error "EnterpriseSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      logger.error "EnterpriseSubscriber: errored & acked. error message: #{e.message}, Backtrace: #{e.backtrace}"
+      subscriber_logger.error "EnterpriseSubscriber, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 
@@ -51,9 +51,9 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "EnterpriseSubscriber#on_enroll_enterprise_events, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      logger.info "EnterpriseSubscriber#on_enroll_enterprise_events: errored & acked. Backtrace: #{e.backtrace}"
-      subscriber_logger.info "EnterpriseSubscriber#on_enroll_enterprise_events, ack: #{payload}"
+      subscriber_logger.error "EnterpriseSubscriber#on_enroll_enterprise_events, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      logger.error "EnterpriseSubscriber#on_enroll_enterprise_events: errored & acked. error message: #{e.message}, Backtrace: #{e.backtrace}"
+      subscriber_logger.error "EnterpriseSubscriber#on_enroll_enterprise_events, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
   end

--- a/app/event_source/subscribers/families/family_members/address_relocated_subscriber.rb
+++ b/app/event_source/subscribers/families/family_members/address_relocated_subscriber.rb
@@ -21,7 +21,7 @@ module Subscribers
 
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
-          subscriber_logger.info(subscriber_key(key, person_hbx_id)) { {payload: payload, error_message: e.message, backtrace: e.backtrace} }
+          subscriber_logger.error(subscriber_key(key, person_hbx_id)) { {payload: payload, error_message: e.message, backtrace: e.backtrace} }
           ack(delivery_info.delivery_tag)
         end
 
@@ -39,7 +39,7 @@ module Subscribers
 
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
-          subscriber_logger.info(subscriber_key(key, person_hbx_id)) { {payload: payload, error_message: e.message, backtrace: e.backtrace} }
+          subscriber_logger.error(subscriber_key(key, person_hbx_id)) { {payload: payload, error_message: e.message, backtrace: e.backtrace} }
           ack(delivery_info.delivery_tag)
         end
 

--- a/app/event_source/subscribers/families/family_members/service_and_rating_area_relocated_subscriber.rb
+++ b/app/event_source/subscribers/families/family_members/service_and_rating_area_relocated_subscriber.rb
@@ -31,7 +31,7 @@ module Subscribers
 
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
-          subscriber_logger.info(subscriber_key(key, enrollment_hbx_id)) { {failure: {payload: payload, error_message: e.message, backtrace: e.backtrace}} }
+          subscriber_logger.error(subscriber_key(key, enrollment_hbx_id)) { {failure: {payload: payload, error_message: e.message, backtrace: e.backtrace}} }
           ack(delivery_info.delivery_tag)
         end
 

--- a/app/event_source/subscribers/families/find_by_requested_subscriber.rb
+++ b/app/event_source/subscribers/families/find_by_requested_subscriber.rb
@@ -18,7 +18,7 @@ module Subscribers
 
         ack(delivery_info.delivery_tag)
       rescue StandardError, SystemStackError => e
-        logger.error "on_find_by_requested error: #{e} backtrace: #{e.backtrace}; acked (nacked)"
+        logger.error "on_find_by_requested error: #{e.message} backtrace: #{e.backtrace}; acked (nacked)"
         ack(delivery_info.delivery_tag)
       end
 
@@ -37,7 +37,7 @@ module Subscribers
         generate_and_publish_payload(subscriber_logger, correlation_id, response)
         subscriber_logger.info "process_find_by_requested_event: ------- end"
       rescue StandardError => e
-        subscriber_logger.error "process_find_by_requested_event: error: #{e} backtrace: #{e.backtrace}"
+        subscriber_logger.error "process_find_by_requested_event: error: #{e.message} backtrace: #{e.backtrace}"
         subscriber_logger.error "process_find_by_requested_event: ------- end"
       end
 

--- a/app/event_source/subscribers/families/iap_applications/rrvs/income_evidences_subscriber.rb
+++ b/app/event_source/subscribers/families/iap_applications/rrvs/income_evidences_subscriber.rb
@@ -19,7 +19,7 @@ module Subscribers
 
           rescue StandardError, SystemStackError => e
             subscriber_logger.error "Rrvs::IncomeEvidencesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-            subscriber_logger.info "Rrvs::IncomeEvidencesSubscriber, ack: #{payload}"
+            subscriber_logger.error "Rrvs::IncomeEvidencesSubscriber, ack: #{payload}"
             ack(delivery_info.delivery_tag)
           end
 
@@ -30,7 +30,7 @@ module Subscribers
             result_str = result.success? ? "Success: #{result.success}" : "Failure: #{result.failure}"
             subscriber_logger.info "Rrvs::IncomeEvidencesSubscriber, determine_verifications result: #{result_str}"
           rescue StandardError => e
-            subscriber_logger.error "Rrvs::IncomeEvidencesSubscriber, response: #{e}"
+            subscriber_logger.error "Rrvs::IncomeEvidencesSubscriber, error_message: #{e.message}, backtrace: #{e.backtrace}"
           end
 
           def subscriber_logger_for(event)

--- a/app/event_source/subscribers/families/iap_applications/rrvs/non_esi_evidences_subscriber.rb
+++ b/app/event_source/subscribers/families/iap_applications/rrvs/non_esi_evidences_subscriber.rb
@@ -19,7 +19,7 @@ module Subscribers
 
           rescue StandardError, SystemStackError => e
             subscriber_logger.error "Rrvs::NonEsiEvidencesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-            subscriber_logger.info "Rrvs::NonEsiEvidencesSubscriber, ack: #{payload}"
+            subscriber_logger.error "Rrvs::NonEsiEvidencesSubscriber, ack: #{payload}"
             ack(delivery_info.delivery_tag)
           end
 
@@ -30,7 +30,7 @@ module Subscribers
             result_str = result.success? ? "Success: #{result.success}" : "Failure: #{result.failure}"
             subscriber_logger.info "Rrvs::NonEsiEvidencesSubscriber, determine_verifications result: #{result_str}"
           rescue StandardError => e
-            subscriber_logger.error "Rrvs::NonEsiEvidencesSubscriber, response: #{e}"
+            subscriber_logger.error "Rrvs::NonEsiEvidencesSubscriber, error_message: #{e.message}, backtrace: #{e.backtrace}"
           end
 
           def subscriber_logger_for(event)

--- a/app/event_source/subscribers/families/notices/fre_notice_generation_requested_subscriber.rb
+++ b/app/event_source/subscribers/families/notices/fre_notice_generation_requested_subscriber.rb
@@ -38,8 +38,8 @@ module Subscribers
 
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
-          subscriber_logger.info "on_enroll_families_notices_fre_notice_generation, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-          logger.info "on_enroll_families_notices_fre_notice_generation: errored & acked. Backtrace: #{e.backtrace}"
+          subscriber_logger.error "on_enroll_families_notices_fre_notice_generation, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+          logger.error "on_enroll_families_notices_fre_notice_generation: errored & acked. error_message: #{e.message}, backtrace: #{e.backtrace}"
           ack(delivery_info.delivery_tag)
         end
       end

--- a/app/event_source/subscribers/fdsh_gateway/eligibilities_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/eligibilities_subscriber.rb
@@ -25,7 +25,7 @@ module Subscribers
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.info "FdshGateway::EligibilitiesSubscriber: on_primary_determination error: #{e.backtrace}"
+        logger.error "FdshGateway::EligibilitiesSubscriber: on_primary_determination error_message: #{e.message}, backtrace: #{e.backtrace}"
       end
 
       subscribe(:on_secondary_determination_complete) do |delivery_info, metadata, response|
@@ -46,7 +46,7 @@ module Subscribers
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.info "FdshGateway::EligibilitiesSubscriber: on_secondary_determination error: #{e.backtrace}"
+        logger.error "FdshGateway::EligibilitiesSubscriber: on_secondary_determination error_message: #{e.message}, backtrace: #{e.backtrace}"
       end
     end
   end

--- a/app/event_source/subscribers/fdsh_gateway/esi_mec_determination_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/esi_mec_determination_subscriber.rb
@@ -23,7 +23,7 @@ module Subscribers
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.info "FdshGateway::ESIMECDeterminationSubscriber: on_esi_mec_determination error: #{e.backtrace}"
+        logger.error "FdshGateway::ESIMECDeterminationSubscriber: on_esi_mec_determination error_message: #{e.message}, backtrace: #{e.backtrace}"
       end
     end
   end

--- a/app/event_source/subscribers/fdsh_gateway/ifsv_determination_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/ifsv_determination_subscriber.rb
@@ -23,7 +23,7 @@ module Subscribers
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.info "FTIGateway::IfsvDeterminationSubscriberr: on_fdsh_eligibilities_ifsv_determined error: #{e.backtrace}"
+        logger.error "FTIGateway::IfsvDeterminationSubscriberr: on_fdsh_eligibilities_ifsv_determined error_message: #{e.message}, backtrace: #{e.backtrace}"
       end
     end
   end

--- a/app/event_source/subscribers/fdsh_gateway/non_esi_mec_determination_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/non_esi_mec_determination_subscriber.rb
@@ -23,7 +23,7 @@ module Subscribers
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.info "FdshGateway::NonESIMECDeterminationSubscriber: on_non_esi_mec_determination error: #{e.backtrace}"
+        logger.error "FdshGateway::NonESIMECDeterminationSubscriber: on_non_esi_mec_determination error_message: #{e.message}, backtrace: #{e.backtrace}"
       end
     end
   end

--- a/app/event_source/subscribers/fdsh_gateway/pvc_mdcr_determination_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/pvc_mdcr_determination_subscriber.rb
@@ -22,7 +22,7 @@ module Subscribers
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.info "FdshGateway::PvcMdcrDeterminationSubscriber: invoked on_periodic_verification_confirmation_determined error: #{e.message} // backtrace #{e.backtrace}"
+        logger.error "FdshGateway::PvcMdcrDeterminationSubscriber: invoked on_periodic_verification_confirmation_determined error: #{e.message} // backtrace #{e.backtrace}"
       end
     end
   end

--- a/app/event_source/subscribers/fdsh_gateway/rrv_ifsv_determination_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/rrv_ifsv_determination_subscriber.rb
@@ -23,7 +23,7 @@ module Subscribers
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.info "FdshGateway::RrvIfsvDeterminationSubscriber: invoked on_magi_medicaid_application_renewal_eligibilities_ifsv_determined error: #{e.backtrace}"
+        logger.error "FdshGateway::RrvIfsvDeterminationSubscriber: invoked on_magi_medicaid_application_renewal_eligibilities_ifsv_determined error_message: #{e.message}, backtrace: #{e.backtrace}"
       end
     end
   end

--- a/app/event_source/subscribers/fdsh_gateway/rrv_mdcr_determination_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/rrv_mdcr_determination_subscriber.rb
@@ -23,7 +23,7 @@ module Subscribers
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.info "FdshGateway::RrvMdcrDeterminationSubscriber: invoked on_magi_medicaid_application_renewal_eligibilities_mdcr_determined error: #{e.backtrace}"
+        logger.error "FdshGateway::RrvMdcrDeterminationSubscriber: invoked on_magi_medicaid_application_renewal_eligibilities_mdcr_determined error_message: #{e.message}, backtrace: #{e.backtrace}"
       end
     end
   end

--- a/app/event_source/subscribers/fdsh_gateway/ssa_verifications_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/ssa_verifications_subscriber.rb
@@ -24,7 +24,7 @@ module Subscribers
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.info "Ssa::SsaverificationsSubscriber: on_ssa_verification_complete error: #{e.backtrace}"
+        logger.error "Ssa::SsaverificationsSubscriber: on_ssa_verification_complete error_message: #{e.message}, backtrace: #{e.backtrace}"
       end
     end
   end

--- a/app/event_source/subscribers/fdsh_gateway/vlp_verifications_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/vlp_verifications_subscriber.rb
@@ -24,7 +24,7 @@ module Subscribers
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.info "Vlp::VlpverificationsSubscriber: on_initial_verification_complete error: #{e.backtrace}"
+        logger.error "Vlp::VlpverificationsSubscriber: on_initial_verification_complete error_message: #{e.message}, backtrace: #{e.backtrace}"
       end
     end
   end

--- a/app/event_source/subscribers/iap/application_determined_subscriber.rb
+++ b/app/event_source/subscribers/iap/application_determined_subscriber.rb
@@ -61,8 +61,8 @@ module Subscribers
     end
 
     def log_error(subscriber_logger, logger, name, err)
-      logger.info "#{name} Error raised when processing given payload message: #{err}, backtrace: #{err.backtrace.join('\n')}" if logger.present?
-      subscriber_logger.info "#{name} Error raised when processing given payload message: #{err}, backtrace: #{err.backtrace.join('\n')}"
+      logger.error "#{name} Error raised when processing given payload message: #{err.message}, backtrace: #{err.backtrace.join('\n')}" if logger.present?
+      subscriber_logger.error "#{name} Error raised when processing given payload message: #{err.message}, backtrace: #{err.backtrace.join('\n')}"
     end
 
     def log_payload(subscriber_logger, logger, payload)

--- a/app/event_source/subscribers/iap/determine_slcsp_subscriber.rb
+++ b/app/event_source/subscribers/iap/determine_slcsp_subscriber.rb
@@ -16,7 +16,7 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      logger.info "on_determine_slcsp: error: #{e} backtrace: #{e.backtrace}"
+      logger.error "on_determine_slcsp: error_message: #{e.message}, backtrace: #{e.backtrace}"
       ack(delivery_info.delivery_tag)
     end
 
@@ -38,8 +38,8 @@ module Subscribers
       end
       subscriber_logger.info "process_determine_slcsp: ------- end"
     rescue StandardError => e
-      subscriber_logger.info "process_determine_slcsp: error: #{e} backtrace: #{e.backtrace}"
-      subscriber_logger.info "process_determine_slcsp: ------- end"
+      subscriber_logger.error "process_determine_slcsp: error_message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "process_determine_slcsp: ------- end"
     end
 
     def subscriber_logger_for(event)

--- a/app/event_source/subscribers/iap/family_rrv_determination_subscriber.rb
+++ b/app/event_source/subscribers/iap/family_rrv_determination_subscriber.rb
@@ -24,9 +24,9 @@ module Subscribers
       ::FinancialAssistance::Operations::Applications::Rrv::CreateRrvRequest.new.call(families: families, assistance_year: payload[:assistance_year])
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "FamilyRrvDeterminationSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      logger.info "FamilyRrvDeterminationSubscriber: errored & acked. Backtrace: #{e.backtrace}"
-      subscriber_logger.info "FamilyRrvDeterminationSubscriber, ack: #{payload}"
+      subscriber_logger.error "FamilyRrvDeterminationSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      logger.error "FamilyRrvDeterminationSubscriber: errored & acked. error_message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "FamilyRrvDeterminationSubscriber, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
   end

--- a/app/event_source/subscribers/individual/open_enrollment_subscriber.rb
+++ b/app/event_source/subscribers/individual/open_enrollment_subscriber.rb
@@ -49,7 +49,7 @@ module Subscribers
         renew_enrollments(family)
         @logger.info "Processed family with bson_id: #{id} for Enrollments Renewal"
       rescue StandardError => e
-        @logger.error "Error: OpenEnrollmentSubscriber, payload: #{payload}; response: #{e}, inspect: #{e.inspect}"
+        @logger.error "Error: OpenEnrollmentSubscriber, payload: #{payload}; error_message: #{e.message}, backtrace: #{e.backtrace}, inspect: #{e.inspect}"
       end
 
       def renew_osse_eligibility(person)

--- a/app/event_source/subscribers/irs_groups/family_found_subscriber.rb
+++ b/app/event_source/subscribers/irs_groups/family_found_subscriber.rb
@@ -17,7 +17,7 @@ module Subscribers
 
         ack(delivery_info.delivery_tag)
       rescue StandardError, SystemStackError => e
-        logger.info "IrsGroups::FamilyFoundSubscriber:: errored & acked. Backtrace: #{e.backtrace}"
+        logger.error "IrsGroups::FamilyFoundSubscriber:: errored & acked. error_message: #{e.message}, backtrace: #{e.backtrace}"
         ack(delivery_info.delivery_tag)
       end
     end

--- a/app/event_source/subscribers/json_subscriber.rb
+++ b/app/event_source/subscribers/json_subscriber.rb
@@ -20,7 +20,7 @@ module Subscribers
         nack(delivery_info.delivery_tag)
       end
     rescue StandardError => e
-      logger.info "on_stream: subscriber_error backtrace: #{e.backtrace} #{'-' * 50}"
+      logger.error "on_stream: subscriber_error error message: #{e.message}, backtrace: #{e.backtrace} #{'-' * 50}"
       nack(delivery_info.delivery_tag)
     end
   end

--- a/app/event_source/subscribers/lawful_presence_determinations_subscriber.rb
+++ b/app/event_source/subscribers/lawful_presence_determinations_subscriber.rb
@@ -13,8 +13,8 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "LawfulPresenceDeterminationsSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      subscriber_logger.info "LawfulPresenceDeterminationsSubscriber, ack: #{payload}"
+      subscriber_logger.error "LawfulPresenceDeterminationsSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "LawfulPresenceDeterminationsSubscriber, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 
@@ -32,7 +32,7 @@ module Subscribers
       result_str = result.success? ? "Success: #{result.success}" : "Failure: #{result.failure}"
       subscriber_logger.info "LawfulPresenceDeterminationsSubscriber, determine_verifications result: #{result_str}"
     rescue StandardError => e
-      subscriber_logger.info "Error: LawfulPresenceDeterminationsSubscriber, response: #{e}"
+      subscriber_logger.error "Error: LawfulPresenceDeterminationsSubscriber, error message: #{e.message}, backtrace: #{e.backtrace}"
     end
 
     private

--- a/app/event_source/subscribers/mec_check_subscriber.rb
+++ b/app/event_source/subscribers/mec_check_subscriber.rb
@@ -28,7 +28,7 @@ module Subscribers
       end
     rescue StandardError => e
       nack(delivery_info.delivery_tag)
-      logger.info "MecCheckSubscriber: error: #{e.backtrace}"
+      logger.info "MecCheckSubscriber: error message: #{e.message}, backtrace: #{e.backtrace}"
     end
   end
 end

--- a/app/event_source/subscribers/notices_subscriber.rb
+++ b/app/event_source/subscribers/notices_subscriber.rb
@@ -30,9 +30,9 @@ module Subscribers
       subscriber_logger.info "Successfully processed NoticesSubscriber, response: #{payload}"
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "NoticesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      logger.info "NoticesSubscriber: errored & acked. Backtrace: #{e.backtrace}"
-      subscriber_logger.info "NoticesSubscriber, ack: #{payload}"
+      subscriber_logger.error "NoticesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      logger.error "NoticesSubscriber: errored & acked. error message: #{e.message}, Backtrace: #{e.backtrace}"
+      subscriber_logger.error "NoticesSubscriber, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
   end

--- a/app/event_source/subscribers/people_subscriber.rb
+++ b/app/event_source/subscribers/people_subscriber.rb
@@ -14,8 +14,8 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "PeopleSubscriber::Save, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      subscriber_logger.info "PeopleSubscriber::Save, ack: #{payload}"
+      subscriber_logger.error "PeopleSubscriber::Save, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "PeopleSubscriber::Save, ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 
@@ -28,8 +28,8 @@ module Subscribers
 
       ack(delivery_info.delivery_tag)
     rescue StandardError, SystemStackError => e
-      subscriber_logger.info "PeopleSubscriber::Update, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-      subscriber_logger.info "PeopleSubscriber::Update,  ack: #{payload}"
+      subscriber_logger.error "PeopleSubscriber::Update, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+      subscriber_logger.error "PeopleSubscriber::Update,  ack: #{payload}"
       ack(delivery_info.delivery_tag)
     end
 
@@ -57,7 +57,7 @@ module Subscribers
         subscriber_logger.info "PeopleSubscriber::Update, determine_verifications result: #{result_str}"
       end
     rescue StandardError => e
-      subscriber_logger.info "Error: PeopleSubscriber::Update, response: #{e}"
+      subscriber_logger.error "Error: PeopleSubscriber::Update, error message: #{e.message}, backtrace: #{e.backtrace}"
     end
 
     private


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/n/projects/2659995/stories/185958065

# A brief description of the changes

Current behavior:
A lot of subscribers on `app/event_source/subscribers/` have a rescue block, however, most of them use the format logger.info instead of logger.error. Update them and also print `e.message` if missing.

New behavior:
Loggers now return better error messages which helps in troubleshooting.
 
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.