### PR TITLE
Correcting missing invocations of VLP services at the wrong time.

### DIFF
--- a/app/controllers/concerns/vlp_doc.rb
+++ b/app/controllers/concerns/vlp_doc.rb
@@ -2,6 +2,7 @@
 
 module VlpDoc
   include ErrorBubble
+  include EventSource::Command
 
   def vlp_doc_params_list
     [
@@ -116,5 +117,36 @@ module VlpDoc
       params_hash = params.permit("tribal_id").to_h
       role.person.tribal_id != params_hash["tribal_id"]
     end
+  end
+
+  # These methods are a fix to make sure that any associated events are
+  # fired correctly.
+  # It's placed here because:
+  #   1. Embedded documents can frequently change the state of consumer
+  #      roles, but those writes/changes can happen after the consumer
+  #      role itself is updated.
+  #   2. If we place the event broadcast into the embedded document itself,
+  #      the result is a tremendous amount of thrashing when this update
+  #      should actually be considered atomic.
+  #   3. We have no desire right now to impact the behaviour of primary family
+  #      members during the entry process.
+  #
+  # All of this logic should be refactored into the correct single operation
+  # when this controller is corrected into the clean code pattern.
+
+  def fire_consumer_roles_create_for_vlp_docs(consumer_role)
+    return unless consumer_role.active_vlp_document.present?
+    event = event('events.individual.consumer_roles.created', attributes: { gid: consumer_role.to_global_id.uri })
+    event.success.publish if event.success?
+  rescue StandardError => e
+    Rails.logger.error { "Couldn't generate consumer role create event due to #{e.backtrace}" }
+  end
+
+  def fire_consumer_roles_update_for_vlp_docs(consumer_role, original_applying_for_coverage)
+    return unless consumer_role.active_vlp_document.present?
+    event = event('events.individual.consumer_roles.updated', attributes: { gid: consumer_role.to_global_id.uri, previous: {is_applying_coverage: original_applying_for_coverage} })
+    event.success.publish if event.success?
+  rescue StandardError => e
+    Rails.logger.error { "Couldn't generate consumer role updated event due to #{e.backtrace}" }
   end
 end

--- a/app/controllers/concerns/vlp_doc.rb
+++ b/app/controllers/concerns/vlp_doc.rb
@@ -135,7 +135,7 @@ module VlpDoc
   # when this controller is corrected into the clean code pattern.
 
   def fire_consumer_roles_create_for_vlp_docs(consumer_role)
-    return unless consumer_role.active_vlp_document.present?
+    return unless consumer_role && consumer_role.active_vlp_document.present?
     event = event('events.individual.consumer_roles.created', attributes: { gid: consumer_role.to_global_id.uri })
     event.success.publish if event.success?
   rescue StandardError => e
@@ -143,7 +143,7 @@ module VlpDoc
   end
 
   def fire_consumer_roles_update_for_vlp_docs(consumer_role, original_applying_for_coverage)
-    return unless consumer_role.active_vlp_document.present?
+    return unless consumer_role && consumer_role.active_vlp_document.present?
     event = event('events.individual.consumer_roles.updated', attributes: { gid: consumer_role.to_global_id.uri, previous: {is_applying_coverage: original_applying_for_coverage} })
     event.success.publish if event.success?
   rescue StandardError => e

--- a/app/controllers/insured/family_members_controller.rb
+++ b/app/controllers/insured/family_members_controller.rb
@@ -180,7 +180,7 @@ class Insured::FamilyMembersController < ApplicationController
       return
     end
     consumer_role = @dependent.family_member.try(:person).try(:consumer_role)
-    original_applying_for_coverage = consumer_role.is_applying_coverage
+    original_applying_for_coverage = consumer_role.present? ? consumer_role.is_applying_coverage : nil
     if @address_errors.blank? && @dependent.update_attributes(dependent_person_params[:dependent]) && update_vlp_documents(consumer_role, 'dependent', @dependent)
       active_family_members_count = @family.active_family_members.count
       household = @family.active_household

--- a/app/controllers/insured/family_members_controller.rb
+++ b/app/controllers/insured/family_members_controller.rb
@@ -4,7 +4,6 @@ class Insured::FamilyMembersController < ApplicationController
   include VlpDoc
   include ApplicationHelper
   include ::L10nHelper
-  include EventSource::Command
 
   before_action :dependent_person_params, only: [:create, :update]
   before_action :set_current_person
@@ -117,7 +116,7 @@ class Insured::FamilyMembersController < ApplicationController
       Rails.logger.info("In FamilyMembersController create action #{params}, #{@family.inspect}") unless active_family_members_count == immediate_household_members_count + extended_family_members_count
       @created = true
       consumer_role = @dependent.family_member.try(:person).try(:consumer_role)
-      fire_consumer_roles_create(consumer_role) if consumer_role
+      fire_consumer_roles_create_for_vlp_docs(consumer_role) if consumer_role
       respond_to do |format|
         format.html { render 'show' }
         format.js { render 'show' }
@@ -195,7 +194,7 @@ class Insured::FamilyMembersController < ApplicationController
           params[:dependent][:is_applying_coverage]
         )
       end
