### PR TITLE
scope family members to those active

### DIFF
--- a/app/domain/operations/notices/ivl_oe_reverification_trigger.rb
+++ b/app/domain/operations/notices/ivl_oe_reverification_trigger.rb
@@ -93,7 +93,7 @@ module Operations
       end
 
       def build_family_member_hash(family)
-        family.family_members.collect do |fm|
+        family.active_family_members.collect do |fm|
           person = fm.person
           outstanding_verification_types = person.consumer_role.types_include_to_notices
           member_hash = {
@@ -144,7 +144,7 @@ module Operations
       end
 
       def documents_needed?(family)
-        family.family_members.any? { |member| member.person.consumer_role.types_include_to_notices.present? }
+        family.active_family_members.any? { |member| member.person.consumer_role.types_include_to_notices.present? }
       end
 
       def build_family_payload(family)

--- a/spec/domain/operations/notices/ivl_oe_reverification_trigger_spec.rb
+++ b/spec/domain/operations/notices/ivl_oe_reverification_trigger_spec.rb
@@ -154,5 +154,16 @@ RSpec.describe ::Operations::Notices::IvlOeReverificationTrigger, dbclean: :afte
         expect(payload[:contact_method]).to eq(contact_method)
       end
     end
+
+    context 'build family member hash' do
+      let!(:inactive_person){ create(:person, hbx_id: "732021")}
+      let!(:family_member) { create(:family_member, family: family, person: inactive_person, is_active: false)}
+      let(:payload) { ::Operations::Notices::IvlOeReverificationTrigger.new.send('build_family_member_hash', family) }
+
+      it 'should include only active family members in the hash' do
+        expect(payload.any? {|members| members[:person][:hbx_id].eql?(person.hbx_id)}).to be_truthy
+        expect(payload.any? {|members| members[:person][:hbx_id].eql?(inactive_person.hbx_id)}).to be_falsey
+      end
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
TT6-186251383

# A brief description of the changes

Current behavior:
The notice trigger considers all family members

New behavior:
The notice trigger considers only the active family members
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.