### PR TITLE
exclude cobra enrollments from osse

### DIFF
--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2865,7 +2865,7 @@ class HbxEnrollment
   end
 
   def is_eligible_for_osse_grant?(key)
-    return false if is_shop? || dental?
+    return false if is_shop? || dental? || is_cobra_status?
     hbx_enrollment_members.any? do |member|
       member.is_eligible_for_osse_grant?(key, effective_on)
     end
@@ -2881,7 +2881,7 @@ class HbxEnrollment
   end
 
   def update_osse_childcare_subsidy
-    return if dental?
+    return if dental? || is_cobra_status?
 
     if is_shop?
       application = sponsored_benefit_package.benefit_application
@@ -2922,7 +2922,7 @@ class HbxEnrollment
   end
 
   def verify_and_reset_osse_subsidy_amount(member_group)
-    return unless is_shop?
+    return unless is_shop? && !is_cobra_status?
 
     update_osse_childcare_subsidy
     hbx_enrollment_members.each do |member|

--- a/spec/models/hbx_enrollment_spec.rb
+++ b/spec/models/hbx_enrollment_spec.rb
@@ -575,6 +575,7 @@ describe 'update_osse_childcare_subsidy', dbclean: :around_each do
   let(:employee_role) { census_employee.employee_role.reload }
   let(:effective_on) { initial_application.start_on.to_date }
   let(:coverage_kind) { "health" }
+  let(:kind) { 'employer_sponsored' }
 
   let(:shop_enrollment) do
     FactoryBot.create(
@@ -583,6 +584,7 @@ describe 'update_osse_childcare_subsidy', dbclean: :around_each do
       :with_enrollment_members,
       :with_product,
       coverage_kind: coverage_kind,
+      kind: kind,
       family: person.primary_family,
       employee_role: employee_role,
       effective_on: (effective_on + 3.months),
@@ -646,6 +648,14 @@ describe 'update_osse_childcare_subsidy', dbclean: :around_each do
         expect(shop_enrollment.reload.eligible_child_care_subsidy.to_f).to eq(0.00)
       end
     end
+
+    context 'when enrollment is cobra' do
+      let(:kind) { 'employer_sponsored_cobra' }
+
+      it 'should not update OSSE subsidy' do
+        expect(shop_enrollment.reload.eligible_child_care_subsidy.to_f).to eq(0.00)
+      end
+    end
   end
 
   context 'when employee is not eligible for OSSE' do
@@ -702,6 +712,26 @@ describe 'update_osse_childcare_subsidy', dbclean: :around_each do
         expect(shop_enrollment.eligible_child_care_subsidy.to_f).to eq excess_subsidy_amount
         shop_enrollment.verify_and_reset_osse_subsidy_amount(member_group)
         expect(shop_enrollment.eligible_child_care_subsidy.to_f).to eq subscriber_premium
+      end
+    end
+
+    context 'when subscriber is cobra eligible, it should not reset the osse value ' do
+      let(:member_group)  { HbxEnrollmentSponsoredCostCalculator.new(shop_enrollment).groups_for_products([shop_enrollment.product]).first }
+      let(:subscriber_premium) do
+        member = shop_enrollment.hbx_enrollment_members.detect(&:is_subscriber?)
+        member_group.group_enrollment.member_enrollments.find{|enrollment| enrollment.member_id == member.id }.product_price
+      end
+      let(:kind) { 'employer_sponsored_cobra' }
+
+
+      before do
+        shop_enrollment.update(eligible_child_care_subsidy: 0.00)
+      end
+
+      it 'should max subsidy at subscriber premium' do
+        expect(shop_enrollment.eligible_child_care_subsidy.to_f).to eq 0.00
+        shop_enrollment.verify_and_reset_osse_subsidy_amount(member_group)
+        expect(shop_enrollment.eligible_child_care_subsidy.to_f).to eq 0.00
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
https://redmine.priv.dchbx.org/issues/102938

# A brief description of the changes

Current behavior:
The HC4CC discount is being applied to EEs' COBRA enrollments

New behavior:
HC4CC discount should not applied to EEs' COBRA enrollments

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.