### PR TITLE
Fix slow families/show and loading of HbxProfile.current_hbx.

### DIFF
--- a/app/models/caches/current_hbx.rb
+++ b/app/models/caches/current_hbx.rb
@@ -6,7 +6,7 @@ module Caches
     end
 
     def self.cache!
-      Thread.current[:__current_hbx_lookup_cache] = HbxProfile.find_by_state_abbreviation(HbxProfile.aca_state_abbreviation)
+      Thread.current[:__current_hbx_lookup_cache] = HbxProfile.find_current_with_proxy_inbox
     end
 
     def self.purge!

--- a/app/models/hbx_profile.rb
+++ b/app/models/hbx_profile.rb
@@ -73,7 +73,37 @@ class HbxProfile
     BrokerRole.inactive
   end
 
+  def eigenclass
+    class << self
+      self
+    end
+  end
+
+  # Module for caching of the inbox
+  module InboxCache
+    def inbox
+      unless @inbox_reloaded
+        @inbox_reloaded = true
+        self.reload
+      end
+      super
+    end
+  end
+
+  # Since we use this optimization when we explicitly pull the record without
+  # the inbox, we'll patch the inbox method to trigger a reload.  We only do
+  # this in the instance itself, so other class instances aren't infected.
+  def extend_with_inbox_reload
+    eigenclass.prepend InboxCache
+    self
+  end
+
   class << self
+    def find_current_with_proxy_inbox
+      org = Organization.unscoped.where("hbx_profile.us_state_abbreviation": aca_state_abbreviation.to_s.upcase).without("hbx_profile.inbox").first
+      org.hbx_profile.extend_with_inbox_reload if org.present?
+    end
+
     def find(id)
       org = Organization.where("hbx_profile._id" => BSON::ObjectId.from_string(id)).first
       org.hbx_profile if org.present?
@@ -95,7 +125,7 @@ class HbxProfile
 
     def current_hbx
       Caches::CurrentHbx.fetch do
-        find_by_state_abbreviation(aca_state_abbreviation)
+        find_current_with_proxy_inbox
       end
     end
 

--- a/components/financial_assistance/spec/dummy/app/models/caches/current_hbx.rb
+++ b/components/financial_assistance/spec/dummy/app/models/caches/current_hbx.rb
@@ -9,7 +9,7 @@ module Caches
     end
 
     def self.cache!
-      Thread.current[:__current_hbx_lookup_cache] = HbxProfile.find_by_state_abbreviation(HbxProfile.aca_state_abbreviation)
+      Thread.current[:__current_hbx_lookup_cache] = HbxProfile.find_current_with_proxy_inbox
     end
 
     def self.purge!

--- a/spec/models/hbx_profile_caching_spec.rb
+++ b/spec/models/hbx_profile_caching_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HbxProfile, "retrieved via .current_hbx, with some messages" do
+  let(:hbx_profile) do
+    FactoryBot.create(:hbx_profile,
+                      :normal_ivl_open_enrollment,
+                      us_state_abbreviation: EnrollRegistry[:enroll_app].setting(:state_abbreviation).item,
+                      cms_id: "#{EnrollRegistry[:enroll_app].setting(:state_abbreviation).item.upcase}0")
+  end
+
+  before :each do
+    org = Organization.where("hbx_profile._id" => hbx_profile.id).first
+    profile = org.hbx_profile
+    profile.inbox.messages << Message.new(
+      {
+        body: "A MESSAGE BODY"
+      }
+    )
+    profile.inbox.save!
+  end
+
+  it "can access those messages" do
+    expect(HbxProfile.current_hbx.inbox.messages.count).to eq(1)
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186206316

# A brief description of the changes

Current behavior:  The families home page is slow.  After investigation we discovered that this is because the HBX Profile object is loading its entire inbox each time it is queried, which contains a large number of messages (currently there are 19845 in ME, and 6468 in DC).

New behavior:  Only load the inbox for the exchange when required, not each time we need to examine the exchange object.