### PR TITLE
skip applying aptc on catastrophic renewals

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -79,7 +79,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
 
   def populate_aptc_hash(renewal_enrollment)
     # Prevents applying APTC to catastrophic enrollment plans irrespective of which tax model is used
-    unless renew_enrollment.product.can_use_aptc?
+    unless renewal_enrollment.product.can_use_aptc?
       @aptc_values = {}
       return
     end

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -79,11 +79,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
 
   def populate_aptc_hash(renewal_enrollment)
     # Prevents applying APTC to catastrophic enrollment plans irrespective of which tax model is used
-    unless renewal_enrollment.product.can_use_aptc?
-      @aptc_values = {}
-      return
-    end
-
+    return unless renewal_enrollment.product.can_use_aptc?
     return unless EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
 
     aptc_op = ::Operations::PremiumCredits::FindAptc.new.call({

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -78,6 +78,12 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   end
 
   def populate_aptc_hash(renewal_enrollment)
+    # Prevents applying APTC to catastrophic enrollment plans irrespective of which tax model is used
+    unless renew_enrollment.product.can_use_aptc?
+      @aptc_values = {}
+      return
+    end
+
     return unless EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
 
     aptc_op = ::Operations::PremiumCredits::FindAptc.new.call({

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -333,6 +333,14 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
       end
 
       context "when consumer covered under catastrophic product" do
+        before do
+          primary.update(dob: renewal_benefit_coverage_period.start_on - 25.years)
+          spouse.person.update(dob: renewal_benefit_coverage_period.start_on - 25.years)
+          child1.person.update(dob: renewal_benefit_coverage_period.start_on - 1.years)
+          child2.person.update(dob: renewal_benefit_coverage_period.start_on - 1.years)
+          child3.person.update(dob: renewal_benefit_coverage_period.start_on - 1.years)
+        end
+
         let!(:current_product) { FactoryBot.create(:active_individual_catastophic_product, hios_id: "11111111122302-01", csr_variant_id: "01", renewal_product_id: renewal_product.id) }
         it 'should return an empty apt hash' do
           allow(::Operations::PremiumCredits::FindAptc).to receive(:new).and_return(
@@ -343,8 +351,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
               )
             )
           )
-          subject.renew
-          expect(subject.aptc_values).to eq({})
+          expect(subject.renew.applied_aptc_amount).to be_zero
         end
       end
 
@@ -588,7 +595,18 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
         end
 
         context "when consumer covered under catastrophic product" do
+          before do
+            primary.update(dob: renewal_benefit_coverage_period.start_on - 25.years)
+            spouse.person.update(dob: renewal_benefit_coverage_period.start_on - 25.years)
+            child1.person.update(dob: renewal_benefit_coverage_period.start_on - 1.years)
+            child2.person.update(dob: renewal_benefit_coverage_period.start_on - 1.years)
+            child3.person.update(dob: renewal_benefit_coverage_period.start_on - 1.years)
+            renewal_product.update(metal_level_kind: :catastrophic)
+          end
+
+          # let!(:renewal_product) { FactoryBot.create(:active_individual_catastophic_product, hios_id: "11111111122302-01", csr_variant_id: "01") }
           let!(:current_product) { FactoryBot.create(:active_individual_catastophic_product, hios_id: "11111111122302-01", csr_variant_id: "01", renewal_product_id: renewal_product.id) }
+
           it 'should return an empty apt hash' do
             allow(::Operations::PremiumCredits::FindAptc).to receive(:new).and_return(
               double(
@@ -598,8 +616,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
                 )
               )
             )
-            subject.renew
-            expect(subject.aptc_values).to eq({})
+            expect(subject.renew.applied_aptc_amount).to be_zero
           end
         end
       end

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -332,6 +332,22 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
         end
       end
 
+      context "when consumer covered under catastrophic product" do
+        let!(:current_product) { FactoryBot.create(:active_individual_catastophic_product, hios_id: "11111111122302-01", csr_variant_id: "01", renewal_product_id: renewal_product.id) }
+        it 'should return an empty apt hash' do
+          allow(::Operations::PremiumCredits::FindAptc).to receive(:new).and_return(
+            double(
+              call: double(
+                success?: true,
+                value!: 100
+              )
+            )
+          )
+          subject.renew
+          expect(subject.aptc_values).to eq({})
+        end
+      end
+
       context 'when mthh enabled' do
         before do
           allow(UnassistedPlanCostDecorator).to receive(:new).and_return(double(total_ehb_premium: 1390, total_premium: 1390))
@@ -568,6 +584,22 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
                                                 })
               expect(subject.assisted).to eq true
             end
+          end
+        end
+
+        context "when consumer covered under catastrophic product" do
+          let!(:current_product) { FactoryBot.create(:active_individual_catastophic_product, hios_id: "11111111122302-01", csr_variant_id: "01", renewal_product_id: renewal_product.id) }
+          it 'should return an empty apt hash' do
+            allow(::Operations::PremiumCredits::FindAptc).to receive(:new).and_return(
+              double(
+                call: double(
+                  success?: true,
+                  value!: 100
+                )
+              )
+            )
+            subject.renew
+            expect(subject.aptc_values).to eq({})
           end
         end
       end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186170438

# A brief description of the changes

Current behavior:
Annual enrollment renewal process does not check if plan can have aptc applied before calculating and updating the aptc amount.

New behavior:
Catastrophic plans cannot have an APTC amount applied in the renewal operation.  This behavior applies to all tax household models: MTHH and single tax household.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: n/a

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.