### PR TITLE
persist reasons why renewal app is not created in renewal_draft state

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/renew.rb
@@ -16,6 +16,8 @@ module FinancialAssistance
             include Dry::Monads[:result, :do, :try]
             include EventSource::Command
 
+            attr_reader :renewal_application
+
             # @param [Hash] opts The options to generate renewal_draft application
             # @option opts [BSON::ObjectId] :family_id (required)
             # @option opts [Integer] :renewal_year (required)
@@ -81,11 +83,11 @@ module FinancialAssistance
                 copied_result = renewal_application_factory.call(application_id: application.id)
                 return Failure(copied_result.failure[:detailed_error_message]) if copied_result.failure?
 
-                renewal_application = copied_result.success
+                @renewal_application = copied_result.success
                 family_members_changed = renewal_application_factory.family_members_changed
                 relationships_changed = renewal_application_factory.relationships_changed
                 calculated_renewal_base_year = calculate_renewal_base_year(application)
-                renewal_application.assign_attributes(
+                additional_attrs = {
                   aasm_state: find_aasm_state(
                     application,
                     family_members_changed,
@@ -97,15 +99,21 @@ module FinancialAssistance
                   renewal_base_year: calculated_renewal_base_year,
                   predecessor_id: application.id,
                   effective_date: Date.new(validated_params[:renewal_year])
-                )
-
+                }
+                additional_attrs[:renewal_draft_blocker_reasons] = [@failure_reason] if @failure_reason
+                renewal_application.assign_attributes(additional_attrs)
                 renewal_application.full_medicaid_determination = application.full_medicaid_determination if full_medicaid_determination_feature_enabled?
 
                 renewal_application.save
                 if renewal_application.renewal_draft?
                   Success(renewal_application)
                 else
-                  Failure("Renewal Application: (#{renewal_application.hbx_id}) failed with aasm_state: (#{renewal_application.aasm_state}), because: (#{@failure_reason || 'Unknown'})")
+                  Failure(
+                    "Renewal Application with hbx_id: #{
+                      renewal_application.hbx_id} is in #{
+                        renewal_application.aasm_state} state instead of renewal_draft because: #{
+                          @failure_reason || 'Unknown'}. Might require user input."
+                  )
                 end
               end.to_result
             end
@@ -126,7 +134,7 @@ module FinancialAssistance
                 @failure_reason = 'missing_relationships'
                 'applicants_update_required'
               elsif !renew_application.valid_relationship_kinds?
-                @failure_reason = 'atleast_one_invalid_relationship'
+                @failure_reason = 'invalid_relationships'
                 'applicants_update_required'
               else
                 'renewal_draft'

--- a/script/renewal_draft_blocker_reasons_report.rb
+++ b/script/renewal_draft_blocker_reasons_report.rb
@@ -14,7 +14,7 @@ applications = ::FinancialAssistance::Application.by_year(assistance_year).where
 
 file_name = "renewal_draft_blocker_reasons_report_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv"
 
-CSV.pen(file_name, 'w', force_quotes: true) do |csv|
+CSV.open(file_name, 'w', force_quotes: true) do |csv|
   csv << [
     'Application Hbx ID',
     'Application Assistance Year',

--- a/script/renewal_draft_blocker_reasons_report.rb
+++ b/script/renewal_draft_blocker_reasons_report.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Report to find applications for renewal year which failed to generate in renewal_draft state
+
+# bundle exec rails r script/renewal_draft_blocker_reasons_report.rb '2024'
+
+require 'csv'
+
+assistance_year = ARGV[0].present? && ARGV[0].respond_to?(:to_i) ? ARGV[0].to_i : TimeKeeper.date_of_record.year
+
+applications = ::FinancialAssistance::Application.by_year(assistance_year).where(
+  :aasm_state.in => ['applicants_update_required', 'income_verification_extension_required']
+)
+
+file_name = "renewal_draft_blocker_reasons_report_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv"
+
+CSV.pen(file_name, 'w', force_quotes: true) do |csv|
+  csv << [
+    'Application Hbx ID',
+    'Application Assistance Year',
+    'Application Aasm State',
+    'Application Renewal Draft Blocker Reason(s)'
+  ]
+
+  applications.each do |application|
+    csv << [
+      application.hbx_id,
+      application.assistance_year,
+      application.aasm_state,
+      application.renewal_draft_blocker_reasons.join(', ')
+    ]
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186202823](https://www.pivotaltracker.com/story/show/186202823)

# A brief description of the changes

Current behavior: We need to look at logs to determine why a renewal application is in a non-renewal('applicants_update_required' or 'income_verification_extension_required') draft state.

New behavior: Reasons why a renewal application is in a non-renewal_draft(applicants_update_required' or 'income_verification_extension_required') state can be found on the renewal application itself as we will be persisting reasons.


# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.