### PR TITLE
moves applicants to outstanding only if they are enrolled in coverage

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/medicare/add_pvc_medicare_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/medicare/add_pvc_medicare_determination.rb
@@ -37,24 +37,29 @@ module FinancialAssistance
             end
 
             def update_applicant(response_app_entity, application, applicant_identifier)
+              enrollments = HbxEnrollment.where(:aasm_state.in => HbxEnrollment::ENROLLED_STATUSES, family_id: application.family_id)
               response_applicant = response_app_entity.applicants.detect {|applicant| applicant.person_hbx_id == applicant_identifier}
               applicant = application.applicants.where(person_hbx_id: applicant_identifier).first
 
               return Failure("applicant not found with #{applicant_identifier} for pvc Medicare") unless applicant
               return Failure("applicant not found in response with #{applicant_identifier} for pvc Medicare") unless response_applicant
 
-              update_applicant_verifications(applicant, response_applicant)
+              update_applicant_verifications(applicant, response_applicant, enrollments)
               Success('Successfully updated Applicant with evidences and verifications')
             end
 
-            def update_applicant_verifications(applicant, response_applicant_entity)
+            def update_applicant_verifications(applicant, response_applicant_entity, enrollments)
               response_non_esi_evidence = response_applicant_entity.non_esi_evidence
               applicant_non_esi_evidence = applicant.non_esi_evidence
 
               if applicant_non_esi_evidence.present?
                 if response_non_esi_evidence.aasm_state == 'outstanding'
-                  due_date = fetch_evidence_due_date_for_bulk_actions(applicant_non_esi_evidence, response_non_esi_evidence)
-                  applicant.set_evidence_outstanding(applicant_non_esi_evidence, due_date)
+                  if enrolled?(applicant, enrollments)
+                    due_date = fetch_evidence_due_date_for_bulk_actions(applicant_non_esi_evidence, response_non_esi_evidence)
+                    applicant.set_evidence_outstanding(applicant_non_esi_evidence, due_date)
+                  else
+                    applicant.set_evidence_to_negative_response(applicant_non_esi_evidence)
+                  end
                 else
                   applicant.set_evidence_attested(applicant_non_esi_evidence)
                 end
@@ -78,6 +83,13 @@ module FinancialAssistance
               end
 
               TimeKeeper.date_of_record + EnrollRegistry[:bulk_call_verification_due_in_days].item.to_i
+            end
+
+            def enrolled?(applicant, enrollments)
+              return false if enrollments.blank?
+
+              family_member_ids = enrollments.flat_map(&:hbx_enrollment_members).flat_map(&:applicant_id).uniq
+              family_member_ids.map(&:to_s).include?(applicant.family_member_id.to_s)
             end
           end
         end

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1324,7 +1324,6 @@ module FinancialAssistance
       return unless evidence.may_move_to_outstanding?
 
       evidence.verification_outstanding = true
-      evidence.due_on = desired_due_date if desired_due_date.present?
       evidence.is_satisfied = false
       evidence.due_on = (desired_due_date || schedule_verification_due_on) if evidence.due_on.blank?
       evidence.move_to_outstanding

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/pvc/medicare/add_pvc_medicare_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/pvc/medicare/add_pvc_medicare_determination_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Pvc::Medicare::A
     DatabaseCleaner.clean
   end
 
+  let(:family) { FactoryBot.create(:family, :with_primary_family_member)}
   let!(:application) do
-    FactoryBot.create(:financial_assistance_application, hbx_id: '200000126', aasm_state: "determined")
+    FactoryBot.create(:financial_assistance_application, hbx_id: '200000126', aasm_state: "determined",
+                                                         family_id: family.id)
   end
-
   let!(:applicant) do
     FactoryBot.create(:financial_assistance_applicant,
                       eligibility_determination_id: nil,
@@ -21,17 +22,20 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Pvc::Medicare::A
                       last_name: 'evidence',
                       ssn: "518124854",
                       dob: Date.new(1988, 11, 11),
+                      family_member_id: family.primary_family_member.id,
                       application: application)
   end
 
   let(:due_on) { nil }
   let(:aasm_state) { 'attested' }
+  let(:enrollment) { nil }
 
   context 'success' do
     context 'FDSH PVC Medicare outstanding response' do
       include_context 'FDSH PVC Medicare sample response'
 
       before do
+        enrollment
         @applicant = application.applicants.first
         @applicant.build_non_esi_evidence(key: :non_esi_mec, title: "NON ESI MEC", aasm_state: aasm_state,
                                           due_on: due_on)
@@ -48,11 +52,15 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Pvc::Medicare::A
 
       it 'should update applicant verification' do
         @applicant.reload
-        expect(@applicant.non_esi_evidence.aasm_state).to eq "outstanding"
+        expect(@applicant.non_esi_evidence.aasm_state).to eq 'negative_response_received'
         expect(@result.success).to eq('Successfully updated Applicant with evidences and verifications')
       end
 
-      context "due_date does not exists" do
+      context "due_date does not exists and enrolled" do
+        let(:enrollment) do
+          FactoryBot.create(:hbx_enrollment, :with_enrollment_members,
+                            family: family, enrollment_members: family.family_members)
+        end
         let(:request_result_hash) do
           {
             :result => "eligible",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/186102251

# A brief description of the changes

Current behavior: Moving applicant to outstanding even though the applicant is not currently enrolled

New behavior:  Moving applicant to outstanding only if the applicant is not currently enrolled

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.