### PR TITLE
add person match validation to consumer role update

### DIFF
--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -11,8 +11,7 @@ class Insured::ConsumerRolesController < ApplicationController
   before_action :decrypt_params, only: [:create]
   before_action :set_cache_headers, only: [:edit, :help_paying_coverage, :privacy, :search]
   before_action :redirect_if_medicaid_tax_credits_link_is_disabled, only: [:privacy, :search]
-  before_action :sanitize_contact_method, only: [:update]
-  before_action :validate_person_match, only: [:update]
+  before_action :sanitize_contact_method, :validate_person_match, only: [:update]
 
   FIELDS_TO_ENCRYPT = [:ssn,:dob,:first_name,:middle_name,:last_name,:gender,:user_id].freeze
 

--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -332,7 +332,7 @@ class Insured::ConsumerRolesController < ApplicationController
     last_name = params[:person][:last_name]
     return unless (first_name != @person.first_name) || (last_name != @person.last_name)
     matched_person = match_person(first_name, last_name)
-    return unless matched_person.present? && matched_person.user.present? && (matched_person.user_id.to_s != @person.user_id.to_s)
+    return unless matched_person.present? && (matched_person.hbx_id != @person.hbx_id)
     flash[:error] = l10n("person_match_error_message", first_name: first_name, last_name: last_name)
     respond_to do |format|
       format.html { redirect_to edit_insured_consumer_role_path(@person.consumer_role.id) }

--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -330,7 +330,7 @@ class Insured::ConsumerRolesController < ApplicationController
   def validate_person_match
     first_name = params[:person][:first_name]
     last_name = params[:person][:last_name]
-    return unless (first_name != @person.first_name) || (last_name != @person.last_name)
+    return if (first_name == @person.first_name) || (last_name == @person.last_name)
     matched_person = match_person(first_name, last_name)
     return unless matched_person.present? && (matched_person.hbx_id != @person.hbx_id)
     flash[:error] = l10n("person_match_error_message", first_name: first_name, last_name: last_name)

--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -331,15 +331,12 @@ class Insured::ConsumerRolesController < ApplicationController
   def validate_person_match
     first_name = params[:person][:first_name]
     last_name = params[:person][:last_name]
-
-    if (first_name != @person.first_name) || (last_name != @person.last_name)
-      matched_person = match_person(first_name, last_name)
-      if matched_person.present? && matched_person.user.present? && (matched_person.user_id.to_s != @person.user_id.to_s)
-        flash[:error] = l10n("person_match_error_message", first_name: first_name, last_name: last_name)
-        respond_to do |format|
-          format.html { redirect_to edit_insured_consumer_role_path(@person.consumer_role.id) }
-        end
-      end
+    return unless (first_name != @person.first_name) || (last_name != @person.last_name)
+    matched_person = match_person(first_name, last_name)
+    return unless matched_person.present? && matched_person.user.present? && (matched_person.user_id.to_s != @person.user_id.to_s)
+    flash[:error] = l10n("person_match_error_message", first_name: first_name, last_name: last_name)
+    respond_to do |format|
+      format.html { redirect_to edit_insured_consumer_role_path(@person.consumer_role.id) }
     end
   end
 

--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -12,6 +12,7 @@ class Insured::ConsumerRolesController < ApplicationController
   before_action :set_cache_headers, only: [:edit, :help_paying_coverage, :privacy, :search]
   before_action :redirect_if_medicaid_tax_credits_link_is_disabled, only: [:privacy, :search]
   before_action :sanitize_contact_method, only: [:update]
+  before_action :validate_person_match, only: [:update]
 
   FIELDS_TO_ENCRYPT = [:ssn,:dob,:first_name,:middle_name,:last_name,:gender,:user_id].freeze
 
@@ -326,6 +327,36 @@ class Insured::ConsumerRolesController < ApplicationController
   end
 
   private
+
+  def validate_person_match
+    first_name = params[:person][:first_name]
+    last_name = params[:person][:last_name]
+
+    if (first_name != @person.first_name) || (last_name != @person.last_name)
+      matched_person = match_person(first_name, last_name)
+      if matched_person.present? && matched_person.user.present? && (matched_person.user_id.to_s != @person.user_id.to_s)
+        flash[:error] = l10n("person_match_error_message", first_name: first_name, last_name: last_name)
+        respond_to do |format|
+          format.html { redirect_to edit_insured_consumer_role_path(@person.consumer_role.id) }
+        end
+      end
+    end
+  end
+
+  def match_person(first_name, last_name)
+    ssn = @person.ssn
+    match_criteria, records = Operations::People::Match.new.call({:dob => @person.dob,
+                                                                  :last_name => last_name,
+                                                                  :first_name => first_name,
+                                                                  :ssn => ssn})
+
+    return nil if records.blank?
+    if (match_criteria == :dob_present && ssn.present? && records.first.employer_staff_roles?) ||
+       (match_criteria == :dob_present && ssn.blank?) ||
+       match_criteria == :ssn_present
+      records.first
+    end
+  end
 
   def mec_check(person_id)
     ::FinancialAssistance::Operations::Applications::MedicaidGateway::RequestMecCheck.new.call(person_id)

--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -330,7 +330,7 @@ class Insured::ConsumerRolesController < ApplicationController
   def validate_person_match
     first_name = params[:person][:first_name]
     last_name = params[:person][:last_name]
