### PR TITLE
Record error messages when a hub call is made for person who does not attest to immigration status 

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -130,6 +130,13 @@ class DocumentsController < ApplicationController
     result = ::Operations::CallFedHub.new.call(request_hash)
     key, message = result.failure? ? result.failure : result.success
 
+    if result.failure?
+      @verification_type.fail_type
+      @verification_type.add_type_history_element(action: "Hub Request Failed",
+                                                  modifier: "System",
+                                                  update_reason: "#{@verification_type.type_name} Request Failed due to #{message}")
+    end
+
     respond_to do |format|
       format.html {
         flash[key] = message

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -706,8 +706,9 @@ class ConsumerRole
   end
 
   def eligible_for_invoking_dhs?
-    is_applying_coverage && [NATURALIZED_CITIZEN_STATUS, ALIEN_LAWFULLY_PRESENT_STATUS,
-                             INELIGIBLE_CITIZEN_VERIFICATION].include?(citizen_status)
+    is_applying_coverage && (
+      [NATURALIZED_CITIZEN_STATUS, ALIEN_LAWFULLY_PRESENT_STATUS] + INELIGIBLE_CITIZEN_VERIFICATION
+    ).include?(citizen_status)
   end
 
   def invoke_verification!(*args)

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -706,7 +706,8 @@ class ConsumerRole
   end
 
   def eligible_for_invoking_dhs?
-    is_applying_coverage && [NATURALIZED_CITIZEN_STATUS, ALIEN_LAWFULLY_PRESENT_STATUS].include?(citizen_status)
+    is_applying_coverage && [NATURALIZED_CITIZEN_STATUS, ALIEN_LAWFULLY_PRESENT_STATUS,
+                             INELIGIBLE_CITIZEN_VERIFICATION].include?(citizen_status)
   end
 
   def invoke_verification!(*args)

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -132,6 +132,24 @@ RSpec.describe DocumentsController, :type => :controller do
           expect(flash[:danger]).to eq('Please fill in your information for Document Description.')
         end
       end
+
+      context 'no vlp document type' do
+        before do
+          person.consumer_role.vlp_documents = []
+          person.save!
+          @immigration_type.update_attributes!(inactive: false)
+        end
+
+        it 'should redirect if verification type is Immigration status' do
+          post :fed_hub_request, params: { verification_type: @immigration_type.id, person_id: person.id }
+
+          person.reload
+          @immigration_type.reload
+          expect(@immigration_type.validation_status).to eq  'negative_response_received'
+          error_message = @immigration_type.type_history_elements.last.update_reason
+          expect(error_message).to match(/Failed due to VLP Document not found/)
+        end
+      end
     end
 
     context 'when admin does not have permissions' do

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe DocumentsController, :type => :controller do
 
           person.reload
           @immigration_type.reload
-          expect(@immigration_type.validation_status).to eq  'negative_response_received'
+          expect(@immigration_type.validation_status).to eq 'negative_response_received'
           error_message = @immigration_type.type_history_elements.last.update_reason
           expect(error_message).to match(/Failed due to VLP Document not found/)
         end

--- a/spec/models/consumer_role_invoke_hub_call_spec.rb
+++ b/spec/models/consumer_role_invoke_hub_call_spec.rb
@@ -30,8 +30,8 @@ describe ConsumerRole, dbclean: :around_each do
       it_behaves_like 'eligibility of invoking dhs call', 'alien_lawfully_present', true, true
       it_behaves_like 'eligibility of invoking dhs call', 'lawful_permanent_resident', true, false
       it_behaves_like 'eligibility of invoking dhs call', 'naturalized_citizen', true, true
-      it_behaves_like 'eligibility of invoking dhs call', 'non_native_not_lawfully_present_in_us', true, false
-      it_behaves_like 'eligibility of invoking dhs call', 'not_lawfully_present_in_us', true, false
+      it_behaves_like 'eligibility of invoking dhs call', 'non_native_not_lawfully_present_in_us', true, true
+      it_behaves_like 'eligibility of invoking dhs call', 'not_lawfully_present_in_us', true, true
       it_behaves_like 'eligibility of invoking dhs call', 'us_citizen', true, false
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186115359

# A brief description of the changes

Current behavior: Error messages are not properly recorded when hub call is made for person who is not lawfully present

New behavior: Record error messages when hub call is made for person who is not lawfully present

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.