### PR TITLE
update FAA UI assistance_year display to account for multi year feature

### DIFF
--- a/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
+++ b/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
@@ -364,5 +364,12 @@ module FinancialAssistance
     def display_esi_fields?(insurance_kind, kind)
       ['employer_sponsored_insurance', 'health_reimbursement_arrangement'].include?(insurance_kind) && (kind == "is_eligible" || !FinancialAssistanceRegistry.feature_enabled?(:short_enrolled_esi_forms))
     end
+
+    def assistance_year
+      return @assistance_year if defined? @assistance_year
+
+      year_selection_enabled = FinancialAssistanceRegistry.feature_enabled?(:iap_year_selection) && (HbxProfile.current_hbx.under_open_enrollment? || FinancialAssistanceRegistry.feature_enabled?(:iap_year_selection_form))
+      @assistance_year = year_selection_enabled ? @application.assistance_year.to_s : FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s
+    end
   end
 end

--- a/components/financial_assistance/app/views/financial_assistance/applications/application_year_selection.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/application_year_selection.html.erb
@@ -23,7 +23,7 @@
                 </div>
                 <div>
                   <h3>
-                    <%= FinancialAssistanceRegistry[:enrollment_dates].settings(:application_year).item.constantize.new.call.value! %>
+                    <%= assistance_year %>
                     <%= l10n("faa.year_selection_oe_year") %>
                   </h3>
                 </div>
@@ -32,7 +32,7 @@
               <div class="faays-body">
                 <p>
                   <%= l10n("faa.see_if_you_qualify_1") %>
-                  <%= FinancialAssistanceRegistry[:enrollment_dates].settings(:application_year).item.constantize.new.call.value! %>
+                  <%= assistance_year %>
                   <%= l10n("faa.see_if_you_qualify_2", short_name: EnrollRegistry[:enroll_app].setting(:short_name).item, medicaid_or_chip_program_short_name: EnrollRegistry[:enroll_app].setting(:short_name).item) %>
                 </p>
                 <p>

--- a/components/financial_assistance/app/views/financial_assistance/applications/review_and_submit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/review_and_submit.html.erb
@@ -192,7 +192,7 @@
                 </div>
 
                 <div class="row row-form-wrapper ptb no-buffer row-height form-content">
-                  <div class="col-md-6"><%= l10n('faa.incomes.from_employer', assistance_year: FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s) %>
+                  <div class="col-md-6"><%= l10n('faa.incomes.from_employer', assistance_year: assistance_year) %>
                   </div>
                   <div class="col-md-6"><%= human_boolean applicant.has_job_income %></div>
                 </div>
@@ -243,13 +243,13 @@
                 <% end %>
 
                 <div class="row row-form-wrapper ptb no-buffer row-height form-content">
-                  <div class="col-md-6"><%= l10n('faa.incomes.from_self_employment', assistance_year: FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s) %></div>
+                  <div class="col-md-6"><%= l10n('faa.incomes.from_self_employment', assistance_year: assistance_year) %></div>
                   <div class="col-md-6"><%= human_boolean applicant.has_self_employment_income %></div>
                 </div>
 
                 <% if FinancialAssistanceRegistry.feature_enabled?(:unemployment_income) %>
                   <div class="row row-form-wrapper ptb no-buffer row-height form-content">
-                    <div class="col-md-6"><%= l10n('faa.other_incomes.unemployment', assistance_year: FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s) %>
+                    <div class="col-md-6"><%= l10n('faa.other_incomes.unemployment', assistance_year: assistance_year) %>
                     </div>
                     <div class="col-md-6"><%= human_boolean applicant.has_unemployment_income %></div>
                   </div>
@@ -264,7 +264,7 @@
                 <% end %>
 
                 <div class="row row-form-wrapper ptb no-buffer row-height form-content">
-                  <div class="col-md-6"><%= l10n('faa.other_incomes.other_sources', assistance_year: FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s) %>
+                  <div class="col-md-6"><%= l10n('faa.other_incomes.other_sources', assistance_year: assistance_year) %>
                   </div>
                   <div class="col-md-6"><%= human_boolean applicant.has_other_income %></div>
                 </div>
@@ -281,7 +281,7 @@
                 </div>
 
                 <div class="row row-form-wrapper ptb no-buffer row-height form-content">
-                  <div class="col-md-6"><%= l10n('faa.deductions.income_adjustments', assistance_year: FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s) %>
+                  <div class="col-md-6"><%= l10n('faa.deductions.income_adjustments', assistance_year: assistance_year) %>
                   </div>
                   <div class="col-md-6"><%= human_boolean applicant.has_deductions %></div>
                 </div>

--- a/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
@@ -18,7 +18,7 @@
     <!--income adjustment driver question-->
     <div class="driver-question row row-form-wrapper radio-align no-buffer fa-align-elements">
       <div class="col-md-6 labelforcoverage">
-        <span class="fa-text-color"><%= l10n('faa.deductions.income_adjustments', assistance_year: FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s) %></span>
+        <span class="fa-text-color"><%= l10n('faa.deductions.income_adjustments', assistance_year: assistance_year) %></span>
       </div>
       <div class="col-md-6 mt11">
         <div class="col-md-3 no-padding">

