### PR TITLE
fixing year to be global for functions

### DIFF
--- a/script/cms_daily_report.rb
+++ b/script/cms_daily_report.rb
@@ -2,7 +2,10 @@ require "set"
 
 # Add year argument in the following format: bundle exec rails r cms_daily_report.rb 2023 -e production
 year = ARGV[0].present? ?  ARGV[0].to_i: Date.today.year.to_i
-next_year = year + 1
+@current_year = year
+def next_year
+  @current_year + 1
+end
 
 all_enrolled_people = HbxEnrollment.collection.aggregate([
   {"$match" => {


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186203334

# A brief description of the changes

Current behavior: year and next year can't be found by functions

New behavior: year and next_year are global

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.