### PR TITLE
populate renewal failure reason on the current enrollment

### DIFF
--- a/app/domain/operations/individual/renew_enrollment.rb
+++ b/app/domain/operations/individual/renew_enrollment.rb
@@ -77,8 +77,25 @@ module Operations
         if renewed_enrollment.is_a?(HbxEnrollment)
           Success(renewed_enrollment)
         else
+          update_enrollment_with_error(enrollment, renewed_enrollment)
           Failure('Unable to renew the enrollment')
         end
+      end
+
+      # @param [ HbxEnrollment ] enrollment Enrollment that needs to be updated.
+      # @param [ String ] renewed_enrollment Error message.
+      # @return [ nil ]
+      # @note This method is used to update the enrollment with the error message.
+      #       This method is called when the enrollment renewal fails.
+      #       Failure raised in this method should not impact the renewal process.
+      def update_enrollment_with_error(enrollment, renewed_enrollment)
+        return unless renewed_enrollment.is_a?(String)
+
+        # Not adding to the exising array of reasons as we need to override the existing reasons if we attempt tp renew the enrollment again.
+        enrollment.successor_creation_failure_reasons = [renewed_enrollment]
+        enrollment.save!
+      rescue StandardError => e
+        Rails.logger.error "Unable to update the enrollment with #{renewed_enrollment} error: #{e.message}"
       end
     end
   end

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -30,6 +30,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
     save_renewal_enrollment(renewal_enrollment)
   rescue StandardError => e
     @logger.info "Enrollment renewal failed for #{enrollment.hbx_id} with error message: #{e} backtrace: #{e.backtrace.join('\n')}"
+    e.message
   end
 
   def clone_enrollment
@@ -354,7 +355,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
 
   def clone_enrollment_members
     old_enrollment_members = eligible_enrollment_members
-    raise "unable to generate enrollment with hbx_id #{@enrollment.hbx_id} due to no enrollment members not present" if old_enrollment_members.blank?
+    raise "Unable to generate renewal for enrollment with hbx_id #{@enrollment.hbx_id} due to missing(eligible) enrollment members." if old_enrollment_members.blank?
 
     latest_enrollment = @enrollment.family.active_household.hbx_enrollments.where(:aasm_state.nin => ['shopping']).order_by(:created_at.desc).first
     old_enrollment_members.inject([]) do |members, hbx_enrollment_member|

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -173,6 +173,15 @@ class HbxEnrollment
   # should not be transmitted to carriers nor reported in metrics.
   field :external_enrollment, type: Boolean, default: false
 
+  # In Individual Market's context the successor_creation_failure_reasons is:
+  #   1. Reasons why a renewal is not created.
+  #   2. Reasons why enrollment is not created during
+  #     i. FA application
+  #     ii. Reinstatment
+  #     iii. Self Service
+  # Currently, this is only used in IVL Renewals context.
+  field :successor_creation_failure_reasons, type: Array
+
   track_history   :modifier_field_optional => true,
                   :on => [:kind,
                           :enrollment_kind,
@@ -318,7 +327,8 @@ class HbxEnrollment
   index({"terminated_on" => 1}, { sparse: true })
   index({"applied_aptc_amount" => 1})
   index({"eligible_child_care_subsidy" => 1})
-
+  index({ 'predecessor_enrollment_id' => 1 })
+  index({ 'successor_creation_failure_reasons' => 1 })
 
   scope :active,              ->{ where(is_active: true).where(:created_at.ne => nil) } # Depricated scope
   scope :open_enrollments,    ->{ where(enrollment_kind: "open_enrollment") }

--- a/spec/domain/operations/individual/renew_enrollment_spec.rb
+++ b/spec/domain/operations/individual/renew_enrollment_spec.rb
@@ -340,6 +340,19 @@ RSpec.describe Operations::Individual::RenewEnrollment, type: :model, dbclean: :
     end
   end
 
+  context 'enrollment renewal failure' do
+    before do
+      enrollment.hbx_enrollment_members.each { |mbr| mbr.person.update_attributes!(is_incarcerated: true) }
+      subject.call(hbx_enrollment: enrollment, effective_on: effective_on)
+    end
+
+    it 'updates the enrollment successor_creation_failure_reasons' do
+      expect(enrollment.successor_creation_failure_reasons).to include(
+        "Unable to generate renewal for enrollment with hbx_id #{enrollment.hbx_id} due to missing(eligible) enrollment members."
+      )
+    end
+  end
+
   context 'for renewal failure' do
     context 'bad input object' do
       before :each do

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -261,7 +261,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
         end
 
         it "should raise an error" do
-          expect { subject.clone_enrollment_members }.to raise_error(RuntimeError, /unable to generate enrollment with hbx_id /)
+          expect { subject.clone_enrollment_members }.to raise_error(RuntimeError, /Unable to generate renewal for enrollment with hbx_id/)
         end
       end
     end
@@ -315,9 +315,11 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
           renewal_rating_area.destroy!
         end
 
-        it 'should return nil and log an error' do
+        it 'returns error message and log the error' do
           expect_any_instance_of(Logger).to receive(:info).with(/Enrollment renewal failed for #{enrollment.hbx_id} with error message: /i)
-          expect(subject.renew).to eq nil
+          expect(subject.renew).to eq(
+            "Cannot renew enrollment #{enrollment.hbx_id}. Error: Rating Area Is Blank"
+          )
         end
       end
 
@@ -326,9 +328,11 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
           renewal_service_area.destroy!
         end
 
-        it 'should return nil and log an error' do
+        it 'returns error message and log the error' do
           expect_any_instance_of(Logger).to receive(:info).with(/Enrollment renewal failed for #{enrollment.hbx_id} with error message: /i)
-          expect(subject.renew).to eq nil
+          expect(subject.renew).to eq(
+            "Cannot renew enrollment #{enrollment.hbx_id}. Error: Product is NOT offered in service area"
+          )
         end
       end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186193198](https://www.pivotaltracker.com/story/show/186193198)

# A brief description of the changes

Current behavior: Currently, we are not persisting successor creation failure reason/s.

New behavior: Moving forward we will be persisting successor creation failure reason/s.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
This new field will be used just in the context of IVL Enrollment Renewals.