### PR TITLE
fix typo in json parse method for oeg trigger

### DIFF
--- a/app/domain/operations/notices/ivl_oe_reverification_trigger.rb
+++ b/app/domain/operations/notices/ivl_oe_reverification_trigger.rb
@@ -163,7 +163,7 @@ module Operations
         entity =
           if financial_application&.determined? && financial_application.eligibility_response_payload.present?
             ::AcaEntities::MagiMedicaid::Operations::InitializeApplication.new.call(
-              JSON.parse(financial_application.eligibility_response_payload, :symbolize_name => true)
+              JSON.parse(financial_application.eligibility_response_payload, :symbolize_names => true)
             )
           else
             build_family_payload(family)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186073888

# A brief description of the changes

Current behavior:
```
JSON.parse(financial_application.eligibility_response_payload, :symbolize_name => true)
```
Note: `:symbolize_name` is an invalid option.

New behavior:
```
JSON.parse(financial_application.eligibility_response_payload, :symbolize_name => true)
```
Note: `:symbolize_names` is the correct option.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
No spec is included as this is a simple typo fix for the option passed to the JSON parse method.