### PR TITLE
fix qhp comparison based on market kind

### DIFF
--- a/app/models/products/qhp_cost_share_variance.rb
+++ b/app/models/products/qhp_cost_share_variance.rb
@@ -90,10 +90,11 @@ class Products::QhpCostShareVariance
 
   def product_for(market_kind = 'aca_shop')
     qhp_product = product
-
-    return qhp_product if qhp_product.benefit_market_kind == market_kind.to_sym || dental?
     market_kinds = [market_kind.to_sym]
-    market_kinds << :aca_individual if market_kind == 'individual' && EnrollRegistry.feature_enabled?(:qhp_product_for_include_aca_individual)
+    market_kinds << :aca_individual if market_kind == 'individual'
+
+    return qhp_product if market_kinds.include?(qhp_product.benefit_market_kind) || dental?
+
     Rails.cache.fetch("qcsv--#{market_kind}-product-#{qhp.active_year}-hios-id-#{hios_plan_and_variant_id}", expires_in: 5.hours) do
       BenefitMarkets::Products::Product.where(
         :hios_base_id => /#{qhp_product.hios_base_id}/,

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -111,8 +111,6 @@ registry:
         is_enabled: false
       - key: :reinstate_nonpayment_ivl_enrollment
         is_enabled: true
-      - key: :qhp_product_for_include_aca_individual
-        is_enabled: <%= ENV['QHP_PRODUCT_FOR_INCLUDE_ACA_INDIVIDUAL_IS_ENABLED'] || false %>
       - key: :display_you_pay
         is_enabled: <%= ENV['DISPLAY_YOU_PAY_IS_ENABLED'] || false %>
       - key: :validate_ssn

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -114,8 +114,6 @@ registry:
         is_enabled: true
       - key: :reinstate_nonpayment_ivl_enrollment
         is_enabled: false
-      - key: :qhp_product_for_include_aca_individual
-        is_enabled: <%= ENV['QHP_PRODUCT_FOR_INCLUDE_ACA_INDIVIDUAL_IS_ENABLED'] || false %>
       - key: :display_you_pay
         is_enabled: <%= ENV['DISPLAY_YOU_PAY_IS_ENABLED'] || false %>
       - key: :validate_ssn

--- a/spec/models/products/qhp_cost_share_variance_spec.rb
+++ b/spec/models/products/qhp_cost_share_variance_spec.rb
@@ -19,23 +19,7 @@ describe Products::QhpCostShareVariance, :type => :model do
     expect(product_qhp.qhp_cost_share_variances.first.product_for('fehb')).to eq fehb_product
   end
 
-  context 'when qhp_product_for_include_aca_individual enabled' do
-    before do
-      allow(EnrollRegistry).to receive(:feature_enabled?).with(:qhp_product_for_include_aca_individual).and_return(true)
-    end
-
-    it "should return aca_individual product for individual market kind" do
-      expect(product_qhp.qhp_cost_share_variances.first.product_for('individual')).to eq aca_individual_product
-    end
-  end
-
-  context 'when qhp_product_for_include_aca_individual disabled' do
-    before do
-      allow(EnrollRegistry).to receive(:feature_enabled?).with(:qhp_product_for_include_aca_individual).and_return(false)
-    end
-
-    it "should return aca_individual product for individual market kind" do
-      expect(product_qhp.qhp_cost_share_variances.first.product_for('individual')).to eq nil
-    end
+  it "should return aca individual product" do
+    expect(product_qhp.qhp_cost_share_variances.first.product_for('individual')).to eq aca_individual_product
   end
 end

--- a/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -111,8 +111,6 @@ registry:
         is_enabled: false
       - key: :reinstate_nonpayment_ivl_enrollment
         is_enabled: true
-      - key: :qhp_product_for_include_aca_individual
-        is_enabled: <%= ENV['QHP_PRODUCT_FOR_INCLUDE_ACA_INDIVIDUAL_IS_ENABLED'] || false %>
       - key: :display_you_pay
         is_enabled: <%= ENV['DISPLAY_YOU_PAY_IS_ENABLED'] || false %>
       - key: :validate_ssn


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-185863921](https://www.pivotaltracker.com/n/projects/2640060/stories/185863921)

# A brief description of the changes

Current behavior: Logic has an outdated flag that and market kind check that would cause consumers shopping on the individual market to receive a failure in their comparison method, causing the comparison modal to fail.

New behavior: Logic removes flag check and  market kind now accounts for individual markets

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.