### PR TITLE
add hidden tooltip to meet aa standards

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -1426,14 +1426,14 @@ a.close-1, a.close-2{
     &.form-action {
       margin: 8px 0 20px;
       display: inline-block;
-      color: <%= EnrollRegistry[:qle_carousel].settings(:color).item %>;
+      color: var(--theme-primary-100, #007bc4);
       font-size: 14px;
       font-weight: bold;
       border-radius: 4px;
       border: solid 1px #b2b2b2;
       background-color: transparent;
       &:hover {
-        border: solid 1px <%= EnrollRegistry[:qle_carousel].settings(:color).item %>;
+        border: solid 1px var(--theme-primary-100, #007bc4);
         background-color: #ffffff;
       }
     }

--- a/app/views/insured/consumer_roles/ridp_agreement.html.erb
+++ b/app/views/insured/consumer_roles/ridp_agreement.html.erb
@@ -17,13 +17,13 @@
       <div class="row row-form-wrapper no-buffer" style="border-top: solid 1px #b7b7b7;">
         <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'agreement_agree')" class="col-lg-2 radio skinned-form-controls skinned-form-controls-mac">
           <%= radio_button_tag :agreement, "agree", true, class: "required floatlabel"  %>
-          <label for="agreement_agree"><span style="white-space: nowrap;">l10n('faa.i_agree')</span></label>
+          <label for="agreement_agree"><span style="white-space: nowrap;"><%= l10n('faa.i_agree') %></span></label>
         </div>
       </div>
       <div class="row row-form-wrapper no-buffer">
         <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'agreement_disagree')" class="col-lg-10 radio skinned-form-controls skinned-form-controls-mac">
           <%= radio_button_tag :agreement, "disagree", false, class: "required floatlabel"  %>
-          <label for="agreement_disagree"><span style="white-space: nowrap;">l10n('faa.i_disagree')</span></label>
+          <label for="agreement_disagree"><span style="white-space: nowrap;"><%= l10n('faa.i_disagree') %></span></label>
         </div>
       </div>
       <br />

--- a/app/views/insured/families/_help_signup.html.erb
+++ b/app/views/insured/families/_help_signup.html.erb
@@ -9,7 +9,7 @@
           <%= l10n("insured.families.click_help_me_sign_up") %>
         </small>
         <br/>
-        <span class="btn btn-default btn-block" data-target="#help_with_plan_shopping" data-toggle="modal">
+        <span id="help_me_sign_up" tabindex="0" onkeydown="handleButtonKeyDown(event, 'help_me_sign_up')" class="btn btn-default btn-block" data-target="#help_with_plan_shopping" data-toggle="modal">
           <%= l10n("help_me_sign_up") %>          
         </span>
         <br/>

--- a/app/views/shared/_shopping_nav_panel.html.haml
+++ b/app/views/shared/_shopping_nav_panel.html.haml
@@ -22,7 +22,7 @@
           = l10n("previous_step")
     - if show_help_button && back_to_account_flag
       %li
-        %a{"data-target" => "#help_with_plan_shopping", "data-toggle" => "modal", style: link_style}
+        %a{"data-target" => "#help_with_plan_shopping", "data-toggle" => "modal", style: link_style, id: "help_me_sign_up", tabindex: "0", onkeydown: "handleButtonKeyDown(event, 'help_me_sign_up')"}
           = l10n("help_sign_up")
     - if show_exit_button
       %li

--- a/app/views/shared/person/_personal_information.html.erb
+++ b/app/views/shared/person/_personal_information.html.erb
@@ -40,7 +40,10 @@
     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 form-group form-group-lg no-pd top-buffer" >
       <%= f.check_box :no_ssn,  :value => false, :onclick=>"$('#person_ssn').prop('disabled', !$('#person_ssn').prop('disabled')); $('#person_ssn').prop('required', !$('#person_ssn').prop('required'))" %>
       <label for="person_no_ssn"><span class='no_ssn'>&nbsp;<%= l10n("do_not_have_ssn") %></span></label>
-      <span><i tabindex="0" class='fa fa-question-circle' id="no_ssn_tooltip" data-toggle="tooltip" title="<%=l10n("insured.consumer_roles.search.no_ssn_tooltip")%>"></i></span>
+      <span>
+        <i tabindex="0" class='fa fa-question-circle' id="no_ssn_tooltip" data-toggle="tooltip" title="<%=l10n("insured.consumer_roles.search.no_ssn_tooltip")%>"></i>
+        <span class="hide"> "<%=l10n("insured.consumer_roles.search.no_ssn_tooltip")%>"</span>
+      </span>    
     </div>
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6 form-group form-group-lg no-pd border_bottom_zero">
       <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_male')" class="radio">
@@ -56,6 +59,7 @@
     </div>
     <span>
       <i tabindex="0" id="gender-tooltip" class='fa fa-question-circle no-pd pull-right'  data-toggle="tooltip" title="<%=l10n("insured.consumer_roles.search.gender_tooltip")%>"></i>
+      <span class="hide"> "<%=l10n("insured.consumer_roles.search.gender_tooltip")%>"</span>
     </span>
   </div>
 </div>

--- a/app/views/shared/person/_personal_information.html.erb
+++ b/app/views/shared/person/_personal_information.html.erb
@@ -48,13 +48,13 @@
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6 form-group form-group-lg no-pd border_bottom_zero">
       <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_male')" class="radio">
         <%= f.radio_button :gender, "male", class: "required floatlabel", id: 'radio_male', required: true %>
-        <label for="radio_male"><span><%=l10n("male").to_s.upcase%></span></label>
+        <label for="radio_male"><span><%= l10n("male").to_s.upcase %></span></label>
       </div>
     </div>
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6 form-group form-group-lg no-pd">
       <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_female')" class="radio">
         <%= f.radio_button :gender, "female", class: "required floatlabel", id: 'radio_female', required: true %>
-        <label class="female" for="radio_female"><span>l10n("female").to_s.upcase</span></label>
+        <label class="female" for="radio_female"><span><%= l10n("female").to_s.upcase %></span></label>
       </div>
     </div>
     <span>

--- a/components/ui_helpers/app/views/workflow/step.html.erb
+++ b/components/ui_helpers/app/views/workflow/step.html.erb
@@ -92,7 +92,7 @@
         </ul>
       </p>
 
-      <div class="btn btn-default btn-block help-me-sign-up" data-target="#help_with_plan_shopping" data-toggle="modal">
+      <div id="help_me_sign_up" tabindex="0" onkeydown="handleButtonKeyDown(event, 'help_me_sign_up')" class="btn btn-default btn-block help-me-sign-up" data-target="#help_with_plan_shopping" data-toggle="modal">
         Help me sign up
       </div>
       <%= render partial: './ui-components/v1/modals/help_with_plan'  %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186426647

# A brief description of the changes

Current behavior: unable to see tooltips without tabbing to hidden tooltip icons

New behavior: You can now see tooltip text without finding hidden tooltip icons

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CR97_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

Cucumber tests will be added via ticket at the end of the workflow (https://www.pivotaltracker.com/story/show/186580246)

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.