### PR TITLE
add evidence verification history during migration

### DIFF
--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -164,9 +164,9 @@ module Eligibilities
       result
     end
 
-    def extend_due_on(period = 30.days, updated_by = nil)
+    def extend_due_on(period = 30.days, updated_by = nil, action = 'extend_due_date')
       self.due_on = verif_due_date + period
-      add_verification_history('extend_due_date', "Extended due date to #{due_on.strftime('%m/%d/%Y')}", updated_by)
+      add_verification_history(action, "Extended due date to #{due_on.strftime('%m/%d/%Y')}", updated_by)
     end
 
     def auto_extend_due_on(period = 30.days, updated_by = nil)
@@ -184,9 +184,14 @@ module Eligibilities
       self.due_on = new_date
     end
 
-    def can_be_extended?(date)
-      return false unless due_on == date && ['rejected', 'outstanding'].include?(self.aasm_state)
-      extensions = verification_histories&.where(action: "auto_extend_due_date")
+    def can_be_auto_extended?(date)
+      return false unless due_on == date
+      can_be_extended?('auto_extend_due_date')
+    end
+
+    def can_be_extended?(action)
+      return false unless ['rejected', 'outstanding'].include?(self.aasm_state)
+      extensions = verification_histories&.where(action: action)
       return true unless extensions&.any?
       #  want this limitation on due date extensions to reset anytime an evidence no longer requires a due date
       # (is moved to 'verified' or 'attested' state) so that an individual can benefit from the extension again in the future.

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/auto_extend_income_evidence.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/auto_extend_income_evidence.rb
@@ -45,7 +45,7 @@ module FinancialAssistance
             application = fetch_eligible_application(family_id, params[:current_due_on])
             next unless application
             application.applicants.each do |applicant|
-              next unless applicant.income_evidence&.can_be_extended?(params[:current_due_on])
+              next unless applicant.income_evidence&.can_be_auto_extended?(params[:current_due_on])
               updated_applicants << applicant.person_hbx_id
               applicant.income_evidence.auto_extend_due_on(params[:extend_by].days, params[:modified_by])
             end

--- a/components/financial_assistance/spec/dummy/app/models/eligibilities/evidence.rb
+++ b/components/financial_assistance/spec/dummy/app/models/eligibilities/evidence.rb
@@ -116,7 +116,7 @@ module Eligibilities
       return unless may_move_to_outstanding?
 
       update(verification_outstanding: true, is_satisfied: false)
-      move_to_outstanding
+      move_to_outstanding!
     end
 
     def move_evidence_to_negative_response_received
@@ -127,7 +127,7 @@ module Eligibilities
 
     def move_evidence_to_attested
       update(verification_outstanding: false, is_satisfied: true, due_on: nil)
-      attest
+      attest!
     end
 
     # Checks if the applicant is enrolled in any APTC or CSR enrollments.
@@ -377,7 +377,8 @@ module Eligibilities
     def record_transition
       self.workflow_state_transitions << WorkflowStateTransition.new(
         from_state: aasm.from_state,
-        to_state: aasm.to_state
+        to_state: aasm.to_state,
+        event: aasm.current_event
       )
     end
 

--- a/components/financial_assistance/spec/dummy/app/models/eligibilities/evidence.rb
+++ b/components/financial_assistance/spec/dummy/app/models/eligibilities/evidence.rb
@@ -164,9 +164,9 @@ module Eligibilities
       result
     end
 
-    def extend_due_on(period = 30.days, updated_by = nil)
+    def extend_due_on(period = 30.days, updated_by = nil, action = 'extend_due_date')
       self.due_on = verif_due_date + period
-      add_verification_history('extend_due_date', "Extended due date to #{due_on.strftime('%m/%d/%Y')}", updated_by)
+      add_verification_history(action, "Extended due date to #{due_on.strftime('%m/%d/%Y')}", updated_by)
     end
 
     def auto_extend_due_on(period = 30.days, updated_by = nil)
@@ -184,9 +184,14 @@ module Eligibilities
       self.due_on = new_date
     end
 
-    def can_be_extended?(date)
-      return false unless due_on == date && ['rejected', 'outstanding'].include?(aasm_state)
-      extensions = verification_histories&.where(action: "auto_extend_due_date")
+    def can_be_auto_extended?(date)
+      return false unless due_on == date
+      can_be_extended?('auto_extend_due_date')
+    end
+
+    def can_be_extended?(action)
+      return false unless ['rejected', 'outstanding'].include?(self.aasm_state)
+      extensions = verification_histories&.where(action: action)
       return true unless extensions&.any?
       #  want this limitation on due date extensions to reset anytime an evidence no longer requires a due date
       # (is moved to 'verified' or 'attested' state) so that an individual can benefit from the extension again in the future.

--- a/components/financial_assistance/spec/dummy/spec/factories/evidences.rb
+++ b/components/financial_assistance/spec/dummy/spec/factories/evidences.rb
@@ -11,5 +11,36 @@ FactoryBot.define do
     aasm_state { :attested }
     due_on { nil }
 
+    trait :with_request_results do
+      after :build do |evidence, _evaluator|
+        evidence.request_results << FactoryBot.build(:request_result)
+      end
+    end
+
+    trait :with_verification_histories do
+      after :build do |evidence, _evaluator|
+        evidence.verification_histories << FactoryBot.build(:verification_history)
+      end
+    end
+
+    trait :outstanding do
+      aasm_state { 'outstanding' }
+      verification_outstanding { true }
+      is_satisfied { false }
+    end
+  end
+
+  factory :osse_evidence, :class => 'Eligibilities::Osse::Evidence' do
+    title { 'Osse Eligibility Evidence' }
+    description { 'Osse Eligibility' }
+    key { :osse_subsidy }
+    is_satisfied { true }
+
+    trait :with_eligibility do
+      after(:build) do |evidence, _evaluator|
+        eligibility ||= evidence.eligibility
+        eligibility { create(:eligibility)} unless eligibility.present?
+      end
+    end
   end
 end

--- a/components/financial_assistance/spec/dummy/spec/factories/evidences.rb
+++ b/components/financial_assistance/spec/dummy/spec/factories/evidences.rb
@@ -11,36 +11,5 @@ FactoryBot.define do
     aasm_state { :attested }
     due_on { nil }
 
