### PR TITLE
skip evidence update when consumer has health and dental enrollments

### DIFF
--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -2530,6 +2530,10 @@ class HbxEnrollment
     coverage_kind == "dental"
   end
 
+  def health?
+    coverage_kind == "health"
+  end
+
   # TODO: Implement behaviour by 16219.
   def composite_rating_tier
     @composite_rating_tier ||= cached_composite_rating_tier

--- a/components/financial_assistance/app/models/financial_assistance/application.rb
+++ b/components/financial_assistance/app/models/financial_assistance/application.rb
@@ -354,10 +354,25 @@ module FinancialAssistance
     end
 
     def enrolled_with(enrollment)
+      active_enrollments = enrollment.family.hbx_enrollments.enrolled_and_renewing
+
       enrollment.hbx_enrollment_members.each do |enrollment_member|
-        applicant = applicants.where(family_member_id: enrollment_member.applicant_id).first
+        family_member_id =  enrollment_member.applicant_id
+        applicant = applicants.where(family_member_id: family_member_id).first
+        next if ineligible_for_evidence_update?(enrollment, active_enrollments, family_member_id)
+
         applicant&.enrolled_with(enrollment)
       end
+    end
+
+    def ineligible_for_evidence_update?(enrollment, active_enrollments, family_member_id)
+      return false if enrollment.health?
+      family_member_enrollments = active_enrollments
+                                  .by_year(enrollment.effective_on.year)
+                                  .by_health
+                                  .map { |en| en.hbx_enrollment_members.any? { |member| member.applicant_id == family_member_id } }
+
+      family_member_enrollments.any?
     end
 
     # fetch existing relationships matrix
@@ -938,7 +953,6 @@ module FinancialAssistance
       self.effective_date.year < TimeKeeper.date_of_record.year
     end
 
-    # rubocop:disable Metrics/AbcSize
     def create_tax_household_groups
       return unless EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
 
@@ -961,7 +975,6 @@ module FinancialAssistance
     rescue StandardError => e
       Rails.logger.error { "FAA create_tax_household_groups error for application with hbx_id: #{hbx_id} message: #{e.message}, backtrace: #{e.backtrace.join('\n')}" }
     end
-    # rubocop:enable Metrics/AbcSize
 
     def trigger_local_mec
       ::FinancialAssistance::Operations::Applications::MedicaidGateway::RequestMecChecks.new.call(application_id: id) if is_local_mec_checkable?

--- a/components/financial_assistance/spec/models/financial_assistance/application_spec_1.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/application_spec_1.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'aasm/rspec'
+
+RSpec.describe ::FinancialAssistance::Application, type: :model, dbclean: :after_each do
+  include Dry::Monads[:result, :do]
+
+  let(:person) { FactoryBot.create(:person, :with_consumer_role)}
+  let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person)}
+  let!(:person2) do
+    per = FactoryBot.create(:person, :with_consumer_role, dob: Date.today - 30.years)
+    person.ensure_relationship_with(per, 'spouse')
+    per.addresses.delete_all
+    person.save!
+    per
+  end
+  let!(:family_member) { FactoryBot.create(:family_member, family: family, person: person2) }
+  let(:product) {double(id: '123', csr_variant_id: '01')}
+
+  let!(:health_enrollment) do
+    FactoryBot.create(
+      :hbx_enrollment,
+      :with_enrollment_members,
+      :individual_assisted,
+      family: family,
+      applied_aptc_amount: Money.new(44_500),
+      consumer_role_id: person.consumer_role.id,
+      enrollment_members: family.family_members,
+      coverage_kind: "health"
+    )
+  end
+
+  let!(:dental_enrollment) do
+    FactoryBot.create(
+      :hbx_enrollment,
+      :with_enrollment_members,
+      :individual_assisted,
+      family: family,
+      applied_aptc_amount: Money.new(0),
+      consumer_role_id: person.consumer_role.id,
+      enrollment_members: family.family_members,
+      coverage_kind: "dental"
+    )
+  end
+
+  let!(:year) { TimeKeeper.date_of_record.year }
+  let!(:application) { FactoryBot.create(:financial_assistance_application, family_id: family.id) }
+  let!(:eligibility_determination1) { FactoryBot.create(:financial_assistance_eligibility_determination, application: application) }
+  let!(:eligibility_determination2) { FactoryBot.create(:financial_assistance_eligibility_determination, application: application) }
+  let!(:applicant1) do
+    FactoryBot.create(:financial_assistance_applicant, eligibility_determination_id: eligibility_determination1.id, application: application, family_member_id: family.family_members[0].id)
+  end
+  let!(:applicant2) { FactoryBot.create(:financial_assistance_applicant, eligibility_determination_id: eligibility_determination2.id, application: application, family_member_id: family.family_members[1].id) }
+
+  let(:create_instate_addresses) do
+    application.applicants.each do |appl|
+      appl.addresses = [FactoryBot.build(:financial_assistance_address,
+                                         :address_1 => '1111 Awesome Street NE',
+                                         :address_2 => '#111',
+                                         :address_3 => '',
+                                         :city => 'Washington',
+                                         :country_name => '',
+                                         :kind => 'home',
+                                         :state => FinancialAssistanceRegistry[:enroll_app].setting(:state_abbreviation).item,
+                                         :zip => '20001',
+                                         county: '')]
+      appl.save!
+    end
+    application.save!
+  end
+
+  let(:create_relationships) do
+    application.applicants.first.update_attributes!(is_primary_applicant: true) unless application.primary_applicant.present?
+    application.ensure_relationship_with_primary(applicant2, 'spouse')
+    application.build_relationship_matrix
+    application.save!
+  end
+
+  before do
+    allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).and_return(false)
+    allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:ifsv_determination).and_return(true)
+    allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:mec_check).and_return(true)
+    allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:esi_mec_determination).and_return(true)
+    allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:non_esi_mec_determination).and_return(true)
+    allow(health_enrollment).to receive(:product).and_return(product)
+    allow(dental_enrollment).to receive(:product).and_return(product)
+
+    applicant1.create_evidences
+    applicant1.create_eligibility_income_evidence
+    applicant1.income_evidence.move_to_verified!
+    applicant2.create_evidences
+    applicant2.create_eligibility_income_evidence
+    applicant2.income_evidence.move_to_verified!
+  end
+
+  context '#enrolled_with' do
+    context 'when consumer has both health and dental enrollments' do
+      context 'when dental enrollment is passed' do
+        it 'should not update income evidence' do
+          application.enrolled_with(dental_enrollment)
+          applicant1.income_evidence.reload
+          expect(applicant1.income_evidence).to be_verified
+        end
+      end
+
+      context 'when uqhp health enrollment is passed' do
+        it 'should set income evidence to negative response received' do
+          health_enrollment.update_attributes(applied_aptc_amount: Money.new(0))
+          application.enrolled_with(health_enrollment)
+          applicant1.income_evidence.reload
+          expect(applicant1.income_evidence).to be_negative_response_received
+        end
+      end
+
+      context 'when aqhp health enrollment is passed' do
+        it 'should set income evidence to negative response received' do
+          application.enrolled_with(health_enrollment)
+          applicant1.income_evidence.reload
+          expect(applicant1.income_evidence).to be_verified
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [Pivotal-186574372](https://www.pivotaltracker.com/story/show/186574372)

# A brief description of the changes

Current behavior: When consumer with health enrollment also chooses dental enrollment, the evidence status is getting updated.

New behavior: Skip updating evidence status when dental enrollment is selected.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.