### PR TITLE
pull verification due in days from resource registry

### DIFF
--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -115,7 +115,8 @@ module Eligibilities
     def move_evidence_to_outstanding
       return unless may_move_to_outstanding?
 
-      due_date = due_on.blank? ? TimeKeeper.date_of_record + 95.days : due_on
+      verification_document_due = EnrollRegistry[:verification_document_due_in_days].item
+      due_date = due_on.blank? ? TimeKeeper.date_of_record + verification_document_due : due_on
       update(verification_outstanding: true, is_satisfied: false, due_on: due_date)
       move_to_outstanding!
     end

--- a/spec/models/eligibilities/evidence_spec.rb
+++ b/spec/models/eligibilities/evidence_spec.rb
@@ -820,10 +820,11 @@ RSpec.describe ::Eligibilities::Evidence, type: :model, dbclean: :after_each do
 
     context "when evidence is not outstanding and due_on is nil" do
       it "should move income evidence to outstanding and set due_on" do
+        verification_document_due = EnrollRegistry[:verification_document_due_in_days].item
         income_evidence.move_evidence_to_outstanding
         income_evidence.reload
         expect(income_evidence.aasm_state).to eq "outstanding"
-        expect(income_evidence.due_on).to eq TimeKeeper.date_of_record + 95.days
+        expect(income_evidence.due_on).to eq TimeKeeper.date_of_record + verification_document_due
         expect(income_evidence.verification_outstanding).to eq true
         expect(income_evidence.is_satisfied).to eq false
       end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640059/stories/186196639#

# A brief description of the changes

Current behavior: Setting 95 due date on outstanding income evidence instead of 96 days

New behavior: Pull verification due in days from resource registry when moving income evidence to outstanding

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.