### PR TITLE
log income evidences with missing due on dates

### DIFF
--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -80,7 +80,7 @@ def get_applicants(application, start_range, end_range)
     end
   
     evidence &&
-    evidence.due_on &&
+      evidence.due_on &&
       valid_aasm_states.include?(evidence.aasm_state) &&
       (evidence.due_on >= start_range && evidence.due_on <= end_range)
   end

--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -44,9 +44,10 @@ namespace :reports do
     CSV.open(file_name, "w", write_headers: true, headers: field_names) do |csv|
       eligibile_families.each do |family|
         application = FinancialAssistance::Application.where(family_id: family.id).determined.max_by(&:submitted_at)
-        applicants = get_applicants(application, start_range, end_range)
+        next unless application
 
-        next if applicants.blank?
+        applicants = get_applicants(application, start_range, end_range)
+        next if applicants&.blank?
 
         applicants.each do |applicant|
           evidence = applicant.income_evidence
@@ -59,7 +60,6 @@ namespace :reports do
           puts "Invalid Applicant for Application with hbx_id #{application&.hbx_id}, Applicant person_hbx_id #{applicant&.person_hbx_id}: #{e.message}"
         end
 
-        update_family_level_due_date_info(application.family)
       rescue StandardError => e
         puts "An error occurred while processing an application with hbx_id #{application&.hbx_id}: #{e.message}"
       end
@@ -75,7 +75,12 @@ def get_applicants(application, start_range, end_range)
   application.applicants.select do |applicant|
     evidence = applicant.income_evidence
 
+    if evidence.due_on.blank?
+      puts "Application #{application.hbx_id}, Applicant #{applicant.person_hbx_id}, Income Evidence: #{evidence.id}, state: #{evidence.aasm_state}"
+    end
+  
     evidence &&
+    evidence.due_on &&
       valid_aasm_states.include?(evidence.aasm_state) &&
       (evidence.due_on >= start_range && evidence.due_on <= end_range)
   end
@@ -99,6 +104,6 @@ def populate_csv_row(family, applicant, new_due_date, successful_save)
     evidence.id,
     evidence.due_on,
     new_due_date,
-    (successful_save ? _ : 'NOT EXTENDED')
+    (successful_save ? successful_save : 'NOT EXTENDED')
   ]
 end

--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -76,7 +76,7 @@ def get_applicants(application, start_range, end_range)
     evidence = applicant.income_evidence
 
     if evidence.due_on.blank?
-      puts "Application #{application.hbx_id}, Applicant #{applicant.person_hbx_id}, Income Evidence: #{evidence.id}, state: #{evidence.aasm_state}"
+      puts "Income evidence missing date: Application #{application.hbx_id}, Applicant #{applicant.person_hbx_id}, Income Evidence: #{evidence.id}, state: #{evidence.aasm_state}"
     end
   
     evidence &&

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
     let!(:income_evidence_2) do
       applicant2.create_income_evidence(key: :income,
                                         title: 'Income',
-                                        aasm_state: 'outstanding',
+                                        aasm_state: 'rejected',
                                         due_on: applicant_2_original_due_date,
                                         verification_outstanding: true,
                                         is_satisfied: false)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [185554801](https://www.pivotaltracker.com/story/show/185554801)

# A brief description of the changes

Current behavior: N/A

New behavior:

#### _This rake task generates a csv of all the applicants with outstanding income evidences due dates between 95 and 160 days_

To generate a csv of users eligible for an income evidence due_on extension without migrating data, run the following:
`RAILS_ENV=production bundle exec rake reports:export_eligible_users_with_outstanding_income_evidences`

To migrate eligible users' income evidences due_on to their new due date, run the following:
`RAILS_ENV=production bundle exec rake reports:export_eligible_users_with_outstanding_income_evidences[true]`

The CSV file will be generated and in the root folder called `users_with_outstanding_income_evidence_due_dates_between_95_and_160_days.csv`

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [ ] DC
- [x] ME

# Additional Context:

This current PR safely skips families without applications and also logs details about income evidence if they are missing due on.

