### PR TITLE
change shop plan year renewals trigger date to 10/20

### DIFF
--- a/config/client_config/dc/config/settings.yml
+++ b/config/client_config/dc/config/settings.yml
@@ -181,7 +181,7 @@ aca:
       earliest_start_prior_to_effective_on:
         months: -3
         # Will occur the day after the date here
-        day_of_month: 0
+        day_of_month: 19
       monthly_open_enrollment_end_on: 13
       publish_due_day_of_month: 10
       application_submission_soft_deadline: 5

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -153,7 +153,7 @@ aca:
       earliest_start_prior_to_effective_on:
         months: -3
         # Will occur the day after the date here
-        day_of_month: 0
+        day_of_month: 19
       monthly_open_enrollment_end_on: 13
       publish_due_day_of_month: 10
       application_submission_soft_deadline: 5


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186135193

# A brief description of the changes

Current behavior: currently SHOP plan year renewals will trigger on 10/1

New behavior: Modified trigger setting, so that renewals will generate on 10/20

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [x] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.