### PR TITLE
pass market_kind as fehb for congressional scenario

### DIFF
--- a/app/models/group_selection_prevarication_adapter.rb
+++ b/app/models/group_selection_prevarication_adapter.rb
@@ -296,6 +296,7 @@ class GroupSelectionPrevaricationAdapter
 
   def create_action_market_kind(params)
     if params[:market_kind].present?
+      return "fehb" if params[:market_kind] == "shop" && is_fehb?(person) && is_fehb_market_enabled?
       params[:market_kind]
     elsif is_shop_market_enabled?
       "shop"

--- a/spec/models/group_selection_prevarication_adapter_spec.rb
+++ b/spec/models/group_selection_prevarication_adapter_spec.rb
@@ -380,4 +380,58 @@ RSpec.describe GroupSelectionPrevaricationAdapter, dbclean: :after_each, :if => 
       end
     end
   end
+
+  context '.create_action_market_kind' do
+    context 'when market_kind is shop' do
+      let(:options) do
+        {
+          market_kind: 'shop'
+        }
+      end
+
+      context 'when fehb employee' do
+
+        before do
+          allow(adapter).to receive(:is_fehb_market_enabled?).and_return(true)
+          allow(adapter).to receive(:is_fehb?).and_return(true)
+        end
+
+        it 'should return fehb' do
+          expect(adapter.create_action_market_kind(options)).to eq 'fehb'
+        end
+      end
+
+      context 'when not an fehb employee' do
+        it 'should return market_kind' do
+          expect(adapter.create_action_market_kind(options)).to eq 'shop'
+        end
+      end
+    end
+
+    context 'when market_kind is individual' do
+      let(:options) do
+        {
+          market_kind: 'individual'
+        }
+      end
+
+      context 'when fehb employee' do
+
+        before do
+          allow(adapter).to receive(:is_fehb_market_enabled?).and_return(true)
+          allow(adapter).to receive(:is_fehb?).and_return(true)
+        end
+
+        it 'should return market_kind' do
+          expect(adapter.create_action_market_kind(options)).to eq 'individual'
+        end
+      end
+
+      context 'when not an fehb employee' do
+        it 'should return market_kind' do
+          expect(adapter.create_action_market_kind(options)).to eq 'individual'
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/103290

# A brief description of the changes

Current behavior: Currently For FEHB employees, when plan shopping using plan comparison tool, enrollments getting created incorrectly with SHOP product instead of FEHB product. This issue is happening due to market_kind parameter being passed as 'shop' instead of 'fehb' for dual role scenarios.

New behavior: Fixed Group Selection Prevarication Adapter helper method to render 'fehb' for the scenarios where employee is congressional. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [x] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.