### PR TITLE
add description of vlp document to the cv transform

### DIFF
--- a/app/domain/operations/transformers/person_to/cv3_person.rb
+++ b/app/domain/operations/transformers/person_to/cv3_person.rb
@@ -153,6 +153,7 @@ module Operations
             next if vlp_document.subject.nil?
             {
               subject: vlp_document.subject,
+              description: vlp_document.description,
               alien_number: vlp_document.alien_number,
               i94_number: vlp_document.i94_number,
               visa_number: vlp_document.visa_number,

--- a/spec/factories/vlp_document.rb
+++ b/spec/factories/vlp_document.rb
@@ -8,5 +8,27 @@ FactoryBot.define do
     country_of_citizenship { "Ukraine" }
     passport_number { "123456" }
     subject { VlpDocument::VLP_DOCUMENT_KINDS[0] } #I-327 (Reentry Permit) and validates on :alien_number
+
+    trait :other_with_i94_number do
+      alien_number { '' }
+      visa_number { '' }
+      naturalization_number { '' }
+      receipt_number { '' }
+      citizenship_number { '' }
+      issuing_country { '' }
+      card_number { '' }
+      title { "untitled" }
+      type { "text" }
+      source { "enroll_system" }
+      language { "en" }
+      status { "not submitted" }
+      subject { "Other (With I-94 Number)" }
+      passport_number { "" }
+      sevis_id { "" }
+      expiration_date { nil }
+      description { "test" }
+      i94_number { "28798256761" }
+      country_of_citizenship { "" }
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186144491

# A brief description of the changes

Current behavior: We are not sending the `description` of the VLP Document, which is failing the contract validation for Hub Calls.

New behavior: Adds description of the VLP Document in the CV3 person transform

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.