### PR TITLE
prevent applying aptc on catastrophic renewal

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -80,9 +80,11 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   end
 
   def populate_aptc_hash(renewal_enrollment)
-    # Prevents applying APTC to catastrophic enrollment plans irrespective of which tax model is used
-    return unless renewal_enrollment.product.can_use_aptc?
+    # APTC is only calculated here when the Multi Tax Household feature is enabled
+    # Legacy APTC calculation is done in Operations::Individual::RenewEnrollment
     return unless EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
+    # blocks aptc calculation if renewal has a catastrophic product
+    return unless renewal_enrollment.product.can_use_aptc?
 
     aptc_op = ::Operations::PremiumCredits::FindAptc.new.call({
                                                                 hbx_enrollment: renewal_enrollment,

--- a/spec/domain/operations/individual/renew_enrollment_spec.rb
+++ b/spec/domain/operations/individual/renew_enrollment_spec.rb
@@ -280,6 +280,8 @@ RSpec.describe Operations::Individual::RenewEnrollment, type: :model, dbclean: :
 
     context 'enrollment product is catastrophic' do
       before do
+        tax_household.update_attributes!(effective_starting_on: next_year_date.beginning_of_year)
+        tax_household.tax_household_members.first.update_attributes!(applicant_id: family_member.id)
         product.update_attributes!(metal_level_kind: 'catastrophic')
         @result = subject.call(hbx_enrollment: enrollment, effective_on: effective_on)
       end
@@ -287,8 +289,6 @@ RSpec.describe Operations::Individual::RenewEnrollment, type: :model, dbclean: :
       it 'should not apply aptc values to the renewal enrollment' do
         expect(@result.success.applied_aptc_amount).to be_zero
         expect(@result.success.elected_aptc_pct).to be_zero
-        # expect(@result.success.max_aptc).to be_zero
-        # expect(@result.success.csr_amt).to be_zero
       end
     end
 

--- a/spec/domain/operations/individual/renew_enrollment_spec.rb
+++ b/spec/domain/operations/individual/renew_enrollment_spec.rb
@@ -278,6 +278,20 @@ RSpec.describe Operations::Individual::RenewEnrollment, type: :model, dbclean: :
       end
     end
 
+    context 'enrollment product is catastrophic' do
+      before do
+        product.update_attributes!(metal_level_kind: 'catastrophic')
+        @result = subject.call(hbx_enrollment: enrollment, effective_on: effective_on)
+      end
+
+      it 'should not apply aptc values to the renewal enrollment' do
+        expect(@result.success.applied_aptc_amount).to be_zero
+        expect(@result.success.elected_aptc_pct).to be_zero
+        # expect(@result.success.max_aptc).to be_zero
+        # expect(@result.success.csr_amt).to be_zero
+      end
+    end
+
     context 'with an expired enrollment by aasm state' do
       before :each do
         enrollment.expire_coverage!


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186447037

# A brief description of the changes

Current behavior:
When MTHH feature is NOT enabled, APTC is applied on enrollment renewal.

New behavior:
When MTHH feature is NOT enabled, APTC is NOT applied on enrollment renewal.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.