### PR TITLE
trigger hub calls when ssn is updated from admin actions

### DIFF
--- a/app/domain/operations/update_dob_ssn.rb
+++ b/app/domain/operations/update_dob_ssn.rb
@@ -41,6 +41,8 @@ module Operations
         person.ssn = params[:person][:ssn]
       end
       person.save!
+      # Updates the no_ssn field to indicate no_ssn and also to trigger the Hub Calls
+      person.update_attributes!({ no_ssn: '1' }) if person.encrypted_ssn.blank?
       CensusEmployee.update_census_employee_records(person, current_user)
       Success([nil, dont_update_ssn])
     rescue StandardError => e

--- a/spec/domain/operations/update_dob_ssn_spec.rb
+++ b/spec/domain/operations/update_dob_ssn_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe Operations::UpdateDobSsn, type: :model, dbclean: :after_each do
                   family_actions_id: 'family_actions_238764'}, jq_datepicker_ignore_person: { dob: "01/01/#{TimeKeeper.date_of_record.year}" }}
     end
 
+    let(:no_ssn_test_params) do
+      { person: { person_id: person.id.to_s,
+                  dob: "#{TimeKeeper.date_of_record.year}-01-01",
+                  ssn: '',
+                  pid: person.id.to_s,
+                  family_actions_id: 'family_actions_238764'}, jq_datepicker_ignore_person: { dob: "01/01/#{TimeKeeper.date_of_record.year}" }}
+    end
+
     context 'success' do
       before do
         person.consumer_role.update_attributes!(active_vlp_document_id: person.consumer_role.vlp_documents.first.id)
@@ -29,6 +37,23 @@ RSpec.describe Operations::UpdateDobSsn, type: :model, dbclean: :after_each do
 
       it 'should return success' do
         expect(@result.success).to eq([nil, nil])
+      end
+    end
+
+    context 'success' do
+      before do
+        person.consumer_role.update_attributes!(active_vlp_document_id: person.consumer_role.vlp_documents.first.id)
+        @result = subject.call(person_id: person.id.to_s, params: no_ssn_test_params, current_user: 'c_user', ssn_require: false)
+      end
+
+      it 'should return success' do
+        expect(@result).to be_a Dry::Monads::Result::Success
+      end
+
+      it 'should return success' do
+        expect(@result.success).to eq([nil, nil])
+        person.reload
+        expect(person.no_ssn).to eq "1"
       end
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186138669

# A brief description of the changes

Current behavior: Hub calls are not triggered when SSN is updated from Admin actions

New behavior: Trigger hub calls when SSN is updated from admin actions

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.