### PR TITLE
change label in data migration file to beginning of reasonable opportunity period

### DIFF
--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -9,11 +9,11 @@ require 'csv'
 # To migrate eligible users' income evidences due_on to their new due date, run the following:
 # RAILS_ENV=production bundle exec rake reports:export_eligible_users_with_outstanding_income_evidences[true]
 
-# The CSV file generated will be called users_with_outstanding_income_evidence_due_dates_between_95_and_160_days.csv, and will be located in the root folder
+# The CSV file generated will be called users_with_outstanding_income_evidence_eligible_for_extension.csv, and will be located in the root folder
 
 namespace :reports do
   task :export_eligible_users_with_outstanding_income_evidences, [:migrate_users] => :environment do |_t, args|
-    file_name = "#{Rails.root}/users_with_outstanding_income_evidence_due_dates_between_95_and_160_days.csv"
+    file_name = "#{Rails.root}/users_with_outstanding_income_evidence_eligible_for_extension.csv"
     today = TimeKeeper.date_of_record
 
     field_names  = [
@@ -23,10 +23,13 @@ namespace :reports do
       :due_date_successfully_extended
     ]
 
+    # 66 days to account for people
+    days_to_extend = (FinancialAssistanceRegistry[:auto_update_income_evidence_due_on].settings(:days).item + 1)
+
     applications = FinancialAssistance::Application.where(
       :"applicants.income_evidence" => { :$exists => true },
       :"applicants.income_evidence.aasm_state" => { :$eq => "outstanding" },
-      :"applicants.income_evidence.due_on" => { :"$gt" => (today - 160.days), :"$lte" => (today - 95.days) }
+      :"applicants.income_evidence.due_on" => { :"$gte" => (today - days_to_extend.days), :"$lte" => today }
     )
 
     CSV.open(file_name, "w", write_headers: true, headers: field_names) do |csv|
@@ -36,11 +39,12 @@ namespace :reports do
           evidence = applicant&.income_evidence
 
           next unless evidence &&
-                      evidence&.aasm_state == 'outstanding' &&
-                      (evidence&.due_on > today - 160.days && evidence&.due_on <= today - 95.days)
+                      evidence.aasm_state == 'outstanding' &&
+                      (evidence.due_on >= today - days_to_extend.days && evidence.due_on <= today)
 
-          original_due_date = evidence.due_on
+          original_due_date = (evidence.due_on - 95.days)
           new_due_date = (original_due_date + 160.days)
+
           successful_save = evidence.update(due_on: new_due_date) if args[:migrate_users]
 
           csv << [applicant.person_hbx_id, original_due_date, new_due_date, successful_save]
@@ -57,15 +61,4 @@ namespace :reports do
 
     puts "Generates a report of all applicants with income evidences eligible for an extension"
   end
-end
-
-def update_family_level_due_date_info(family)
-  ed = family&.eligibility_determination
-  return puts("Family Object with ID #{family.id.to_s} missing Eligibility Determination") unless ed
-
-  min_due_date = family&.min_verification_due_date_on_family
-  current_ed_outstanding_due_date = ed&.outstanding_verification_earliest_due_date
-  return unless min_due_date && current_ed_outstanding_due_date
-
-  ed.update(outstanding_verification_earliest_due_date: min_due_date) if min_due_date > current_ed_outstanding_due_date
 end

--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -18,7 +18,7 @@ namespace :reports do
 
     field_names  = [
       :user_hbx_id,
-      :original_due_date,
+      :beginning_of_reasonable_opportunity_period,
       :due_date_after_extension,
       :due_date_successfully_extended
     ]

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -7,7 +7,7 @@ Rake::Task.define_task(:environment)
 
 RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences', :type => :task, dbclean: :after_each do
   let(:rake) { Rake::Task["reports:export_eligible_users_with_outstanding_income_evidences"] }
-  let(:file_name) { "#{Rails.root}/users_with_outstanding_income_evidence_due_dates_between_95_and_160_days.csv" }
+  let(:file_name) { "#{Rails.root}/users_with_outstanding_income_evidence_eligible_for_extension.csv" }
 
   describe "Rake Task" do
     let!(:person) { FactoryBot.create(:person) }
@@ -54,10 +54,10 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
                         person_hbx_id: family2.family_members[0].person.hbx_id)
     end
 
-    let(:applicant_1_original_due_date) { TimeKeeper.date_of_record - 159.days }
-    let(:applicant_2_original_due_date) { TimeKeeper.date_of_record - 125.days }
-    let(:applicant_3_original_due_date) { TimeKeeper.date_of_record - 50.days }
-    let(:applicant_4_original_due_date) { TimeKeeper.date_of_record - 97.days }
+    let(:applicant_1_original_due_date) { TimeKeeper.date_of_record - 65.days }
+    let(:applicant_2_original_due_date) { TimeKeeper.date_of_record - 66.days }
+    let(:applicant_3_original_due_date) { TimeKeeper.date_of_record - 97.days }
+    let(:applicant_4_original_due_date) { TimeKeeper.date_of_record - 64.days }
 
     let!(:income_evidence_1) do
       applicant.create_income_evidence(key: :income,
@@ -142,7 +142,7 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
 
       it "should update the income evidence due_on to the correct due date" do
         evidence = applicant.income_evidence
-        projected_due_date = applicant_1_original_due_date + 160.days
+        projected_due_date = applicant_1_original_due_date + 65.days
         evidence.reload
 
         expect(evidence.due_on).to_not eq(applicant_1_original_due_date)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [185554801](https://www.pivotaltracker.com/story/show/185554801)

# A brief description of the changes

Current behavior: N/A

New behavior:

#### _This rake task generates a csv of all the applicants with outstanding income evidences due dates between 95 and 160 days_

To generate a csv of users eligible for an income evidence due_on extension without migrating data, run the following:
`RAILS_ENV=production bundle exec rake reports:export_eligible_users_with_outstanding_income_evidences`

To migrate eligible users' income evidences due_on to their new due date, run the following:
`RAILS_ENV=production bundle exec rake reports:export_eligible_users_with_outstanding_income_evidences[true]`

The CSV file will be generated and in the root folder called `users_with_outstanding_income_evidence_due_dates_between_95_and_160_days.csv`

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [ ] DC
- [x] ME

# Additional Context: 
See _New Behavior_ section above.