### PR TITLE
deactivate prospective tax households only when there is a dependent add or drop

### DIFF
--- a/app/domain/operations/families/add_financial_assistance_eligibility_determination.rb
+++ b/app/domain/operations/families/add_financial_assistance_eligibility_determination.rb
@@ -116,7 +116,7 @@ module Operations
       def deactivate_latest_tax_households(values)
         primary_applicant = values[:applicants].select{|app| app["is_primary_applicant"]}.first
         ed = values[:eligibility_determinations].select{|ed| ed["_id"] == primary_applicant["eligibility_determination_id"]}.first
-        Operations::Households::DeactivateFinancialAssistanceEligibility.new.call(params: {family_id: values[:family_id], date: ed["effective_starting_on"]})
+        Operations::Households::DeactivateFinancialAssistanceEligibility.new.call(params: { deactivate_action_type: 'current_only', family_id: values[:family_id], date: ed["effective_starting_on"]})
       end
 
       def update_family_attributes(family, case_id)

--- a/app/domain/operations/families/create_tax_household_group_on_fa_determination.rb
+++ b/app/domain/operations/families/create_tax_household_group_on_fa_determination.rb
@@ -37,7 +37,9 @@ module Operations
 
       def end_current_taxhousehold_groups(family, application_entity)
         new_effective_date = application_entity.tax_households.first.effective_on
-        ::Operations::TaxHouseholdGroups::Deactivate.new.call({ family: family, new_effective_date: new_effective_date })
+        ::Operations::TaxHouseholdGroups::Deactivate.new.call({ deactivate_action_type: 'current_only',
+                                                                family: family,
+                                                                new_effective_date: new_effective_date })
       end
 
       def create_tax_household_groups(application_entity)

--- a/app/domain/operations/families/tax_household_groups/create_on_fa_determination.rb
+++ b/app/domain/operations/families/tax_household_groups/create_on_fa_determination.rb
@@ -21,7 +21,11 @@ module Operations
 
         def deactivate_current_thhg(application)
           new_effective_date = application.eligibility_determinations.pluck(:effective_starting_on).compact.first
-          ::Operations::TaxHouseholdGroups::Deactivate.new.call({ family: application.family, new_effective_date: new_effective_date })
+          ::Operations::TaxHouseholdGroups::Deactivate.new.call({
+                                                                  deactivate_action_type: 'current_only',
+                                                                  family: application.family,
+                                                                  new_effective_date: new_effective_date
+                                                                })
         end
 
         def create_new_thhg(application)

--- a/app/domain/operations/irs_groups/build_seed_request.rb
+++ b/app/domain/operations/irs_groups/build_seed_request.rb
@@ -34,7 +34,7 @@ module Operations
       end
 
       def validate_payload(value)
-        result = AcaEntities::Contracts::Families::FamilyContract.new.call(cv3_family.value!)
+        result = AcaEntities::Contracts::Families::FamilyContract.new.call(value)
         if result.success?
           Success(result)
         else

--- a/app/domain/operations/irs_groups/build_seed_request.rb
+++ b/app/domain/operations/irs_groups/build_seed_request.rb
@@ -34,7 +34,7 @@ module Operations
       end
 
       def validate_payload(value)
-        result = AcaEntities::Contracts::Families::FamilyContract.new.call(value)
+        result = AcaEntities::Contracts::Families::FamilyContract.new.call(cv3_family.value!)
         if result.success?
           Success(result)
         else

--- a/app/domain/operations/tax_household_groups/create_eligibility.rb
+++ b/app/domain/operations/tax_household_groups/create_eligibility.rb
@@ -32,7 +32,11 @@ module Operations
         @family = values[:family]
         @effective_date = Date.strptime(values[:th_group_info][:effective_date], '%m/%d/%Y')
 
-        ::Operations::TaxHouseholdGroups::Deactivate.new.call({ family: @family, new_effective_date: @effective_date })
+        ::Operations::TaxHouseholdGroups::Deactivate.new.call({
+                                                                deactivate_action_type: 'current_only',
+                                                                family: @family,
+                                                                new_effective_date: @effective_date
+                                                              })
       end
 
       def create_taxhousehold_group(th_group_info)

