### PR TITLE
set due date when evidence moves to outstanding

### DIFF
--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -115,7 +115,8 @@ module Eligibilities
     def move_evidence_to_outstanding
       return unless may_move_to_outstanding?
 
-      update(verification_outstanding: true, is_satisfied: false)
+      due_date = due_on.blank? ? TimeKeeper.date_of_record + 95.days : due_on
+      update(verification_outstanding: true, is_satisfied: false, due_on: due_date)
       move_to_outstanding!
     end
 

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -805,6 +805,43 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
       end
     end
   end
+
+  context 'move_evidence_to_outstanding' do
+    let(:income_evidence) do
+      applicant.create_income_evidence(
+        key: :income,
+        title: 'Income',
+        aasm_state: 'pending',
+        due_on: nil,
+        verification_outstanding: false,
+        is_satisfied: true
+      )
+    end
+
+    context "when evidence is not outstanding and due_on is nil" do
+      it "should move income evidence to outstanding and set due_on" do
+        income_evidence.move_evidence_to_outstanding
+        income_evidence.reload
+        expect(income_evidence.aasm_state).to eq "outstanding"
+        expect(income_evidence.due_on).to eq TimeKeeper.date_of_record + 95.days
+        expect(income_evidence.verification_outstanding).to eq true
+        expect(income_evidence.is_satisfied).to eq false
+      end
+    end
+
+    context "when evidence is outstanding and due_on already exists" do
+      before do
+        income_evidence.update_attributes(aasm_state: :outstanding, due_on: TimeKeeper.date_of_record)
+      end
+
+      it "should move income evidence to outstanding and set due_on" do
+        income_evidence.move_evidence_to_outstanding
+        income_evidence.reload
+        expect(income_evidence.aasm_state).to eq "outstanding"
+        expect(income_evidence.due_on).to eq TimeKeeper.date_of_record
+      end
+    end
+  end
 end
 
 def create_embedded_docs_for_evidence(evidence)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/186196639

# A brief description of the changes

Current behavior: Due date on evidence is not being set when `move_evidence_to_outstanding` method is being called on evidence

New behavior: Setting `due_on` date on evidence when `move_evidence_to_outstanding` method is called.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.