-    trait :with_request_results do
-      after :build do |evidence, _evaluator|
-        evidence.request_results << FactoryBot.build(:request_result)
-      end
-    end
-
-    trait :with_verification_histories do
-      after :build do |evidence, _evaluator|
-        evidence.verification_histories << FactoryBot.build(:verification_history)
-      end
-    end
-
-    trait :outstanding do
-      aasm_state { 'outstanding' }
-      verification_outstanding { true }
-      is_satisfied { false }
-    end
-  end
-
-  factory :osse_evidence, :class => 'Eligibilities::Osse::Evidence' do
-    title { 'Osse Eligibility Evidence' }
-    description { 'Osse Eligibility' }
-    key { :osse_subsidy }
-    is_satisfied { true }
-
-    trait :with_eligibility do
-      after(:build) do |evidence, _evaluator|
-        eligibility ||= evidence.eligibility
-        eligibility { create(:eligibility)} unless eligibility.present?
-      end
-    end
   end
 end

--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -83,7 +83,7 @@ def get_applicants(application, start_range, end_range)
     evidence&.due_on &&
       valid_aasm_states.include?(evidence&.aasm_state) &&
       (evidence.due_on >= start_range && evidence.due_on <= end_range) &&
-      evidence.can_be_extended?('auto_extend_due_date')
+      evidence&.can_be_extended?('auto_extend_due_date')
   end
 end
 

--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -45,16 +45,17 @@ namespace :reports do
       eligibile_families.each do |family|
         application = FinancialAssistance::Application.where(family_id: family.id).determined.max_by(&:submitted_at)
         next unless application
-
+        
         applicants = get_applicants(application, start_range, end_range)
         next if applicants&.blank?
-
+        
         applicants.each do |applicant|
           evidence = applicant.income_evidence
           total_extension_days = days_to_extend.days
           new_due_date = (evidence.due_on + total_extension_days)
 
-          successful_save = evidence.extend_due_on(total_extension_days, 'system', 'migration_extend_due_date') if args[:migrate_users]
+          evidence.extend_due_on(total_extension_days, 'system', 'migration_extend_due_date') if args[:migrate_users]
+          successful_save = (evidence.due_on == new_due_date)
 
           csv << populate_csv_row(family, applicant, new_due_date, successful_save)
         rescue StandardError => e
@@ -76,7 +77,7 @@ def get_applicants(application, start_range, end_range)
   application.applicants.select do |applicant|
     evidence = applicant.income_evidence
 
-    if evidence.due_on.blank?
+    if evidence&.due_on&.blank?
       puts "Income evidence missing date: Application #{application.hbx_id}, Applicant #{applicant.person_hbx_id}, Income Evidence: #{evidence.id}, state: #{evidence.aasm_state}"
     end
   

--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -45,10 +45,10 @@ namespace :reports do
       eligibile_families.each do |family|
         application = FinancialAssistance::Application.where(family_id: family.id).determined.max_by(&:submitted_at)
         next unless application
-        
+
         applicants = get_applicants(application, start_range, end_range)
         next if applicants&.blank?
-        
+
         applicants.each do |applicant|
           evidence = applicant.income_evidence
           total_extension_days = days_to_extend.days

--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -31,7 +31,7 @@ namespace :reports do
       :due_date_successfully_extended
     ]
 
-    days_to_extend = FinancialAssistanceRegistry[:auto_update_income_evidence_due_on].settings(:days).item
+    days_to_extend = (FinancialAssistanceRegistry[:auto_update_income_evidence_due_on]&.settings(:days)&.item || 65)
     end_range = TimeKeeper.date_of_record
     start_range = (end_range - (days_to_extend + 1).days)
 

--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -77,13 +77,11 @@ def get_applicants(application, start_range, end_range)
   application.applicants.select do |applicant|
     evidence = applicant.income_evidence
 
-    if evidence&.due_on&.blank?
-      puts "Income evidence missing date: Application #{application.hbx_id}, Applicant #{applicant.person_hbx_id}, Income Evidence: #{evidence.id}, state: #{evidence.aasm_state}"
-    end
-  
-    evidence &&
-      evidence.due_on &&
-      valid_aasm_states.include?(evidence.aasm_state) &&
+    # NOTE: this line is rubocop's fault
+    puts "Income evidence missing date: Application #{application.hbx_id}, Applicant #{applicant.person_hbx_id}, Income Evidence: #{evidence.id}, state: #{evidence.aasm_state}" if evidence&.due_on&.blank?
+
+    evidence&.due_on &&
+      valid_aasm_states.include?(evidence&.aasm_state) &&
       (evidence.due_on >= start_range && evidence.due_on <= end_range) &&
       evidence.can_be_extended?('migration_extend_due_date')
   end

--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -105,6 +105,6 @@ def populate_csv_row(family, applicant, new_due_date, successful_save)
     evidence.id,
     evidence.due_on,
     new_due_date,
-    (successful_save ? successful_save : 'NOT EXTENDED')
+    (successful_save ? 'TRUE' : 'NOT EXTENDED')
   ]
 end

--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -51,9 +51,10 @@ namespace :reports do
 
         applicants.each do |applicant|
           evidence = applicant.income_evidence
-          new_due_date = (evidence.due_on + days_to_extend.days)
+          total_extension_days = days_to_extend.days
+          new_due_date = (evidence.due_on + total_extension_days)
 
-          successful_save = evidence.update(due_on: new_due_date) if args[:migrate_users]
+          successful_save = evidence.extend_due_on(total_extension_days, 'system', 'migration_extend_due_date') if args[:migrate_users]
 
           csv << populate_csv_row(family, applicant, new_due_date, successful_save)
         rescue StandardError => e
@@ -82,7 +83,8 @@ def get_applicants(application, start_range, end_range)
     evidence &&
       evidence.due_on &&
       valid_aasm_states.include?(evidence.aasm_state) &&
-      (evidence.due_on >= start_range && evidence.due_on <= end_range)
+      (evidence.due_on >= start_range && evidence.due_on <= end_range) &&
+      evidence.can_be_extended?('migration_extend_due_date')
   end
 end
 

--- a/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
+++ b/lib/tasks/export_eligible_users_with_outstanding_income_evidences.rake
@@ -54,7 +54,7 @@ namespace :reports do
           total_extension_days = days_to_extend.days
           new_due_date = (evidence.due_on + total_extension_days)
 
-          evidence.extend_due_on(total_extension_days, 'system', 'migration_extend_due_date') if args[:migrate_users]
+          evidence.extend_due_on(total_extension_days, 'system', 'auto_extend_due_date') if args[:migrate_users]
           successful_save = (evidence.due_on == new_due_date)
 
           csv << populate_csv_row(family, applicant, new_due_date, successful_save)