--- a/app/domain/operations/tax_household_groups/deactivate.rb
+++ b/app/domain/operations/tax_household_groups/deactivate.rb
@@ -8,6 +8,7 @@ module Operations
     # this operation is to end current taxhouseholdgroups
     class Deactivate
       send(:include, Dry::Monads[:result, :do])
+      DEACTIVATE_ACTION_TYPES = ['current_only', 'current_and_prospective'].freeze
 
       def call(params)
         values = yield validate(params)
@@ -19,7 +20,7 @@ module Operations
       private
 
       def validate(params)
-        if params[:family].is_a?(Family) && params[:new_effective_date].is_a?(Date)
+        if params[:family].is_a?(Family) && params[:new_effective_date].is_a?(Date) && DEACTIVATE_ACTION_TYPES.include?(params[:deactivate_action_type])
           Success(params)
         else
           Failure('Invalid params. family should be an instance of Family and new_effective_date should be an instance of Date')
@@ -33,7 +34,13 @@ module Operations
       end
 
       def deactivate(values)
-        tax_household_groups = values[:family].tax_household_groups.active.current_and_prospective_by_year(values[:new_effective_date].year)
+        active_thh_groups = values[:family].tax_household_groups.active
+        tax_household_groups = case values[:deactivate_action_type]
+                               when 'current_only'
+                                 active_thh_groups.by_year(values[:new_effective_date].year)
+                               when 'current_and_prospective'
+                                 active_thh_groups.current_and_prospective_by_year(values[:new_effective_date].year)
+                               end
         return Success('No Active Tax Household Groups to deactivate') if tax_household_groups.blank?
 
         tax_household_groups.each do |th_group|

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -1392,7 +1392,11 @@ class Family
     return unless EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
     return if !effective_date.is_a?(Date) || active_thhg(effective_date.year).blank?
 
-    deactivated = ::Operations::TaxHouseholdGroups::Deactivate.new.call({ family: self, new_effective_date: effective_date })
+    deactivated = ::Operations::TaxHouseholdGroups::Deactivate.new.call({
+                                                                          deactivate_action_type: 'current_and_prospective',
+                                                                          family: self,
+                                                                          new_effective_date: effective_date
+                                                                        })
 
     if deactivated.failure?
       Rails.logger.error { "Failed to deactivate tax household groups for family with hbx_id: #{hbx_assigned_id}, Failure: #{deactivated.failure}" }

--- a/app/models/family_member.rb
+++ b/app/models/family_member.rb
@@ -203,7 +203,9 @@ class FamilyMember
     family.deactivate_financial_assistance(TimeKeeper.date_of_record)
     return if family.active_household.latest_active_tax_household_with_year(TimeKeeper.date_of_record.year).blank?
 
-    Operations::Households::DeactivateFinancialAssistanceEligibility.new.call(params: {family_id: family.id, date: TimeKeeper.date_of_record})
+    Operations::Households::DeactivateFinancialAssistanceEligibility.new.call(params: {
+                                                                                deactivate_action_type: 'current_and_prospective', family_id: family.id, date: TimeKeeper.date_of_record
+                                                                              })
   rescue StandardError => e
     Rails.logger.error {"Unable to do action Operations::Households::DeactivateFinancialAssistanceEligibility for family_member with object_id: #{self.id} due to #{e.message}"}
   end

--- a/spec/domain/operations/households/deactivate_financial_assistance_eligibility_spec.rb
+++ b/spec/domain/operations/households/deactivate_financial_assistance_eligibility_spec.rb
@@ -21,10 +21,27 @@ RSpec.describe Operations::Households::DeactivateFinancialAssistanceEligibility,
 
       it 'deactivates current and future year active tax households' do
         expect(household.tax_households.active_tax_household.pluck(:id)).to include(prospective_year_tax_household.id, tax_household.id, retrospective_year_tax_household.id)
