### PR TITLE
removes unused family hbx_assigned_id param in RRV requests

### DIFF
--- a/app/domain/operations/families/iap_applications/rrvs/income_evidences/build_determination_request.rb
+++ b/app/domain/operations/families/iap_applications/rrvs/income_evidences/build_determination_request.rb
@@ -53,8 +53,7 @@ module Operations
             end
 
             def publish_event(family, application)
-              payload = { application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id }
-              event = build_event(payload)
+              event = build_event({ application_hbx_id: application.hbx_id })
               event.success.publish
             end
 

--- a/app/domain/operations/families/iap_applications/rrvs/income_evidences/request_determination.rb
+++ b/app/domain/operations/families/iap_applications/rrvs/income_evidences/request_determination.rb
@@ -28,7 +28,7 @@ module Operations
             private
 
             def validate(params)
-              errors = params[:application_hbx_id] ? [] : ['application hbx_id is missing']
+              errors = params[:application_hbx_id].present? ? [] : ['application hbx_id is missing']
               errors.empty? ? Success(params) : Failure(errors)
             end
 

--- a/app/domain/operations/families/iap_applications/rrvs/income_evidences/request_determination.rb
+++ b/app/domain/operations/families/iap_applications/rrvs/income_evidences/request_determination.rb
@@ -28,10 +28,7 @@ module Operations
             private
 
             def validate(params)
-              errors = []
-              errors << 'application hbx_id is missing' unless params[:application_hbx_id]
-              errors << 'family_hbx_id is missing' unless params[:family_hbx_id]
-
+              errors = params[:application_hbx_id] ? [] : ['application hbx_id is missing']
               errors.empty? ? Success(params) : Failure(errors)
             end
 

--- a/app/domain/operations/families/iap_applications/rrvs/non_esi_evidences/build_determination_request.rb
+++ b/app/domain/operations/families/iap_applications/rrvs/non_esi_evidences/build_determination_request.rb
@@ -52,8 +52,7 @@ module Operations
             end
 
             def publish_event(family, application)
-              payload = { application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id }
-              event = build_event(payload)
+              event = build_event({ application_hbx_id: application.hbx_id })
               event.success.publish
             end
 

--- a/app/domain/operations/families/iap_applications/rrvs/non_esi_evidences/request_determination.rb
+++ b/app/domain/operations/families/iap_applications/rrvs/non_esi_evidences/request_determination.rb
@@ -28,7 +28,7 @@ module Operations
             private
 
             def validate(params)
-              errors = params[:application_hbx_id] ? [] : ['application hbx_id is missing']
+              errors = params[:application_hbx_id].present? ? [] : ['application hbx_id is missing']
               errors.empty? ? Success(params) : Failure(errors)
             end
 

--- a/app/domain/operations/families/iap_applications/rrvs/non_esi_evidences/request_determination.rb
+++ b/app/domain/operations/families/iap_applications/rrvs/non_esi_evidences/request_determination.rb
@@ -28,10 +28,7 @@ module Operations
             private
 
             def validate(params)
-              errors = []
-              errors << 'application hbx_id is missing' unless params[:application_hbx_id]
-              errors << 'family_hbx_id is missing' unless params[:family_hbx_id]
-
+              errors = params[:application_hbx_id] ? [] : ['application hbx_id is missing']
               errors.empty? ? Success(params) : Failure(errors)
             end
 

--- a/spec/domain/operations/families/iap_applications/rrvs/income_evidences/request_determination_spec.rb
+++ b/spec/domain/operations/families/iap_applications/rrvs/income_evidences/request_determination_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::IncomeEvidences::Req
 
   context 'success' do
     it 'should return success if assistance year is passed' do
-      result = subject.call({application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id})
+      result = subject.call({ application_hbx_id: application.hbx_id })
       expect(result).to be_success
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::IncomeEvidences::Req
     before do
       allow(EnrollRegistry).to receive(:feature_enabled?).and_return(false)
       allow(EnrollRegistry).to receive(:feature_enabled?).with(:validate_and_record_publish_application_errors).and_return(true)
-      @result = subject.call({application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id})
+      @result = subject.call({ application_hbx_id: application.hbx_id })
       application.reload
     end
 
@@ -200,7 +200,7 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::IncomeEvidences::Req
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:validate_and_record_publish_application_errors).and_return(true)
         application.applicants.last.unset(:encrypted_ssn)
         application.save!
-        @result = subject.call({application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id})
+        @result = subject.call({ application_hbx_id: application.hbx_id })
         application.reload
       end
 
