### PR TITLE
allow two applicants with the same name to persist via atp

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -309,7 +309,8 @@ module FinancialAssistance
             applicants = iap_hash['applicants']
             applicants.each do |applicant_hash|
               family_member = @family.family_members.select do |fm|
-                fm.person.first_name.downcase == applicant_hash['name']['first_name'].downcase &&
+                fm.person.dob == applicant_hash['demographic']['dob'].to_date &&
+                  fm.person.first_name.downcase == applicant_hash['name']['first_name'].downcase &&
                   fm.person.last_name.downcase == applicant_hash['name']['last_name'].downcase
               end.first
               citizen_status_info = applicant_hash['citizenship_immigration_status_information']

--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -517,7 +517,7 @@ module FinancialAssistance
           def fill_applicants_form(payload, application) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
             applications = payload["family"]['magi_medicaid_applications'].first
             applications[:applicants].each do |applicant|
-              persisted_applicant = application.applicants.where(first_name: /^#{applicant[:first_name]}$/i, last_name: /^#{applicant[:last_name]}$/i).first
+              persisted_applicant = application.applicants.where(first_name: /^#{applicant[:first_name]}$/i, last_name: /^#{applicant[:last_name]}$/i, dob: applicant[:dob]).first
               return Failure("No matching applicant") unless persisted_applicant.present?
               claimed_by = application.applicants.where(ext_app_id: applicant[:claimed_as_tax_dependent_by]).first
               persisted_applicant.is_physically_disabled = applicant[:is_physically_disabled]

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
         before do
           record = serializer.parse(xml)
           @transformed = transformer.transform(record.to_hash(identifier: true))
+          @transformed[:family][:family_members][1][:person][:person_name][:first_name] = "Laura"
           @transformed[:family][:magi_medicaid_applications].first[:applicants][1][:name][:first_name] = "Laura"
           @result = subject.call(@transformed)
         end
@@ -50,6 +51,12 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
           app = FinancialAssistance::Application.find(@result.value!)
           @transformed.deep_symbolize_keys!
           expect(app.applicants.count).to eql(@transformed[:family][:magi_medicaid_applications].first[:applicants].count)
+        end
+
+        it "persists unique family member ids" do
+          app = FinancialAssistance::Application.find(@result.value!)
+          @transformed.deep_symbolize_keys!
+          expect(app.applicants.pluck(:family_member_id).uniq.count).to eql(@transformed[:family][:magi_medicaid_applications].first[:applicants].count)
         end
       end
 

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -38,6 +38,21 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
         expect(app.transferred_at).not_to eq nil
       end
 
+      context "two applicants share the same first and last name" do
+        before do
+          record = serializer.parse(xml)
+          @transformed = transformer.transform(record.to_hash(identifier: true))
+          @transformed[:family][:magi_medicaid_applications].first[:applicants][1][:name][:first_name] = "Laura"
+          @result = subject.call(@transformed)
+        end
+
+        it "persists all applicants" do
+          app = FinancialAssistance::Application.find(@result.value!)
+          @transformed.deep_symbolize_keys!
+          expect(app.applicants.count).to eql(@transformed[:family][:magi_medicaid_applications].first[:applicants].count)
+        end
+      end
+
       context 'load_county_on_inbound_transfer feature is enabled' do
         it 'should return success if zips with county are present in database' do
           expect(@result).to be_success


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-186428449](https://www.pivotaltracker.com/n/projects/2640060/stories/186428449)

# A brief description of the changes

Current behavior: If there are two applicants with the same name being transferred in, we are only persisting the first applicant.

New behavior: We persist all applicants being transferred in even if they have the same first and last name. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.