### PR TITLE
request hub call irrespective of the presence of the vlp document

### DIFF
--- a/app/controllers/concerns/vlp_doc.rb
+++ b/app/controllers/concerns/vlp_doc.rb
@@ -135,8 +135,6 @@ module VlpDoc
   # when this controller is corrected into the clean code pattern.
 
   def fire_consumer_roles_create_for_vlp_docs(consumer_role)
-    return unless consumer_role && consumer_role.active_vlp_document.present?
-
     event = event('events.individual.consumer_roles.created', attributes: { gid: consumer_role.to_global_id.uri })
     event.success.publish if event.success?
   rescue StandardError => e
@@ -144,8 +142,6 @@ module VlpDoc
   end
 
   def fire_consumer_roles_update_for_vlp_docs(consumer_role, original_applying_for_coverage)
-    return unless consumer_role && consumer_role.active_vlp_document.present?
-
     event = event('events.individual.consumer_roles.updated', attributes: { gid: consumer_role.to_global_id.uri, previous: {is_applying_coverage: original_applying_for_coverage} })
     event.success.publish if event.success?
   rescue StandardError => e


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [pivotal-186153069](https://www.pivotaltracker.com/n/projects/2640059/stories/186153069#)

# A brief description of the changes

Current behavior: When there is not vlp document for Immigrant scenario, there is no hub call request made.

New behavior: Hub call should be requested irrespective of the presence of the vlp document.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.