@@ -237,7 +237,7 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::IncomeEvidences::Req
           applicant.unset(:encrypted_ssn)
         end
         application.save!
-        @result = subject.call({application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id})
+        @result = subject.call({ application_hbx_id: application.hbx_id })
         application.reload
       end
 
@@ -267,10 +267,9 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::IncomeEvidences::Req
     end
   end
 
-  context 'failure' do
-    it "should fail if application_hbx_id is not given" do
-      result = subject.call(family_hbx_id: family.hbx_assigned_id)
-      expect(result).not_to be_success
+  context 'without params' do
+    it 'returns failure with error messages' do
+      expect(subject.call({})).to eq Failure(['application hbx_id is missing'])
     end
   end
 end

--- a/spec/domain/operations/families/iap_applications/rrvs/non_esi_evidences/request_determination_spec.rb
+++ b/spec/domain/operations/families/iap_applications/rrvs/non_esi_evidences/request_determination_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::NonEsiEvidences::Req
 
   context 'success' do
     it 'should return success if assistance year is passed' do
-      result = subject.call({application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id})
+      result = subject.call({ application_hbx_id: application.hbx_id })
       expect(result).to be_success
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::NonEsiEvidences::Req
       allow(EnrollRegistry).to receive(:feature_enabled?).and_return(false)
       allow(EnrollRegistry).to receive(:feature_enabled?).with(:validate_and_record_publish_application_errors).and_return(true)
       applicant2.update_attributes!(ssn: "756841234")
-      @result = subject.call({application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id})
+      @result = subject.call({ application_hbx_id: application.hbx_id })
       application.reload
     end
 
@@ -201,7 +201,7 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::NonEsiEvidences::Req
       allow(EnrollRegistry).to receive(:feature_enabled?).and_return(false)
       allow(EnrollRegistry).to receive(:feature_enabled?).with(:validate_and_record_publish_application_errors).and_return(true)
       applicant2.update_attributes!(ssn: "756841234", is_applying_coverage: false, is_ia_eligible: false)
-      @result = subject.call({application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id})
+      @result = subject.call({ application_hbx_id: application.hbx_id })
       application.reload
     end
 
@@ -230,7 +230,7 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::NonEsiEvidences::Req
       before do
         allow(EnrollRegistry).to receive(:feature_enabled?).and_return(false)
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:validate_and_record_publish_application_errors).and_return(true)
-        @result = subject.call({application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id})
+        @result = subject.call({ application_hbx_id: application.hbx_id })
         application.reload
       end
 
@@ -265,7 +265,7 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::NonEsiEvidences::Req
         allow(EnrollRegistry).to receive(:feature_enabled?).and_return(false)
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:validate_and_record_publish_application_errors).and_return(true)
         applicant2.update_attributes!(is_applying_coverage: false, is_ia_eligible: false)
-        @result = subject.call({application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id})
+        @result = subject.call({ application_hbx_id: application.hbx_id })
         application.reload
       end
 
@@ -297,7 +297,7 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::NonEsiEvidences::Req
           applicant.unset(:encrypted_ssn)
         end
         application.save!
-        @result = subject.call({application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id})
+        @result = subject.call({ application_hbx_id: application.hbx_id })
         application.reload
       end
 
@@ -336,7 +336,7 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::NonEsiEvidences::Req
         end
         applicant2.update_attributes!(is_applying_coverage: false, is_ia_eligible: false)
         application.save!
-        @result = subject.call({application_hbx_id: application.hbx_id, family_hbx_id: family.hbx_assigned_id})
+        @result = subject.call({ application_hbx_id: application.hbx_id })
         application.reload
       end
 
@@ -360,10 +360,9 @@ RSpec.describe Operations::Families::IapApplications::Rrvs::NonEsiEvidences::Req
     end
   end
 
-  context 'failure' do
-    it "should fail if application_hbx_id is not given" do
-      result = subject.call(family_hbx_id: family.hbx_assigned_id)
-      expect(result).not_to be_success
+  context 'without input params' do
+    it 'returns failure with error messages' do
+      expect(subject.call({})).to eq Failure(['application hbx_id is missing'])
     end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186307578](https://www.pivotaltracker.com/story/show/186307578)

# A brief description of the changes

Current behavior: The family's hbx_assigned_id is included in the payload in the integration within the Enroll App. The hbx_assigned_id has no value as it is not sent to FTI or Fdsh GW.

New behavior: The family's hbx_assigned_id is not included in the payloads within the Enroll App.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.