### PR TITLE
default is_ia_eligible to false

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/add_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/add_determination.rb
@@ -50,11 +50,11 @@ module FinancialAssistance
                                               eligibility_response_payload: application_entity.to_h.to_json })
 
               add_eligibility_determination(application, application_entity)
-              application.save
+              return Failure("Failed to update application with Eligibility Determinations due to validation errors: #{application.errors.full_messages} ") unless application.valid?
+              application.save!
               application.determine_renewal
 
-              return Success('Successfully updated Application object with Full Eligibility Determination') if application.save
-
+              return Success('Successfully updated Application object with Full Eligibility Determination') if application.save!
               Failure('Failed to updated Application object with Full Eligibility Determination')
             end
 
@@ -84,7 +84,7 @@ module FinancialAssistance
                                               magi_medicaid_monthly_household_income: ped_entity.magi_medicaid_monthly_household_income,
                                               is_without_assistance: ped_entity.is_uqhp_eligible,
                                               csr_percent_as_integer: get_csr_value(ped_entity),
-                                              is_ia_eligible: ped_entity.is_ia_eligible,
+                                              is_ia_eligible: ped_entity.is_ia_eligible || false,
                                               is_medicaid_chip_eligible: ped_entity.is_medicaid_chip_eligible || ped_entity.is_magi_medicaid,
                                               is_totally_ineligible: ped_entity.is_totally_ineligible,
                                               is_eligible_for_non_magi_reasons: ped_entity.is_eligible_for_non_magi_reasons,

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/add_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/add_determination.rb
@@ -55,7 +55,7 @@ module FinancialAssistance
               application.determine_renewal
 
               return Success('Successfully updated Application object with Full Eligibility Determination') if application.save!
-              Failure('Failed to updated Application object with Full Eligibility Determination')
+              Failure('Failed to transition application to a determined state')
             end
 
             def add_eligibility_determination(application, application_entity)

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/add_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/add_determination_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AptcCsrCreditEli
                       last_name: 'Rivers',
                       dob: Date.new(Date.today.year - 22, Date.today.month, Date.today.day),
                       application: application)
+    FactoryBot.create(:financial_assistance_applicant,
+                      eligibility_determination_id: ed.id,
+                      person_hbx_id: '96',
+                      is_primary_applicant: true,
+                      first_name: 'Bob',
+                      last_name: 'Rivers',
+                      dob: Date.new(Date.today.year - 22, Date.today.month, Date.today.day),
+                      application: application)
   end
 
   context 'success' do
@@ -102,6 +110,10 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AptcCsrCreditEli
       context 'for Applicant' do
         it 'should update is_ia_eligible' do
           expect(@applicant.is_ia_eligible).to eq(true)
+        end
+
+        it 'should set is_ia_eligible to false if is_ia_eligible is nil' do
+          expect(@ed.applicants.last.is_ia_eligible).to eq(false)
         end
 
         it 'should update is_medicaid_chip_eligible' do

--- a/components/financial_assistance/spec/shared_examples/medicaid_gateway/test_case_d_response.rb
+++ b/components/financial_assistance/spec/shared_examples/medicaid_gateway/test_case_d_response.rb
@@ -129,7 +129,30 @@ RSpec.shared_context 'cms ME simple_scenarios test_case_d', :shared_context => :
                                                         :last_name => "Rivers",
                                                         :dob => member_dob,
                                                         :person_hbx_id => "95" }
-                            }] }],
+                            },
+                            {
+                             :product_eligibility_determination => { :is_ia_eligible => nil,
+                                                                     :is_medicaid_chip_eligible => false,
+                                                                     :is_totally_ineligible => nil,
+                                                                     :is_magi_medicaid => false,
+                                                                     :is_uqhp_eligible => nil,
+                                                                     :is_csr_eligible => true,
+                                                                     is_eligible_for_non_magi_reasons: true,
+                                                                     :csr => "limited",
+                                                                     :is_non_magi_medicaid_eligible => false,
+                                                                     :is_without_assistance => false,
+                                                                     :member_determinations => [{
+                                                                                                  :kind => 'Insurance Assistance Determination',
+                                                                                                  :criteria_met => true,
+                                                                                                  :determination_reasons => [],
+                                                                                                  eligibility_overrides: []
+                                                                                                }]},
+                             :applicant_reference => { :first_name => "Bob",
+                                                       :last_name => "Rivers",
+                                                       :dob => member_dob,
+                                                       :person_hbx_id => "96" }
+                            }
+                            ] }],
       :relationships => [],
       :us_state => "DC",
       :hbx_id => "200000126",