@@ -83,7 +83,7 @@ def get_applicants(application, start_range, end_range)
     evidence&.due_on &&
       valid_aasm_states.include?(evidence&.aasm_state) &&
       (evidence.due_on >= start_range && evidence.due_on <= end_range) &&
-      evidence.can_be_extended?('migration_extend_due_date')
+      evidence.can_be_extended?('auto_extend_due_date')
   end
 end
 

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
 
   let(:applicant_1_original_due_date) { TimeKeeper.date_of_record - 65.days }
   let(:applicant_2_original_due_date) { TimeKeeper.date_of_record - 66.days }
-  let(:applicant_3_original_due_date) { TimeKeeper.date_of_record - 64.days }
+  let(:applicant_3_original_due_date) { TimeKeeper.date_of_record - 34.days }
   let(:applicant_5_original_due_date) { TimeKeeper.date_of_record - 97.days }
   let(:applicant_6_original_due_date) { TimeKeeper.date_of_record - 40.days }
-  let(:applicant_7_original_due_date) { TimeKeeper.date_of_record - 67.days }
+  let(:applicant_7_original_due_date) { TimeKeeper.date_of_record - 80.days }
 
   describe "Generating a report of users eligible to have their income_evidence due_on date extended" do
 

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -13,105 +13,52 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
     let!(:person) { FactoryBot.create(:person) }
     let!(:person2) { FactoryBot.create(:person) }
     let!(:person3) { FactoryBot.create(:person) }
+    let!(:person4) { FactoryBot.create(:person) }
+
     let!(:family) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person) }
     let!(:family2) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person2) }
     let!(:family3) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person3) }
+    let!(:family4) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person4) }
 
-    let!(:application) { FactoryBot.create(:application, family_id: family.id, aasm_state: "determined", effective_date: (TimeKeeper.date_of_record - 12.days), assistance_year: '2023') }
-    let!(:application2) { FactoryBot.create(:application, family_id: family2.id, aasm_state: "determined", effective_date: (TimeKeeper.date_of_record - 18.days), assistance_year: '2023') }
-    let!(:application3) { FactoryBot.create(:application, family_id: family3.id, aasm_state: "determined", effective_date: (TimeKeeper.date_of_record - 18.days), assistance_year: '2023') }
+    let!(:application) { FactoryBot.create(:application, family_id: family.id, aasm_state: "determined") }
+    let!(:application2) { FactoryBot.create(:application, family_id: family2.id, aasm_state: "determined") }
+    let!(:application3) { FactoryBot.create(:application, family_id: family3.id, aasm_state: "determined") }
+    let!(:application4) { FactoryBot.create(:application, family_id: family4.id, aasm_state: "determined") }
 
-    let!(:applicant) do
-      FactoryBot.create(:financial_assistance_applicant,
-                        application: application,
-                        dob: TimeKeeper.date_of_record - 40.years,
-                        is_primary_applicant: true,
-                        family_member_id: family.family_members[0].id,
-                        person_hbx_id: person.hbx_id)
-    end
+    # Both eligible for income_evidence extension
+    let!(:applicant) { FactoryBot.create(:financial_assistance_applicant, application: application, is_primary_applicant: true, family_member_id: family.family_members[0].id, person_hbx_id: person.hbx_id) }
+    let!(:applicant2) { FactoryBot.create(:financial_assistance_applicant, application: application, family_member_id: family.family_members[1].id, person_hbx_id: family.family_members[1].person.hbx_id) }
 
-    let!(:applicant2) do
-      FactoryBot.create(:applicant,
-                        application: application,
-                        dob: TimeKeeper.date_of_record - 25.years,
-                        is_primary_applicant: false,
-                        family_member_id: family.family_members[1].id,
-                        person_hbx_id: family.family_members[1].person.hbx_id)
-    end
+    # One ineligible, one w/o income_evidence
+    let!(:applicant3) { FactoryBot.create(:financial_assistance_applicant, application: application2, is_primary_applicant: true, family_member_id: family2.family_members[0].id, person_hbx_id: person2.hbx_id) }
+    let!(:applicant4) { FactoryBot.create(:financial_assistance_applicant, application: application2, family_member_id: family2.family_members[1].id, person_hbx_id: family2.family_members[1].person.hbx_id) }
 
-    let!(:applicant3) do
-      FactoryBot.create(:applicant,
-                        application: application2,
-                        dob: TimeKeeper.date_of_record - 25.years,
-                        is_primary_applicant: false,
-                        family_member_id: family2.family_members[0].id,
-                        person_hbx_id: family2.family_members[0].person.hbx_id)
-    end
+    # All members ineligible
+    let!(:applicant5) { FactoryBot.create(:financial_assistance_applicant, application: application3, is_primary_applicant: true, family_member_id: family3.family_members[0].id, person_hbx_id: person3.hbx_id) }
 
-    let!(:applicant4) do
-      FactoryBot.create(:applicant,
-                        application: application2,
-                        dob: TimeKeeper.date_of_record - 27.years,
-                        is_primary_applicant: false,
-                        family_member_id: family2.family_members[1].id,
-                        person_hbx_id: family2.family_members[1].person.hbx_id)
-    end
-
-    let!(:applicant5) do
-      FactoryBot.create(:applicant,
-                        application: application3,
-                        dob: TimeKeeper.date_of_record - 40.years,
-                        is_primary_applicant: true,
-                        family_member_id: family3.family_members[0].id,
-                        person_hbx_id: family3.family_members[0].person.hbx_id)
-    end
+    # First member eligible, second ineligible for income_evidence extension
+    let!(:applicant6) { FactoryBot.create(:financial_assistance_applicant, application: application4, is_primary_applicant: true, family_member_id: family4.family_members[0].id, person_hbx_id: person4.hbx_id) }
+    let!(:applicant7) { FactoryBot.create(:financial_assistance_applicant, application: application4, family_member_id: family4.family_members[1].id, person_hbx_id: family4.family_members[1].person.hbx_id) }
 
     let(:applicant_1_original_due_date) { TimeKeeper.date_of_record - 65.days }
     let(:applicant_2_original_due_date) { TimeKeeper.date_of_record - 66.days }
