### PR TITLE
generates initial enrollment on subscriber drop during ivl enr renewal

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -3,6 +3,7 @@
 class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   include FloatHelper
   include Config::AcaHelper
+
   attr_accessor :enrollment, :renewal_coverage_start, :assisted, :aptc_values
 
   CAT_AGE_OFF_HIOS_IDS = ["94506DC0390008", "86052DC0400004"]
@@ -24,7 +25,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
 
     # elected aptc should be the minimun between applied_aptc and EHB premium.
     renewal_enrollment = assisted_enrollment(renewal_enrollment) if @assisted.present? && renewal_enrollment.is_health_enrollment?
-    renewal_enrollment.renew_enrollment
+    transition_enrollment(renewal_enrollment)
     verify_and_set_osse_minimum_aptc(renewal_enrollment) if @assisted
     renewal_enrollment.update_osse_childcare_subsidy
     save_renewal_enrollment(renewal_enrollment)
@@ -378,6 +379,19 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
       message = "Enrollment: #{@enrollment.hbx_id}, \n" \
       "Error(s): \n #{renewal_enrollment.errors.map{|k,v| "#{k} = #{v}"}.join(" & \n")} \n"
       @logger.info message
+    end
+  end
+
+  def subscriber_dropped?(renewal_enrollment)
+    EnrollRegistry.feature_enabled?(:generate_initial_enrollment_on_subscriber_drop) &&
+      renewal_enrollment.hbx_enrollment_members.map(&:applicant_id).exclude?(enrollment.subscriber.applicant_id)
+  end
+
+  def transition_enrollment(renewal_enrollment)
+    if subscriber_dropped?(renewal_enrollment)
+      renewal_enrollment.select_coverage!
+    else
+      renewal_enrollment.renew_enrollment
     end
   end
 end

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/enrollment_renewals.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/enrollment_renewals.yml
@@ -1,0 +1,10 @@
+---
+registry:
+  - namespace:
+    - :enroll_app
+    - :aca_individual_market
+    - :enrollment_renewals
+    features:
+      - key: :generate_initial_enrollment_on_subscriber_drop
+        item: :generate_initial_enrollment_on_subscriber_drop
+        is_enabled: <%= ENV['GENERATE_INITIAL_ENROLLMENT_ON_SUBSCRIBER_DROP_IS_ENABLED'] || false %>

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/enrollment_renewals.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/enrollment_renewals.yml
@@ -1,0 +1,10 @@
+---
+registry:
+  - namespace:
+    - :enroll_app
+    - :aca_individual_market
+    - :enrollment_renewals
+    features:
+      - key: :generate_initial_enrollment_on_subscriber_drop
+        item: :generate_initial_enrollment_on_subscriber_drop
+        is_enabled: <%= ENV['GENERATE_INITIAL_ENROLLMENT_ON_SUBSCRIBER_DROP_IS_ENABLED'] || false %>

--- a/spec/client_config/enrollments/default_configuration_spec.rb
+++ b/spec/client_config/enrollments/default_configuration_spec.rb
@@ -23,4 +23,14 @@ RSpec.describe 'default enrollments namespace client specific configurations' do
       end
     end
   end
+
+  describe 'generate_initial_enrollment_on_subscriber_drop' do
+    context 'for default value' do
+      it 'returns default value false' do
+        expect(
+          EnrollRegistry.feature_enabled?(:generate_initial_enrollment_on_subscriber_drop)
+        ).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec_1.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec_1.rb
@@ -204,6 +204,72 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
       end
     end
 
+    describe '#subscriber_dropped?' do
+      before do
+        allow(
+          EnrollRegistry[:generate_initial_enrollment_on_subscriber_drop].feature
+        ).to receive(:is_enabled).and_return(feature_enabled)
+      end
+
+      let(:fer_instance) do
+        subject.enrollment = enrollment
+        subject
+      end
+
+      let(:renew_enrollment) do
+        double(
+          'HbxEnrollment',
+          hbx_enrollment_members: [
+            double('HbxEnrollmentMember', applicant_id: renewal_applicant_id)
+          ]
+        )
+      end
+
+      let(:enrollment) do
+        double(
+          'HbxEnrollment', subscriber: double(
+            'HbxEnrollmentMember', applicant_id: subscriber_applicant_id
+          )
+        )
+      end
+
+      context 'when feature is disabled' do
+        let(:feature_enabled) { false }
+        let(:renewal_applicant_id) { '11111' }
+        let(:subscriber_applicant_id) { '11111' }
+
+        it 'returns false' do
+          expect(
+            fer_instance.subscriber_dropped?(renew_enrollment)
+          ).to be_falsey
+        end
+      end
+
+      context 'when feature is enabled and subscriber is not dropped' do
+        let(:feature_enabled) { true }
+        let(:renewal_applicant_id) { '11111' }
+        let(:subscriber_applicant_id) { '11111' }
+
+        it 'returns false' do
+          expect(
+            fer_instance.subscriber_dropped?(renew_enrollment)
+          ).to be_falsey
+        end
+      end
+
+      context 'when feature is enabled and subscriber is dropped' do
+        let(:feature_enabled) { true }
+        let(:renewal_applicant_id) { '22222' }
+        let(:subscriber_applicant_id) { '11111' }
+
+        it 'returns true' do
+          expect(
+            fer_instance.subscriber_dropped?(renew_enrollment)
+          ).to be_truthy
+        end
+      end
+    end
+
     after :all do
       file_path = "#{Rails.root}/log/family_enrollment_renewal_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
       FileUtils.rm_rf(file_path) if File.file?(file_path)

--- a/system/config/templates/features/aca_individual_market/enrollment_renewals.yml
+++ b/system/config/templates/features/aca_individual_market/enrollment_renewals.yml
@@ -1,0 +1,10 @@
+---
+registry:
+  - namespace:
+    - :enroll_app
+    - :aca_individual_market
+    - :enrollment_renewals
+    features:
+      - key: :generate_initial_enrollment_on_subscriber_drop
+        item: :generate_initial_enrollment_on_subscriber_drop
+        is_enabled: <%= ENV['GENERATE_INITIAL_ENROLLMENT_ON_SUBSCRIBER_DROP_IS_ENABLED'] || false %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186435140](https://www.pivotaltracker.com/story/show/186435140)

# A brief description of the changes

Current behavior: All prospective year enrollments are generated as passive renewals irrespective of whether the subscriber is dropped from the enrollment.

New behavior: When a subscriber is dropped during renewal the new enrollment is generated in the `coverage_selected` state instead of `auto_renewing` state. This will ensure that the transaction flows to Glue from Enroll as `initial` and not `auto_renew`. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [x] DC
- [x] ME

RR configuration details:

- `:generate_initial_enrollment_on_subscriber_drop`
- `GENERATE_INITIAL_ENROLLMENT_ON_SUBSCRIBER_DROP_IS_ENABLED`

# Additional Context
Include any additional context that may be relevant to the peer review process.