### PR TITLE
adds env vars to toggle the oe begin date

### DIFF
--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -392,7 +392,7 @@ registry:
         is_enabled: true
         settings:
           - key: :ivl_enrollment_renewal_begin_effective_day
-            item: 1
+            item: <%= ENV['IVL_ENROLLMENT_RENEWAL_BEGIN_EFFECTIVE_DAY'] || 1 %>
           - key: :ivl_enrollment_renewal_begin_effective_month
             item: <%= ENV['IVL_ENROLLMENT_RENEWAL_BEGIN_EFFECTIVE_MONTH'] || 11 %>
       - key: :exclude_child_only_offering

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -397,9 +397,9 @@ registry:
         is_enabled: true
         settings:
           - key: :ivl_enrollment_renewal_begin_effective_day
-            item: 1
+            item: <%= ENV['IVL_ENROLLMENT_RENEWAL_BEGIN_EFFECTIVE_DAY'] || 1 %>
           - key: :ivl_enrollment_renewal_begin_effective_month
-            item: 11
+            item: <%= ENV['IVL_ENROLLMENT_RENEWAL_BEGIN_EFFECTIVE_MONTH'] || 11 %>
       - key: :exclude_child_only_offering
         item: :exclude_child_only_offering
         is_enabled: true

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -392,7 +392,7 @@ registry:
         is_enabled: true
         settings:
           - key: :ivl_enrollment_renewal_begin_effective_day
-            item: 1
+            item: <%= ENV['IVL_ENROLLMENT_RENEWAL_BEGIN_EFFECTIVE_DAY'] || 1 %>
           - key: :ivl_enrollment_renewal_begin_effective_month
             item: <%= ENV['IVL_ENROLLMENT_RENEWAL_BEGIN_EFFECTIVE_MONTH'] || 11 %>
       - key: :exclude_child_only_offering


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186170799](https://www.pivotaltracker.com/story/show/186170799)

# A brief description of the changes

Current behavior: Environment variables are missing for ME which is a misalignment in code.

New behavior: Adds env variables for the RR configuration to be able to toggle the feature and also make it align with DC.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.