### PR TITLE
updates plan compare language on choose plan for health enrollments

### DIFF
--- a/app/views/insured/plan_shoppings/show.html.slim
+++ b/app/views/insured/plan_shoppings/show.html.slim
@@ -8,7 +8,7 @@
       .col-lg-8.col-md-8.col-sm-8.col-xs-12
         .ct-1
           h1.heading-text = l10n("insured.plan_shoppings.show.title")
-          - if @coverage_kind == "health"
+          - if @hbx_enrollment.is_health_enrollment?
             h4.switch-header = l10n("insured.plan_shoppings.show.health_title.content")
           - else
             h4.switch-header = l10n("insured.plan_shoppings.show.dental_title.content")

--- a/app/views/insured/plan_shoppings/show.html.slim
+++ b/app/views/insured/plan_shoppings/show.html.slim
@@ -8,7 +8,7 @@
       .col-lg-8.col-md-8.col-sm-8.col-xs-12
         .ct-1
           h1.heading-text = l10n("insured.plan_shoppings.show.title")
-          - if @hbx_enrollment.is_health_enrollment?
+          - if @coverage_kind == "health"
             h4.switch-header = l10n("insured.plan_shoppings.show.health_title.content")
           - else
             h4.switch-header = l10n("insured.plan_shoppings.show.dental_title.content")

--- a/app/views/insured/plan_shoppings/show.html.slim
+++ b/app/views/insured/plan_shoppings/show.html.slim
@@ -9,7 +9,7 @@
         .ct-1
           h1.heading-text = l10n("insured.plan_shoppings.show.title")
           - if @coverage_kind == "health"
-            h4.switch-header = l10n("insured.plan_shoppings.show.title.content")
+            h4.switch-header = l10n("insured.plan_shoppings.show.health_title.content")
           - else
             h4.switch-header = l10n("insured.plan_shoppings.show.dental_title.content")
           h4.swtich-header

--- a/app/views/insured/plan_shoppings/show.html.slim
+++ b/app/views/insured/plan_shoppings/show.html.slim
@@ -8,7 +8,10 @@
       .col-lg-8.col-md-8.col-sm-8.col-xs-12
         .ct-1
           h1.heading-text = l10n("insured.plan_shoppings.show.title")
-          h4.switch-header = l10n("insured.plan_shoppings.show.title.content")
+          - if @coverage_kind == "health"
+            h4.switch-header = l10n("insured.plan_shoppings.show.title.content")
+          - else
+            h4.switch-header = l10n("insured.plan_shoppings.show.dental_title.content")
           h4.swtich-header
           - if @market_kind == "shop" && EnrollRegistry.feature_enabled?(:display_cost_warning_message)
             - if @hbx_enrollment.sponsored_benefit.single_plan_type?

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -508,6 +508,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.print' => "Print",
   :'en.insured.plan_shoppings.show.title' => "Choose Plan",
   :'en.insured.plan_shoppings.show.title.content' => "Find a quality, affordable health insurance plan that's right for you, or for you and your family. Use 'Filter Results', 'Compare' and 'Details' features to narrow your choices. When you find the plan you want, 'Select Plan'.",
+  :'en.insured.plan_shoppings.show.dental_title.content' => "Find a quality, affordable health insurance plan that's right for you, or for you and your family. Use 'Filter Results', 'Compare' and 'Details' features to narrow your choices. When you find the plan you want, 'Select Plan'.",
   :'en.compare_plans' => "Compare Plans",
   :'en.insured.plan_shoppings.final_cost_change' => "Please note your final cost may change based on the final enrollment of all employees.",
   :'en.sort_by' => "Sort By",

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -507,7 +507,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.plan_shoppings.print_waiver.print_waiver_html' => "<h3>Waiver confirmation</h3><p>You have successfully waived the coverage at %{updated_at}. </p><p>Waiver Reason : %{waiver_reason}. </p><p>Please print this page for your records. </p>",
   :'en.print' => "Print",
   :'en.insured.plan_shoppings.show.title' => "Choose Plan",
-  :'en.insured.plan_shoppings.show.title.content' => "Find a quality, affordable health insurance plan that's right for you, or for you and your family. Use 'Filter Results', 'Compare' and 'Details' features to narrow your choices. When you find the plan you want, 'Select Plan'.",
+  :'en.insured.plan_shoppings.show.health_title.content' => "Find a quality, affordable health insurance plan that's right for you, or for you and your family. Use 'Filter Results', 'Compare' and 'Details' features to narrow your choices. When you find the plan you want, 'Select Plan'.",
   :'en.insured.plan_shoppings.show.dental_title.content' => "Find a quality, affordable health insurance plan that's right for you, or for you and your family. Use 'Filter Results', 'Compare' and 'Details' features to narrow your choices. When you find the plan you want, 'Select Plan'.",
   :'en.compare_plans' => "Compare Plans",
   :'en.insured.plan_shoppings.final_cost_change' => "Please note your final cost may change based on the final enrollment of all employees.",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -510,6 +510,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.print' => "Print",
   :'en.insured.plan_shoppings.show.title' => "Choose Plan",
   :'en.insured.plan_shoppings.show.title.content' => "If you already know what plan you want, use 'Select Plan' below to choose it. If you want to see which plans include your providers, hospital, prescriptions and an estimate of your total out-of-pocket costs, use Plan Compare.",
