### PR TITLE
add check for infinite or nan values being returned for applied aptc pct

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -93,7 +93,12 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
     default_percentage = EnrollRegistry[:aca_individual_assistance_benefits].setting(:default_applied_aptc_percentage).item
     applied_percentage = enrollment.elected_aptc_pct > 0 ? enrollment.elected_aptc_pct : default_percentage
     ehb_premium = renewal_enrollment.total_ehb_premium
-    applied_aptc = float_fix([(max_aptc * applied_percentage), ehb_premium].min)
+    applied_aptc = if applied_percentage.infinite? || applied_percentage.nan?
+                     float_fix(ehb_premium)
+                   else
+                     float_fix([(max_aptc * applied_percentage), ehb_premium].min)
+                   end
+
     @assisted = true if max_aptc > 0.0
 
     @aptc_values.merge!({


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[186232761](https://www.pivotaltracker.com/n/projects/2640057/stories/186232761)

# A brief description of the changes

Current behavior:
In rare instances a NaN or Infinity value is returned for an enrollment's applied_aptc_pct and is breaking during renewals.

New behavior:
Avoid factoring these values into the applied_aptc calculation.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.