-        subject.call(params: { family_id: family.id, date: current_year_start })
+        subject.call(params: { deactivate_action_type: 'current_and_prospective',
+                               family_id: family.id, date: current_year_start })
         household.reload
         expect(household.tax_households.active_tax_household.pluck(:id)).to include(prospective_year_tax_household.id)
         expect(household.tax_households.inactive.pluck(:id)).to include(tax_household.id, retrospective_year_tax_household.id)
+      end
+    end
+
+    context 'with current_only deactivation type' do
+      before do
+        prospective_year_tax_household
+        retrospective_year_tax_household
+      end
+
+      it 'deactivates current and future year active tax households' do
+        expect(household.tax_households.active_tax_household.pluck(:id)).to include(prospective_year_tax_household.id, tax_household.id, retrospective_year_tax_household.id)
+        subject.call(params: { deactivate_action_type: 'current_only',
+                               family_id: family.id, date: current_year_start })
+        household.reload
+        expect(household.tax_households.active_tax_household.pluck(:id)).to include(prospective_year_tax_household.id)
+        expect(household.tax_households.inactive.pluck(:id)).to include(tax_household.id)
       end
     end
   end
@@ -35,7 +52,8 @@ RSpec.describe Operations::Households::DeactivateFinancialAssistanceEligibility,
 
   context 'invalid arguments' do
     it 'should return a failure' do
-      result = subject.call(params: {family_id: 'family_id', date: Date.new(2020, 1, 1)})
+      result = subject.call(params: {deactivate_action_type: 'current_and_prospective',
+                                     family_id: 'family_id', date: Date.new(2020, 1, 1)})
       expect(result.failure).to eq('family_id is expected in BSON format and date in required')
     end
   end
@@ -43,14 +61,16 @@ RSpec.describe Operations::Households::DeactivateFinancialAssistanceEligibility,
   # should not fail for UQHP cases too
   context 'no tax_households for uqhp family' do
     it 'should return success' do
-      result = subject.call(params: {family_id: family2.id, date: Date.new(2020, 1, 1)})
+      result = subject.call(params: {deactivate_action_type: 'current_and_prospective',
+                                     family_id: family2.id, date: Date.new(2020, 1, 1)})
       expect(result.success).to eq 'No Active Tax Households to deactivate'
     end
   end
 
   context 'update tax households' do
     it 'should success for update' do
-      result = subject.call(params: {family_id: family.id, date: Date.new(tax_household.effective_starting_on.year, 1, 1)})
+      result = subject.call(params: {deactivate_action_type: 'current_and_prospective',
+                                     family_id: family.id, date: Date.new(tax_household.effective_starting_on.year, 1, 1)})
       expect(result.success).to eq "End dated all the Active Tax Households for given family with bson_id: #{family.id}"
     end
   end
@@ -59,7 +79,8 @@ RSpec.describe Operations::Households::DeactivateFinancialAssistanceEligibility,
     context 'input date falls before effective_starting_on' do
       before do
         tax_household.update_attributes(effective_starting_on: Date.new(2021,2,1))
-        @result = subject.call(params: { family_id: family.id, date: tax_household.effective_starting_on.prev_month })
+        @result = subject.call(params: { deactivate_action_type: 'current_and_prospective',
+                                         family_id: family.id, date: tax_household.effective_starting_on.prev_month })
       end
 
       it 'should end date thh' do
@@ -74,7 +95,8 @@ RSpec.describe Operations::Households::DeactivateFinancialAssistanceEligibility,
     end
 
     it 'should return success' do
-      result = subject.call(params: {family_id: family.id, date: tax_household.effective_starting_on.next_year})
+      result = subject.call(params: {deactivate_action_type: 'current_and_prospective',
+                                     family_id: family.id, date: tax_household.effective_starting_on.next_year})
       expect(result.success).to eq 'No Active Tax Households to deactivate'
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186390560

# A brief description of the changes

Current behavior: Deactivating prospective tax household groups when a current year FAA application is submitted during OE

New behavior: Only deactivate prospective tax household groups when there is a family member add/drop 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
