### PR TITLE
account for resident role

### DIFF
--- a/app/domain/operations/notices/ivl_enr_notice_trigger.rb
+++ b/app/domain/operations/notices/ivl_enr_notice_trigger.rb
@@ -58,7 +58,7 @@ module Operations
       end
 
       def update_and_build_verification_types(person)
-        person_role(person)&.types_include_to_notices.collect do |verification_type|
+        person_role(person)&.types_include_to_notices&.collect do |verification_type|
           {
             type_name: verification_type.type_name,
             validation_status: verification_type.validation_status,

--- a/app/models/resident_role.rb
+++ b/app/models/resident_role.rb
@@ -181,4 +181,14 @@ class ResidentRole
   def residency_verified?
     is_state_resident?
   end
+
+  def verification_types
+    person&.verification_types&.active&.where(applied_roles: "resident_role")
+  end
+
+  def types_include_to_notices
+    verification_types.find_all do |type|
+      type.type_unverified?
+    end
+  end
 end

--- a/app/models/resident_role.rb
+++ b/app/models/resident_role.rb
@@ -187,8 +187,6 @@ class ResidentRole
   end
 
   def types_include_to_notices
-    verification_types.find_all do |type|
-      type.type_unverified?
-    end
+    verification_types.find_all(&:type_unverified?)
   end
 end

--- a/spec/domain/operations/notices/ivl_enr_notice_trigger_spec.rb
+++ b/spec/domain/operations/notices/ivl_enr_notice_trigger_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe ::Operations::Notices::IvlEnrNoticeTrigger, dbclean: :after_each 
   describe 'ivl enrollment notice trigger' do
     let(:person) { FactoryBot.create(:person, :with_consumer_role)}
     let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person)}
+    let(:person_resident) { FactoryBot.create(:person, :with_resident_role)}
+    let(:family_resident) { FactoryBot.create(:family, :with_primary_family_member, person: person_resident)}
     let(:issuer) { FactoryBot.create(:benefit_sponsors_organizations_issuer_profile, abbrev: 'ANTHM') }
     let(:product) { FactoryBot.create(:benefit_markets_products_health_products_health_product, :ivl_product, issuer_profile: issuer) }
     let(:aasm_state) { 'coverage_selected' }
@@ -25,6 +27,19 @@ RSpec.describe ::Operations::Notices::IvlEnrNoticeTrigger, dbclean: :after_each 
         applied_aptc_amount: Money.new(44_500),
         consumer_role_id: person.consumer_role.id,
         enrollment_members: family.family_members
+      )
+    end
+    let(:enrollment_resident) do
+      FactoryBot.create(
+        :hbx_enrollment,
+        :with_enrollment_members,
+        :coverall_unassisted,
+        family: family_resident,
+        aasm_state: aasm_state,
+        product_id: product.id,
+        applied_aptc_amount: Money.new(44_500),
+        resident_role_id: person_resident.resident_role.id,
+        enrollment_members: family_resident.family_members
       )
     end
 
@@ -54,10 +69,20 @@ RSpec.describe ::Operations::Notices::IvlEnrNoticeTrigger, dbclean: :after_each 
       context 'when an auto renewing enrollment is present' do
         let(:aasm_state) { 'auto_renewing' }
 
-        it 'should return sucess' do
+        it 'should return success' do
           result = subject.call(params)
           expect(result.success?).to be_truthy
         end
+      end
+    end
+
+    context 'with resident role' do
+
+      let(:params) {{enrollment: enrollment_resident}}
+
+      it 'should return success' do
+        result = subject.call(params)
+        expect(result.success?).to be_truthy
       end
     end
 

--- a/spec/factories/hbx_enrollments.rb
+++ b/spec/factories/hbx_enrollments.rb
@@ -72,6 +72,13 @@ FactoryBot.define do
       aasm_state { "coverage_selected" }
     end
 
+    trait :coverall_unassisted do
+      kind { "coverall" }
+      elected_premium_credit { 0 }
+      applied_premium_credit { 0 }
+      aasm_state { "coverage_selected" }
+    end
+
     trait :individual_shopping do
       kind { 'individual' }
       aasm_state { 'shopping' }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186384928

# A brief description of the changes

Current behavior:
The notice script breaks when there is no consumer_role present for example on coverall enrollments with resident_role
New behavior:
The notice script handles both consumer roles and resident roles properly
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.