-    let(:applicant_3_original_due_date) { TimeKeeper.date_of_record - 97.days }
-    let(:applicant_5_original_due_date) { TimeKeeper.date_of_record - 64.days }
+    let(:applicant_3_original_due_date) { TimeKeeper.date_of_record - 64.days }
+    let(:applicant_5_original_due_date) { TimeKeeper.date_of_record - 97.days }
+    let(:applicant_6_original_due_date) { TimeKeeper.date_of_record - 40.days }
+    let(:applicant_7_original_due_date) { TimeKeeper.date_of_record - 67.days }
 
-    let!(:income_evidence_1) do
-      applicant.create_income_evidence(key: :income,
-                                       title: 'Income',
-                                       aasm_state: 'outstanding',
-                                       due_on: applicant_1_original_due_date,
-                                       verification_outstanding: true,
-                                       is_satisfied: false)
-    end
-
-    let!(:income_evidence_2) do
-      applicant2.create_income_evidence(key: :income,
-                                        title: 'Income',
-                                        aasm_state: 'rejected',
-                                        due_on: applicant_2_original_due_date,
-                                        verification_outstanding: true,
-                                        is_satisfied: false)
-    end
-
-    let!(:income_evidence_3) do
-      applicant3.create_income_evidence(key: :income,
-                                        title: 'Income',
-                                        aasm_state: 'outstanding',
-                                        due_on: applicant_3_original_due_date,
-                                        verification_outstanding: true,
-                                        is_satisfied: false)
-    end
-
-    let!(:income_evidence_4) do
-      applicant5.create_income_evidence(key: :income,
-                                        title: 'Income',
-                                        aasm_state: 'rejected',
-                                        due_on: applicant_5_original_due_date,
-                                        verification_outstanding: true,
-                                        is_satisfied: false)
-    end
-
+    let!(:income_evidence_1) { applicant.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_1_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:income_evidence_2) { applicant2.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_2_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:income_evidence_3) { applicant3.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_3_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:income_evidence_5) { applicant5.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_5_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:income_evidence_6) { applicant6.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_6_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:income_evidence_7) { applicant7.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_7_original_due_date, verification_outstanding: true, is_satisfied: false) }
 
     before do
       min_date_1 = family.min_verification_due_date_on_family
       min_date_2 = family2.min_verification_due_date_on_family
       min_date_3 = family3.min_verification_due_date_on_family
+      min_date_4 = family4.min_verification_due_date_on_family
 
       family.create_eligibility_determination
       family.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
@@ -127,10 +74,15 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
       family3.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
                                                 outstanding_verification_earliest_due_date: min_date_3,
                                                 outstanding_verification_document_status: 'Partially Uploaded')
+
+      family4.create_eligibility_determination
+      family4.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
+                                                outstanding_verification_earliest_due_date: min_date_4,
+                                                outstanding_verification_document_status: 'Partially Uploaded')
     end
 
     after do
-      File.delete(file_name)
+      # File.delete(file_name)
     end
 
     context "when generating a report on a dry run" do
@@ -146,13 +98,13 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
 
         expect(csv[0]["applicant_person_hbx_id"]).to eq(applicant.person_hbx_id)
         expect(csv[1]["applicant_person_hbx_id"]).to eq(applicant2.person_hbx_id)
-        expect(csv[2]["applicant_person_hbx_id"]).to eq(applicant5.person_hbx_id)
+        expect(csv[2]["applicant_person_hbx_id"]).to eq(applicant3.person_hbx_id)
       end
 
       it "should not update the income evidence due dates for any user" do
         expect(applicant.income_evidence.due_on).to eq(applicant_1_original_due_date)
         expect(applicant2.income_evidence.due_on).to eq(applicant_2_original_due_date)
-        expect(applicant5.income_evidence.due_on).to eq(applicant_5_original_due_date)
+        expect(applicant3.income_evidence.due_on).to eq(applicant_3_original_due_date)
       end
     end
 
@@ -163,12 +115,43 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
       end
 
       it "should update the income evidence due_on to the correct due date" do
+        applicant.reload
+        applicant3.reload
+
         evidence = applicant.income_evidence
-        projected_due_date = applicant_1_original_due_date + 65.days
-        evidence.reload
+        evidence3 = applicant3.income_evidence
+        projected_due_date_1 = applicant_1_original_due_date + 65.days
+        projected_due_date_3 = applicant_3_original_due_date + 65.days
 
         expect(evidence.due_on).to_not eq(applicant_1_original_due_date)
-        expect(evidence.due_on).to eq(projected_due_date)
+        expect(evidence.due_on).to eq(projected_due_date_1)
+        expect(evidence3.due_on).to_not eq(applicant_3_original_due_date)
+        expect(evidence3.due_on).to eq(projected_due_date_3)
+      end
+
+      it "should add a verification history to all relevant evidences" do
+        applicant.reload
+        applicant2.reload
+        evidence_histories = applicant.income_evidence.verification_histories
+        evidence_histories2 = applicant2.income_evidence.verification_histories
+
+        expect(evidence_histories.size).to eq(1)
+        expect(evidence_histories2.size).to eq(1)
+      end
+
+      it "should have a verification history with the correct action and updated_by fields" do
+        applicant.reload
+        evidence_histories = applicant.income_evidence.verification_histories
+        
+        expect(evidence_histories.first.action).to eq('migration_extend_due_date')
+        expect(evidence_histories.first.updated_by).to eq('system')
+      end
+
+      it "should not add a verification history to ineligilble evidences" do
+        applicant5.reload
+        evidence_histories = applicant5.income_evidence.verification_histories
+
+        expect(evidence_histories.size).to eq(0)
       end
     end
 

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -54,6 +54,8 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
   let!(:evidence7) { applicant7.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_7_original_due_date, verification_outstanding: true, is_satisfied: false) }
 
   before do
+    allow(FinancialAssistanceRegistry[:auto_update_income_evidence_due_on].setting(:days)).to receive(:item).and_return(65)
+
     min_date1 = family1.min_verification_due_date_on_family
     min_date2 = family2.min_verification_due_date_on_family
     min_date3 = family3.min_verification_due_date_on_family

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -10,24 +10,24 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
   let(:file_name) { "#{Rails.root}/users_with_outstanding_income_evidence_eligible_for_extension.csv" }
 
   describe "Generating a report of users eligible to have their income_evidence due_on date extended" do
-    let!(:person) { FactoryBot.create(:person) }
+    let!(:person1) { FactoryBot.create(:person) }
     let!(:person2) { FactoryBot.create(:person) }
     let!(:person3) { FactoryBot.create(:person) }
     let!(:person4) { FactoryBot.create(:person) }
 
