### PR TITLE
checking for contribution unit presence

### DIFF
--- a/components/benefit_sponsors/app/models/benefit_sponsors/contribution_calculators/simple_shop_reference_plan_contribution_calculator.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/contribution_calculators/simple_shop_reference_plan_contribution_calculator.rb
@@ -24,7 +24,12 @@ module BenefitSponsors
 
         def add(member)
           if !@is_contribution_prohibited
-            c_factor = contribution_factor_for(member)
+            c_unit = get_contribution_unit(member)
+            if c_unit.blank?
+              @member_contributions[member.member_id] = 0.00
+              return self
+            end
+            c_factor = contribution_factor_for(c_unit)
             c_amount = calc_contribution_amount_for(member, c_factor)
             @member_contributions[member.member_id] = c_amount 
             @total_contribution = BigDecimal((@total_contribution + c_amount).to_s).round(2)
@@ -54,9 +59,8 @@ module BenefitSponsors
           )
         end
 
-        def contribution_factor_for(roster_entry_member)
-          cu = get_contribution_unit(roster_entry_member)
-          cl = @level_map[cu.id]
+        def contribution_factor_for(c_unit)
+          cl = @level_map[c_unit.id]
           cl.contribution_factor
         end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186063639

# A brief description of the changes

Current behavior: checking for contribution unit presence to handle cases when family members with realtionships like parent, unrelated etc exists on enrollment.

New behavior: it raises 500 error when trying to calculate total premium

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.