--- a/components/financial_assistance/spec/shared_examples/medicaid_gateway/test_case_d_response.rb
+++ b/components/financial_assistance/spec/shared_examples/medicaid_gateway/test_case_d_response.rb
@@ -129,29 +129,7 @@ RSpec.shared_context 'cms ME simple_scenarios test_case_d', :shared_context => :
                                                         :last_name => "Rivers",
                                                         :dob => member_dob,
                                                         :person_hbx_id => "95" }
-                            },
-                                                       {
-                                                         :product_eligibility_determination => { :is_ia_eligible => nil,
-                                                                                                 :is_medicaid_chip_eligible => false,
-                                                                                                 :is_totally_ineligible => nil,
-                                                                                                 :is_magi_medicaid => false,
-                                                                                                 :is_uqhp_eligible => nil,
-                                                                                                 :is_csr_eligible => true,
-                                                                                                 is_eligible_for_non_magi_reasons: true,
-                                                                                                 :csr => "limited",
-                                                                                                 :is_non_magi_medicaid_eligible => false,
-                                                                                                 :is_without_assistance => false,
-                                                                                                 :member_determinations => [{
-                                                                                                   :kind => 'Insurance Assistance Determination',
-                                                                                                   :criteria_met => true,
-                                                                                                   :determination_reasons => [],
-                                                                                                   eligibility_overrides: []
-                                                                                                 }]},
-                                                         :applicant_reference => { :first_name => "Bob",
-                                                                                   :last_name => "Rivers",
-                                                                                   :dob => member_dob,
-                                                                                   :person_hbx_id => "96" }
-                                                       }] }],
+                            }] }],
       :relationships => [],
       :us_state => "DC",
       :hbx_id => "200000126",

--- a/components/financial_assistance/spec/shared_examples/medicaid_gateway/test_case_d_response.rb
+++ b/components/financial_assistance/spec/shared_examples/medicaid_gateway/test_case_d_response.rb
@@ -130,29 +130,28 @@ RSpec.shared_context 'cms ME simple_scenarios test_case_d', :shared_context => :
                                                         :dob => member_dob,
                                                         :person_hbx_id => "95" }
                             },
-                            {
-                             :product_eligibility_determination => { :is_ia_eligible => nil,
-                                                                     :is_medicaid_chip_eligible => false,
-                                                                     :is_totally_ineligible => nil,
-                                                                     :is_magi_medicaid => false,
-                                                                     :is_uqhp_eligible => nil,
-                                                                     :is_csr_eligible => true,
-                                                                     is_eligible_for_non_magi_reasons: true,
-                                                                     :csr => "limited",
-                                                                     :is_non_magi_medicaid_eligible => false,
-                                                                     :is_without_assistance => false,
-                                                                     :member_determinations => [{
-                                                                                                  :kind => 'Insurance Assistance Determination',
-                                                                                                  :criteria_met => true,
-                                                                                                  :determination_reasons => [],
-                                                                                                  eligibility_overrides: []
-                                                                                                }]},
-                             :applicant_reference => { :first_name => "Bob",
-                                                       :last_name => "Rivers",
-                                                       :dob => member_dob,
-                                                       :person_hbx_id => "96" }
-                            }
-                            ] }],
+                                                       {
+                                                         :product_eligibility_determination => { :is_ia_eligible => nil,
+                                                                                                 :is_medicaid_chip_eligible => false,
+                                                                                                 :is_totally_ineligible => nil,
+                                                                                                 :is_magi_medicaid => false,
+                                                                                                 :is_uqhp_eligible => nil,
+                                                                                                 :is_csr_eligible => true,
+                                                                                                 is_eligible_for_non_magi_reasons: true,
+                                                                                                 :csr => "limited",
+                                                                                                 :is_non_magi_medicaid_eligible => false,
+                                                                                                 :is_without_assistance => false,
+                                                                                                 :member_determinations => [{
+                                                                                                   :kind => 'Insurance Assistance Determination',
+                                                                                                   :criteria_met => true,
+                                                                                                   :determination_reasons => [],
+                                                                                                   eligibility_overrides: []
+                                                                                                 }]},
+                                                         :applicant_reference => { :first_name => "Bob",
+                                                                                   :last_name => "Rivers",
+                                                                                   :dob => member_dob,
+                                                                                   :person_hbx_id => "96" }
+                                                       }] }],
       :relationships => [],
       :us_state => "DC",
       :hbx_id => "200000126",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
TT6-186215699

# A brief description of the changes

Defaults `is_ia_eligible` on redeterminations to account for applicant validations
Current behavior:
Field is set nil when nil
New behavior:
Field is set to false when nil

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

Also raises a Failure when the application fails to save to catch errors at the source.