### PR TITLE
remove old ifsv cases

### DIFF
--- a/app/data_migrations/remove_old_ifsv_cases.rb
+++ b/app/data_migrations/remove_old_ifsv_cases.rb
@@ -1,0 +1,45 @@
+require File.join(Rails.root, "lib/mongoid_migration_task")
+
+class RemoveOldIfsvCases < MongoidMigrationTask
+  def migrate
+    hbx_ids = ENV['hbx_ids'].split(',')
+    ssns    = ENV['ssns'].split(',')
+
+    destroyed_hbx_enrollment_ids = []
+    destroyed_ssns = []
+
+
+    destroy_hbx_enrollments(hbx_ids, destroyed_hbx_enrollment_ids)
+
+    destroy_people(ssns, destroyed_ssns)
+
+    if destroyed_hbx_enrollment_ids.count == hbx_ids.count
+      puts "All specified (#{hbx_ids.count}) hbx_enrollments were destroyed"
+    else
+      puts "The following hbx_enrollments were not destroyed: #{hbx_ids - destroyed_hbx_enrollment_ids}"
+    end
+
+    if destroyed_ssns.count == ssns.count
+      puts "All specified (#{destroyed_ssns.count}) people were destroyed"
+    else
+      puts "The following SSNs people were not destroyed: #{ssns - destroyed_ssns}"
+    end
+
+  end
+
+  def destroy_hbx_enrollments(hbx_ids, destroyed_hbx_enrollment_ids)
+    hbx_enrollments = HbxEnrollment.where(hbx_id: hbx_ids)
+    hbx_enrollments.each do |hbx_enrollment|
+      destroyed_hbx_enrollment_ids.push(hbx_enrollment.hbx_id) if hbx_enrollment.destroy
+    end
+  end
+
+  def destroy_people(ssns, destroyed_ssns)
+    ssns.each do |ssn|
+      person = Person.find_by_ssn(ssn)
+      if person
+        destroyed_ssns.push(ssn) if person.destroy
+      end
+    end
+  end
+end

--- a/app/data_migrations/remove_old_ifsv_cases.rb
+++ b/app/data_migrations/remove_old_ifsv_cases.rb
@@ -1,5 +1,7 @@
-require File.join(Rails.root, "lib/mongoid_migration_task")
+# frozen_string_literal: true
 
+require File.join(Rails.root, "lib/mongoid_migration_task")
+# Task to remove specified hbx_enrollments and people records
 class RemoveOldIfsvCases < MongoidMigrationTask
   def migrate
     hbx_ids = ENV['hbx_ids'].split(',')
@@ -7,7 +9,6 @@ class RemoveOldIfsvCases < MongoidMigrationTask
 
     destroyed_hbx_enrollment_ids = []
     destroyed_ssns = []
-
 
     destroy_hbx_enrollments(hbx_ids, destroyed_hbx_enrollment_ids)
 
@@ -24,7 +25,6 @@ class RemoveOldIfsvCases < MongoidMigrationTask
     else
       puts "The following SSNs people were not destroyed: #{ssns - destroyed_ssns}"
     end
-
   end
 
   def destroy_hbx_enrollments(hbx_ids, destroyed_hbx_enrollment_ids)
@@ -37,9 +37,7 @@ class RemoveOldIfsvCases < MongoidMigrationTask
   def destroy_people(ssns, destroyed_ssns)
     ssns.each do |ssn|
       person = Person.find_by_ssn(ssn)
-      if person
-        destroyed_ssns.push(ssn) if person.destroy
-      end
+      destroyed_ssns.push(ssn) if person&.destroy
     end
   end
 end

--- a/lib/tasks/remove_old_ifsv_cases.rake
+++ b/lib/tasks/remove_old_ifsv_cases.rake
@@ -4,5 +4,5 @@ require File.join(Rails.root, "app", "data_migrations", "remove_old_ifsv_cases")
 
 namespace :migrations do
   desc "remove hbx_enrollments and people records by HBX ID and SSN"
-  RemoveSsn.define_task :remove_old_ifsv_cases => :environment
+  RemoveOldIfsvCases.define_task :remove_old_ifsv_cases => :environment
 end

--- a/lib/tasks/remove_old_ifsv_cases.rake
+++ b/lib/tasks/remove_old_ifsv_cases.rake
@@ -1,0 +1,8 @@
+require File.join(Rails.root, "app", "data_migrations", "remove_old_ifsv_cases")
+# This rake task is to remove specified hbx_enrollments and people records
+# RAILS_ENV=production bundle exec rake migrations:remove_old_ifsv_cases.rb HBX_IDS=123,456 SSNS=123456789,987654321
+
+namespace :migrations do
+  desc "remove hbx_enrollments and people records by HBX ID and SSN"
+  RemoveSsn.define_task :remove_old_ifsv_cases => :environment
+end


### PR DESCRIPTION
PR that will add a rake task to delete records from the `HbxEnrollment` collection and the `People` collection. Whomever runs the script simply will need to provide a comma separated list of `hbx_ids` for the `HbxEnrollment` records and  comma separated list of `ssn` values for the `People` records. 


# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186315858

# A brief description of the changes

Current behavior: N/A

New behavior: There is now a rake task that will enable cleaning up old IFSV records from QA/testing. It can be run like so: 

```
RAILS_ENV=production bundle exec rake migrations:remove_old_ifsv_cases.rb HBX_IDS=123,456 SSNS=123456789,987654321
```
