### PR TITLE
add spacing between radio button and text and default radio check box to renewal year during OE

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/applications/_year_selection_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/_year_selection_form.html.erb
@@ -15,8 +15,8 @@
           <p><b><%= l10n("faa.assitance_year_option1", year: oe_year) %></b><br> <%= l10n("faa.see_if_you_qualify_1", short_name: EnrollRegistry[:enroll_app].setting(:short_name).item, medicaid_or_chip_program_short_name: FinancialAssistanceRegistry[:medicaid_or_chip_program_short_name].setting(:name).item) %> <%= l10n("faa.year_selection_oe_range_from") %> <%= HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on %> <%= l10n("faa.year_selection_oe_range_through") %> <%= HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_end_on %>.</p>
           <p><b><%= l10n("faa.assitance_year_option2", year: current_year) %></b><br> <%= l10n("faa.see_if_you_qualify_2", short_name: EnrollRegistry[:enroll_app].setting(:short_name).item, medicaid_or_chip_program_short_name: FinancialAssistanceRegistry[:medicaid_or_chip_program_short_name].setting(:name).item) %>. <%= sanitize link_to l10n("faa.learn_more_about_life_changes"), FinancialAssistanceRegistry[:iap_year_selection_form].setting(:iap_year_sep_link).item %>.</p>
           <h3><%= l10n("faa.choose_a_plan_year") %></h3>
-          <label><%= f.radio_button :assistance_year, oe_year %> <%= l10n("faa.assitance_year_option1", year: oe_year) %></label><br>
-          <label><%= f.radio_button :assistance_year, current_year %><%= l10n("faa.assitance_year_option2", year: current_year) %></label>
+          <label><%= f.radio_button :assistance_year, oe_year, checked: true %> <span class="ml-half"> <%= l10n("faa.assitance_year_option1", year: oe_year) %> </span></label><br>
+          <label><%= f.radio_button :assistance_year, current_year, checked: false %><span class="ml-half"> <%= l10n("faa.assitance_year_option2", year: current_year) %></span></label>
           <% if FinancialAssistanceRegistry.feature_enabled?(:iap_year_selection_form) %>
           <p><b><%= l10n("faa.update_reminder", year: current_year, year2: oe_year) %></b><br></p>
           <% end %>

--- a/components/financial_assistance/app/views/financial_assistance/applications/_year_selection_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/_year_selection_form.html.erb
@@ -15,8 +15,8 @@
           <p><b><%= l10n("faa.assitance_year_option1", year: oe_year) %></b><br> <%= l10n("faa.see_if_you_qualify_1", short_name: EnrollRegistry[:enroll_app].setting(:short_name).item, medicaid_or_chip_program_short_name: FinancialAssistanceRegistry[:medicaid_or_chip_program_short_name].setting(:name).item) %> <%= l10n("faa.year_selection_oe_range_from") %> <%= HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_start_on %> <%= l10n("faa.year_selection_oe_range_through") %> <%= HbxProfile.current_hbx.benefit_sponsorship.benefit_coverage_periods.last.open_enrollment_end_on %>.</p>
           <p><b><%= l10n("faa.assitance_year_option2", year: current_year) %></b><br> <%= l10n("faa.see_if_you_qualify_2", short_name: EnrollRegistry[:enroll_app].setting(:short_name).item, medicaid_or_chip_program_short_name: FinancialAssistanceRegistry[:medicaid_or_chip_program_short_name].setting(:name).item) %>. <%= sanitize link_to l10n("faa.learn_more_about_life_changes"), FinancialAssistanceRegistry[:iap_year_selection_form].setting(:iap_year_sep_link).item %>.</p>
           <h3><%= l10n("faa.choose_a_plan_year") %></h3>
-          <label><%= f.radio_button :assistance_year, oe_year, checked: true %> <span class="ml-half"> <%= l10n("faa.assitance_year_option1", year: oe_year) %> </span></label><br>
-          <label><%= f.radio_button :assistance_year, current_year, checked: false %><span class="ml-half"> <%= l10n("faa.assitance_year_option2", year: current_year) %></span></label>
+          <label><%= f.radio_button :assistance_year, oe_year, checked: true, id: 'renewal_assistance_year' %> <span class="ml-half"> <%= l10n("faa.assitance_year_option1", year: oe_year) %> </span></label><br>
+          <label><%= f.radio_button :assistance_year, current_year, checked: false, id: 'current_assistance_year' %><span class="ml-half"> <%= l10n("faa.assitance_year_option2", year: current_year) %></span></label>
           <% if FinancialAssistanceRegistry.feature_enabled?(:iap_year_selection_form) %>
           <p><b><%= l10n("faa.update_reminder", year: current_year, year2: oe_year) %></b><br></p>
           <% end %>

--- a/features/financial_assistance/step_definitions/work_flow_steps.rb
+++ b/features/financial_assistance/step_definitions/work_flow_steps.rb
@@ -76,6 +76,7 @@ Then(/^the user will navigate to the assistance year selection page with multipl
   expect(page).to have_content(l10n("faa.year_selection_header"))
   expect(page).to have_content(l10n("faa.assitance_year_option1", year: oe_year))
   expect(page).to have_content(l10n("faa.assitance_year_option2", year: current_year))
+  expect(find("#renewal_assistance_year")).to be_checked
 end
 
 Then(/the user will navigate to the non-OE assistance year selection page/) do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186172448

# A brief description of the changes

Current behavior: No spacing between radio button and text on Multi-year selection form during OE

New behavior: Add spacing between radio button and text on Multi-year selection form during OE

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context

<img width="1277" alt="Screenshot 2023-10-04 at 11 28 57 AM" src="https://github.com/ideacrew/enroll/assets/15880971/0b5cb892-74ca-4123-b2c2-94e36b369a76">
