### PR TITLE
default block_renewal_application_transfers to true for DC

### DIFF
--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -166,7 +166,7 @@ registry:
     - key: :non_magi_transfer
       is_enabled: <%= ENV['NON_MAGI_TRANSFER_IS_ENABLED'] || false %>
     - key: :block_renewal_application_transfers
-      is_enabled: <%= ENV['ATP_ON_RENEWALS_IS_ENABLED'] || false %>
+      is_enabled: <%= ENV['ATP_ON_RENEWALS_IS_ENABLED'] || true %>
     - key: :load_county_on_inbound_transfer
       is_enabled: <%= ENV['LOAD_COUNTY_ON_INBOUND_TRANSFER_IS_ENABLED'] || false %>
     - key: :automatic_submission

--- a/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -166,7 +166,7 @@ registry:
     - key: :non_magi_transfer
       is_enabled: <%= ENV['NON_MAGI_TRANSFER_IS_ENABLED'] || false %>
     - key: :block_renewal_application_transfers
-      is_enabled: <%= ENV['ATP_ON_RENEWALS_IS_ENABLED'] || false %>
+      is_enabled: <%= ENV['ATP_ON_RENEWALS_IS_ENABLED'] || true %>
     - key: :load_county_on_inbound_transfer
       is_enabled: <%= ENV['LOAD_COUNTY_ON_INBOUND_TRANSFER_IS_ENABLED'] || false %>
     - key: :automatic_submission


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186283871](https://www.pivotaltracker.com/story/show/186283871)

# A brief description of the changes

Current behavior: Currently, the default value for :block_renewal_application_transfers is false for DC

New behavior: The default value for :block_renewal_application_transfers is true for DC

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.