### PR TITLE
fix aptc_pct infinite value

### DIFF
--- a/app/models/plan_selection.rb
+++ b/app/models/plan_selection.rb
@@ -17,7 +17,15 @@ class PlanSelection
   def apply_aptc_if_needed(elected_aptc, max_aptc)
     decorated_plan = UnassistedPlanCostDecorator.new(plan, hbx_enrollment, elected_aptc)
     hbx_enrollment.update_hbx_enrollment_members_premium(decorated_plan)
-    hbx_enrollment.update_attributes!(applied_aptc_amount: decorated_plan.total_aptc_amount, elected_aptc_pct: elected_aptc / max_aptc, ehb_premium: decorated_plan.total_ehb_premium)
+    # this protects us from trying to divide by 0.00 and recieve an infinity response
+    aptc_pct = if max_aptc.to_d == 0.00.to_d
+                 0.00
+               else
+                 (elected_aptc / max_aptc).round(2)
+               end
+    # this protects against potential float rounding issues
+    aptc_pct = aptc_pct > 1.00 ? 1.00 : aptc_pct
+    hbx_enrollment.update_attributes!(applied_aptc_amount: decorated_plan.total_aptc_amount, elected_aptc_pct: aptc_pct, ehb_premium: decorated_plan.total_ehb_premium)
   end
 
   # FIXME: Needs to deactivate the parent enrollment, also, we set the sep here? WAT


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640057/stories/186293210

# A brief description of the changes

Current behavior: There were instances during the ME 2024 enrollment renewal dry run where there was an infinity value stored in elected_aptc_pct. This value is a result of dividing a non-zero Integer by 0.0 as a Float value. When calculating applied_aptc, if the max_aptc is 0.0 it is then multiplied by the previous Infinity value to return NaN, causing the renewal to fail.

New behavior: If the max_aptc is 0.0, then the elected_aptc_pct is set to 0.00. If the max_aptc is greater than 0.00, run the calculations to find the elected_aptc_pct. If that variable is greater than 1.00, reset it to 1.00. If not, save the variable as-is.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.