### PR TITLE
add async layer to expire coverages process

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 9c2b4ca35fbdd25fad957177c43b2fcdbb0e7e3b
+  revision: cda3c7a47f8994fb85cf32fe9bc89f012aa7d355
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 438f819c1bb682dbaddafad9b8c125bec260da43
+  revision: 9c2b4ca35fbdd25fad957177c43b2fcdbb0e7e3b
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Operations
+  module HbxEnrollments
+    # Publish events to expire IVL enrollment coverages
+    class ExpirationHandler
+      include EventSource::Command
+      include Dry::Monads[:result, :do]
+
+      # @param [Hash] params
+      # @option params [Hash] :query_criteria
+      # @return [Dry::Monads::Result]
+      def call(params)
+        query_criteria        = yield validate(params)
+        enrollments_to_expire = yield enrollments_to_expire_query(query_criteria)
+        result                = yield publish_enrollment_expirations(enrollments_to_expire)
+
+        Success(result)
+      end
+
+      private
+
+      def validate(params)
+        return Failure('Missing query_criteria.') unless params.is_a?(Hash) && params[:query_criteria].is_a?(Hash)
+
+        Success(params[:query_criteria])
+      end
+
+      def enrollments_to_expire_query(query_criteria)
+        enrollments_to_expire = HbxEnrollment.where(query_criteria)
+
+        if enrollments_to_expire.present?
+          Success(enrollments_to_expire)
+        else
+          Failure("No enrollments found for query criteria: #{query_criteria}")
+        end
+      rescue StandardError => e
+        Failure("Error generating enrollments_to_expire query: #{e.message}; with query criteria: #{query_criteria}")
+      end
+
+      def publish_enrollment_expirations(enrollments_to_expire)
+        enrollments_to_expire.no_timeout.each do |enrollment|
+          # TODO: use global id instead of hbx_id
+          enrollment_hbx_id = enrollment.hbx_id
+          event = event("events.individual.enrollments.expire_coverages.expire", attributes: { enrollment_hbx_id: enrollment_hbx_id })
+          publish_event(event, enrollment_hbx_id)
+        end
+        Success("Done publishing enrollment expiration events. See hbx_enrollments_expiration_handler log for results.")
+      end
+
+      def publish_event(event, enrollment_hbx_id)
+        if event.success?
+          handler_logger.info "Publishing expiration event for enrollment hbx id: #{enrollment_hbx_id}"
+          event.success.publish
+        else
+          handler_logger.error "ERROR - Publishing expiration event failed for enrollment hbx id: #{enrollment_hbx_id}"
+        end
+      end
+
+      def handler_logger
+        @handler_logger ||= Logger.new("#{Rails.root}/log/hbx_enrollments_expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+      end
+    end
+  end
+end

--- a/app/domain/operations/hbx_enrollments/expire.rb
+++ b/app/domain/operations/hbx_enrollments/expire.rb
@@ -12,7 +12,6 @@ module Operations
       def call(params)
         enrollment_hbx_id = yield validate(params)
         hbx_enrollment    = yield find_enrollment(enrollment_hbx_id)
-        _valid_expiration = yield validate_expiration(hbx_enrollment)
         result            = yield expire_enrollment(hbx_enrollment)
 
         Success(result)
@@ -22,7 +21,6 @@ module Operations
 
       def validate(params)
         return Failure('Missing enrollment_hbx_id') unless params.key?(:enrollment_hbx_id)
-
         Success(params[:enrollment_hbx_id])
       end
 
@@ -30,22 +28,14 @@ module Operations
         Operations::HbxEnrollments::Find.new.call({hbx_id: enrollment_hbx_id})
       end
 
-      def validate_expiration(enrollment)
-        failures = []
-        failures << "#{enrollment.kind} is not a valid IVL enrollment kind" unless enrollment.market_name == 'Individual'
-        failures << "enrollment does not meet the expiration criteria" unless enrollment.may_expire_coverage?
-        if failures.empty?
-          Success(enrollment)
-        else
-          Failure("Unable to expire enrollment hbx id #{enrollment.hbx_id} - #{failures.join(', ')}")
-        end
-      end
-
       def expire_enrollment(enrollment)
-        result = enrollment.expire_coverage!
-        return Failure("Failed to expire enrollment hbx id #{enrollment.hbx_id}.") unless result
+        return Failure("Failed to expire enrollment hbx id #{enrollment.hbx_id} - #{enrollment.kind} is not a valid IVL enrollment kind") unless enrollment.is_ivl_by_kind?
+
+        enrollment.expire_coverage!
 
         Success("Successfully expired enrollment hbx id #{enrollment.hbx_id}")
+      rescue StandardError => e
+        Failure("Failed to expire enrollment hbx id #{enrollment.hbx_id} - #{e.message}")
       end
     end
   end

--- a/app/event_source/events/individual/enrollments/expire_coverages/expire.rb
+++ b/app/event_source/events/individual/enrollments/expire_coverages/expire.rb
@@ -4,8 +4,8 @@ module Events
   module Individual
     module Enrollments
       module ExpireCoverages
-      # Registers event for requesting IVL enrollment expirations
-        class  Request < EventSource::Event
+      # Registers event for expiring Enrollment
+        class Expire < EventSource::Event
           publisher_path 'publishers.individual.enrollments.expire_coverages_publisher'
         end
       end

--- a/app/event_source/publishers/individual/enrollments/expire_coverages_publisher.rb
+++ b/app/event_source/publishers/individual/enrollments/expire_coverages_publisher.rb
@@ -8,6 +8,7 @@ module Publishers
         include ::EventSource::Publisher[amqp: 'enroll.individual.enrollments.expire_coverages']
 
         register_event 'request'
+        register_event 'expire'
 
       end
     end

--- a/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
+++ b/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
@@ -9,10 +9,25 @@ module Subscribers
 
         subscribe(:on_request) do |delivery_info, _metadata, response|
           @logger = subscriber_logger_for(:on_enroll_individual_enrollments_expire_coverages_request)
+          payload = JSON.parse(response).deep_symbolize_keys
+
+          @logger.info "ExpireCoveragesSubscriber on_request, response: #{payload}"
+          result = Operations::HbxEnrollments::ExpirationHandler.new.call(payload)
+
+          result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
+          ack(delivery_info.delivery_tag)
+        rescue StandardError, SystemStackError => e
+          @logger.error "ExpireCoveragesSubscriber on_request, response: #{response}, error message: #{e.message}, backtrace: #{e.backtrace}"
+          @logger.error "ExpireCoveragesSubscriber on_request, ack: #{response}"
+          ack(delivery_info.delivery_tag)
+        end
+
+        subscribe(:on_expire) do |delivery_info, _metadata, response|
+          @logger = subscriber_logger_for(:on_enroll_individual_enrollments_expire_coverages_expire)
           payload = JSON.parse(response, symbolize_names: true)
           enrollment_hbx_id = payload[:enrollment_hbx_id]
 
-          @logger.info "ExpireCoveragesSubscriber, response: #{payload}"
+          @logger.info "ExpireCoveragesSubscriber on_expire, response: #{payload}"
           @logger.info "------------ Processing enrollment: #{enrollment_hbx_id}, index_id: #{payload[:index_id]} ------------"
           result = Operations::HbxEnrollments::Expire.new.call(payload)
           @logger.info "Processed enrollment: #{enrollment_hbx_id}"
@@ -20,8 +35,8 @@ module Subscribers
           result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
-          @logger.error "ExpireCoveragesSubscriber, payload: #{payload}, error message: #{e.message}, backtrace: #{e.backtrace}"
-          @logger.error "ExpireCoveragesSubscriber, ack: #{payload}"
+          @logger.error "ExpireCoveragesSubscriber on_expire, response: #{response}, error message: #{e.message}, backtrace: #{e.backtrace}"
+          @logger.error "ExpireCoveragesSubscriber on_expire, ack: #{response}"
           ack(delivery_info.delivery_tag)
         end
 

--- a/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
+++ b/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
@@ -28,7 +28,7 @@ module Subscribers
           enrollment_hbx_id = payload[:enrollment_hbx_id]
 
           @logger.info "ExpireCoveragesSubscriber on_expire, response: #{payload}"
-          @logger.info "------------ Processing enrollment: #{enrollment_hbx_id}, index_id: #{payload[:index_id]} ------------"
+          @logger.info "------------ Processing enrollment: #{enrollment_hbx_id} ------------"
           result = Operations::HbxEnrollments::Expire.new.call(payload)
           @logger.info "Processed enrollment: #{enrollment_hbx_id}"
 

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_each do
+
+  let(:family)      { FactoryBot.create(:family, :with_primary_family_member) }
+  let!(:enrollment) { FactoryBot.create(:hbx_enrollment, :individual_unassisted, family: family, aasm_state: "auto_renewing") }
+
+  describe 'with invalid params' do
+    let(:result) { described_class.new.call(params) }
+
+    context 'params is not a hash' do
+      let(:params) { 'bad params' }
+
+      it 'fails due to missing query criteria' do
+        expect(result.success?).to be_falsey
+        expect(result.failure).to eq('Missing query_criteria.')
+      end
+    end
+
+    context 'missing query criteria' do
+      let(:params) { {} }
+
+      it 'fails due to missing query criteria' do
+        expect(result.success?).to be_falsey
+        expect(result.failure).to eq('Missing query_criteria.')
+      end
+    end
+
+    context 'with invalid query criteria' do
+      let(:params) { { query_criteria: 'bad query' } }
+      let(:result) { described_class.new.call(params) }
+
+      it 'fails due to invalid query' do
+        expect(result.success?).to be_falsey
+        expect(result.failure).to eq("Missing query_criteria.")
+      end
+    end
+  end
+
+  describe 'with valid params' do
+    let(:query_criteria) do
+      {
+        :kind.in => ["individual", "coverall"],
+        :aasm_state.in => ["auto_renewing", "renewing_coverage_selected"]
+      }
+    end
+    let(:params) { { query_criteria: query_criteria } }
+    let(:result) { described_class.new.call(params) }
+
+    it 'succeeds with message' do
+      expect(result.success?).to be_truthy
+      expect(result.value!).to eq("Done publishing enrollment expiration events. See hbx_enrollments_expiration_handler log for results.")
+    end
+
+    context 'with no enrollments found to expire' do
+      before do
+        enrollment.update_attributes(aasm_state: "coverage_expired")
+      end
+
+      it 'fails due to no enrollments found' do
+        expect(result.success?).to be_falsey
+        expect(result.failure).to eq("No enrollments found for query criteria: #{query_criteria}")
+      end
+    end
+  end
+end

--- a/spec/domain/operations/hbx_enrollments/expire_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expire_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe ::Operations::HbxEnrollments::Expire, dbclean: :after_each do
     end
   end
 
-  # add example for coverall enrollment
   describe 'with valid params' do
     let(:params) { { enrollment_hbx_id: enrollment.hbx_id } }
     let(:result) { described_class.new.call(params) }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186637879

# A brief description of the changes

Current behavior:
Async expiration events are published in the same thread that is processing other operations triggered by the system date change.

New behavior:
A single event is published on system date change that initiates the batch publishing of expiration events for discrete enrollment expiration events.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: `ASYNC_EXPIRE_AND_BEGIN_COVERAGES_IS_ENABLED`

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

- Line 43 in `app/domain/operations/hbx_enrollments/expiration_handler.rb` contains a comment about refactoring to use global_id.  This work will be picked up by @saikumar9 on [this ticket](https://www.pivotaltracker.com/n/projects/2640059/stories/186580328).

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.