### PR TITLE
transitions the app to the 'applications_update_required' state due to invalid relationships

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
@@ -125,6 +125,9 @@ module FinancialAssistance
               elsif missing_relationships?(relationships_changed, renew_application)
                 @failure_reason = 'missing_relationships'
                 'applicants_update_required'
+              elsif !renew_application.valid_relationship_kinds?
+                @failure_reason = 'atleast_one_invalid_relationship'
+                'applicants_update_required'
               else
                 'renewal_draft'
               end

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -1195,6 +1195,10 @@ module FinancialAssistance
       is_valid.all?(true)
     end
 
+    def valid_relationship_kinds?
+      relationships.all?(&:valid_relationship_kind?)
+    end
+
     def valid_relations?
       matrix = build_relationship_matrix
       EnrollRegistry.feature_enabled?(:mitc_relationships) ? validate_relationships(matrix) : true

--- a/components/financial_assistance/app/models/financial_assistance/relationship.rb
+++ b/components/financial_assistance/app/models/financial_assistance/relationship.rb
@@ -124,5 +124,9 @@ module FinancialAssistance
       return unless application.draft?
       FinancialAssistance::Operations::Application::RelationshipHandler.new.call({relationship: self})
     end
+
+    def valid_relationship_kind?
+      ::AcaEntities::MagiMedicaid::Types::RelationshipKind.values.include?(kind)
+    end
   end
 end

--- a/components/financial_assistance/spec/models/financial_assistance/relationship_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/relationship_spec.rb
@@ -145,4 +145,23 @@ RSpec.describe FinancialAssistance::Relationship, type: :model, dbclean: :after_
       expect(@second_application.relationships.first.relative).to be_a(::FinancialAssistance::Applicant)
     end
   end
+
+  describe '#valid_relationship_kind?' do
+    let(:relationship) { application.relationships.build(applicant_id: BSON::ObjectId.new, kind: relation_kind, relative_id: BSON::ObjectId.new)}
+    let(:relation_kind) { 'spouse' }
+
+    context 'valid relationship_kind' do
+      let(:relation_kind) { 'spouse' }
+      it 'should return true' do
+        expect(relationship.valid_relationship_kind?).to be_truthy
+      end
+    end
+
+    context 'relationship_kind is invalid' do
+      let(:relation_kind) { 'life_partner' }
+      it 'should return false' do
+        expect(relationship.valid_relationship_kind?).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/story/show/186187600
https://www.pivotaltracker.com/story/show/186187740

# A brief description of the changes

Current behavior: Application with applicants who have invalid relationships is not being renewed and being present in submitted state

New behavior: Move application which has invalid relationships to `applicants_update_required` state during the renewal process

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.