### PR TITLE
update county for a dependent when primary county info is updated

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -343,6 +343,7 @@ private
     dep_address.city = @person_new_home_address.city
     dep_address.state = @person_new_home_address.state
     dep_address.zip = @person_new_home_address.zip
+    dep_address.county = @person_new_home_address.county if @person_new_home_address.county.present?
     dep_address.save!
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -345,6 +345,7 @@ private
     dep_address.zip = @person_new_home_address.zip
     dep_address.county = @person_new_home_address.county if @person_new_home_address.county.present?
     dep_address.save!
+    dependent.person.save!
   end
 
   def sanitize_person_params

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -327,7 +327,7 @@ class Address
   def same_address?(another_address)
     return(false) if another_address.nil?
     attrs_to_match = [:address_1, :address_2, :address_3, :city, :state, :zip]
-    attrs_to_match << 'county' if EnrollRegistry.feature_enabled?(:display_county)
+    attrs_to_match << :county if EnrollRegistry.feature_enabled?(:display_county)
     attrs_to_match.all? { |attr| attribute_matches?(attr, another_address) }
   end
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -327,6 +327,7 @@ class Address
   def same_address?(another_address)
     return(false) if another_address.nil?
     attrs_to_match = [:address_1, :address_2, :address_3, :city, :state, :zip]
+    attrs_to_match << 'county' if EnrollRegistry.feature_enabled?(:display_county)
     attrs_to_match.all? { |attr| attribute_matches?(attr, another_address) }
   end
 

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -222,8 +222,9 @@ RSpec.describe PeopleController, dbclean: :after_each do
       post :update, params: { id: person.id, person: person_attributes }
 
       person.reload
+      dependent.reload
       primary_address = person.addresses.select{|address| address.kind == 'home'}.first
-      dependent_address = person.primary_family.family_members.reject(&:is_primary_applicant?).first.person.addresses.first
+      dependent_address = dependent.addresses.first
       expect(primary_address.same_address?(dependent_address)).to eq true
       expect(primary_address.county).to eq dependent_address.county
     end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -393,6 +393,65 @@ describe '#matches_addresses?' do
   end
 end
 
+describe '#same_address' do
+  let(:address_1) do
+    FactoryBot.build(:address,address_1: "An address line 1",
+                              address_2: "An address line 2",
+                              city: "A City",
+                              state: "ME",
+                              county: county_1,
+                              zip: "21222")
+  end
+  let(:address_2) do
+    FactoryBot.build(:address,address_1: "An address line 1",
+                              address_2: "An address line 2",
+                              city: "A City",
+                              state: "ME",
+                              county: county_2,
+                              zip: "21222")
+  end
+  let(:county_1) { 'test_1' }
+  let(:county_2) { 'test_2' }
+  let(:setting) { double }
+
+  before do
+    allow(EnrollRegistry).to receive(:feature_enabled?).with(:validate_quadrant).and_return(false)
+  end
+
+
+  context 'addresses with different counties and display county is flag is false' do
+    before do
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:display_county).and_return(false)
+    end
+
+    it 'should return true' do
+      expect(address_1.same_address?(address_2)).to eq(true)
+    end
+  end
+
+  context 'addresses with different counties and display county is flag is true' do
+    before do
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:display_county).and_return(true)
+    end
+    it 'should return true' do
+      expect(address_1.same_address?(address_2)).to eq(false)
+    end
+  end
+
+  context 'addresses with same counties and display county is flag is true' do
+    let(:county_1) { 'test_1' }
+    let(:county_2) { 'test_1' }
+
+    before do
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:display_county).and_return(true)
+    end
+
+    it 'should return true' do
+      expect(address_1.same_address?(address_2)).to eq(true)
+    end
+  end
+end
+
 describe "#kind" do
   let(:office_location) {FactoryBot.build(:office_location, :primary)}
   let(:address) {FactoryBot.build(:address)}


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186083084

# A brief description of the changes

Current behavior: County information on dependent is not updated when primary updated his zip and dependent attests that he lives with primary

New behavior: Update county information on dependent when primary updated his zip and dependent attests that he lives with primary

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.