### PR TITLE
Fix extra 'No VLP Documents' error in history.

### DIFF
--- a/app/controllers/concerns/vlp_doc.rb
+++ b/app/controllers/concerns/vlp_doc.rb
@@ -161,7 +161,7 @@ module VlpDoc
     consumer_role.verification_types.active.where(:type_name.in => ["Citizenship", "Immigration status"]).each do |v_type|
       type_history_ele = v_type.type_history_elements.max_by(:created_at)
       if type_history_ele.present? && type_history_ele.update_reason.match(/No VLP Documents/)
-        type_history_ele.destory
+        type_history_ele.destroy
       end
     end
     consumer_role.save!

--- a/app/controllers/concerns/vlp_doc.rb
+++ b/app/controllers/concerns/vlp_doc.rb
@@ -136,6 +136,9 @@ module VlpDoc
 
   def fire_consumer_roles_create_for_vlp_docs(consumer_role)
     return unless consumer_role && consumer_role.active_vlp_document.present?
+
+    clear_history_noise_if_present_from(consumer_role)
+
     event = event('events.individual.consumer_roles.created', attributes: { gid: consumer_role.to_global_id.uri })
     event.success.publish if event.success?
   rescue StandardError => e
@@ -144,9 +147,24 @@ module VlpDoc
 
   def fire_consumer_roles_update_for_vlp_docs(consumer_role, original_applying_for_coverage)
     return unless consumer_role && consumer_role.active_vlp_document.present?
+
+    clear_history_noise_if_present_from(consumer_role)
+
     event = event('events.individual.consumer_roles.updated', attributes: { gid: consumer_role.to_global_id.uri, previous: {is_applying_coverage: original_applying_for_coverage} })
     event.success.publish if event.success?
   rescue StandardError => e
     Rails.logger.error { "Couldn't generate consumer role updated event due to #{e.backtrace}" }
   end
+
+  # rubocop:disable Style/IfUnlessModifier
+  def clear_history_noise_if_present_from(consumer_role)
+    consumer_role.verification_types.active.where(:type_name.in => ["Citizenship", "Immigration status"]).each do |v_type|
+      type_history_ele = v_type.type_history_elements.max_by(:created_at)
+      if type_history_ele.present? && type_history_ele.update_reason.match(/No VLP Documents/)
+        type_history_ele.destory
+      end
+    end
+    consumer_role.save!
+  end
+  # rubocop:enable Style/IfUnlessModifier
 end

--- a/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
+++ b/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe Insured::FamilyMembersController do
         local_residency_validation: nil,
         residency_determined_at: nil,
         to_global_id: global_id,
-        active_vlp_document: vlp_document
+        active_vlp_document: vlp_document,
+        verification_types: []
       )
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186146967

# A brief description of the changes

Current behavior:

Dependent history would have an additional, noisy 'No VLP Documents' message during normal registration flow.

New behavior:

Don't produce the error when VLP documents are actually provided.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME