### PR TITLE
additional async layer in enrollment expiration process

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 438f819c1bb682dbaddafad9b8c125bec260da43
+  revision: 9c2b4ca35fbdd25fad957177c43b2fcdbb0e7e3b
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/domain/operations/hbx_enrollments/begin_coverage_handler.rb
+++ b/app/domain/operations/hbx_enrollments/begin_coverage_handler.rb
@@ -1,63 +1,62 @@
 # frozen_string_literal: true
 
 module Operations
-    module HbxEnrollments
-      # Publish events to begin IVL enrollment coverages
-      class BeginCoverageHandler
-        include EventSource::Command
-        include Dry::Monads[:result, :do]
-  
-        def initialize
-          @logger = Logger.new("#{Rails.root}/log/hbx_enrollments_begin_coverage_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+  module HbxEnrollments
+    # Publish events to begin IVL enrollment coverages
+    class BeginCoverageHandler
+      include EventSource::Command
+      include Dry::Monads[:result, :do]
+
+      def initialize
+        @logger = Logger.new("#{Rails.root}/log/hbx_enrollments_begin_coverage_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+      end
+
+      # @param [Hash] params
+      # @option params [String] :query_criteria
+      # @return [Dry::Monads::Result]
+      def call(params)
+        query_criteria = yield validate(params)
+        enrollments_to_begin = yield enrollments_to_begin_query(query_criteria)
+        result                = yield publish_enrollment_expirations(enrollments_to_begin)
+
+        Success(result)
+      end
+
+      private
+
+      def validate(params)
+        return Failure('Missing query_criteria') unless params.key?(:query_criteria)
+
+        Success(params[:query_criteria])
+      end
+
+      def enrollments_to_begin_query(query_criteria)
+        enrollments_to_begin = HbxEnrollment.where(query_criteria)
+        # evaluating the criteria here to ensure the query is valid
+        enrollments_to_begin.count
+
+        Success(enrollments_to_begin)
+      rescue StandardError => e
+        Failure("Error generating enrollments_to_begin query: #{e.message}; with query criteria: #{query_criteria}")
+      end
+
+      def publish_enrollment_expirations(enrollments_to_expire)
+        enrollments_to_expire.no_timeout.each_with_index do |enrollment, index|
+          enrollment_hbx_id = enrollment.hbx_id
+          event = event("events.individual.enrollments.begin_coverages.begin", attributes: { enrollment_hbx_id: enrollment_hbx_id, index_id: index})
+          publish_event(event)
         end
-  
-        # @param [Hash] params
-        # @option params [String] :query_criteria
-        # @return [Dry::Monads::Result]
-        def call(params)
-          query_criteria        = yield validate(params)
-          enrollments_to_begin = yield enrollments_to_begin_query(query_criteria)
-          result                = yield publish_enrollment_expirations(enrollments_to_begin)
-  
-          Success(result)
-        end
-  
-        private
-  
-        def validate(params)
-          return Failure('Missing query_criteria') unless params.key?(:query_criteria)
-  
-          Success(params[:query_criteria])
-        end
-  
-        def enrollments_to_begin_query(query_criteria)
-          enrollments_to_begin = HbxEnrollment.where(query_criteria)
-          # evaluating the criteria here to ensure the query is valid
-          enrollments_to_begin.count
-  
-          Success(enrollments_to_begin)
-        rescue StandardError => e
-          Failure("Error generating enrollments_to_begin query: #{e.message}; with query criteria: #{query_criteria}")
-        end
-  
-        def publish_enrollment_expirations(enrollments_to_expire)
-          enrollments_to_expire.no_timeout.each_with_index do |enrollment, index|
-            enrollment_hbx_id = enrollment.hbx_id
-            event = event("events.individual.enrollments.begin_coverages.begin", attributes: { enrollment_hbx_id: enrollment_hbx_id, index_id: index})
-            publish_event(event)
-          end
-          Success("Done publishing begin coverage enrollment events.  See hbx_enrollments_begin_coverage_handler log for results.")
-        end
-  
-        def publish_event(event)
-          if event.success?
-            @logger.info "Publishing begin coverage event for enrollment hbx id: #{enrollment_hbx_id}"
-            event.success.publish
-          else
-            @logger.error "ERROR - Publishing begin coverage event failed for enrollment hbx id: #{enrollment_hbx_id}"
-          end
+        Success("Done publishing begin coverage enrollment events.  See hbx_enrollments_begin_coverage_handler log for results.")
+      end
+
+      def publish_event(event)
+        if event.success?
+          @logger.info "Publishing begin coverage event for enrollment hbx id: #{enrollment_hbx_id}"
+          event.success.publish
+        else
+          @logger.error "ERROR - Publishing begin coverage event failed for enrollment hbx id: #{enrollment_hbx_id}"
         end
       end
     end
   end
-  
+end

--- a/app/domain/operations/hbx_enrollments/begin_coverage_handler.rb
+++ b/app/domain/operations/hbx_enrollments/begin_coverage_handler.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Operations
+    module HbxEnrollments
+      # Publish events to begin IVL enrollment coverages
+      class BeginCoverageHandler
+        include EventSource::Command
+        include Dry::Monads[:result, :do]
+  
+        def initialize
+          @logger = Logger.new("#{Rails.root}/log/hbx_enrollments_begin_coverage_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+        end
+  
+        # @param [Hash] params
+        # @option params [String] :query_criteria
+        # @return [Dry::Monads::Result]
+        def call(params)
+          query_criteria        = yield validate(params)
+          enrollments_to_begin = yield enrollments_to_begin_query(query_criteria)
+          result                = yield publish_enrollment_expirations(enrollments_to_begin)
+  
+          Success(result)
+        end
+  
+        private
+  
+        def validate(params)
+          return Failure('Missing query_criteria') unless params.key?(:query_criteria)
+  
+          Success(params[:query_criteria])
+        end
+  
+        def enrollments_to_begin_query(query_criteria)
+          enrollments_to_begin = HbxEnrollment.where(query_criteria)
+          # evaluating the criteria here to ensure the query is valid
+          enrollments_to_begin.count
+  
+          Success(enrollments_to_begin)
+        rescue StandardError => e
+          Failure("Error generating enrollments_to_begin query: #{e.message}; with query criteria: #{query_criteria}")
+        end
+  
+        def publish_enrollment_expirations(enrollments_to_expire)
+          enrollments_to_expire.no_timeout.each_with_index do |enrollment, index|
+            enrollment_hbx_id = enrollment.hbx_id
+            event = event("events.individual.enrollments.begin_coverages.begin", attributes: { enrollment_hbx_id: enrollment_hbx_id, index_id: index})
+            publish_event(event)
+          end
+          Success("Done publishing begin coverage enrollment events.  See hbx_enrollments_begin_coverage_handler log for results.")
+        end
+  
+        def publish_event(event)
+          if event.success?
+            @logger.info "Publishing begin coverage event for enrollment hbx id: #{enrollment_hbx_id}"
+            event.success.publish
+          else
+            @logger.error "ERROR - Publishing begin coverage event failed for enrollment hbx id: #{enrollment_hbx_id}"
+          end
+        end
+      end
+    end
+  end
+  

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -7,10 +7,6 @@ module Operations
       include EventSource::Command
       include Dry::Monads[:result, :do]
 
-      def initialize
-        @logger = Logger.new("#{Rails.root}/log/hbx_enrollments_expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
-      end
-
       # @param [Hash] params
       # @option params [Hash] :query_criteria
       # @return [Dry::Monads::Result]
@@ -54,11 +50,15 @@ module Operations
 
       def publish_event(event, enrollment_hbx_id)
         if event.success?
-          @logger.info "Publishing expiration event for enrollment hbx id: #{enrollment_hbx_id}"
+          handler_logger.info "Publishing expiration event for enrollment hbx id: #{enrollment_hbx_id}"
           event.success.publish
         else
-          @logger.error "ERROR - Publishing expiration event failed for enrollment hbx id: #{enrollment_hbx_id}"
+          handler_logger.error "ERROR - Publishing expiration event failed for enrollment hbx id: #{enrollment_hbx_id}"
         end
+      end
+
+      def handler_logger
+        @handler_logger ||= Logger.new("#{Rails.root}/log/hbx_enrollments_expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
       end
     end
   end

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -12,7 +12,7 @@ module Operations
       end
 
       # @param [Hash] params
-      # @option params [String] :query_criteria
+      # @option params [Hash] :query_criteria
       # @return [Dry::Monads::Result]
       def call(params)
         query_criteria        = yield validate(params)
@@ -25,31 +25,34 @@ module Operations
       private
 
       def validate(params)
-        return Failure('Missing query_criteria') unless params.key?(:query_criteria)
+        return Failure('Missing query_criteria.') unless params.is_a?(Hash) && params[:query_criteria].is_a?(Hash)
 
         Success(params[:query_criteria])
       end
 
       def enrollments_to_expire_query(query_criteria)
         enrollments_to_expire = HbxEnrollment.where(query_criteria)
-        # evaluating the criteria here to ensure the query is valid
-        enrollments_to_expire.count
 
-        Success(enrollments_to_expire)
+        if enrollments_to_expire.present?
+          Success(enrollments_to_expire)
+        else
+          Failure("No enrollments found for query criteria: #{query_criteria}")
+        end
       rescue StandardError => e
         Failure("Error generating enrollments_to_expire query: #{e.message}; with query criteria: #{query_criteria}")
       end
 
       def publish_enrollment_expirations(enrollments_to_expire)
-        enrollments_to_expire.no_timeout.each_with_index do |enrollment, index|
+        enrollments_to_expire.no_timeout.each do |enrollment|
+          # TODO: use global id instead of hbx_id
           enrollment_hbx_id = enrollment.hbx_id
-          event = event("events.individual.enrollments.expire_coverages.expire", attributes: { enrollment_hbx_id: enrollment_hbx_id, index_id: index})
-          publish_event(event)
+          event = event("events.individual.enrollments.expire_coverages.expire", attributes: { enrollment_hbx_id: enrollment_hbx_id })
+          publish_event(event, enrollment_hbx_id)
         end
-        Success("Done publishing enrollment expiration events.  See hbx_enrollments_expiration_handler log for results.")
+        Success("Done publishing enrollment expiration events. See hbx_enrollments_expiration_handler log for results.")
       end
 
-      def publish_event(event)
+      def publish_event(event, enrollment_hbx_id)
         if event.success?
           @logger.info "Publishing expiration event for enrollment hbx id: #{enrollment_hbx_id}"
           event.success.publish

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -43,6 +43,7 @@ module Operations
               event = event("events.individual.enrollments.expire_coverages.expire", attributes: { enrollment_hbx_id: enrollment_hbx_id, index_id: index})
               publish_event(event)
             end
+            Success("Done publishing enrollment expiration events.  See hbx_enrollments_expiration_handler log for results.")
         end
 
         def publish_event(event)

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -32,9 +32,12 @@ module Operations
 
       def enrollments_to_expire_query(query_criteria)
         enrollments_to_expire = HbxEnrollment.where(query_criteria)
+        # evaluating the criteria here to ensure the query is valid
+        enrollments_to_expire.count
+
         Success(enrollments_to_expire)
       rescue StandardError => e
-        Failure("Error generating enrollments_to_expire query: #{e.message}")
+        Failure("Error generating enrollments_to_expire query: #{e.message}; with query criteria: #{query_criteria}")
       end
 
       def publish_enrollment_expirations(enrollments_to_expire)

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Operations
+    module HbxEnrollments
+      # Publish events to expire IVL enrollment coverages
+      class ExpirationHandler
+        include EventSource::Command
+        include Dry::Monads[:result, :do]
+
+        def initialize
+          @logger = Logger.new("#{Rails.root}/log/hbx_enrollments_expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+        end
+
+        # @param [Hash] params
+        # @option params [String] :query_criteria
+        # @return [Dry::Monads::Result]
+        def call(params)
+          query_criteria        = yield validate(params)
+          enrollments_to_expire = yield enrollments_to_expire_query(query_criteria)
+          result                = yield publish_enrollment_expirations(enrollments_to_expire)
+
+          Success(result)
+        end
+  
+        private
+  
+        def validate(params)
+          return Failure('Missing query_criteria') unless params.key?(:query_criteria)
+  
+          Success(params[:query_criteria])
+        end
+  
+        def enrollments_to_expire_query(enrollment_hbx_id)
+          enrollments_to_expire = HbxEnrollment.where(query_criteria)
+          Success(enrollments_to_expire)
+        rescue StandardError => e
+            Failure("Error generating enrollments_to_expire query: #{e.message}")
+        end
+
+        def publish_enrollment_expirations(enrollments_to_expire)
+            enrollments_to_expire.no_timeout.each_with_index do |enrollment, index|
+              enrollment_hbx_id = enrollment.hbx_id
+              event = event("events.individual.enrollments.expire_coverages.expire", attributes: { enrollment_hbx_id: enrollment_hbx_id, index_id: index})
+              publish_event(event)
+            end
+        end
+
+        def publish_event(event)
+            if event.success?
+                @logger.info "Publishing expiration event for enrollment hbx id: #{enrollment_hbx_id}"
+                event.success.publish
+            else
+                @logger.error "ERROR - Publishing expiration event failed for enrollment hbx id: #{enrollment_hbx_id}"
+            end
+        end
+      end
+    end
+  end
+  

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -1,60 +1,59 @@
 # frozen_string_literal: true
 
 module Operations
-    module HbxEnrollments
-      # Publish events to expire IVL enrollment coverages
-      class ExpirationHandler
-        include EventSource::Command
-        include Dry::Monads[:result, :do]
+  module HbxEnrollments
+    # Publish events to expire IVL enrollment coverages
+    class ExpirationHandler
+      include EventSource::Command
+      include Dry::Monads[:result, :do]
 
-        def initialize
-          @logger = Logger.new("#{Rails.root}/log/hbx_enrollments_expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
-        end
+      def initialize
+        @logger = Logger.new("#{Rails.root}/log/hbx_enrollments_expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+      end
 
-        # @param [Hash] params
-        # @option params [String] :query_criteria
-        # @return [Dry::Monads::Result]
-        def call(params)
-          query_criteria        = yield validate(params)
-          enrollments_to_expire = yield enrollments_to_expire_query(query_criteria)
-          result                = yield publish_enrollment_expirations(enrollments_to_expire)
+      # @param [Hash] params
+      # @option params [String] :query_criteria
+      # @return [Dry::Monads::Result]
+      def call(params)
+        query_criteria        = yield validate(params)
+        enrollments_to_expire = yield enrollments_to_expire_query(query_criteria)
+        result                = yield publish_enrollment_expirations(enrollments_to_expire)
 
-          Success(result)
-        end
-  
-        private
-  
-        def validate(params)
-          return Failure('Missing query_criteria') unless params.key?(:query_criteria)
-  
-          Success(params[:query_criteria])
-        end
-  
-        def enrollments_to_expire_query(enrollment_hbx_id)
-          enrollments_to_expire = HbxEnrollment.where(query_criteria)
-          Success(enrollments_to_expire)
-        rescue StandardError => e
-            Failure("Error generating enrollments_to_expire query: #{e.message}")
-        end
+        Success(result)
+      end
 
-        def publish_enrollment_expirations(enrollments_to_expire)
-            enrollments_to_expire.no_timeout.each_with_index do |enrollment, index|
-              enrollment_hbx_id = enrollment.hbx_id
-              event = event("events.individual.enrollments.expire_coverages.expire", attributes: { enrollment_hbx_id: enrollment_hbx_id, index_id: index})
-              publish_event(event)
-            end
-            Success("Done publishing enrollment expiration events.  See hbx_enrollments_expiration_handler log for results.")
-        end
+      private
 
-        def publish_event(event)
-            if event.success?
-                @logger.info "Publishing expiration event for enrollment hbx id: #{enrollment_hbx_id}"
-                event.success.publish
-            else
-                @logger.error "ERROR - Publishing expiration event failed for enrollment hbx id: #{enrollment_hbx_id}"
-            end
+      def validate(params)
+        return Failure('Missing query_criteria') unless params.key?(:query_criteria)
+
+        Success(params[:query_criteria])
+      end
+
+      def enrollments_to_expire_query(query_criteria)
+        enrollments_to_expire = HbxEnrollment.where(query_criteria)
+        Success(enrollments_to_expire)
+      rescue StandardError => e
+        Failure("Error generating enrollments_to_expire query: #{e.message}")
+      end
+
+      def publish_enrollment_expirations(enrollments_to_expire)
+        enrollments_to_expire.no_timeout.each_with_index do |enrollment, index|
+          enrollment_hbx_id = enrollment.hbx_id
+          event = event("events.individual.enrollments.expire_coverages.expire", attributes: { enrollment_hbx_id: enrollment_hbx_id, index_id: index})
+          publish_event(event)
+        end
+        Success("Done publishing enrollment expiration events.  See hbx_enrollments_expiration_handler log for results.")
+      end
+
+      def publish_event(event)
+        if event.success?
+          @logger.info "Publishing expiration event for enrollment hbx id: #{enrollment_hbx_id}"
+          event.success.publish
+        else
+          @logger.error "ERROR - Publishing expiration event failed for enrollment hbx id: #{enrollment_hbx_id}"
         end
       end
     end
   end
-  
+end

--- a/app/domain/operations/hbx_enrollments/expire.rb
+++ b/app/domain/operations/hbx_enrollments/expire.rb
@@ -12,7 +12,6 @@ module Operations
       def call(params)
         enrollment_hbx_id = yield validate(params)
         hbx_enrollment    = yield find_enrollment(enrollment_hbx_id)
-        _valid_expiration = yield validate_expiration(hbx_enrollment)
         result            = yield expire_enrollment(hbx_enrollment)
 
         Success(result)
@@ -22,7 +21,6 @@ module Operations
 
       def validate(params)
         return Failure('Missing enrollment_hbx_id') unless params.key?(:enrollment_hbx_id)
-
         Success(params[:enrollment_hbx_id])
       end
 
@@ -30,22 +28,14 @@ module Operations
         Operations::HbxEnrollments::Find.new.call({hbx_id: enrollment_hbx_id})
       end
 
-      def validate_expiration(enrollment)
-        failures = []
-        failures << "#{enrollment.kind} is not a valid IVL enrollment kind" unless enrollment.market_name == 'Individual'
-        failures << "enrollment does not meet the expiration criteria" unless enrollment.may_expire_coverage?
-        if failures.empty?
-          Success(enrollment)
-        else
-          Failure("Unable to expire enrollment hbx id #{enrollment.hbx_id} - #{failures.join(', ')}")
-        end
-      end
-
       def expire_enrollment(enrollment)
-        result = enrollment.expire_coverage!
-        return Failure("Failed to expire enrollment hbx id #{enrollment.hbx_id}.") unless result
+        return Failure("Failed to expire enrollment hbx id #{enrollment.hbx_id} - #{enrollment.kind} is not a valid IVL enrollment kind") unless enrollment.is_ivl_by_kind?
+
+        enrollment.expire_coverage!
 
         Success("Successfully expired enrollment hbx id #{enrollment.hbx_id}")
+      rescue StandardError => e
+        Failure("Failed to expire enrollment hbx id #{enrollment.hbx_id} - #{e.message}")
       end
     end
   end

--- a/app/event_source/events/individual/enrollments/begin_coverages/begin.rb
+++ b/app/event_source/events/individual/enrollments/begin_coverages/begin.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Events
+    module Individual
+      module Enrollments
+        module BeginCoverages
+        # Registers event for beginning IVL enrollment coverage
+          class Begin < EventSource::Event
+            publisher_path 'publishers.individual.enrollments.begin_coverages_publisher'
+          end
+        end
+      end
+    end
+  end

--- a/app/event_source/events/individual/enrollments/begin_coverages/begin.rb
+++ b/app/event_source/events/individual/enrollments/begin_coverages/begin.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 module Events
-    module Individual
-      module Enrollments
-        module BeginCoverages
-        # Registers event for beginning IVL enrollment coverage
-          class Begin < EventSource::Event
-            publisher_path 'publishers.individual.enrollments.begin_coverages_publisher'
-          end
+  module Individual
+    module Enrollments
+      module BeginCoverages
+      # Registers event for beginning IVL enrollment coverage
+        class Begin < EventSource::Event
+          publisher_path 'publishers.individual.enrollments.begin_coverages_publisher'
         end
       end
     end
   end
+end

--- a/app/event_source/events/individual/enrollments/expire_coverages/expire.rb
+++ b/app/event_source/events/individual/enrollments/expire_coverages/expire.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 module Events
-    module Individual
-      module Enrollments
-        module ExpireCoverages
-        # Registers event for expiring Enrollment
-          class Expire < EventSource::Event
-            publisher_path 'publishers.individual.enrollments.expire_coverages_publisher'
-          end
+  module Individual
+    module Enrollments
+      module ExpireCoverages
+      # Registers event for expiring Enrollment
+        class Expire < EventSource::Event
+          publisher_path 'publishers.individual.enrollments.expire_coverages_publisher'
         end
       end
     end
   end
+end

--- a/app/event_source/events/individual/enrollments/expire_coverages/expire.rb
+++ b/app/event_source/events/individual/enrollments/expire_coverages/expire.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Events
+    module Individual
+      module Enrollments
+        module ExpireCoverages
+        # Registers event for expiring Enrollment
+          class Expire < EventSource::Event
+            publisher_path 'publishers.individual.enrollments.expire_coverages_publisher'
+          end
+        end
+      end
+    end
+  end

--- a/app/event_source/events/individual/enrollments/expire_coverages/request.rb
+++ b/app/event_source/events/individual/enrollments/expire_coverages/request.rb
@@ -4,7 +4,7 @@ module Events
   module Individual
     module Enrollments
       module ExpireCoverages
-      # Registers event for initiating annual IVL enrollment expirations
+      # Registers event for requesting IVL enrollment expirations
         class  Request < EventSource::Event
           publisher_path 'publishers.individual.enrollments.expire_coverages_publisher'
         end

--- a/app/event_source/publishers/individual/enrollments/begin_coverages_publisher.rb
+++ b/app/event_source/publishers/individual/enrollments/begin_coverages_publisher.rb
@@ -8,6 +8,7 @@ module Publishers
         include ::EventSource::Publisher[amqp: 'enroll.individual.enrollments.begin_coverages']
 
         register_event 'request'
+        register_event 'begin'
 
       end
     end

--- a/app/event_source/publishers/individual/enrollments/expire_coverages_publisher.rb
+++ b/app/event_source/publishers/individual/enrollments/expire_coverages_publisher.rb
@@ -8,6 +8,7 @@ module Publishers
         include ::EventSource::Publisher[amqp: 'enroll.individual.enrollments.expire_coverages']
 
         register_event 'request'
+        register_event 'expire'
 
       end
     end

--- a/app/event_source/subscribers/individual/enrollments/begin_coverages_subscriber.rb
+++ b/app/event_source/subscribers/individual/enrollments/begin_coverages_subscriber.rb
@@ -10,20 +10,35 @@ module Subscribers
         subscribe(:on_request) do |delivery_info, _metadata, response|
           @logger = subscriber_logger_for(:on_enroll_individual_enrollments_begin_coverages_request)
           payload = JSON.parse(response, symbolize_names: true)
-          enrollment_hbx_id = payload[:enrollment_hbx_id]
 
-          @logger.info "BeginCoveragesSubscriber, response: #{payload}"
-          @logger.info "------------ Processing enrollment: #{enrollment_hbx_id}, index_id: #{payload[:index_id]} ------------"
+          @logger.info "BeginCoveragesSubscriber on_request, response: #{payload}"
           result = Operations::HbxEnrollments::BeginCoverage.new.call(payload)
-          @logger.info "Processed enrollment: #{enrollment_hbx_id}"
 
           result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
-          @logger.error "BeginCoveragesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-          @logger.error "BeginCoveragesSubscriber, ack: #{payload}"
+          @logger.error "BeginCoveragesSubscriber on_request, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+          @logger.error "BeginCoveragesSubscriber on_request, ack: #{payload}"
           ack(delivery_info.delivery_tag)
         end
+
+        subscribe(:on_begin) do |delivery_info, _metadata, response|
+            @logger = subscriber_logger_for(:on_enroll_individual_enrollments_begin_coverages_request)
+            payload = JSON.parse(response, symbolize_names: true)
+            enrollment_hbx_id = payload[:enrollment_hbx_id]
+  
+            @logger.info "BeginCoveragesSubscriber on_begin, response: #{payload}"
+            @logger.info "------------ Processing enrollment: #{enrollment_hbx_id}, index_id: #{payload[:index_id]} ------------"
+            result = Operations::HbxEnrollments::BeginCoverage.new.call(payload)
+            @logger.info "Processed enrollment: #{enrollment_hbx_id}"
+  
+            result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
+            ack(delivery_info.delivery_tag)
+          rescue StandardError, SystemStackError => e
+            @logger.error "BeginCoveragesSubscriber on_begin, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+            @logger.error "BeginCoveragesSubscriber on_begin, ack: #{payload}"
+            ack(delivery_info.delivery_tag)
+          end
 
         private
 

--- a/app/event_source/subscribers/individual/enrollments/begin_coverages_subscriber.rb
+++ b/app/event_source/subscribers/individual/enrollments/begin_coverages_subscriber.rb
@@ -23,22 +23,22 @@ module Subscribers
         end
 
         subscribe(:on_begin) do |delivery_info, _metadata, response|
-            @logger = subscriber_logger_for(:on_enroll_individual_enrollments_begin_coverages_request)
-            payload = JSON.parse(response, symbolize_names: true)
-            enrollment_hbx_id = payload[:enrollment_hbx_id]
-  
-            @logger.info "BeginCoveragesSubscriber on_begin, response: #{payload}"
-            @logger.info "------------ Processing enrollment: #{enrollment_hbx_id}, index_id: #{payload[:index_id]} ------------"
-            result = Operations::HbxEnrollments::BeginCoverage.new.call(payload)
-            @logger.info "Processed enrollment: #{enrollment_hbx_id}"
-  
-            result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
-            ack(delivery_info.delivery_tag)
-          rescue StandardError, SystemStackError => e
-            @logger.error "BeginCoveragesSubscriber on_begin, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-            @logger.error "BeginCoveragesSubscriber on_begin, ack: #{payload}"
-            ack(delivery_info.delivery_tag)
-          end
+          @logger = subscriber_logger_for(:on_enroll_individual_enrollments_begin_coverages_request)
+          payload = JSON.parse(response, symbolize_names: true)
+          enrollment_hbx_id = payload[:enrollment_hbx_id]
+
+          @logger.info "BeginCoveragesSubscriber on_begin, response: #{payload}"
+          @logger.info "------------ Processing enrollment: #{enrollment_hbx_id}, index_id: #{payload[:index_id]} ------------"
+          result = Operations::HbxEnrollments::BeginCoverage.new.call(payload)
+          @logger.info "Processed enrollment: #{enrollment_hbx_id}"
+
+          result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
+          ack(delivery_info.delivery_tag)
+        rescue StandardError, SystemStackError => e
+          @logger.error "BeginCoveragesSubscriber on_begin, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+          @logger.error "BeginCoveragesSubscriber on_begin, ack: #{payload}"
+          ack(delivery_info.delivery_tag)
+        end
 
         private
 

--- a/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
+++ b/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
@@ -17,8 +17,8 @@ module Subscribers
           result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
-          @logger.error "ExpireCoveragesSubscriber on_request, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-          @logger.error "ExpireCoveragesSubscriber on_request, ack: #{payload}"
+          @logger.error "ExpireCoveragesSubscriber on_request, response: #{response}, error message: #{e.message}, backtrace: #{e.backtrace}"
+          @logger.error "ExpireCoveragesSubscriber on_request, ack: #{response}"
           ack(delivery_info.delivery_tag)
         end
 
@@ -35,8 +35,8 @@ module Subscribers
           result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
-          @logger.error "ExpireCoveragesSubscriber on_expire, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-          @logger.error "ExpireCoveragesSubscriber on_expire, ack: #{payload}"
+          @logger.error "ExpireCoveragesSubscriber on_expire, response: #{response}, error message: #{e.message}, backtrace: #{e.backtrace}"
+          @logger.error "ExpireCoveragesSubscriber on_expire, ack: #{response}"
           ack(delivery_info.delivery_tag)
         end
 

--- a/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
+++ b/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
@@ -9,7 +9,7 @@ module Subscribers
 
         subscribe(:on_request) do |delivery_info, _metadata, response|
           @logger = subscriber_logger_for(:on_enroll_individual_enrollments_expire_coverages_request)
-          payload = JSON.parse(response)
+          payload = JSON.parse(response, symbolize_names: true)
 
           @logger.info "ExpireCoveragesSubscriber on_request, response: #{payload}"
           result = Operations::HbxEnrollments::ExpirationHandler.new.call(payload)
@@ -24,7 +24,7 @@ module Subscribers
 
         subscribe(:on_expire) do |delivery_info, _metadata, response|
           @logger = subscriber_logger_for(:on_enroll_individual_enrollments_expire_coverages_expire)
-          payload = JSON.parse(response)
+          payload = JSON.parse(response, symbolize_names: true)
           enrollment_hbx_id = payload[:enrollment_hbx_id]
 
           @logger.info "ExpireCoveragesSubscriber on_expire, response: #{payload}"

--- a/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
+++ b/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
@@ -9,10 +9,25 @@ module Subscribers
 
         subscribe(:on_request) do |delivery_info, _metadata, response|
           @logger = subscriber_logger_for(:on_enroll_individual_enrollments_expire_coverages_request)
-          payload = JSON.parse(response, symbolize_names: true)
+          payload = JSON.parse(response)
+
+          @logger.info "ExpireCoveragesSubscriber on_request, response: #{payload}"
+          result = Operations::HbxEnrollments::ExpirationHandler.new.call(payload)
+
+          result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
+          ack(delivery_info.delivery_tag)
+        rescue StandardError, SystemStackError => e
+          @logger.error "ExpireCoveragesSubscriber on_request, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+          @logger.error "ExpireCoveragesSubscriber on_request, ack: #{payload}"
+          ack(delivery_info.delivery_tag)
+        end
+
+        subscribe(:on_expire) do |delivery_info, _metadata, response|
+          @logger = subscriber_logger_for(:on_enroll_individual_enrollments_expire_coverages_expire)
+          payload = JSON.parse(response)
           enrollment_hbx_id = payload[:enrollment_hbx_id]
 
-          @logger.info "ExpireCoveragesSubscriber, response: #{payload}"
+          @logger.info "ExpireCoveragesSubscriber on_expire, response: #{payload}"
           @logger.info "------------ Processing enrollment: #{enrollment_hbx_id}, index_id: #{payload[:index_id]} ------------"
           result = Operations::HbxEnrollments::Expire.new.call(payload)
           @logger.info "Processed enrollment: #{enrollment_hbx_id}"
@@ -20,8 +35,8 @@ module Subscribers
           result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
-          @logger.error "ExpireCoveragesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-          @logger.error "ExpireCoveragesSubscriber, ack: #{payload}"
+          @logger.error "ExpireCoveragesSubscriber on_expire, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
+          @logger.error "ExpireCoveragesSubscriber on_expire, ack: #{payload}"
           ack(delivery_info.delivery_tag)
         end
 

--- a/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
+++ b/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
@@ -9,7 +9,7 @@ module Subscribers
 
         subscribe(:on_request) do |delivery_info, _metadata, response|
           @logger = subscriber_logger_for(:on_enroll_individual_enrollments_expire_coverages_request)
-          payload = JSON.parse(response, symbolize_names: true)
+          payload = JSON.parse(response).deep_symbolize_keys
 
           @logger.info "ExpireCoveragesSubscriber on_request, response: #{payload}"
           result = Operations::HbxEnrollments::ExpirationHandler.new.call(payload)

--- a/app/models/services/ivl_enrollment_service.rb
+++ b/app/models/services/ivl_enrollment_service.rb
@@ -47,9 +47,9 @@ module Services
 
     def process_async_expirations_request
       query_criteria = {
-        :effective_on.lt => current_benefit_period.start_on,
-        :kind.in => ["individual", "coverall"],
-        :aasm_state.in => HbxEnrollment::ENROLLED_STATUSES - ["coverage_termination_pending"]
+        "effective_on": { "$lt": current_benefit_period.start_on },
+        "kind": { "$in": ["individual", "coverall"] },
+        "aasm_state": { "$in": HbxEnrollment::ENROLLED_STATUSES - ["coverage_termination_pending"] }
       }
       publish_expirations_request_event(query_criteria)
     end
@@ -98,9 +98,9 @@ module Services
 
     def process_async_begin_coverages_request
       query_criteria = {
-        :effective_on => { "$gte" => current_benefit_period.start_on, "$lt" => current_benefit_period.end_on },
-        :kind.in => ["individual", "coverall"],
-        :aasm_state.in => ["auto_renewing", "renewing_coverage_selected"]
+        "effective_on": { "$gte": current_benefit_period.start_on, "$lt": current_benefit_period.end_on },
+        "kind": { "$in": ["individual", "coverall"] },
+        "aasm_state": { "$in": ["auto_renewing", "renewing_coverage_selected"] }
       }
       publish_begin_coverage_request_event(query_criteria)
     end

--- a/app/models/services/ivl_enrollment_service.rb
+++ b/app/models/services/ivl_enrollment_service.rb
@@ -7,6 +7,7 @@ module Services
 
     def initialize
       @logger = Logger.new("#{Rails.root}/log/family_advance_day_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+      @current_benefit_period = HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period
     end
 
     def process_enrollments(new_date)
@@ -46,9 +47,8 @@ module Services
     end
 
     def process_async_expirations_request
-      current_benefit_period = HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period
       query_criteria = {
-        :effective_on.lt => current_benefit_period.start_on,
+        :effective_on.lt => @current_benefit_period.start_on,
         :kind.in => ["individual", "coverall"],
         :aasm_state.in => HbxEnrollment::ENROLLED_STATUSES - ["coverage_termination_pending"]
       }
@@ -98,9 +98,8 @@ module Services
     end
 
     def process_async_begin_coverages_request
-      current_benefit_period = HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period
       query_criteria = {
-        :effective_on => { "$gte" => current_benefit_period.start_on, "$lt" => current_benefit_period.end_on },
+        :effective_on => { "$gte" => @current_benefit_period.start_on, "$lt" => @current_benefit_period.end_on },
         :kind.in => ["individual", "coverall"],
         :aasm_state.in => ["auto_renewing", "renewing_coverage_selected"]
       }

--- a/spec/domain/operations/hbx_enrollments/begin_coverage_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/begin_coverage_handler_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::Operations::HbxEnrollments::BeginCoverageHandler, dbclean: :after_each do
+
+  let(:family)      { FactoryBot.create(:family, :with_primary_family_member) }
+  let!(:enrollment) { FactoryBot.create(:hbx_enrollment, :individual_unassisted, family: family) }
+
+  describe 'with invalid params' do
+    let(:params) { {} }
+    let(:result) { described_class.new.call(params) }
+
+    context 'missing query criteria' do
+      it 'fails due to missing query criteria' do
+        expect(result.success?).to be_falsey
+        expect(result.failure).to eq('Missing query_criteria')
+      end
+    end
+
+    context 'with invalid query criteria' do
+      let(:params) { { query_criteria: 'bad query' } }
+      let(:result) { described_class.new.call(params) }
+
+      it 'fails due to invalid query' do
+        expect(result.success?).to be_falsey
+        expect(result.failure).to match(/Error generating enrollments_to_begin query/)
+      end
+    end
+  end
+
+  describe 'with valid params' do
+    let(:query_criteria) do
+      {
+        :kind.in => ["individual", "coverall"],
+        :aasm_state.in => ["auto_renewing", "renewing_coverage_selected"]
+      }
+    end
+    let(:params) { { query_criteria: query_criteria } }
+    let(:result) { described_class.new.call(params) }
+
+    it 'succeeds with message' do
+      expect(result.success?).to be_truthy
+      expect(result.value!).to eq("Done publishing begin coverage enrollment events.  See hbx_enrollments_begin_coverage_handler log for results.")
+    end
+  end
+end

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -8,10 +8,20 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
   let!(:enrollment) { FactoryBot.create(:hbx_enrollment, :individual_unassisted, family: family, aasm_state: "auto_renewing") }
 
   describe 'with invalid params' do
-    let(:params) { {} }
     let(:result) { described_class.new.call(params) }
 
+    context 'params is not a hash' do
+      let(:params) { 'bad params' }
+
+      it 'fails due to missing query criteria' do
+        expect(result.success?).to be_falsey
+        expect(result.failure).to eq('Missing query_criteria.')
+      end
+    end
+
     context 'missing query criteria' do
+      let(:params) { {} }
+
       it 'fails due to missing query criteria' do
         expect(result.success?).to be_falsey
         expect(result.failure).to eq('Missing query_criteria.')

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -45,7 +45,14 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
     end
 
     context 'with no enrollments found to expire' do
-        # TODO
+      before do
+        enrollment.update_attributes(aasm_state: "coverage_expired")
+      end
+
+      it 'fails due to no enrollments found' do
+        expect(result.success?).to be_falsey
+        expect(result.failure).to eq("No enrollments found for query criteria: #{query_criteria}")
+      end
     end
   end
 end

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
 
     it 'succeeds with message' do
       expect(result.success?).to be_truthy
-      expect(result.value!).to eq("Done publishing enrollment expiration events.  See hbx_enrollments_expiration_handler log for results.")
+      expect(result.value!).to eq("Done publishing enrollment expiration events. See hbx_enrollments_expiration_handler log for results.")
     end
 
     context 'with no enrollments found to expire' do

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_each do
 
   let(:family)      { FactoryBot.create(:family, :with_primary_family_member) }
-  let!(:enrollment) { FactoryBot.create(:hbx_enrollment, :individual_unassisted, family: family) }
+  let!(:enrollment) { FactoryBot.create(:hbx_enrollment, :individual_unassisted, family: family, aasm_state: "auto_renewing") }
 
   describe 'with invalid params' do
     let(:params) { {} }
@@ -14,7 +14,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
     context 'missing query criteria' do
       it 'fails due to missing query criteria' do
         expect(result.success?).to be_falsey
-        expect(result.failure).to eq('Missing query_criteria')
+        expect(result.failure).to eq('Missing query_criteria.')
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
 
       it 'fails due to invalid query' do
         expect(result.success?).to be_falsey
-        expect(result.failure).to match(/Error generating enrollments_to_expire query/)
+        expect(result.failure).to eq("Missing query_criteria.")
       end
     end
   end
@@ -42,6 +42,10 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
     it 'succeeds with message' do
       expect(result.success?).to be_truthy
       expect(result.value!).to eq("Done publishing enrollment expiration events.  See hbx_enrollments_expiration_handler log for results.")
+    end
+
+    context 'with no enrollments found to expire' do
+        # TODO
     end
   end
 end

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_each do
+
+  let(:family)      { FactoryBot.create(:family, :with_primary_family_member) }
+  let!(:enrollment) { FactoryBot.create(:hbx_enrollment, :individual_unassisted, family: family) }
+
+  describe 'with invalid params' do
+    let(:params) { {} }
+    let(:result) { described_class.new.call(params) }
+
+    it 'fails due to missing enrollment hbx id' do
+      expect(result.success?).to be_falsey
+      expect(result.failure).to eq('Missing query_criteria')
+    end
+  end
+
+  describe 'with invalid query criteria' do
+    let(:params) { { query_criteria: { 'bad query'} } }
+    let(:result) { described_class.new.call(params) }
+
+    it 'fails due to invalid enrollment kind' do
+      expect(result.success?).to be_falsey
+      expect(result.failure).to eq(/Error generating enrollments_to_expire query/)
+    end
+  end
+
+  describe 'with valid params' do
+    let(:params) { { query_criteria: enrollment.hbx_id } }
+    let(:result) { described_class.new.call(params) }
+
+    it 'succeeds with message' do
+      expect(result.success?).to be_truthy
+      expect(result.value!).to eq("Done publishing enrollment expiration events.  See hbx_enrollments_expiration_handler log for results.")
+    end
+  end
+end

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -11,24 +11,32 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
     let(:params) { {} }
     let(:result) { described_class.new.call(params) }
 
-    it 'fails due to missing enrollment hbx id' do
-      expect(result.success?).to be_falsey
-      expect(result.failure).to eq('Missing query_criteria')
+    context 'missing query criteria' do
+      it 'fails due to missing query criteria' do
+        expect(result.success?).to be_falsey
+        expect(result.failure).to eq('Missing query_criteria')
+      end
     end
-  end
 
-  describe 'with invalid query criteria' do
-    let(:params) { { query_criteria: { 'bad query'} } }
-    let(:result) { described_class.new.call(params) }
+    context 'with invalid query criteria' do
+      let(:params) { { query_criteria: { 'bad' => 'query'} } }
+      let(:result) { described_class.new.call(params) }
 
-    it 'fails due to invalid enrollment kind' do
-      expect(result.success?).to be_falsey
-      expect(result.failure).to eq(/Error generating enrollments_to_expire query/)
+      it 'fails due to invalid enrollment kind' do
+        expect(result.success?).to be_falsey
+        expect(result.failure).to eq(/Error generating enrollments_to_expire query/)
+      end
     end
   end
 
   describe 'with valid params' do
-    let(:params) { { query_criteria: enrollment.hbx_id } }
+    let(:query_criteria) do
+      {
+        :kind.in => ["individual", "coverall"],
+        :aasm_state.in => ["auto_renewing", "renewing_coverage_selected"]
+      }
+    end
+    let(:params) { { query_criteria: {} } }
     let(:result) { described_class.new.call(params) }
 
     it 'succeeds with message' do

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
     end
 
     context 'with invalid query criteria' do
-      let(:params) { { query_criteria: { 'bad' => 'query'} } }
+      let(:params) { { query_criteria: 'bad query' } }
       let(:result) { described_class.new.call(params) }
 
-      it 'fails due to invalid enrollment kind' do
+      it 'fails due to invalid query' do
         expect(result.success?).to be_falsey
-        expect(result.failure).to eq(/Error generating enrollments_to_expire query/)
+        expect(result.failure).to match(/Error generating enrollments_to_expire query/)
       end
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
         :aasm_state.in => ["auto_renewing", "renewing_coverage_selected"]
       }
     end
-    let(:params) { { query_criteria: {} } }
+    let(:params) { { query_criteria: query_criteria } }
     let(:result) { described_class.new.call(params) }
 
     it 'succeeds with message' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186637879

# A brief description of the changes

Current behavior:
Async expiration events are published in the same thread that is processing other operations triggered by the system date change.

New behavior:
A single event is published on system date change that initiates the batch publishing of expiration events for discrete enrollment expiration events.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: ASYNC_EXPIRE_AND_BEGIN_COVERAGES_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
This PR includes an update to the aca_entities ref in Gemfile.lock because the new events/publishers added here cannot be decoupled from the version of aca_entities that includes the new async api config.  Otherwise the build will break.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.