-    let!(:family) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person) }
+    let!(:family1) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person1) }
     let!(:family2) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person2) }
     let!(:family3) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person3) }
     let!(:family4) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person4) }
 
-    let!(:application) { FactoryBot.create(:application, family_id: family.id, aasm_state: "determined") }
+    let!(:application1) { FactoryBot.create(:application, family_id: family1.id, aasm_state: "determined") }
     let!(:application2) { FactoryBot.create(:application, family_id: family2.id, aasm_state: "determined") }
     let!(:application3) { FactoryBot.create(:application, family_id: family3.id, aasm_state: "determined") }
     let!(:application4) { FactoryBot.create(:application, family_id: family4.id, aasm_state: "determined") }
 
     # Both eligible for income_evidence extension
-    let!(:applicant) { FactoryBot.create(:applicant, application: application, is_primary_applicant: true, family_member_id: family.family_members[0].id, person_hbx_id: person.hbx_id) }
-    let!(:applicant2) { FactoryBot.create(:applicant, application: application, family_member_id: family.family_members[1].id, person_hbx_id: family.family_members[1].person.hbx_id) }
+    let!(:applicant1) { FactoryBot.create(:applicant, application: application1, is_primary_applicant: true, family_member_id: family1.family_members[0].id, person_hbx_id: person1.hbx_id) }
+    let!(:applicant2) { FactoryBot.create(:applicant, application: application1, family_member_id: family1.family_members[1].id, person_hbx_id: family1.family_members[1].person.hbx_id) }
 
     # One ineligible, one w/o income_evidence
     let!(:applicant3) { FactoryBot.create(:applicant, application: application2, is_primary_applicant: true, family_member_id: family2.family_members[0].id, person_hbx_id: person2.hbx_id) }
@@ -47,23 +47,23 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
     let(:applicant_6_original_due_date) { TimeKeeper.date_of_record - 40.days }
     let(:applicant_7_original_due_date) { TimeKeeper.date_of_record - 67.days }
 
-    let!(:income_evidence1) { applicant.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_1_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:income_evidence2) { applicant2.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_2_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:income_evidence3) { applicant3.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_3_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:income_evidence5) { applicant5.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_5_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:income_evidence6) { applicant6.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_6_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:income_evidence7) { applicant7.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_7_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:evidence1) { applicant1.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_1_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:evidence2) { applicant2.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_2_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:evidence3) { applicant3.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_3_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:evidence5) { applicant5.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_5_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:evidence6) { applicant6.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_6_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:evidence7) { applicant7.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_7_original_due_date, verification_outstanding: true, is_satisfied: false) }
 
     before do
-      min_date1 = family.min_verification_due_date_on_family
+      min_date1 = family1.min_verification_due_date_on_family
       min_date2 = family2.min_verification_due_date_on_family
       min_date3 = family3.min_verification_due_date_on_family
       min_date4 = family4.min_verification_due_date_on_family
 
-      family.create_eligibility_determination
-      family.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
-                                               outstanding_verification_earliest_due_date: min_date1,
-                                               outstanding_verification_document_status: 'Partially Uploaded')
+      family1.create_eligibility_determination
+      family1.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
+                                                outstanding_verification_earliest_due_date: min_date1,
+                                                outstanding_verification_document_status: 'Partially Uploaded')
 
       family2.create_eligibility_determination
       family2.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
@@ -96,15 +96,15 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
 
         expect(csv.size).to eq(3)
 
-        expect(csv[0]["applicant_person_hbx_id"]).to eq(applicant.person_hbx_id)
+        expect(csv[0]["applicant_person_hbx_id"]).to eq(applicant1.person_hbx_id)
         expect(csv[1]["applicant_person_hbx_id"]).to eq(applicant2.person_hbx_id)
         expect(csv[2]["applicant_person_hbx_id"]).to eq(applicant3.person_hbx_id)
       end
 
       it "should not update the income evidence due dates for any user" do
-        expect(income_evidence1.due_on).to eq(applicant_1_original_due_date)
-        expect(income_evidence2.due_on).to eq(applicant_2_original_due_date)
-        expect(income_evidence3.due_on).to eq(applicant_3_original_due_date)
+        expect(evidence1.due_on).to eq(applicant_1_original_due_date)
+        expect(evidence2.due_on).to eq(applicant_2_original_due_date)
+        expect(evidence3.due_on).to eq(applicant_3_original_due_date)
       end
     end
 
@@ -115,41 +115,38 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
       end
 
       it "should update the income evidence due_on to the correct due date" do
-        applicant.reload
-        applicant3.reload
-
-        evidence = applicant.income_evidence
-        evidence3 = applicant3.income_evidence
+        evidence1.reload
+        evidence3.reload
         projected_due_date1 = applicant_1_original_due_date + 65.days
         projected_due_date3 = applicant_3_original_due_date + 65.days
 
-        expect(evidence.due_on).to_not eq(applicant_1_original_due_date)
-        expect(evidence.due_on).to eq(projected_due_date1)
+        expect(evidence1.due_on).to_not eq(applicant_1_original_due_date)
+        expect(evidence1.due_on).to eq(projected_due_date1)
         expect(evidence3.due_on).to_not eq(applicant_3_original_due_date)
         expect(evidence3.due_on).to eq(projected_due_date3)
       end
 
       it "should add a verification history to all relevant evidences" do
-        income_evidence1.reload
-        income_evidence2.reload
-        evidence_histories = income_evidence1.verification_histories
-        evidence_histories2 = income_evidence2.verification_histories
+        evidence1.reload
+        evidence2.reload
+        evidence_histories = evidence1.verification_histories
+        evidence_histories2 = evidence2.verification_histories
 
         expect(evidence_histories.size).to eq(1)
         expect(evidence_histories2.size).to eq(1)
       end
 
       it "should have a verification history with the correct action and updated_by fields" do
-        income_evidence1.reload
-        evidence_histories = income_evidence1.verification_histories
+        evidence1.reload
+        evidence_histories = evidence1.verification_histories
 
         expect(evidence_histories.first.action).to eq('migration_extend_due_date')
         expect(evidence_histories.first.updated_by).to eq('system')
       end
 
       it "should not add a verification history to ineligilble evidences" do
-        applicant5.reload
-        evidence_histories = income_evidence5.verification_histories
+        evidence5.reload
+        evidence_histories = evidence5.verification_histories
 
         expect(evidence_histories.size).to eq(0)
       end