+  :'en.insured.plan_shoppings.show.dental_title.content' => "If you already know what plan you want, use 'Select Plan' below to choose it.",
   :'en.compare_plans' => "Compare Plans",
   :'en.insured.plan_shoppings.final_cost_change' => "Please note your final cost may change based on the final enrollment of all employees.",
   :'en.sort_by' => "Sort By",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -509,7 +509,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.plan_shoppings.print_waiver.print_waiver_html' => "<h3>Waiver confirmation</h3><p>You have successfully waived the coverage at %{updated_at}. </p><p>Waiver Reason : %{waiver_reason}. </p><p>Please print this page for your records. </p>",
   :'en.print' => "Print",
   :'en.insured.plan_shoppings.show.title' => "Choose Plan",
-  :'en.insured.plan_shoppings.show.title.content' => "If you already know what plan you want, use 'Select Plan' below to choose it. If you want to see which plans include your providers, hospital, prescriptions and an estimate of your total out-of-pocket costs, use Plan Compare.",
+  :'en.insured.plan_shoppings.show.health_title.content' => "If you already know what plan you want, use 'Select Plan' below to choose it. If you want to see which plans include your providers, hospital, prescriptions and an estimate of your total out-of-pocket costs, use Plan Compare.",
   :'en.insured.plan_shoppings.show.dental_title.content' => "If you already know what plan you want, use 'Select Plan' below to choose it.",
   :'en.compare_plans' => "Compare Plans",
   :'en.insured.plan_shoppings.final_cost_change' => "Please note your final cost may change based on the final enrollment of all employees.",

--- a/features/group_selection/ivl_plan_shopping.feature
+++ b/features/group_selection/ivl_plan_shopping.feature
@@ -144,3 +144,34 @@ Feature: IVL plan purchase
     Then consumer should see all the family members names
     And consumer clicked on shop for new plan
     Then consumer should see 0 premiums for all plans
+
+  Scenario: Health Plans Title Content should be displayed on Plan Shopping page
+    Given EnrollRegistry go_to_plan_compare_link feature is enabled
+    Given a consumer exists
+    And the consumer is logged in
+    And consumer has a dependent in child relationship with age less than 26
+    And consumer has successful ridp
+    When consumer visits home page
+    And consumer clicked on "Married" qle
+    And I select a past qle date
+    Then I should see confirmation and continue
+    When ivl clicked continue on household info page
+    Then consumer should see all the family members names
+    And consumer clicked on shop for new plan
+    Then employee should see health title content
+
+  Scenario: Dental Plans Title Content should be displayed on Plan Shopping page
+    Given EnrollRegistry go_to_plan_compare_link feature is enabled
+    Given a consumer exists
+    And the consumer is logged in
+    And consumer has a dependent in child relationship with age less than 26
+    And consumer has successful ridp
+    When consumer visits home page
+    And consumer clicked on "Married" qle
+    And I select a past qle date
+    Then I should see confirmation and continue
+    When ivl clicked continue on household info page
+    Then consumer should see all the family members names
+    And individual selects dental for coverage kind
+    And consumer clicked on shop for new plan
+    Then employee should see dental title content

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -28,7 +28,7 @@ end
 
 Then(/^\w+ should see (.*) title content$/) do |coverage_kind|
   if coverage_kind == "health"
-    expect(page).to have_content(l10n("insured.plan_shoppings.show.title.content"))
+    expect(page).to have_content(l10n("insured.plan_shoppings.show.health_title.content"))
   else
     expect(page).to have_content(l10n("insured.plan_shoppings.show.dental_title.content"))
   end

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -26,6 +26,14 @@ Then(/^\w+ should see Go To Plan Compare button$/) do
   expect(page).to have_content("CHECKBOOK")
 end
 
+Then(/^\w+ should see (.*) title content$/) do |coverage_kind|
+  if coverage_kind == "health"
+    expect(page).to have_content(l10n("insured.plan_shoppings.show.title.content"))
+  else
+    expect(page).to have_content(l10n("insured.plan_shoppings.show.dental_title.content"))
+  end
+end
+
 When(/^\w+ visits? the Insured portal outside of open enrollment$/) do
   FactoryBot.create(:hbx_profile, :no_open_enrollment_coverage_period)
   FactoryBot.create(:qualifying_life_event_kind, market_kind: "individual")


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-186562760](https://www.pivotaltracker.com/n/projects/2640060/stories/186562760)

# A brief description of the changes

Current behavior: Text was updated improperly when selecting dental plans

New behavior: Dental Text remains the same while the health plan header changes to the new approved text

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.