### PR TITLE
checking for broker staff role for census employee create/update

### DIFF
--- a/components/benefit_sponsors/app/policies/benefit_sponsors/employer_profile_policy.rb
+++ b/components/benefit_sponsors/app/policies/benefit_sponsors/employer_profile_policy.rb
@@ -59,7 +59,7 @@ module BenefitSponsors
 
     def updateable?
       return false if (user.blank? || user.person.blank?)
-      return true if  (user.has_hbx_staff_role? && can_modify_employer?) || is_broker_for_employer?(record) || is_general_agency_staff_for_employer?(record)
+      return true if  (user.has_hbx_staff_role? && can_modify_employer?) || is_broker_for_employer?(record) || is_general_agency_staff_for_employer?(record) || is_broker_staff_role_for_employer?(record)
       is_staff_role_for_employer?(record)
     end
 

--- a/spec/controllers/employers/census_employees_controller_spec.rb
+++ b/spec/controllers/employers/census_employees_controller_spec.rb
@@ -76,6 +76,24 @@ RSpec.describe Employers::CensusEmployeesController, dbclean: :after_each do
         expect(response).not_to render_template("new")
       end
     end
+
+    context 'with broker agency staff role' do
+      let(:user) { FactoryBot.create(:user) }
+      let!(:person) { FactoryBot.create(:person, user: user) }
+      let!(:site) { FactoryBot.create(:benefit_sponsors_site, :with_benefit_market, :as_hbx_profile, :dc) }
+      let!(:broker_organization) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+      let!(:broker_agency_profile) { broker_organization.broker_agency_profile }
+      let!(:broker_agency_staff_role) { FactoryBot.create(:broker_agency_staff_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, person: person) }
+      let!(:broker_agency_accounts) { FactoryBot.create(:benefit_sponsors_accounts_broker_agency_account, broker_agency_profile: broker_agency_profile, benefit_sponsorship: benefit_sponsorship) }
+
+      it "should not render the new template" do
+        EnrollRegistry[:aca_shop_market].feature.stub(:is_enabled).and_return(true)
+        sign_in(user)
+        get :new, params: {:employer_profile_id => employer_profile_id}
+        expect(response).not_to be_redirect
+        expect(response).to render_template("new")
+      end
+    end
   end
 
   describe "POST create", dbclean: :around_each do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/102663

# A brief description of the changes

Current behavior: broker staff role does not have access to create/update census employee.

New behavior: Giving access to broker staff role to create/update census employee

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.