### PR TITLE
prevent applying aptc to coverall renewals

### DIFF
--- a/spec/domain/operations/individual/renew_enrollment_spec.rb
+++ b/spec/domain/operations/individual/renew_enrollment_spec.rb
@@ -190,6 +190,21 @@ RSpec.describe Operations::Individual::RenewEnrollment, type: :model, dbclean: :
             expect(@result.success.product_id).to eq(renewal_product.id)
           end
         end
+
+        context 'current enrollment is Coverall kind' do
+          before do
+            enrollment.update_attributes!(kind: 'coverall')
+            enrollment.update_attributes!(elected_aptc_pct: 0.5, applied_aptc_amount: 50.0)
+            eligibilty_determination.update_attributes!(max_aptc: 100.00)
+            @result = subject.call(hbx_enrollment: enrollment, effective_on: effective_on)
+          end
+
+          context 'and APTC determination is present for prospective year coverage' do
+            it 'should not apply aptc values to the renewal enrollment' do
+              expect(@result.success.applied_aptc_amount).to be_zero
+            end
+          end
+        end
       end
 
       context 'renewal enrollment with csr product' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186447684

# A brief description of the changes

Current behavior:
APTC is applied to coverall renewal enrollments if an APTC determination is present on the tax household for the prospective year.

New behavior:
APTC is not applied to coverall renewal enrollments, no matter what eligibility determination is on the tax household for the prospective year.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.