### PR TITLE
finds hbx_enrollment before recalculating elected aptc

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -79,11 +79,11 @@ class Insured::PlanShoppingsController < ApplicationController
   end
 
   def thankyou
+    @enrollment = HbxEnrollment.find(params.require(:id))
     set_elected_aptc_by_params(params[:elected_aptc]) if params[:elected_aptc].present?
     set_consumer_bookmark_url(family_account_path)
     set_admin_bookmark_url(family_account_path)
     @plan = BenefitMarkets::Products::Product.find(params[:plan_id])
-    @enrollment = HbxEnrollment.find(params.require(:id))
     @enrollment.set_special_enrollment_period
 
     if @enrollment.is_shop?

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -730,6 +730,20 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
       get :thankyou, params: {id: hbx_enrollment.id, plan_id: product.id}
       expect(response).to render_template('insured/plan_shoppings/thankyou.html.erb')
     end
+
+    context 'set_elected_aptc_by_params' do
+      before do
+        EnrollRegistry[:temporary_configuration_enable_multi_tax_household_feature].feature.stub(:is_enabled).and_return(true)
+      end
+
+      it 'does not raise error' do
+        sign_in(user)
+        session_variables = { elected_aptc: 630, max_aptc: 630, aptc_grants: double }
+        expect do
+          get :thankyou, params: { id: hbx_enrollment.id, plan_id: product.id, elected_aptc: 605 }, session: session_variables
+        end.not_to raise_error(NoMethodError)
+      end
+    end
   end
 
   context '#set_elected_aptc_by_params', :dbclean => :around_each  do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/185126399

# A brief description of the changes

Current behavior: Throwing 500 error on thankyou page when elected_aptc is set and a plan is selected

New behavior: Fix 500 error on thank you page

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.