@@ -157,7 +154,7 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
 
     context 'when there are invalid records' do
       before do
-        income_evidence1.update(due_on: nil)
+        evidence1.update(due_on: nil)
 
         rake.reenable
         rake.invoke(true)

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -112,11 +112,14 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
       before do
         rake.reenable
         rake.invoke(true) # including 'true' as an arg when running the rake task will migrate the data
+
+        evidence1.reload
+        evidence2.reload
+        evidence3.reload
+        evidence5.reload
       end
 
       it "should update the income evidence due_on to the correct due date" do
-        evidence1.reload
-        evidence3.reload
         projected_due_date1 = applicant_1_original_due_date + 65.days
         projected_due_date3 = applicant_3_original_due_date + 65.days
 
@@ -127,8 +130,6 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
       end
 
       it "should add a verification history to all relevant evidences" do
-        evidence1.reload
-        evidence2.reload
         evidence_histories = evidence1.verification_histories
         evidence_histories2 = evidence2.verification_histories
 
@@ -137,7 +138,6 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
       end
 
       it "should have a verification history with the correct action and updated_by fields" do
-        evidence1.reload
         evidence_histories = evidence1.verification_histories
 
         expect(evidence_histories.first.action).to eq('migration_extend_due_date')
@@ -145,7 +145,6 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
       end
 
       it "should not add a verification history to ineligilble evidences" do
-        evidence5.reload
         evidence_histories = evidence5.verification_histories
 
         expect(evidence_histories.size).to eq(0)

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
   let(:rake) { Rake::Task["reports:export_eligible_users_with_outstanding_income_evidences"] }
   let(:file_name) { "#{Rails.root}/users_with_outstanding_income_evidence_eligible_for_extension.csv" }
 
+  before :all do
+    DatabaseCleaner.clean
+  end
+
   let!(:person1) { FactoryBot.create(:person) }
   let!(:person2) { FactoryBot.create(:person) }
   let!(:person3) { FactoryBot.create(:person) }

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
       it "should have a verification history with the correct action and updated_by fields" do
         applicant.reload
         evidence_histories = applicant.income_evidence.verification_histories
-        
+
         expect(evidence_histories.first.action).to eq('migration_extend_due_date')
         expect(evidence_histories.first.updated_by).to eq('system')
       end

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
   let(:rake) { Rake::Task["reports:export_eligible_users_with_outstanding_income_evidences"] }
   let(:file_name) { "#{Rails.root}/users_with_outstanding_income_evidence_eligible_for_extension.csv" }
 
-  describe "Rake Task" do
+  describe "Generating a report of users eligible to have their income_evidence due_on date extended" do
     let!(:person) { FactoryBot.create(:person) }
     let!(:person2) { FactoryBot.create(:person) }
     let!(:person3) { FactoryBot.create(:person) }
@@ -26,19 +26,19 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
     let!(:application4) { FactoryBot.create(:application, family_id: family4.id, aasm_state: "determined") }
 
     # Both eligible for income_evidence extension
-    let!(:applicant) { FactoryBot.create(:financial_assistance_applicant, application: application, is_primary_applicant: true, family_member_id: family.family_members[0].id, person_hbx_id: person.hbx_id) }
-    let!(:applicant2) { FactoryBot.create(:financial_assistance_applicant, application: application, family_member_id: family.family_members[1].id, person_hbx_id: family.family_members[1].person.hbx_id) }
+    let!(:applicant) { FactoryBot.create(:applicant, application: application, is_primary_applicant: true, family_member_id: family.family_members[0].id, person_hbx_id: person.hbx_id) }
+    let!(:applicant2) { FactoryBot.create(:applicant, application: application, family_member_id: family.family_members[1].id, person_hbx_id: family.family_members[1].person.hbx_id) }
 
     # One ineligible, one w/o income_evidence
-    let!(:applicant3) { FactoryBot.create(:financial_assistance_applicant, application: application2, is_primary_applicant: true, family_member_id: family2.family_members[0].id, person_hbx_id: person2.hbx_id) }
-    let!(:applicant4) { FactoryBot.create(:financial_assistance_applicant, application: application2, family_member_id: family2.family_members[1].id, person_hbx_id: family2.family_members[1].person.hbx_id) }
+    let!(:applicant3) { FactoryBot.create(:applicant, application: application2, is_primary_applicant: true, family_member_id: family2.family_members[0].id, person_hbx_id: person2.hbx_id) }
+    let!(:applicant4) { FactoryBot.create(:applicant, application: application2, family_member_id: family2.family_members[1].id, person_hbx_id: family2.family_members[1].person.hbx_id) }
 
     # All members ineligible
-    let!(:applicant5) { FactoryBot.create(:financial_assistance_applicant, application: application3, is_primary_applicant: true, family_member_id: family3.family_members[0].id, person_hbx_id: person3.hbx_id) }
+    let!(:applicant5) { FactoryBot.create(:applicant, application: application3, is_primary_applicant: true, family_member_id: family3.family_members[0].id, person_hbx_id: person3.hbx_id) }
 
     # First member eligible, second ineligible for income_evidence extension
-    let!(:applicant6) { FactoryBot.create(:financial_assistance_applicant, application: application4, is_primary_applicant: true, family_member_id: family4.family_members[0].id, person_hbx_id: person4.hbx_id) }
-    let!(:applicant7) { FactoryBot.create(:financial_assistance_applicant, application: application4, family_member_id: family4.family_members[1].id, person_hbx_id: family4.family_members[1].person.hbx_id) }
+    let!(:applicant6) { FactoryBot.create(:applicant, application: application4, is_primary_applicant: true, family_member_id: family4.family_members[0].id, person_hbx_id: person4.hbx_id) }
+    let!(:applicant7) { FactoryBot.create(:applicant, application: application4, family_member_id: family4.family_members[1].id, person_hbx_id: family4.family_members[1].person.hbx_id) }
 
     let(:applicant_1_original_due_date) { TimeKeeper.date_of_record - 65.days }
     let(:applicant_2_original_due_date) { TimeKeeper.date_of_record - 66.days }
@@ -47,37 +47,37 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
     let(:applicant_6_original_due_date) { TimeKeeper.date_of_record - 40.days }
     let(:applicant_7_original_due_date) { TimeKeeper.date_of_record - 67.days }
 
