### PR TITLE
updating cms report and enrollment report to check to_state for renewal status

### DIFF
--- a/lib/tasks/hbx_reports/enrollment_report.rake
+++ b/lib/tasks/hbx_reports/enrollment_report.rake
@@ -58,7 +58,7 @@ namespace :reports do
       end
     end
 
-    def previously_renewed_enrollments(enr, all_enrollments, person)
+    def renewed_enrollments(enr, all_enrollments, person)
       states = HbxEnrollment::RENEWAL_STATUSES + HbxEnrollment::ENROLLED_STATUSES + HbxEnrollment::TERMINATED_STATUSES
       all_enrollments.select do |enrollment|
         enrollment_member_hbx_ids = enrollment.hbx_enrollment_members.flat_map(&:person).pluck(:hbx_id)
@@ -111,8 +111,8 @@ namespace :reports do
     def member_status(enr)
       enrs_between_nov_and_dec_set = has_effectuated_coverage_in_prev_year_during_oe?(enr)
       re_enrolled_member_set = @enrollments&.map(&:hbx_id)
-      active_renewals_set = (re_enrolled_member_set & @post_11_1_purchases&.map(&:hbx_id)) - @previously_renewed_enrollments&.map(&:hbx_id)
-      passive_renewals_set = re_enrolled_member_set - (@post_11_1_purchases&.map(&:hbx_id) - @previously_renewed_enrollments&.map(&:hbx_id))
+      active_renewals_set = (re_enrolled_member_set & @post_11_1_purchases&.map(&:hbx_id)) - @renewed_enrollments&.map(&:hbx_id)
+      passive_renewals_set = re_enrolled_member_set - (@post_11_1_purchases&.map(&:hbx_id) - @renewed_enrollments&.map(&:hbx_id))
 
       if active_renewals_set.present? && enrs_between_nov_and_dec_set.present?
         "Active Re-enrollee"
@@ -180,7 +180,7 @@ namespace :reports do
                 @enrollments = all_enrollments_for_year(enr, all_enrollments_for_person, per)
                 @pre_11_1_purchases = pre_11_1_purchase_enrollments(enr, all_enrollments_for_person, per)
                 @post_11_1_purchases = post_11_1_purchase_enrollments(enr, all_enrollments_for_person, per)
-                @previously_renewed_enrollments = previously_renewed_enrollments(enr, all_enrollments_for_person, per)
+                @renewed_enrollments = renewed_enrollments(enr, all_enrollments_for_person, per)
                 @previous_enrollments = all_effectuated_enrollments_for_prev_year(enr, all_enrollments_for_person, per)
                 @all_expired_enrollments = all_expired_enrollments_for_prev_year(enr, all_enrollments_for_person, per)
                 csv << [

--- a/lib/tasks/hbx_reports/enrollment_report.rake
+++ b/lib/tasks/hbx_reports/enrollment_report.rake
@@ -66,7 +66,9 @@ namespace :reports do
           enrollment.coverage_kind == enr.coverage_kind &&
           enrollment.effective_on >= enr.effective_on.beginning_of_year &&
           enrollment_member_hbx_ids.include?(person.hbx_id) &&
-          enrollment.was_in_renewal_status?
+          enrollment.workflow_state_transitions.any? do |wst|
+            HbxEnrollment::RENEWAL_STATUSES.include?(wst.from_state.to_s) || HbxEnrollment::RENEWAL_STATUSES.include?(wst.to_state.to_s)
+          end
       end
     end
 

--- a/script/cms_daily_report.rb
+++ b/script/cms_daily_report.rb
@@ -236,7 +236,7 @@ end
 post_11_1_purchase_set = Set.new(post_11_1_ids)
 
 renewal_statuses = HbxEnrollment::RENEWAL_STATUSES.map(&:to_s)
-previously_renewed = all_enrolled_people = HbxEnrollment.collection.aggregate([
+has_been_renewed = all_enrolled_people = HbxEnrollment.collection.aggregate([
   {"$match" => {
       "hbx_enrollment_members" => {"$ne" => nil},
       "external_enrollment" => {"$ne" => true},
@@ -272,15 +272,15 @@ previously_renewed = all_enrolled_people = HbxEnrollment.collection.aggregate([
   {"$project" => {"_id" => "$person_id", "total" => {"$sum" => 1}}}
 ])
 
-previously_renewed_ids = previously_renewed.map do |rec|
+has_been_renewed_ids = has_been_renewed.map do |rec|
   rec["_id"]
 end
 
-previously_renewed_set = Set.new(post_11_1_ids)
+has_been_renewed_set = Set.new(post_11_1_ids)
 
-active_renewals_set = (re_enrolled_member_set & post_11_1_purchase_set) - previously_renewed_set
+active_renewals_set = (re_enrolled_member_set & post_11_1_purchase_set) - has_been_renewed_set
 
-passive_renewals_set = re_enrolled_member_set - (post_11_1_purchase_set - previously_renewed_set)
+passive_renewals_set = re_enrolled_member_set - (post_11_1_purchase_set - has_been_renewed_set)
 
 puts "Total Member Enrolled(2023) Count: #{all_enrolled_people_set.size}"
 puts "Total New Member/Consumer selected 2023 enrollments after 11/1/2022 : #{new_member_set.size}"

--- a/script/cms_daily_report.rb
+++ b/script/cms_daily_report.rb
@@ -197,7 +197,7 @@ end
 post_11_1_purchase_set = Set.new(post_11_1_ids)
 
 renewal_statuses = HbxEnrollment::RENEWAL_STATUSES.map(&:to_s)
-has_been_renewed = all_enrolled_people = HbxEnrollment.collection.aggregate([
+has_been_renewed = HbxEnrollment.collection.aggregate([
   {"$match" => {
       "hbx_enrollment_members" => {"$ne" => nil},
       "external_enrollment" => {"$ne" => true},

--- a/script/cms_daily_report.rb
+++ b/script/cms_daily_report.rb
@@ -245,7 +245,10 @@ previously_renewed = all_enrolled_people = HbxEnrollment.collection.aggregate([
       "product_id" => { "$ne" => nil},
       "aasm_state" => {"$in" => HbxEnrollment::RENEWAL_STATUSES + HbxEnrollment::ENROLLED_STATUSES},
       "effective_on" => {"$gte" => Date.new(2023,1,1)},
-      'workflow_state_transitions.from_state': { '$in' => renewal_statuses }
+      '$or' => [
+        {'workflow_state_transitions.from_state': { '$in' => renewal_statuses }},
+        {'workflow_state_transitions.to_state': { '$in' => renewal_statuses }}
+      ]
   }
   },
   {"$project" => {"family_id" => "$family_id", "hbx_enrollment_members" => "$hbx_enrollment_members"}},


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/n/projects/2502930/stories/186124378, https://www.pivotaltracker.com/n/projects/2502930/stories/185462778

# A brief description of the changes

Current behavior: When checking for previously renewed status, we don't consider if an enrollment is ~currently~ in renewing status since we only check the from_state

New behavior:  Now we check both the from_state AND the to_state to see if the enrollment was ever in renewing status

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.