### PR TITLE
Update Choose Plan text for Enrolling Health Plans

### DIFF
--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -509,7 +509,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.plan_shoppings.print_waiver.print_waiver_html' => "<h3>Waiver confirmation</h3><p>You have successfully waived the coverage at %{updated_at}. </p><p>Waiver Reason : %{waiver_reason}. </p><p>Please print this page for your records. </p>",
   :'en.print' => "Print",
   :'en.insured.plan_shoppings.show.title' => "Choose Plan",
-  :'en.insured.plan_shoppings.show.title.content' => "If you already know what plan you want, use 'Select Plan' below to choose it.",
+  :'en.insured.plan_shoppings.show.title.content' => "If you already know what plan you want, use 'Select Plan' below to choose it. If you want to see which plans include your providers, hospital, prescriptions and an estimate of your total out-of-pocket costs, use Plan Compare.",
   :'en.compare_plans' => "Compare Plans",
   :'en.insured.plan_shoppings.final_cost_change' => "Please note your final cost may change based on the final enrollment of all employees.",
   :'en.sort_by' => "Sort By",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/186562760

# A brief description of the changes

Current behavior: Translation text says 
`If you already know what plan you want, use 'Select Plan' below to choose it.`


New behavior: Updated Text for 
`If you already know what plan you want, use 'Select Plan' below to choose it. If you want to see which plans include your providers, hospital, prescriptions and an estimate of your total out-of-pocket costs, use Plan Compare.
`

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: No Variables

- [ ] DC
- [x] ME

# Additional Context
Change is for ME Only

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.