-    let!(:income_evidence_1) { applicant.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_1_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:income_evidence_2) { applicant2.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_2_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:income_evidence_3) { applicant3.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_3_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:income_evidence_5) { applicant5.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_5_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:income_evidence_6) { applicant6.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_6_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:income_evidence_7) { applicant7.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_7_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:income_evidence1) { applicant.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_1_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:income_evidence2) { applicant2.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_2_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:income_evidence3) { applicant3.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_3_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:income_evidence5) { applicant5.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_5_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:income_evidence6) { applicant6.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_6_original_due_date, verification_outstanding: true, is_satisfied: false) }
+    let!(:income_evidence7) { applicant7.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_7_original_due_date, verification_outstanding: true, is_satisfied: false) }
 
     before do
-      min_date_1 = family.min_verification_due_date_on_family
-      min_date_2 = family2.min_verification_due_date_on_family
-      min_date_3 = family3.min_verification_due_date_on_family
-      min_date_4 = family4.min_verification_due_date_on_family
+      min_date1 = family.min_verification_due_date_on_family
+      min_date2 = family2.min_verification_due_date_on_family
+      min_date3 = family3.min_verification_due_date_on_family
+      min_date4 = family4.min_verification_due_date_on_family
 
       family.create_eligibility_determination
       family.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
-                                               outstanding_verification_earliest_due_date: min_date_1,
+                                               outstanding_verification_earliest_due_date: min_date1,
                                                outstanding_verification_document_status: 'Partially Uploaded')
 
       family2.create_eligibility_determination
       family2.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
-                                                outstanding_verification_earliest_due_date: min_date_2,
+                                                outstanding_verification_earliest_due_date: min_date2,
                                                 outstanding_verification_document_status: 'Partially Uploaded')
 
       family3.create_eligibility_determination
       family3.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
-                                                outstanding_verification_earliest_due_date: min_date_3,
+                                                outstanding_verification_earliest_due_date: min_date3,
                                                 outstanding_verification_document_status: 'Partially Uploaded')
 
       family4.create_eligibility_determination
       family4.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
-                                                outstanding_verification_earliest_due_date: min_date_4,
+                                                outstanding_verification_earliest_due_date: min_date4,
                                                 outstanding_verification_document_status: 'Partially Uploaded')
     end
 
@@ -102,9 +102,9 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
       end
 
       it "should not update the income evidence due dates for any user" do
-        expect(applicant.income_evidence.due_on).to eq(applicant_1_original_due_date)
-        expect(applicant2.income_evidence.due_on).to eq(applicant_2_original_due_date)
-        expect(applicant3.income_evidence.due_on).to eq(applicant_3_original_due_date)
+        expect(income_evidence1.due_on).to eq(applicant_1_original_due_date)
+        expect(income_evidence2.due_on).to eq(applicant_2_original_due_date)
+        expect(income_evidence3.due_on).to eq(applicant_3_original_due_date)
       end
     end
 
@@ -120,28 +120,28 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
 
         evidence = applicant.income_evidence
         evidence3 = applicant3.income_evidence
-        projected_due_date_1 = applicant_1_original_due_date + 65.days
-        projected_due_date_3 = applicant_3_original_due_date + 65.days
+        projected_due_date1 = applicant_1_original_due_date + 65.days
+        projected_due_date3 = applicant_3_original_due_date + 65.days
 
         expect(evidence.due_on).to_not eq(applicant_1_original_due_date)
-        expect(evidence.due_on).to eq(projected_due_date_1)
+        expect(evidence.due_on).to eq(projected_due_date1)
         expect(evidence3.due_on).to_not eq(applicant_3_original_due_date)
-        expect(evidence3.due_on).to eq(projected_due_date_3)
+        expect(evidence3.due_on).to eq(projected_due_date3)
       end
 
       it "should add a verification history to all relevant evidences" do
-        applicant.income_evidence.reload
-        applicant2.income_evidence.reload
-        evidence_histories = applicant.income_evidence.verification_histories
-        evidence_histories2 = applicant2.income_evidence.verification_histories
+        income_evidence1.reload
+        income_evidence2.reload
+        evidence_histories = income_evidence1.verification_histories
+        evidence_histories2 = income_evidence2.verification_histories
 
         expect(evidence_histories.size).to eq(1)
         expect(evidence_histories2.size).to eq(1)
       end
 
       it "should have a verification history with the correct action and updated_by fields" do
-        applicant.reload
-        evidence_histories = applicant.income_evidence.verification_histories
+        income_evidence1.reload
+        evidence_histories = income_evidence1.verification_histories
 
         expect(evidence_histories.first.action).to eq('migration_extend_due_date')
         expect(evidence_histories.first.updated_by).to eq('system')
@@ -149,7 +149,7 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
 
       it "should not add a verification history to ineligilble evidences" do
         applicant5.reload
-        evidence_histories = applicant5.income_evidence.verification_histories
+        evidence_histories = income_evidence5.verification_histories
 
         expect(evidence_histories.size).to eq(0)
       end
@@ -157,7 +157,7 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
 
     context 'when there are invalid records' do
       before do
-        applicant.income_evidence.update(due_on: nil)
+        income_evidence1.update(due_on: nil)
 
         rake.reenable
         rake.invoke(true)

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
       it "should have a verification history with the correct action and updated_by fields" do
         evidence_histories = evidence1.verification_histories
 
-        expect(evidence_histories.first.action).to eq('migration_extend_due_date')
+        expect(evidence_histories.first.action).to eq('auto_extend_due_date')
         expect(evidence_histories.first.updated_by).to eq('system')
       end
 

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
   let(:rake) { Rake::Task["reports:export_eligible_users_with_outstanding_income_evidences"] }
   let(:file_name) { "#{Rails.root}/users_with_outstanding_income_evidence_eligible_for_extension.csv" }
 
-  before :all do
-    DatabaseCleaner.clean
-  end
-
   let!(:person1) { FactoryBot.create(:person) }
   let!(:person2) { FactoryBot.create(:person) }
   let!(:person3) { FactoryBot.create(:person) }
@@ -50,46 +46,45 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
   let(:applicant_6_original_due_date) { TimeKeeper.date_of_record - 40.days }
   let(:applicant_7_original_due_date) { TimeKeeper.date_of_record - 80.days }
 
