### PR TITLE
removes event attribute as it collides with event_source event

### DIFF
--- a/spec/factories/transmittable/process_states.rb
+++ b/spec/factories/transmittable/process_states.rb
@@ -6,8 +6,4 @@ FactoryBot.define do
     started_at {DateTime.now}
     message {"initial"}
   end
-
-  before(:create) do |instance|
-    instance.event = "initial"
-  end
 end

--- a/spec/factories/transmittable/process_states.rb
+++ b/spec/factories/transmittable/process_states.rb
@@ -2,9 +2,12 @@
 
 FactoryBot.define do
   factory :transmittable_process_state, class: "::Transmittable::ProcessState" do
-    event {"initial"}
     state_key {:initial}
     started_at {DateTime.now}
     message {"initial"}
+  end
+
+  before(:create) do |instance|
+    instance.event = "initial"
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [#186639196](https://www.pivotaltracker.com/story/show/186639196)

# A brief description of the changes

Current behavior: when attempting to switch clients (eg. from DC to ME), the application will throw an error due to a conflicting attribute in a factory

New behavior: clients can now be switched locally with no issues from the factory

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [x] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.