-    return if (first_name == @person.first_name) || (last_name == @person.last_name)
+    return if (first_name == @person.first_name) && (last_name == @person.last_name)
     matched_person = match_person(first_name, last_name)
     return unless matched_person.present? && (matched_person.hbx_id != @person.hbx_id)
     flash[:error] = l10n("person_match_error_message", first_name: first_name, last_name: last_name)

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -579,5 +579,6 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.eligible' => "Eligible",
   :'en.ineligible' => "Ineligible",
   :'en.your_tax_credit' => "Your Tax Credit",
-  :'en.your_tax_credit_for_hc4cc' => "Your Tax Credit: HC4CC eligible households must use at least 85 percent of the credit."
+  :'en.your_tax_credit_for_hc4cc' => "Your Tax Credit: HC4CC eligible households must use at least 85 percent of the credit.",
+  :'en.person_match_error_message' => "%{first_name} %{last_name} is already affiliated with another account."
 }.freeze

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -581,5 +581,6 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.eligible' => "Eligible",
   :'en.ineligible' => "Ineligible",
   :'en.your_tax_credit' => "Your Tax Credit",
-  :'en.your_tax_credit_for_hc4cc' => "Your Tax Credit: HC4CC eligible households must use at least 85 percent of the credit."
+  :'en.your_tax_credit_for_hc4cc' => "Your Tax Credit: HC4CC eligible households must use at least 85 percent of the credit.",
+  :'en.person_match_error_message' => "%{first_name} %{last_name} is already affiliated with another account."
 }.freeze

--- a/spec/controllers/insured/consumer_roles_controller/consumer_roles_controller_update_spec.rb
+++ b/spec/controllers/insured/consumer_roles_controller/consumer_roles_controller_update_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Insured::ConsumerRolesController do
         first_name: "John",
         last_name: "Smith",
         ssn: "123",
-        dob: TimeKeeper.date_of_record - 30.years,
+        dob: TimeKeeper.date_of_record - 30.years
       )
     end
     let(:consumer_role) do

--- a/spec/controllers/insured/consumer_roles_controller/consumer_roles_controller_update_spec.rb
+++ b/spec/controllers/insured/consumer_roles_controller/consumer_roles_controller_update_spec.rb
@@ -27,7 +27,11 @@ RSpec.describe Insured::ConsumerRolesController do
         no_dc_address: false,
         has_multiple_roles?: false,
         id: person_id,
-        agent?: false
+        agent?: false,
+        first_name: "John",
+        last_name: "Smith",
+        ssn: "123",
+        dob: TimeKeeper.date_of_record - 30.years,
       )
     end
     let(:consumer_role) do

--- a/spec/controllers/insured/consumer_roles_controller_spec.rb
+++ b/spec/controllers/insured/consumer_roles_controller_spec.rb
@@ -525,12 +525,12 @@ RSpec.describe Insured::ConsumerRolesController, dbclean: :after_each, :type => 
         person.unset(:encrypted_ssn)
         put :update, params: { person: person_params.deep_symbolize_keys, id: person.consumer_role.id }
       end
-    
+
       let(:person_params) do
         {"family" => {"application_type" => "Curam"}, us_citizen: "true", naturalized_citizen: "true",
-        "dob" => person.dob, "first_name" => person1.first_name,"gender" => 
-          "male","last_name" => person1.last_name,"middle_name" => "","name_sfx" => "","ssn" => 
-          person.ssn,"user_id" => "xyz"}
+         "dob" => person.dob, "first_name" => person1.first_name,"gender" =>
+         "male","last_name" => person1.last_name,"middle_name" => "","name_sfx" => "","ssn" =>
+         person.ssn,"user_id" => "xyz"}
       end
 
       it "displays an error message" do

--- a/spec/controllers/insured/consumer_roles_controller_spec.rb
+++ b/spec/controllers/insured/consumer_roles_controller_spec.rb
@@ -518,8 +518,6 @@ RSpec.describe Insured::ConsumerRolesController, dbclean: :after_each, :type => 
 
       let!(:person) {FactoryBot.create(:person, :with_consumer_role)}
       let!(:person1) {FactoryBot.create(:person, :with_consumer_role)}
-      let!(:user) { FactoryBot.create(:user, person: person) }
-      let!(:user1) { FactoryBot.create(:user, person: person1) }
 
       before do
         person.unset(:encrypted_ssn)

--- a/spec/models/forms/consumer_candidate_spec.rb
+++ b/spec/models/forms/consumer_candidate_spec.rb
@@ -42,7 +42,7 @@ describe Forms::ConsumerCandidate, "asked to match a person", dbclean: :after_ea
       it "should add errors" do
         subject.uniq_ssn
         expect(subject.errors[:ssn_taken]).to eq ["The social security number you entered is affiliated with another account."]
-      end
+      end  
     end
 
     context 'when ssn matches with unclaimed user account' do

--- a/spec/models/forms/consumer_candidate_spec.rb
+++ b/spec/models/forms/consumer_candidate_spec.rb
@@ -42,7 +42,7 @@ describe Forms::ConsumerCandidate, "asked to match a person", dbclean: :after_ea
       it "should add errors" do
         subject.uniq_ssn
         expect(subject.errors[:ssn_taken]).to eq ["The social security number you entered is affiliated with another account."]
-      end  
+      end
     end
 
     context 'when ssn matches with unclaimed user account' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-186282944](https://www.pivotaltracker.com/n/projects/2640060/stories/186282944)

# A brief description of the changes

Current behavior: When a person is on the person information page, there is no validation in place restricting them from updating their record to match an existing person

New behavior: Add validation restricting the update of a consumer role to match an existing person

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.