+  let!(:evidence1) { applicant1.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_1_original_due_date, verification_outstanding: true, is_satisfied: false) }
+  let!(:evidence2) { applicant2.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_2_original_due_date, verification_outstanding: true, is_satisfied: false) }
+  let!(:evidence3) { applicant3.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_3_original_due_date, verification_outstanding: true, is_satisfied: false) }
+  let!(:evidence5) { applicant5.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_5_original_due_date, verification_outstanding: true, is_satisfied: false) }
+  let!(:evidence6) { applicant6.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_6_original_due_date, verification_outstanding: true, is_satisfied: false) }
+  let!(:evidence7) { applicant7.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_7_original_due_date, verification_outstanding: true, is_satisfied: false) }
+
+  before do
+    min_date1 = family1.min_verification_due_date_on_family
+    min_date2 = family2.min_verification_due_date_on_family
+    min_date3 = family3.min_verification_due_date_on_family
+    min_date4 = family4.min_verification_due_date_on_family
+
+    family1.create_eligibility_determination
+    family1.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
+                                              outstanding_verification_earliest_due_date: min_date1,
+                                              outstanding_verification_document_status: 'Partially Uploaded')
+
+    family2.create_eligibility_determination
+    family2.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
+                                              outstanding_verification_earliest_due_date: min_date2,
+                                              outstanding_verification_document_status: 'Partially Uploaded')
+
+    family3.create_eligibility_determination
+    family3.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
+                                              outstanding_verification_earliest_due_date: min_date3,
+                                              outstanding_verification_document_status: 'Partially Uploaded')
+
+    family4.create_eligibility_determination
+    family4.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
+                                              outstanding_verification_earliest_due_date: min_date4,
+                                              outstanding_verification_document_status: 'Partially Uploaded')
+  end
+
+  after do
+    File.delete(file_name)
+  end
+
   describe "Generating a report of users eligible to have their income_evidence due_on date extended" do
-
-    let!(:evidence1) { applicant1.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_1_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:evidence2) { applicant2.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_2_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:evidence3) { applicant3.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_3_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:evidence5) { applicant5.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_5_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:evidence6) { applicant6.create_income_evidence(key: :income, title: 'Income', aasm_state: 'rejected', due_on: applicant_6_original_due_date, verification_outstanding: true, is_satisfied: false) }
-    let!(:evidence7) { applicant7.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_7_original_due_date, verification_outstanding: true, is_satisfied: false) }
-
-    before do
-      min_date1 = family1.min_verification_due_date_on_family
-      min_date2 = family2.min_verification_due_date_on_family
-      min_date3 = family3.min_verification_due_date_on_family
-      min_date4 = family4.min_verification_due_date_on_family
-
-      family1.create_eligibility_determination
-      family1.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
-                                                outstanding_verification_earliest_due_date: min_date1,
-                                                outstanding_verification_document_status: 'Partially Uploaded')
-
-      family2.create_eligibility_determination
-      family2.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
-                                                outstanding_verification_earliest_due_date: min_date2,
-                                                outstanding_verification_document_status: 'Partially Uploaded')
-
-      family3.create_eligibility_determination
-      family3.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
-                                                outstanding_verification_earliest_due_date: min_date3,
-                                                outstanding_verification_document_status: 'Partially Uploaded')
-
-      family4.create_eligibility_determination
-      family4.eligibility_determination.update!(outstanding_verification_status: 'outstanding',
-                                                outstanding_verification_earliest_due_date: min_date4,
-                                                outstanding_verification_document_status: 'Partially Uploaded')
-    end
-
-    after do
-      File.delete(file_name)
-    end
-
     context "when generating a report on a dry run" do
       before do
         rake.reenable

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -54,8 +54,6 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
   let!(:evidence7) { applicant7.create_income_evidence(key: :income, title: 'Income', aasm_state: 'outstanding', due_on: applicant_7_original_due_date, verification_outstanding: true, is_satisfied: false) }
 
   before do
-    allow(FinancialAssistanceRegistry[:auto_update_income_evidence_due_on].setting(:days)).to receive(:item).and_return(65)
-
     min_date1 = family1.min_verification_due_date_on_family
     min_date2 = family2.min_verification_due_date_on_family
     min_date3 = family3.min_verification_due_date_on_family

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
     end
 
     after do
-      # File.delete(file_name)
+      File.delete(file_name)
     end
 
     context "when generating a report on a dry run" do

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
       end
 
       it "should add a verification history to all relevant evidences" do
-        applicant.reload
-        applicant2.reload
+        applicant.income_evidence.reload
+        applicant2.income_evidence.reload
         evidence_histories = applicant.income_evidence.verification_histories
         evidence_histories2 = applicant2.income_evidence.verification_histories
 
@@ -157,16 +157,16 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
 
     context 'when there are invalid records' do
       before do
-        allow_any_instance_of(Eligibilities::Evidence).to receive(:update).and_raise(StandardError)
+        applicant.income_evidence.update(due_on: nil)
 
         rake.reenable
         rake.invoke(true)
       end
 
-      it 'should create the csv despite invalid records' do
+      it 'should create the csv despite and ignore invalid records' do
         csv = CSV.read(file_name, headers: true)
 
-        expect(csv.size).to eq(0)
+        expect(csv.size).to eq(2)
       end
     end
   end

--- a/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
+++ b/spec/lib/tasks/export_eligible_users_with_outstanding_income_evidences_spec.rb
@@ -9,10 +9,6 @@ RSpec.describe 'reports:export_eligible_users_with_outstanding_income_evidences'
   let(:rake) { Rake::Task["reports:export_eligible_users_with_outstanding_income_evidences"] }
   let(:file_name) { "#{Rails.root}/users_with_outstanding_income_evidence_eligible_for_extension.csv" }
 
-  before :all do
-    DatabaseCleaner.clean
-  end
-
   let!(:person1) { FactoryBot.create(:person) }
   let!(:person2) { FactoryBot.create(:person) }
   let!(:person3) { FactoryBot.create(:person) }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [185554801](https://www.pivotaltracker.com/story/show/185554801)

# A brief description of the changes

Current behavior: N/A

New behavior:

#### _This rake task generates a csv of all the applicants with outstanding income evidences due dates between 95 and 160 days_

To generate a csv of users eligible for an income evidence due_on extension without migrating data, run the following:
`RAILS_ENV=production bundle exec rake reports:export_eligible_users_with_outstanding_income_evidences`

To migrate eligible users' income evidences due_on to their new due date, run the following:
`RAILS_ENV=production bundle exec rake reports:export_eligible_users_with_outstanding_income_evidences[true]`

The CSV file will be generated and in the root folder called `users_with_outstanding_income_evidence_due_dates_between_95_and_160_days.csv`

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [ ] DC
- [x] ME

# Additional Context: 
See _New Behavior_ section above.