--- a/components/financial_assistance/app/views/financial_assistance/incomes/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/incomes/index.html.erb
@@ -19,7 +19,7 @@
 
     <div class="driver-question row row-form-wrapper radio-align no-buffer fa-align-elements">
       <div class='col-md-6 labelforcoverage'>
-        <span class="fa-text-color"><%= l10n('faa.incomes.from_employer', assistance_year: FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s) %></span>
+        <span class="fa-text-color"><%= l10n('faa.incomes.from_employer', assistance_year: assistance_year) %></span>
       </div>
       <div class='col-md-6 mt11'>
         <div class='col-md-3 no-padding'>
@@ -54,7 +54,7 @@
 
     <div class="driver-question row row-form-wrapper radio-align no-buffer fa-align-elements">
       <div class='col-md-6 labelforcoverage'>
-        <span class="fa-text-color"><%= l10n('faa.incomes.from_self_employment', assistance_year: FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s) %></span>
+        <span class="fa-text-color"><%= l10n('faa.incomes.from_self_employment', assistance_year: assistance_year) %></span>
       </div>
       <div class='col-md-6 mt11'>
         <div class='col-md-3 no-padding'>

--- a/components/financial_assistance/app/views/financial_assistance/incomes/other.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/incomes/other.html.erb
@@ -19,7 +19,7 @@
     <% if FinancialAssistanceRegistry.feature_enabled?(:unemployment_income) %>
       <div class="row row-form-wrapper radio-align no-buffer fa-align-elements">
         <div class='col-md-6 labelforcoverage'>
-          <span class="fa-text-color"><%= l10n('faa.other_incomes.unemployment', assistance_year: FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s) %></span>
+          <span class="fa-text-color"><%= l10n('faa.other_incomes.unemployment', assistance_year: assistance_year) %></span>
         </div>
         <div class='col-md-6 mt11'>
           <div class='col-md-3 no-padding'>
@@ -54,7 +54,7 @@
 
     <div class="driver-question row row-form-wrapper radio-align no-buffer fa-align-elements">
       <div class='col-md-6 labelforcoverage'>
-        <span class="fa-text-color"><%= l10n('faa.other_incomes.other_sources', assistance_year: FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s) %></span>
+        <span class="fa-text-color"><%= l10n('faa.other_incomes.other_sources', assistance_year: assistance_year) %></span>
       </div>
       <div class='col-md-6 mt11'>
         <div class='col-md-3 no-padding'>

--- a/components/financial_assistance/app/views/financial_assistance/shared/_modal_support_text.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/shared/_modal_support_text.html.erb
@@ -8,7 +8,7 @@
         </button>
       </div>
       <div class="modal-body">
-        <%= l10n("#{key}", application_applicable_year: FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s) %>
+        <%= l10n("#{key}", application_applicable_year: assistance_year) %>
       </div>
     </div>
   </div>

--- a/components/financial_assistance/app/views/financial_assistance/shared/_status_header.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/shared/_status_header.html.erb
@@ -1,10 +1,10 @@
 <div class="row app-year-header">
   <div class="col-xs-4 app-year-column">
     <div class="row text-center">
-      <%= application.assistance_year.to_s[0..1] %>
+      <%= assistance_year[0..1] %>
     </div>
     <div class="row text-center">
-      <b><%= application.assistance_year.to_s[2..3] %></b>
+      <b><%= assistance_year[2..3] %></b>
     </div>
   </div>
   <div class="col-xs-8 app-year-title">

--- a/features/financial_assistance/step_definitions/financial_assistance_steps.rb
+++ b/features/financial_assistance/step_definitions/financial_assistance_steps.rb
@@ -65,7 +65,9 @@ Given(/IAP Assistance Year Display feature is disabled/) do
 end
 
 Then(/They should see the application assistance year above Info Needed/) do
-  assistance_year = FinancialAssistance::Application.all.first.assistance_year.to_s
+  application = FinancialAssistance::Application.all.first
+  assistance_year = assistance_year_display(application)
+
   expect(page).to have_content(assistance_year[0..1])
   expect(page).to have_content(assistance_year[2..3])
 end

--- a/features/support/worlds/financial_assistance/financial_assistance_world.rb
+++ b/features/support/worlds/financial_assistance/financial_assistance_world.rb
@@ -259,6 +259,11 @@ module FinancialAssistance
       end
       application.update_attributes!(aasm_state: 'determined')
     end
+
+    def assistance_year_display(application)
+      year_selection_enabled = FinancialAssistanceRegistry.feature_enabled?(:iap_year_selection) && (HbxProfile.current_hbx.under_open_enrollment? || FinancialAssistanceRegistry.feature_enabled?(:iap_year_selection_form))
+      year_selection_enabled ? application.assistance_year.to_s : FinancialAssistanceRegistry[:enrollment_dates].setting(:application_year).item.constantize.new.call.value!.to_s
+    end
   end
 end
 # rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[186172655](https://www.pivotaltracker.com/n/projects/2640057/stories/186172655)

# A brief description of the changes

Current behavior:
Assistance year displayed through FAA flow does not account for multi year applications.

New behavior:
Assistance year display will no longer default to the setting in EnrollRegistry

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.