### PR TITLE
changes when notifications are sent for VLP document

### DIFF
--- a/app/controllers/insured/family_members_controller.rb
+++ b/app/controllers/insured/family_members_controller.rb
@@ -108,7 +108,7 @@ class Insured::FamilyMembersController < ApplicationController
       end
       return
     end
-    if @address_errors.blank? && @dependent.save && update_vlp_documents(@dependent.family_member.try(:person).try(:consumer_role), 'dependent', @dependent)
+    if @address_errors.blank? && @dependent.save && update_vlp_documents(consumer_role_for_create(@dependent), 'dependent', @dependent)
       active_family_members_count = @family.active_family_members.count
       household = @family.active_household
       immediate_household_members_count = household.immediate_family_coverage_household.coverage_household_members.count
@@ -264,6 +264,12 @@ class Insured::FamilyMembersController < ApplicationController
   end
 
   private
+
+  def consumer_role_for_create(dependent)
+    consumer_role = dependent.family_member.try(:person).try(:consumer_role)
+    consumer_role.skip_consumer_role_callbacks = true if consumer_role.present?
+    consumer_role
+  end
 
   def dependent_person_params
     params.permit(:dependent => {})

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -308,7 +308,7 @@ class ConsumerRole
 
   def setup_lawful_determination_instance
     unless self.lawful_presence_determination.present?
-      self.lawful_presence_determination = LawfulPresenceDetermination.new
+      self.lawful_presence_determination = LawfulPresenceDetermination.new(skip_lawful_presence_determination_callbacks: skip_consumer_role_callbacks)
     end
   end
 

--- a/app/models/forms/family_member.rb
+++ b/app/models/forms/family_member.rb
@@ -144,7 +144,11 @@ module Forms
       return false unless try_create_person(person)
       family_member = family.relate_new_member(person, self.relationship)
       if self.is_consumer_role == "true"
-        family_member.family.build_consumer_role(family_member, extract_consumer_role_params.merge({skip_consumer_role_callbacks: @skip_consumer_role_callbacks}))
+
+        # DO NOT change the order of the key value pairs
+        additional_params = { skip_consumer_role_callbacks: @skip_consumer_role_callbacks }.merge(extract_consumer_role_params)
+
+        family_member.family.build_consumer_role(family_member, additional_params)
       elsif self.is_resident_role == "true"
         family_member.family.build_resident_role(family_member)
       end

--- a/app/models/lawful_presence_determination.rb
+++ b/app/models/lawful_presence_determination.rb
@@ -27,6 +27,8 @@ class LawfulPresenceDetermination
   field :aasm_state, type: String
   embeds_many :workflow_state_transitions, as: :transitional
 
+  attr_accessor :skip_lawful_presence_determination_callbacks
+
   after_create :publish_created_event
   after_update :publish_updated_event
 
@@ -150,6 +152,7 @@ class LawfulPresenceDetermination
   end
 
   def publish_created_event
+    return if skip_lawful_presence_determination_callbacks
     attrs = { consumer_role_id: ivl_role.id }.merge!(self.changes)
     # TODO: This should be refactored to use created instead of updated.
     event = event('events.individual.consumer_roles.lawful_presence_determinations.updated', attributes: attrs)
@@ -159,6 +162,7 @@ class LawfulPresenceDetermination
   end
 
   def publish_updated_event
+    return if skip_lawful_presence_determination_callbacks
     attrs = { consumer_role_id: ivl_role.id }.merge!(self.changes)
     event = event('events.individual.consumer_roles.lawful_presence_determinations.updated', attributes: attrs)
     event.success.publish if event.success?


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186146967](https://www.pivotaltracker.com/story/show/186146967)

# A brief description of the changes

Current behavior: We are making a call to the hub before we create VLP Documents.

New behavior: Skips unwanted Hub Calls before VLP Documents are created to fix the `No VLP Documents` issue.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.