### PR TITLE
add feature flag for async_expire_and_begin_coverages feature

### DIFF
--- a/app/models/services/ivl_enrollment_service.rb
+++ b/app/models/services/ivl_enrollment_service.rb
@@ -16,55 +16,66 @@ module Services
     end
 
     def expire_individual_market_enrollments
-      @logger.info "Started expire_individual_market_enrollments process at #{TimeKeeper.datetime_of_record.to_s}"
-      current_benefit_period = HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period
-      batch_size = 500
-      offset = 0
-      individual_market_enrollments = HbxEnrollment.where(
-        :effective_on.lt => current_benefit_period.start_on,
-        :kind.in => ["individual", "coverall"],
-        :aasm_state.in => HbxEnrollment::ENROLLED_STATUSES - ["coverage_termination_pending"]
-      )
-      @logger.info "Total enrollments to expire count: #{individual_market_enrollments.count}"
-      while offset <= individual_market_enrollments.count
-        individual_market_enrollments.offset(offset).limit(batch_size).no_timeout.each do |enrollment|
-          enrollment.expire_coverage! if enrollment.may_expire_coverage?
-          @logger.info "Processed enrollment: #{enrollment.hbx_id}"
-        rescue StandardError => e
-          @logger.info "Unable to expire enrollment #{enrollment.id}, error: #{e.backtrace}"
+      if EnrollRegistry.feature_enabled?(:async_expire_and_begin_coverages)
+        Rails.logger.error "async_expire_and_begin_coverages feature flag is enabled but async expire_individual_market_enrollments still needs to be implemented!"
+      else
+        @logger.info "Started expire_individual_market_enrollments process at #{TimeKeeper.datetime_of_record.to_s}"
+        current_benefit_period = HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period
+        batch_size = 500
+        offset = 0
+        individual_market_enrollments = HbxEnrollment.where(
+          :effective_on.lt => current_benefit_period.start_on,
+          :kind.in => ["individual", "coverall"],
+          :aasm_state.in => HbxEnrollment::ENROLLED_STATUSES - ["coverage_termination_pending"]
+        )
+        @logger.info "Total enrollments to expire count: #{individual_market_enrollments.count}"
+        while offset <= individual_market_enrollments.count
+  
+          # insert new async code here
+          # use each with index and log with index
+          individual_market_enrollments.offset(offset).limit(batch_size).no_timeout.each do |enrollment|
+            enrollment.expire_coverage! if enrollment.may_expire_coverage?
+            @logger.info "Processed enrollment: #{enrollment.hbx_id}"
+          rescue StandardError => e
+            @logger.info "Unable to expire enrollment #{enrollment.id}, error: #{e.backtrace}"
+          end
+          offset += batch_size
         end
-        offset += batch_size
+        @logger.info "Total remaining enrollments from expire query count: #{individual_market_enrollments.count}"
+        @logger.info "Ended expire_individual_market_enrollments process at #{TimeKeeper.datetime_of_record}"
       end
-      @logger.info "Total remaining enrollments from expire query count: #{individual_market_enrollments.count}"
-      @logger.info "Ended expire_individual_market_enrollments process at #{TimeKeeper.datetime_of_record}"
     end
 
     def begin_coverage_for_ivl_enrollments
-      @logger.info "Started begin_coverage_for_ivl_enrollments process at #{TimeKeeper.datetime_of_record.to_s}"
-      current_benefit_period = HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period
-      batch_size = 500
-      offset = 0
-      ivl_enrollments = HbxEnrollment.where(
-        :effective_on => { "$gte" => current_benefit_period.start_on, "$lt" => current_benefit_period.end_on },
-        :kind.in => ["individual", "coverall"],
-        :aasm_state.in => ["auto_renewing", "renewing_coverage_selected"]
-      )
-      @logger.info "Total IVL auto renewing enrollment count: #{ivl_enrollments.count}"
-      count = 0
-      while offset <= ivl_enrollments.count
-        ivl_enrollments.offset(offset).limit(batch_size).no_timeout.each do |enrollment|
-          if enrollment.may_begin_coverage?
-            enrollment.begin_coverage!
-            count += 1
-            @logger.info "Processed enrollment: #{enrollment.hbx_id}"
+      if EnrollRegistry.feature_enabled?(:async_expire_and_begin_coverages)
+        Rails.logger.error "async_expire_and_begin_coverages feature flag is enabled but async begin_coverage_for_ivl_enrollments still needs to be implemented!"
+      else
+        @logger.info "Started begin_coverage_for_ivl_enrollments process at #{TimeKeeper.datetime_of_record.to_s}"
+        current_benefit_period = HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period
+        batch_size = 500
+        offset = 0
+        ivl_enrollments = HbxEnrollment.where(
+          :effective_on => { "$gte" => current_benefit_period.start_on, "$lt" => current_benefit_period.end_on },
+          :kind.in => ["individual", "coverall"],
+          :aasm_state.in => ["auto_renewing", "renewing_coverage_selected"]
+        )
+        @logger.info "Total IVL auto renewing enrollment count: #{ivl_enrollments.count}"
+        count = 0
+        while offset <= ivl_enrollments.count
+          ivl_enrollments.offset(offset).limit(batch_size).no_timeout.each do |enrollment|
+            if enrollment.may_begin_coverage?
+              enrollment.begin_coverage!
+              count += 1
+              @logger.info "Processed enrollment: #{enrollment.hbx_id}"
+            end
+          rescue StandardError => e
+            @logger.info "Unable to begin coverage for #{enrollment.id}, error: #{e.backtrace}"
           end