-      fire_consumer_roles_update(consumer_role, original_applying_for_coverage)
+      fire_consumer_roles_update_for_vlp_docs(consumer_role, original_applying_for_coverage)
       respond_to do |format|
         format.html { render 'show' }
         format.js { render 'show' }
@@ -261,35 +260,6 @@ class Insured::FamilyMembersController < ApplicationController
       format.html
       format.js
     end
-  end
-
-  # These methods are a fix to make sure that any associated events are
-  # fired correctly.
-  # It's placed here because:
-  #   1. Embedded documents can frequently change the state of consumer
-  #      roles, but those writes/changes can happen after the consumer
-  #      role itself is updated.
-  #   2. If we place the event broadcast into the embedded document itself,
-  #      the result is a tremendous amount of thrashing when this update
-  #      should actually be considered atomic.
-  #   3. We have no desire right now to impact the behaviour of primary family
-  #      members during the entry process.
-  #
-  # All of this logic should be refactored into the correct single operation
-  # when this controller is corrected into the clean code pattern.
-
-  def fire_consumer_roles_create(consumer_role)
-    event = event('events.individual.consumer_roles.created', attributes: { gid: consumer_role.to_global_id.uri })
-    event.success.publish if event.success?
-  rescue StandardError => e
-    Rails.logger.error { "Couldn't generate consumer role create event due to #{e.backtrace}" }
-  end
-
-  def fire_consumer_roles_update(consumer_role, original_applying_for_coverage)
-    event = event('events.individual.consumer_roles.updated', attributes: { gid: consumer_role.to_global_id.uri, previous: {is_applying_coverage: original_applying_for_coverage} })
-    event.success.publish if event.success?
-  rescue StandardError => e
-    Rails.logger.error { "Couldn't generate consumer role updated event due to #{e.backtrace}" }
   end
 
   private

--- a/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
+++ b/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
@@ -46,8 +46,13 @@ RSpec.describe Insured::FamilyMembersController do
         person: double(is_homeless: false, is_temporarily_out_of_state: false),
         local_residency_validation: nil,
         residency_determined_at: nil,
-        to_global_id: global_id
+        to_global_id: global_id,
+        active_vlp_document: vlp_document
       )
+    end
+
+    let(:vlp_document) do
+      instance_double(VlpDocument)
     end
 
     let(:global_id) do

--- a/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
+++ b/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
@@ -45,8 +45,13 @@ RSpec.describe Insured::FamilyMembersController do
         ConsumerRole,
         person: double(is_homeless: false, is_temporarily_out_of_state: false),
         local_residency_validation: nil,
-        residency_determined_at: nil
+        residency_determined_at: nil,
+        global_id: global_id
       )
+    end
+
+    let(:global_id) do
+      ConsumerRole.new.to_global_id
     end
 
     let(:dependent_controller_parameters) do

--- a/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
+++ b/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe Insured::FamilyMembersController do
     end
 
     describe "when the value for 'is_applying_coverage' is provided" do
+      before :each do
+        allow(consumer_role).to receive(:is_applying_coverage).and_return(!is_applying_coverage_value)
+      end
+
       let(:is_applying_coverage_value) { "false" }
       let(:dependent_update_properties) do
         { "first_name" => "Dependent First Name", "same_with_primary" => "true", "is_applying_coverage" => is_applying_coverage_value }
@@ -77,6 +81,10 @@ RSpec.describe Insured::FamilyMembersController do
     end
 
     describe "when the value for 'is_applying_coverage' is NOT provided" do
+      before :each do
+        allow(consumer_role).to receive(:is_applying_coverage).and_return(true)
+      end
+
       let(:dependent_update_properties) do
         { "first_name" => "Dependent First Name", "same_with_primary" => "true" }
       end

--- a/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
+++ b/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Insured::FamilyMembersController do
         person: double(is_homeless: false, is_temporarily_out_of_state: false),
         local_residency_validation: nil,
         residency_determined_at: nil,
-        global_id: global_id
+        to_global_id: global_id
       )
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186142780

Current behavior:

The underlying issue is that VLP triggers are not always fired every time VLP documents are updated.  This occurs because our current method for detecting this change relies on after save callbacks on the Consumer Role.

There are multiple circumstances where changes to VLP documents and their values don’t update the consumer role parent document, and thus the after save call back on Consumer Role won’t ‘catch’ changes to VLP documents.  When that happens we won’t invoke/update Fedhub calls like we should.  It just so happens that by will be triggered more frequently on dependent updates.

New behavior:

We're going to correct this issue by invoking explicit broadcast of the event in the controller for family members after all consumer roles are persisted.

We were initially examining using a callback on instances of VlpDocument, but discovered this created an unacceptable level of thrashing on a standard workflow.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME
