### PR TITLE
add AA compliance for personal info page 2

### DIFF
--- a/app/views/shared/person/_personal_information.html.erb
+++ b/app/views/shared/person/_personal_information.html.erb
@@ -45,13 +45,13 @@
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6 form-group form-group-lg no-pd border_bottom_zero">
       <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_male')" class="radio">
         <%= f.radio_button :gender, "male", class: "required floatlabel", id: 'radio_male', required: true %>
-        <label for="radio_male"><span>MALE</span></label>
+        <label for="radio_male"><span><%=l10n("male")%></span></label>
       </div>
     </div>
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6 form-group form-group-lg no-pd">
       <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_female')" class="radio">
         <%= f.radio_button :gender, "female", class: "required floatlabel", id: 'radio_female', required: true %>
-        <label class="female" for="radio_female"><span>FEMALE</span></label>
+        <label class="female" for="radio_female"><span>l10n("female")</span></label>
       </div>
     </div>
     <span>

--- a/app/views/shared/person/_personal_information.html.erb
+++ b/app/views/shared/person/_personal_information.html.erb
@@ -40,22 +40,22 @@
     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 form-group form-group-lg no-pd top-buffer" >
       <%= f.check_box :no_ssn,  :value => false, :onclick=>"$('#person_ssn').prop('disabled', !$('#person_ssn').prop('disabled')); $('#person_ssn').prop('required', !$('#person_ssn').prop('required'))" %>
       <label for="person_no_ssn"><span class='no_ssn'>&nbsp;<%= l10n("do_not_have_ssn") %></span></label>
-      <span><i class='fa fa-question-circle' id="no_ssn_tooltip" data-toggle="tooltip" title="<%=l10n("insured.consumer_roles.search.no_ssn_tooltip")%>"></i></span>
+      <span><i tabindex="0" class='fa fa-question-circle' id="no_ssn_tooltip" data-toggle="tooltip" title="<%=l10n("insured.consumer_roles.search.no_ssn_tooltip")%>"></i></span>
     </div>
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6 form-group form-group-lg no-pd border_bottom_zero">
-      <div class="radio">
+      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_male')" class="radio">
         <%= f.radio_button :gender, "male", class: "required floatlabel", id: 'radio_male', required: true %>
         <label for="radio_male"><span>MALE</span></label>
       </div>
     </div>
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6 form-group form-group-lg no-pd">
-      <div class="radio">
+      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_female')" class="radio">
         <%= f.radio_button :gender, "female", class: "required floatlabel", id: 'radio_female', required: true %>
-        <label  class="female" for="radio_female"><span>FEMALE</span></label>
+        <label class="female" for="radio_female"><span>FEMALE</span></label>
       </div>
     </div>
     <span>
-      <i id="gender-tooltip" class='fa fa-question-circle no-pd pull-right'  data-toggle="tooltip" title="<%=l10n("insured.consumer_roles.search.gender_tooltip")%>"></i>
+      <i tabindex="0" id="gender-tooltip" class='fa fa-question-circle no-pd pull-right'  data-toggle="tooltip" title="<%=l10n("insured.consumer_roles.search.gender_tooltip")%>"></i>
     </span>
   </div>
 </div>

--- a/app/views/shared/person/_personal_information.html.erb
+++ b/app/views/shared/person/_personal_information.html.erb
@@ -45,13 +45,13 @@
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6 form-group form-group-lg no-pd border_bottom_zero">
       <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_male')" class="radio">
         <%= f.radio_button :gender, "male", class: "required floatlabel", id: 'radio_male', required: true %>
-        <label for="radio_male"><span><%=l10n("male")%></span></label>
+        <label for="radio_male"><span><%=l10n("male").to_s.upcase%></span></label>
       </div>
     </div>
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6 form-group form-group-lg no-pd">
       <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_female')" class="radio">
         <%= f.radio_button :gender, "female", class: "required floatlabel", id: 'radio_female', required: true %>
-        <label class="female" for="radio_female"><span>l10n("female")</span></label>
+        <label class="female" for="radio_female"><span>l10n("female").to_s.upcase</span></label>
       </div>
     </div>
     <span>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186426647

# A brief description of the changes

Current behavior: unable to completely navigate through the second page of the personal info section of the registration workflow

New behavior: You can now navigate through the radio buttons and tooltips with tab

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CR97_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
<img width="1728" alt="Screenshot 2023-12-06 at 9 01 41 AM" src="https://github.com/ideacrew/enroll/assets/45053146/ddb8b628-8ab9-46ad-b001-978d64f603b1">

Cucumber tests will be added via ticket at the end of the workflow (https://www.pivotaltracker.com/story/show/186580246)

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.