### PR TITLE
handle nil class error on plan summary detail page

### DIFF
--- a/app/helpers/insured/families_helper.rb
+++ b/app/helpers/insured/families_helper.rb
@@ -419,7 +419,7 @@ module Insured::FamiliesHelper
                              l10n('enrollment.latest_transition_data',
                                   from_state: transition.from_state,
                                   to_state: transition.to_state,
-                                  created_at: transition.created_at.in_time_zone('Eastern Time (US & Canada)').strftime("%m/%d/%Y %-I:%M%p"))
+                                  created_at: transition.created_at&.in_time_zone('Eastern Time (US & Canada)')&.strftime("%m/%d/%Y %-I:%M%p"))
                            end
       end
       all_transitions.join("\n")

--- a/spec/helpers/insured/families_helper_spec.rb
+++ b/spec/helpers/insured/families_helper_spec.rb
@@ -714,6 +714,15 @@ RSpec.describe Insured::FamiliesHelper, :type => :helper, dbclean: :after_each  
       end
     end
 
+    context 'created_at nil on workflowstate_transitions' do
+      before { hbx_enr.renew_enrollment }
+
+      it 'returns latest_transition_data' do
+        hbx_enr.workflow_state_transitions.first.update_attributes(created_at: nil)
+        expect(helper.all_transitions(hbx_enr)).to match(/From shopping to auto_renewing at/)
+      end
+    end
+
     context 'without state transitions' do
       it 'does not return latest_transition_data' do
         expect(helper.all_transitions(hbx_enr)).to eq(l10n('not_available'))


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/186214176

# A brief description of the changes

Current behavior: 500 error due to created_at being nil on enrollment workflow_state_transitions

New behavior: Handling 500 error on plan summary detail page

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.