### PR TITLE
aa compliance for personal info page 3

### DIFF
--- a/app/assets/stylesheets/left_nav.scss.erb
+++ b/app/assets/stylesheets/left_nav.scss.erb
@@ -29,14 +29,14 @@
   }
 
   .active.indent-w {
-    border-left: 7px solid #fff !important;
+    border-left: 7px solid var(--theme-secondary, #fff) !important;
   }
   .white-font {
     color: #CBE6FF;
   }
 
   .activer.global-nav > a {
-    color: #CBE6FF;
+    color: var(--primary-white, #CBE6FF);
   }
 
   li:not(.activer) a:not(.disabled) {

--- a/app/assets/stylesheets/ui-components/mahc-theme.scss
+++ b/app/assets/stylesheets/ui-components/mahc-theme.scss
@@ -264,9 +264,9 @@ fieldset[disabled] .btn {
 }
 
 .btn-default {
-  color: $secondary-button-text;
+  color: var(--theme-primary-100, $secondary-button-text);
   background-color: $secondary-button-background;
-  border-color: $secondary-button-border;
+  border-color: var(--theme-primary-100, $secondary-button-border);
   text-transform: $secondary-button-text-casing;
   font-weight: $primary-bold;
   box-sizing: border-box;

--- a/app/views/insured/consumer_roles/_tribe_fields.html.erb
+++ b/app/views/insured/consumer_roles/_tribe_fields.html.erb
@@ -13,13 +13,13 @@
        </label>
     </div>
     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd border_bottom_zero">
-      <div class="radio">
+      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'indian_tribe_member_yes')" class="radio">
         <%= f.radio_button :indian_tribe_member, "true", class: "required floatlabel", id: 'indian_tribe_member_yes' %>
         <label for="indian_tribe_member_yes"><span class="yes_no_pair"><%= l10n("Yes") %></span></label>
       </div>
     </div>
     <div class="col-lg-1 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
-      <div class="radio">
+      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'indian_tribe_member_no')" class="radio">
         <%= f.radio_button :indian_tribe_member, "false", class: "required floatlabel", id: 'indian_tribe_member_no' %>
         <label for="indian_tribe_member_no"><span class="yes_no_pair"><%= l10n("no") %></span></label>
       </div>

--- a/app/views/shared/_consumer_fields.html.erb
+++ b/app/views/shared/_consumer_fields.html.erb
@@ -12,15 +12,15 @@
           <label>Is this person a US citizen or US national? *</label>
         </div>
         <div class="col-lg-3 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
-          <div class="radio skinned-form-controls skinned-form-controls-mac">
-            <%= f.radio_button :us_citizen, true, required: true, class: "required floatlabel" %>
+          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_us_citizen_true')" class="radio skinned-form-controls skinned-form-controls-mac">
+            <%= f.radio_button :us_citizen, true, required: true, class: "required floatlabel"%>
             <%= f.label :us_citizen, :value => true do %>
               <span class="yes_no_pair">Yes</span>
             <% end %>
           </div>
         </div>
         <div class="col-lg-1 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
-          <div class="radio skinned-form-controls skinned-form-controls-mac">
+          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_us_citizen_false')" class="radio skinned-form-controls skinned-form-controls-mac">
             <%= f.radio_button :us_citizen, false, required: true, class: "required floatlabel" %>
             <%= f.label :us_citizen, :value => false do %>
               <span class="yes_no_pair">No</span>
@@ -38,7 +38,7 @@
           <label> <%= l10n("insured.consumer_roles.naturalized_question") %> *</label>
         </div>
         <div class="col-lg-3 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-          <div class="radio skinned-form-controls skinned-form-controls-mac">
+          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_naturalized_citizen_true')" class="radio skinned-form-controls skinned-form-controls-mac">
             <%= f.radio_button :naturalized_citizen, true, required: true, class: "required floatlabel" %>
             <%= f.label :naturalized_citizen, :value => true do %>
               <span class="yes_no_pair">Yes</span>
@@ -46,7 +46,7 @@
           </div>
         </div>
         <div class="col-lg-1 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-          <div class="radio skinned-form-controls skinned-form-controls-mac">
+          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_naturalized_citizen_false')" class="radio skinned-form-controls skinned-form-controls-mac">
             <%= f.radio_button :naturalized_citizen, false, required: true, class: "required floatlabel" %>
             <%= f.label :naturalized_citizen, :value => false do %>
               <span class="yes_no_pair">No</span>
@@ -75,7 +75,7 @@
           </div>
         <% else %>
           <div class="col-lg-3 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-            <div class="radio skinned-form-controls skinned-form-controls-mac">
+            <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_eligible_immigration_status_true')" class="radio skinned-form-controls skinned-form-controls-mac">
               <%= f.radio_button :eligible_immigration_status, true, class: "required floatlabel" %>
               <%= f.label :eligible_immigration_status, :value => true do %>
                 <span class="yes_no_pair">Yes</span>
@@ -83,7 +83,7 @@
             </div>
           </div>
           <div class="col-lg-1 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-            <div class="radio skinned-form-controls skinned-form-controls-mac">
+            <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_eligible_immigration_status_false')" class="radio skinned-form-controls skinned-form-controls-mac">
               <%= f.radio_button :eligible_immigration_status, false, class: "required floatlabel" %>
               <%= f.label :eligible_immigration_status, :value => false do %>
                 <span class="yes_no_pair">No</span>
@@ -109,13 +109,13 @@
           <label class="required no-pd">Is this person currently incarcerated? *</label>
         </div>
         <div class="col-lg-3 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd border_bottom_zero">
-          <div class="radio">
+          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_incarcerated_yes')" class="radio">
             <%= f.radio_button :is_incarcerated, true, class: "required floatlabel", id: 'radio_incarcerated_yes', required: true %>
             <label for="radio_incarcerated_yes"><span class="yes_no_pair">Yes</span></label>
           </div>
         </div>
         <div class="col-lg-1 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
-          <div class="radio">
+          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_incarcerated_no')" class="radio">
             <%= f.radio_button :is_incarcerated, false, class: "required floatlabel", id: 'radio_incarcerated_no', required: true %>
             <label for="radio_incarcerated_no"><span class="yes_no_pair">No</span></label>
           </div>

--- a/app/views/shared/_consumer_home_address_fields.html.erb
+++ b/app/views/shared/_consumer_home_address_fields.html.erb
@@ -161,9 +161,9 @@
 </div>
 
 <% if f.object.addresses[1].present? %>
-<span class="form-action btn btn-default <%= pundit_class Family, :updateable?%>" data-cuke="remove_mailing_address">Remove Mailing Address</span>
+<span tabindex="0" onkeydown="handleButtonKeyDown(event, 'remove_mailing_address')" class="form-action btn btn-default <%= pundit_class Family, :updateable?%>" id="remove_mailing_address" data-cuke="remove_mailing_address">Remove Mailing Address</span>
 <% else %>
-<span class="form-action btn btn-default <%= pundit_class Family, :updateable?%>">Add Mailing Address</span>
+<span tabindex="0" onkeydown="handleButtonKeyDown(event, 'add_mailing_address')" id="add_mailing_address" class="form-action btn btn-default <%= pundit_class Family, :updateable?%>">Add Mailing Address</span>
 <% end %>
 
 

--- a/app/views/shared/_glossary.html.erb
+++ b/app/views/shared/_glossary.html.erb
@@ -5,6 +5,7 @@
 <% end %>
 
 <span class="glossary"
+      tabindex="0"
       data-toggle="popover"
       data-placement="auto top"
       data-trigger="click focus"

--- a/app/views/shared/_help_me_sign_up.html.erb
+++ b/app/views/shared/_help_me_sign_up.html.erb
@@ -1,3 +1,3 @@
-<div class="btn btn-default btn-block help-me-sign-up" data-target="#help_with_plan_shopping" data-toggle="modal">
+<div tabindex="0" onkeydown="handleButtonKeyDown(event, 'help_me_sign_up')" id="help_me_sign_up" class="btn btn-default btn-block help-me-sign-up" data-target="#help_with_plan_shopping" data-toggle="modal">
   Help me sign up
 </div>

--- a/app/views/shared/person/_personal_information.html.erb
+++ b/app/views/shared/person/_personal_information.html.erb
@@ -51,7 +51,7 @@
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6 form-group form-group-lg no-pd">
       <div class="radio">
         <%= f.radio_button :gender, "female", class: "required floatlabel", id: 'radio_female', required: true %>
-        <label  class="female" for="radio_female"><span>FEMALE</span></label>
+        <label class="female" for="radio_female"><span>FEMALE</span></label>
       </div>
     </div>
     <span>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186426708

# A brief description of the changes

Current behavior: unable to completely navigate through the third page of the personal info section of the registration workflow

New behavior: You can now navigate through the radio buttons and tooltips with tab, along with both side navigations meeting AA contrast standards

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CR97_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
<img width="1728" alt="Screenshot 2023-12-06 at 9 10 50 AM" src="https://github.com/ideacrew/enroll/assets/45053146/e94c1b44-fc16-4f15-bae2-49580e18a6e5">
<img width="1728" alt="Screenshot 2023-12-06 at 9 11 02 AM" src="https://github.com/ideacrew/enroll/assets/45053146/46299461-f0c6-40bc-a803-4dd4a8b4951a">

Cucumber tests will be added via ticket at the end of the workflow (https://www.pivotaltracker.com/story/show/186580246)

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.