### PR TITLE
use concatenation operator instead of append operator

### DIFF
--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -1497,7 +1497,7 @@ class HbxEnrollment
 
   def can_make_changes_for_ivl_enrollment?
     allowed_statuses = ENROLLED_AND_RENEWAL_STATUSES
-    allowed_statuses << 'coverage_terminated' if EnrollRegistry.feature_enabled?(:enrollment_plan_tile_update)
+    allowed_statuses += ["coverage_terminated"] if EnrollRegistry.feature_enabled?(:enrollment_plan_tile_update)
     return true if allowed_statuses.include?(aasm_state)
     false
   end

--- a/spec/models/hbx_enrollment_spec.rb
+++ b/spec/models/hbx_enrollment_spec.rb
@@ -792,3 +792,36 @@ describe HbxEnrollment, "with index definitions" do
     HbxEnrollment.create_indexes
   end
 end
+
+describe '#can_make_changes_for_ivl_enrollment?' do
+  let(:hbx_enrollment) { HbxEnrollment.new }
+  context 'when enrollment_plan_tile_update feature is disabled' do
+    before do
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:enrollment_plan_tile_update).and_return(false)
+      hbx_enrollment.can_make_changes_for_ivl_enrollment?
+    end
+
+    it 'returns original count' do
+      expect(HbxEnrollment::ENROLLED_AND_RENEWAL_STATUSES.count).to be 14
+    end
+
+    it 'should not have coverage_terminated' do
+      expect(HbxEnrollment::ENROLLED_AND_RENEWAL_STATUSES).not_to include('coverage_terminated')
+    end
+  end
+
+  context 'when enrollment_plan_tile_update feature is enabled' do
+    before do
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:enrollment_plan_tile_update).and_return(true)
+      hbx_enrollment.can_make_changes_for_ivl_enrollment?
+    end
+
+    it 'returns original count' do
+      expect(HbxEnrollment::ENROLLED_AND_RENEWAL_STATUSES.count).to be 14
+    end
+
+    it 'should not have coverage_terminated' do
+      expect(HbxEnrollment::ENROLLED_AND_RENEWAL_STATUSES).not_to include('coverage_terminated')
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [pivotal_186467029](https://www.pivotaltracker.com/n/projects/2640060/stories/186467029)

# A brief description of the changes

Current behavior: The append operator (<<) modifies the original constant array, causing it to persist for the entire session.

New behavior: The concatenation operator (+=) creates a new array and does not alter the values in ENROLLED_AND_RENEWAL_STATUSES, thereby preventing inaccurate results.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.