-        rescue StandardError => e
-          @logger.info "Unable to begin coverage for #{enrollment.id}, error: #{e.backtrace}"
+          offset += batch_size
         end
-        offset += batch_size
+        @logger.info "Total IVL auto renewing enrollment processed count: #{count}"
+        @logger.info "Ended begin_coverage_for_ivl_enrollments process at #{TimeKeeper.datetime_of_record.to_s}"
       end
-      @logger.info "Total IVL auto renewing enrollment processed count: #{count}"
-      @logger.info "Ended begin_coverage_for_ivl_enrollments process at #{TimeKeeper.datetime_of_record.to_s}"
     end
 
     def enrollment_notice_for_ivl_families(new_date)

--- a/app/models/services/ivl_enrollment_service.rb
+++ b/app/models/services/ivl_enrollment_service.rb
@@ -19,7 +19,7 @@ module Services
       if EnrollRegistry.feature_enabled?(:async_expire_and_begin_coverages)
         Rails.logger.error "async_expire_and_begin_coverages feature flag is enabled but async expire_individual_market_enrollments still needs to be implemented!"
       else
-        @logger.info "Started expire_individual_market_enrollments process at #{TimeKeeper.datetime_of_record.to_s}"
+        @logger.info "Started expire_individual_market_enrollments process at #{TimeKeeper.datetime_of_record}"
         current_benefit_period = HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period
         batch_size = 500
         offset = 0
@@ -30,9 +30,6 @@ module Services
         )
         @logger.info "Total enrollments to expire count: #{individual_market_enrollments.count}"
         while offset <= individual_market_enrollments.count
-  
-          # insert new async code here
-          # use each with index and log with index
           individual_market_enrollments.offset(offset).limit(batch_size).no_timeout.each do |enrollment|
             enrollment.expire_coverage! if enrollment.may_expire_coverage?
             @logger.info "Processed enrollment: #{enrollment.hbx_id}"
@@ -50,7 +47,7 @@ module Services
       if EnrollRegistry.feature_enabled?(:async_expire_and_begin_coverages)
         Rails.logger.error "async_expire_and_begin_coverages feature flag is enabled but async begin_coverage_for_ivl_enrollments still needs to be implemented!"
       else
-        @logger.info "Started begin_coverage_for_ivl_enrollments process at #{TimeKeeper.datetime_of_record.to_s}"
+        @logger.info "Started begin_coverage_for_ivl_enrollments process at #{TimeKeeper.datetime_of_record}"
         current_benefit_period = HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period
         batch_size = 500
         offset = 0
@@ -74,7 +71,7 @@ module Services
           offset += batch_size
         end
         @logger.info "Total IVL auto renewing enrollment processed count: #{count}"
-        @logger.info "Ended begin_coverage_for_ivl_enrollments process at #{TimeKeeper.datetime_of_record.to_s}"
+        @logger.info "Ended begin_coverage_for_ivl_enrollments process at #{TimeKeeper.datetime_of_record}"
       end
     end
 

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -920,3 +920,6 @@ registry:
       - key: :oeg_notice_income_verification_only
         item: :oeg_notice_income_verification_only
         is_enabled: <%= ENV['OEG_NOTICE_INCOME_VERIFICATION_ONLY_IS_ENABLED'] || false %>
+      - key: :async_expire_and_begin_coverages
+        item: :async_expire_and_begin_coverages
+        is_enabled: <%= ENV['ASYNC_EXPIRE_AND_BEGIN_COVERAGES_IS_ENABLED'] || false %>

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -907,3 +907,6 @@ registry:
       - key: :oeg_notice_income_verification_only
         item: :oeg_notice_income_verification_only
         is_enabled: <%= ENV['OEG_NOTICE_INCOME_VERIFICATION_ONLY_IS_ENABLED'] || false %>
+      - key: :async_expire_and_begin_coverages
+        item: :async_expire_and_begin_coverages
+        is_enabled: <%= ENV['ASYNC_EXPIRE_AND_BEGIN_COVERAGES_IS_ENABLED'] || false %>

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -920,3 +920,6 @@ registry:
       - key: :oeg_notice_income_verification_only
         item: :oeg_notice_income_verification_only
         is_enabled: <%= ENV['OEG_NOTICE_INCOME_VERIFICATION_ONLY_IS_ENABLED'] || false %>
+      - key: :async_expire_and_begin_coverages
+        item: :async_expire_and_begin_coverages
+        is_enabled: <%= ENV['ASYNC_EXPIRE_AND_BEGIN_COVERAGES_IS_ENABLED'] || false %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186327106 

# A brief description of the changes

Current behavior:
No feature flag exists for controlling the async_expire_and_begin_coverages feature

New behavior:
Feature flag exists for controlling the async_expire_and_begin_coverages feature.  If feature is turned on, error is logged indicating that feature still needs to be implemented.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: ASYNC_EXPIRE_AND_BEGIN_COVERAGES_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.