### PR TITLE
cr97 feature flag and initial style file

### DIFF
--- a/app/javascript/css/cr97.scss
+++ b/app/javascript/css/cr97.scss
@@ -1,0 +1,21 @@
+:root {
+    --font: Barlow, sans-serif;
+    --default-font-color: #323130;
+  
+    --placeholder-color: #676767;
+    --placeholder-font-weight: 400;
+    --floatlabel-color: #767676;
+    --floatlabel-onclick-color:#676767;
+    --input-text-color: #454545;
+    --form-element-text-color: #454545;
+  
+    --button-default-color: #4A7EA6;
+    --button-default-hover-color: #345F80;
+    --button-default-active-color: #274760;
+  
+    --enrollment-status-red: #A21E1F;
+    --enrollment-status-green: #027314;
+    --enrollment-status-yellow: #E5A900;
+    --enrollment-status-blue: #003260;
+    --enrollment-status-grey: #3B3A39;
+}

--- a/app/javascript/packs/cr97.js
+++ b/app/javascript/packs/cr97.js
@@ -1,0 +1,1 @@
+import '../css/cr97.scss';

--- a/app/views/layouts/bootstrap_4.html.erb
+++ b/app/views/layouts/bootstrap_4.html.erb
@@ -13,6 +13,12 @@
     <%= stylesheet_pack_tag 'application' %>
     <%= javascript_pack_tag ENV['CLIENT'] %>
     <%= stylesheet_pack_tag ENV['CLIENT'] %>
+
+    <% if ENV['CR97_IS_ENABLED'] %>
+      <%= javascript_pack_tag 'cr97' %>
+      <%= stylesheet_pack_tag 'cr97' %>
+    <% end %>
+
     <%= action_cable_meta_tag %>
     <%= csrf_meta_tags %>
     <% if EnrollRegistry.feature_enabled?(:live_chat_widget) %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186537609

# A brief description of the changes

Current behavior: Only use me and dc stylesheets

New behavior: Adding feature flag to wrap around new cr97 approved stylesheet and javascript and initializing said-stylesheet

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CR97_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

No tests were added with this PR as this is just setting up use of the feature flag. Automated tests will be introduced via axe-gems when delivering actual pages for CR97.