### PR TITLE
recalculates aptc on thank you page when user clicks browser back

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -602,19 +602,23 @@ class Insured::PlanShoppingsController < ApplicationController
 
   def set_elected_aptc_by_params(elected_aptc)
     return if session[:elected_aptc].to_d == elected_aptc.to_d
-
     aptc = if EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
-             return if session[:max_aptc].to_f.zero?
-
-             default_aptc_percentage = EnrollRegistry[:enroll_app].setting(:default_aptc_percentage).item
-             percentage = [elected_aptc.to_f / session[:max_aptc], default_aptc_percentage.to_f / 100].min
-             max_aptc = ::Operations::PremiumCredits::FindAptc.new.call({ hbx_enrollment: @enrollment, effective_on: @enrollment.effective_on }).value!.to_f
-             elected_aptc = percentage * max_aptc
-             session[:elected_aptc] = elected_aptc.to_f
+             calcuate_aptc(elected_aptc)
            else
              elected_aptc.to_f
            end
     session[:elected_aptc] = aptc
+  end
+
+  def calcuate_aptc(elected_aptc)
+    if session[:max_aptc].to_f.zero?
+      0.0
+    else
+      default_aptc_percentage = EnrollRegistry[:enroll_app].setting(:default_aptc_percentage).item
+      percentage = [elected_aptc.to_f / session[:max_aptc], default_aptc_percentage.to_f / 100].min
+      max_aptc = ::Operations::PremiumCredits::FindAptc.new.call({ hbx_enrollment: @enrollment, effective_on: @enrollment.effective_on }).value!.to_f
+      percentage * max_aptc
+    end
   end
 
   def validate_rating_address

--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -603,22 +603,20 @@ class Insured::PlanShoppingsController < ApplicationController
   def set_elected_aptc_by_params(elected_aptc)
     return if session[:elected_aptc].to_d == elected_aptc.to_d
     aptc = if EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
-             calcuate_aptc(elected_aptc)
+             recalcuate_elected_aptc(elected_aptc)
            else
              elected_aptc.to_f
            end
     session[:elected_aptc] = aptc
   end
 
-  def calcuate_aptc(elected_aptc)
-    if session[:max_aptc].to_f.zero?
-      0.0
-    else
-      default_aptc_percentage = EnrollRegistry[:enroll_app].setting(:default_aptc_percentage).item
-      percentage = [elected_aptc.to_f / session[:max_aptc], default_aptc_percentage.to_f / 100].min
-      max_aptc = ::Operations::PremiumCredits::FindAptc.new.call({ hbx_enrollment: @enrollment, effective_on: @enrollment.effective_on }).value!.to_f
-      percentage * max_aptc
-    end
+  def recalcuate_elected_aptc(elected_aptc)
+    return 0.0 if session[:max_aptc].to_f.zero?
+
+    default_aptc_percentage = EnrollRegistry[:enroll_app].setting(:default_aptc_percentage).item
+    percentage = [elected_aptc.to_f / session[:max_aptc], default_aptc_percentage.to_f / 100].min
+    max_aptc = ::Operations::PremiumCredits::FindAptc.new.call({ hbx_enrollment: @enrollment, effective_on: @enrollment.effective_on }).value!.to_f
+    percentage * max_aptc
   end
 
   def validate_rating_address

--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -601,9 +601,20 @@ class Insured::PlanShoppingsController < ApplicationController
   end
 
   def set_elected_aptc_by_params(elected_aptc)
-    if session[:elected_aptc].to_f != elected_aptc.to_f
-      session[:elected_aptc] = elected_aptc.to_f
-    end
+    return if session[:elected_aptc].to_d == elected_aptc.to_d
+
+    aptc = if EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
+             return if session[:max_aptc].to_f.zero?
+
+             default_aptc_percentage = EnrollRegistry[:enroll_app].setting(:default_aptc_percentage).item
+             percentage = [elected_aptc.to_f / session[:max_aptc], default_aptc_percentage.to_f / 100].min
+             max_aptc = ::Operations::PremiumCredits::FindAptc.new.call({ hbx_enrollment: @enrollment, effective_on: @enrollment.effective_on }).value!.to_f
+             elected_aptc = percentage * max_aptc
+             session[:elected_aptc] = elected_aptc.to_f
+           else
+             elected_aptc.to_f
+           end
+    session[:elected_aptc] = aptc
   end
 
   def validate_rating_address

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -761,6 +761,35 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
       end
     end
 
+    context 'when max_aptc is zero' do
+      let(:elected_aptc) { 500.0 }
+      let(:max_aptc)   { 0.0 }
+      let(:given_aptc) { 300.0 }
+      let(:session_variables) { { elected_aptc: elected_aptc, max_aptc: max_aptc, aptc_grants: double } }
+
+      before do
+        EnrollRegistry[:temporary_configuration_enable_multi_tax_household_feature].feature.stub(:is_enabled).and_return(true)
+
+        allow(::Operations::PremiumCredits::FindAptc).to receive(:new).and_return(
+          double(
+            call: double(
+              success?: true,
+              value!: max_aptc
+            )
+          )
+        )
+      end
+
+      it 'returns zero' do
+        subject = Insured::PlanShoppingsController.new
+        request = ActionDispatch::Request.new({})
+        request.session = session_variables
+        subject.request = request
+        subject.send(:set_elected_aptc_by_params, given_aptc)
+        expect(subject.request.session[:elected_aptc]).to eq(max_aptc)
+      end
+    end
+
     context 'elected_aptc is greater than the max_aptc and aptc in session' do
       let(:elected_aptc) { 605.0 }
       let(:max_aptc)   { 605.0 }

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -732,7 +732,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
     end
   end
 
-  context '#set_elected_aptc_by_params' do
+  context '#set_elected_aptc_by_params', :dbclean => :around_each  do
     context 'both elected_aptc and aptc in session are same' do
       let(:elected_aptc) { 637.0 }
       let(:max_aptc)   { 637.0 }

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -768,6 +768,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
       let(:session_variables) { { elected_aptc: elected_aptc, max_aptc: max_aptc, aptc_grants: double } }
       before do
         EnrollRegistry[:temporary_configuration_enable_multi_tax_household_feature].feature.stub(:is_enabled).and_return(true)
+        EnrollRegistry[:enroll_app].settings(:default_aptc_percentage).stub(:item).and_return(100)
         allow(::Operations::PremiumCredits::FindAptc).to receive(:new).and_return(
           double(
             call: double(


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/185126399

# A brief description of the changes

Current behavior: APTC is not being appropriately applied when user first lands on the Plan shopping thank you page clicks back browser, and then selects the same plan again

New behavior: Display the correct APTC on the thank you page when user clicks back browser button and again comes to thank you page.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would turn on/off the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.