### PR TITLE
setup request transmittable for 1/1 enrollment expirations

### DIFF
--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -7,6 +7,8 @@ module Operations
       include EventSource::Command
       include Dry::Monads[:result, :do]
 
+      attr_reader :job, :logger
+
       # @param [Hash] params
       # @option params [Hash] :query_criteria, :transmittable_identifiers
       # @return [Dry::Monads::Result]
@@ -21,11 +23,11 @@ module Operations
       #   }
       # }
       def call(params)
-        logger                = yield initialize_logger
-        values                = yield validate(logger, params)
-        job                   = yield find_job(values[:transmittable_identifiers][:job_gid], logger)
+        @logger               = yield initialize_logger
+        values                = yield validate(params)
+        @job                  = yield find_job(values[:transmittable_identifiers][:job_gid])
         enrollments_to_expire = yield enrollments_to_expire_query(values[:query_criteria])
-        result                = yield publish_enrollment_expirations(enrollments_to_expire, job, logger)
+        result                = yield publish_enrollment_expirations(enrollments_to_expire)
 
         Success(result)
       end
@@ -40,7 +42,7 @@ module Operations
         )
       end
 
-      def validate(logger, params)
+      def validate(params)
         unless params.is_a?(Hash)
           msg = "Invalid input params: #{params}. Expected a hash."
           logger.error msg
@@ -68,7 +70,7 @@ module Operations
         Success(params)
       end
 
-      def find_job(job_gid, logger)
+      def find_job(job_gid)
         job = GlobalID::Locator.locate(job_gid)
 
         if job.present?
@@ -93,7 +95,7 @@ module Operations
         Failure("Error generating enrollments_to_expire query: #{e.message}; with query criteria: #{query_criteria}")
       end
 
-      def publish_enrollment_expirations(enrollments_to_expire, job, logger)
+      def publish_enrollment_expirations(enrollments_to_expire)
         enrollments_to_expire.no_timeout.each do |enrollment|
           result = ::Operations::HbxEnrollments::PublishExpirationEvent.new.call(
             { enrollment: enrollment, job: job }

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -102,7 +102,7 @@ module Operations
           )
 
           if result.success?
-            logger.info "Successfully published expiration event for enrollment hbx id: #{enrollment.hbx_id}"
+            logger.info result.success
           else
             logger.error "Failed to publish expiration event for enrollment hbx id: #{enrollment.hbx_id}"
           end

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -37,7 +37,7 @@ module Operations
       def initialize_logger
         Success(
           Logger.new(
-            "#{Rails.root}/log/expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+            "#{Rails.root}/log/hbx_enrollments_expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
           )
         )
       end

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -108,6 +108,8 @@ module Operations
           end
         end
 
+        success_msg = 'Done publishing enrollment expiration events. See hbx_enrollments_expiration_handler log for results.'
+        logger.info success_msg
         Success('Done publishing enrollment expiration events. See hbx_enrollments_expiration_handler log for results.')
       end
     end

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -8,22 +8,77 @@ module Operations
       include Dry::Monads[:result, :do]
 
       # @param [Hash] params
-      # @option params [Hash] :query_criteria
+      # @option params [Hash] :query_criteria, :transmittable_identifiers
       # @return [Dry::Monads::Result]
+      # @example params: {
+      #   query_criteria: {
+      #     'aasm_state': { '$in': HbxEnrollment::ENROLLED_STATUSES - ['coverage_termination_pending'] },
+      #     'effective_on': { '$lt': start_on },
+      #     'kind': { '$in': ['individual', 'coverall'] }
+      #   },
+      #   transmittable_identifiers: {
+      #     job_gid: 'gid://enroll/Transmittable::Job/65739e355b4dc03a97f26c3b'
+      #   }
+      # }
       def call(params)
-        query_criteria        = yield validate(params)
-        enrollments_to_expire = yield enrollments_to_expire_query(query_criteria)
-        result                = yield publish_enrollment_expirations(enrollments_to_expire)
+        logger                = yield initialize_logger
+        values                = yield validate(logger, params)
+        job                   = yield find_job(values[:transmittable_identifiers][:job_gid], logger)
+        enrollments_to_expire = yield enrollments_to_expire_query(values[:query_criteria])
+        result                = yield publish_enrollment_expirations(enrollments_to_expire, job, logger)
 
         Success(result)
       end
 
       private
 
-      def validate(params)
-        return Failure('Missing query_criteria.') unless params.is_a?(Hash) && params[:query_criteria].is_a?(Hash)
+      def initialize_logger
+        Success(
+          Logger.new(
+            "#{Rails.root}/log/expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+          )
+        )
+      end
 
-        Success(params[:query_criteria])
+      def validate(logger, params)
+        unless params.is_a?(Hash)
+          msg = "Invalid input params: #{params}. Expected a hash."
+          logger.error msg
+          return Failure(msg)
+        end
+
+        unless params[:query_criteria].is_a?(Hash)
+          msg = "Invalid query_criteria in params: #{params}. Expected a hash."
+          logger.error msg
+          return Failure(msg)
+        end
+
+        unless params[:transmittable_identifiers].is_a?(Hash)
+          msg = "Invalid transmittable_identifiers in params: #{params}. Expected a hash."
+          logger.error msg
+          return Failure(msg)
+        end
+
+        if params[:transmittable_identifiers][:job_gid].blank?
+          msg = "Missing job_gid in transmittable_identifiers of params: #{params}."
+          logger.error msg
+          return Failure(msg)
+        end
+
+        Success(params)
+      end
+
+      def find_job(job_gid, logger)
+        job = GlobalID::Locator.locate(job_gid)
+
+        if job.present?
+          logger.info "Found Transmittable::Job with given id: #{job_gid}"
+          Success(job)
+        else
+          msg = "No Transmittable::Job found with given id: #{job_gid}"
+          logger.error msg
+          Failure(msg)
+        end
       end
 
       def enrollments_to_expire_query(query_criteria)
@@ -38,27 +93,20 @@ module Operations
         Failure("Error generating enrollments_to_expire query: #{e.message}; with query criteria: #{query_criteria}")
       end
 
-      def publish_enrollment_expirations(enrollments_to_expire)
+      def publish_enrollment_expirations(enrollments_to_expire, job, logger)
         enrollments_to_expire.no_timeout.each do |enrollment|
-          # TODO: use global id instead of hbx_id
-          enrollment_hbx_id = enrollment.hbx_id
-          event = event("events.individual.enrollments.expire_coverages.expire", attributes: { enrollment_hbx_id: enrollment_hbx_id })
-          publish_event(event, enrollment_hbx_id)
-        end
-        Success("Done publishing enrollment expiration events. See hbx_enrollments_expiration_handler log for results.")
-      end
+          result = ::Operations::HbxEnrollments::PublishExpirationEvent.new.call(
+            { enrollment: enrollment, job: job }
+          )
 
-      def publish_event(event, enrollment_hbx_id)
-        if event.success?
-          handler_logger.info "Publishing expiration event for enrollment hbx id: #{enrollment_hbx_id}"
-          event.success.publish
-        else
-          handler_logger.error "ERROR - Publishing expiration event failed for enrollment hbx id: #{enrollment_hbx_id}"
+          if result.success?
+            logger.info "Successfully published expiration event for enrollment hbx id: #{enrollment.hbx_id}"
+          else
+            logger.error "Failed to publish expiration event for enrollment hbx id: #{enrollment.hbx_id}"
+          end
         end
-      end
 
-      def handler_logger
-        @handler_logger ||= Logger.new("#{Rails.root}/log/hbx_enrollments_expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+        Success('Done publishing enrollment expiration events. See hbx_enrollments_expiration_handler log for results.')
       end
     end
   end

--- a/app/domain/operations/hbx_enrollments/expiration_handler.rb
+++ b/app/domain/operations/hbx_enrollments/expiration_handler.rb
@@ -89,7 +89,9 @@ module Operations
         if enrollments_to_expire.present?
           Success(enrollments_to_expire)
         else
-          Failure("No enrollments found for query criteria: #{query_criteria}")
+          failure_msg = "No enrollments found for query criteria: #{query_criteria}"
+          logger.error failure_msg
+          Failure(failure_msg)
         end
       rescue StandardError => e
         Failure("Error generating enrollments_to_expire query: #{e.message}; with query criteria: #{query_criteria}")

--- a/app/domain/operations/hbx_enrollments/publish_expiration_event.rb
+++ b/app/domain/operations/hbx_enrollments/publish_expiration_event.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Operations
+  module HbxEnrollments
+    # Publish expiration event for each enrollment
+    class PublishExpirationEvent
+      include EventSource::Command
+      include Dry::Monads[:result, :do]
+
+      # @param [Hash] params
+      # @option params [Hash] :enrollment, :job
+      # @return [Dry::Monads::Result]
+      # @example params: { enrollment: HbxEnrollment.new, job: Transmittable::Job.new }
+      def call(params)
+        values       = yield validate(params)
+        transmission = yield create_transmission(values[:enrollment], values[:job])
+        transaction  = yield create_transaction(values[:enrollment], transmission)
+        event        = yield build_event(values, transmission, transaction)
+        result       = yield publish_event(values[:enrollment], event)
+
+        Success(result)
+      end
+
+      private
+
+      def validate(params)
+        if params.is_a?(Hash) && params[:enrollment].is_a?(::HbxEnrollment) && params[:job].is_a?(::Transmittable::Job)
+          Success(params)
+        else
+          Failure("Invalid input params: #{params}. Expected a hash.")
+        end
+      end
+
+      def create_transmission(enrollment, job)
+        ::Operations::Transmittable::CreateTransmission.new.call(
+          {
+            job: job,
+            key: :hbx_enrollments_expiration_request,
+            title: "Transmission request to expire enrollment with hbx id: #{enrollment.hbx_id}.",
+            description: "Transmission request to expire enrollment with hbx id: #{enrollment.hbx_id}.",
+            publish_on: Date.today,
+            started_at: DateTime.now,
+            event: 'initial',
+            state_key: :initial,
+            transmission_id: enrollment.hbx_id,
+            correlation_id: enrollment.hbx_id,
+          }
+        )
+      end
+
+      def create_transaction(enrollment, transmission)
+        ::Operations::Transmittable::CreateTransaction.new.call(
+          {
+            transmission: transmission,
+            subject: enrollment,
+            key: :hbx_enrollments_expiration_request,
+            title: "Enrollment expiration request transaction for #{enrollment.hbx_id}.",
+            description: "Transaction request to expire enrollment with hbx id: #{enrollment.hbx_id}.",
+            publish_on: Date.today,
+            started_at: DateTime.now,
+            event: 'initial',
+            state_key: :initial,
+          }
+        )
+      end
+
+      def build_event(values, transmission, transaction)
+        event(
+          'events.individual.enrollments.expire_coverages.expire',
+          attributes: {
+            enrollment_gid: values[:enrollment].to_global_id.uri,
+            transmittable_identifiers: {
+              job_gid: values[:job].to_global_id.uri,
+              transmission_gid: transmission.to_global_id.uri,
+              transaction_gid: transaction.to_global_id.uri,
+              subject_gid: values[:enrollment].to_global_id.uri
+            }
+          }
+        )
+      end
+
+      def publish_event(enrollment, event)
+        event.publish
+        Success("Published expiration event: #{event.name} for enrollment with gid: #{enrollment.to_global_id.uri}.")
+      end
+    end
+  end
+end

--- a/app/domain/operations/hbx_enrollments/publish_expiration_event.rb
+++ b/app/domain/operations/hbx_enrollments/publish_expiration_event.rb
@@ -17,9 +17,9 @@ module Operations
       def call(params)
         values              = yield validate(params)
         transmission_params = yield construct_transmission_params(values[:enrollment], values[:job])
-        @transmission       = yield create_transmission(transmission_params, values[:job])
+        @transmission       = yield create_request_transmission(transmission_params, values[:job])
         transaction_params  = yield construct_transaction_params(values[:enrollment])
-        @transaction        = yield create_transaction(transaction_params, values[:job])
+        @transaction        = yield create_request_transaction(transaction_params, values[:job])
         event               = yield build_event(values)
         result              = yield publish_event(values[:enrollment], event)
 

--- a/app/domain/operations/hbx_enrollments/publish_expiration_event.rb
+++ b/app/domain/operations/hbx_enrollments/publish_expiration_event.rb
@@ -74,6 +74,7 @@ module Operations
           'events.individual.enrollments.expire_coverages.expire',
           attributes: {
             enrollment_gid: values[:enrollment].to_global_id.uri,
+            enrollment_hbx_id: values[:enrollment].hbx_id,
             transmittable_identifiers: {
               job_gid: values[:job].to_global_id.uri,
               transmission_gid: transmission.to_global_id.uri,

--- a/app/domain/operations/hbx_enrollments/publish_expiration_event.rb
+++ b/app/domain/operations/hbx_enrollments/publish_expiration_event.rb
@@ -43,7 +43,7 @@ module Operations
             event: 'initial',
             state_key: :initial,
             transmission_id: enrollment.hbx_id,
-            correlation_id: enrollment.hbx_id,
+            correlation_id: enrollment.hbx_id
           }
         )
       end
@@ -59,7 +59,7 @@ module Operations
             publish_on: Date.today,
             started_at: DateTime.now,
             event: 'initial',
-            state_key: :initial,
+            state_key: :initial
           }
         )
       end

--- a/app/domain/operations/hbx_enrollments/request_expirations.rb
+++ b/app/domain/operations/hbx_enrollments/request_expirations.rb
@@ -7,15 +7,18 @@ module Operations
       include EventSource::Command
       include Dry::Monads[:result, :do]
 
+      attr_reader :job, :logger
+
       # @param [Hash] opts The options to request expiration all active IVL enrollments for the previous years
       # @option opts [Hash] :params
       # @return [Dry::Monads::Result]
       def call(_params)
-        logger         = yield initialize_logger
-        job            = yield create_job
-        query_criteria = yield fetch_query_critiria
-        event          = yield build_event(query_criteria, job)
-        result         = yield publish(event, logger)
+        @logger        = yield initialize_logger
+        bcp_start_on   = yield fetch_bcp_start_on
+        @job           = yield create_job(bcp_start_on)
+        query_criteria = yield fetch_query_critiria(bcp_start_on)
+        event          = yield build_event(query_criteria)
+        result         = yield publish(event)
 
         Success(result)
       end
@@ -30,16 +33,22 @@ module Operations
         )
       end
 
-      def start_on
-        @start_on ||= HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period.start_on
+      def fetch_bcp_start_on
+        start_on = HbxProfile.current_hbx&.benefit_sponsorship&.current_benefit_coverage_period&.start_on
+
+        if start_on.present?
+          Success(start_on)
+        else
+          Failure('Unable to find the start_on date for current benefit coverage period.')
+        end
       end
 
-      def create_job
+      def create_job(bcp_start_on)
         ::Operations::Transmittable::CreateJob.new.call(
           {
             key: :hbx_enrollments_expiration,
-            title: "Request expiration of all active IVL enrollments before #{start_on}.",
-            description: "Job that requests expiration of all active IVL enrollments before #{start_on}.",
+            title: "Request expiration of all active IVL enrollments before #{bcp_start_on}.",
+            description: "Job that requests expiration of all active IVL enrollments before #{bcp_start_on}.",
             publish_on: DateTime.now,
             started_at: DateTime.now
           }
@@ -48,17 +57,17 @@ module Operations
 
       # TODO: Remove hard coded aaasm_state and kind values.
       #       Define constants for them in HbxEnrollment class and use them.
-      def fetch_query_critiria
+      def fetch_query_critiria(bcp_start_on)
         Success(
           {
             'aasm_state': { '$in': HbxEnrollment::ENROLLED_STATUSES - ['coverage_termination_pending'] },
-            'effective_on': { '$lt': start_on },
+            'effective_on': { '$lt': bcp_start_on },
             'kind': { '$in': ['individual', 'coverall'] }
           }
         )
       end
 
-      def build_event(query_criteria, job)
+      def build_event(query_criteria)
         event(
           'events.individual.enrollments.expire_coverages.request',
           attributes: {
@@ -68,7 +77,7 @@ module Operations
         )
       end
 
-      def publish(event, logger)
+      def publish(event)
         event.publish
         msg = "Successfully published event: #{event.name} to request expiration of all active IVL enrollments effective before #{start_on}."
         logger.info(msg)

--- a/app/domain/operations/hbx_enrollments/request_expirations.rb
+++ b/app/domain/operations/hbx_enrollments/request_expirations.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Operations
+  module HbxEnrollments
+    # Publish event to request expiration of all active IVL enrollments for the previous years
+    class RequestExpirations
+      include EventSource::Command
+      include Dry::Monads[:result, :do]
+
+      # @param [Hash] opts The options to request expiration all active IVL enrollments for the previous years
+      # @option opts [Hash] :params
+      # @return [Dry::Monads::Result]
+      def call(params)
+        logger         = yield initialize_logger
+        job            = yield create_job
+        query_criteria = yield fetch_query_critiria
+        event          = yield build_event(fetch_query_critiria, job)
+        result         = yield publish(event, logger)
+
+        Success(result)
+      end
+
+      private
+
+      def initialize_logger
+        Success(
+          Logger.new(
+            "#{Rails.root}/log/request_expirations_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+          )
+        )
+      end
+
+      def start_on
+        @start_on ||= HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period.start_on
+      end
+
+      def create_job
+        ::Operations::Transmittable::CreateJob.new.call(
+          {
+            key: :hbx_enrollments_expiration,
+            title: "Request expiration of all active IVL enrollments before #{start_on}.",
+            description: "Job that requests expiration of all active IVL enrollments before #{start_on}.",
+            publish_on: DateTime.now,
+            started_at: DateTime.now,
+          }
+        )
+      end
+
+      # TODO: Remove hard coded aaasm_state and kind values.
+      #       Define constants for them in HbxEnrollment class and use them.
+      def fetch_query_critiria
+        Success(
+          {
+            'aasm_state': { '$in': HbxEnrollment::ENROLLED_STATUSES - ['coverage_termination_pending'] },
+            'effective_on': { '$lt': start_on },
+            'kind': { '$in': ['individual', 'coverall'] }
+          }
+        )
+      end
+
+      def build_event(query_criteria, job)
+        event(
+          'events.individual.enrollments.expire_coverages.request',
+          attributes: {
+            query_criteria: query_criteria,
+            transmittable_identifiers: { job_gid: job.to_global_id.uri }
+          }
+        )
+      end
+
+      def publish(event, logger)
+        event.publish
+        msg = "Successfully published event: #{event.name} to request expiration of all active IVL enrollments effective before #{start_on}."
+        logger.info(msg)
+        Success(msg)
+      end
+    end
+  end
+end

--- a/app/domain/operations/hbx_enrollments/request_expirations.rb
+++ b/app/domain/operations/hbx_enrollments/request_expirations.rb
@@ -10,11 +10,11 @@ module Operations
       # @param [Hash] opts The options to request expiration all active IVL enrollments for the previous years
       # @option opts [Hash] :params
       # @return [Dry::Monads::Result]
-      def call(params)
+      def call(_params)
         logger         = yield initialize_logger
         job            = yield create_job
         query_criteria = yield fetch_query_critiria
-        event          = yield build_event(fetch_query_critiria, job)
+        event          = yield build_event(query_criteria, job)
         result         = yield publish(event, logger)
 
         Success(result)
@@ -41,7 +41,7 @@ module Operations
             title: "Request expiration of all active IVL enrollments before #{start_on}.",
             description: "Job that requests expiration of all active IVL enrollments before #{start_on}.",
             publish_on: DateTime.now,
-            started_at: DateTime.now,
+            started_at: DateTime.now
           }
         )
       end

--- a/app/domain/operations/hbx_enrollments/request_expirations.rb
+++ b/app/domain/operations/hbx_enrollments/request_expirations.rb
@@ -18,7 +18,7 @@ module Operations
         @job           = yield create_job(bcp_start_on)
         query_criteria = yield fetch_query_critiria(bcp_start_on)
         event          = yield build_event(query_criteria)
-        result         = yield publish(event)
+        result         = yield publish(bcp_start_on, event)
 
         Success(result)
       end
@@ -77,9 +77,9 @@ module Operations
         )
       end
 
-      def publish(event)
+      def publish(bcp_start_on, event)
         event.publish
-        msg = "Successfully published event: #{event.name} to request expiration of all active IVL enrollments effective before #{start_on}."
+        msg = "Successfully published event: #{event.name} to request expiration of all active IVL enrollments effective before #{bcp_start_on}."
         logger.info(msg)
         Success(msg)
       end

--- a/app/domain/operations/hbx_enrollments/request_expirations.rb
+++ b/app/domain/operations/hbx_enrollments/request_expirations.rb
@@ -57,7 +57,7 @@ module Operations
         )
       end
 
-      # TODO: Remove hard coded aaasm_state and kind values.
+      # TODO: Remove hard coded aasm_state and kind values.
       #       Define constants for them in HbxEnrollment class and use them.
       def fetch_query_critiria(bcp_start_on)
         Success(

--- a/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
+++ b/app/event_source/subscribers/individual/enrollments/expire_coverages_subscriber.rb
@@ -10,10 +10,8 @@ module Subscribers
         subscribe(:on_request) do |delivery_info, _metadata, response|
           @logger = subscriber_logger_for(:on_enroll_individual_enrollments_expire_coverages_request)
           payload = JSON.parse(response).deep_symbolize_keys
-
           @logger.info "ExpireCoveragesSubscriber on_request, response: #{payload}"
-          result = Operations::HbxEnrollments::ExpirationHandler.new.call(payload)
-
+          result = ::Operations::HbxEnrollments::ExpirationHandler.new.call(payload)
           result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
@@ -26,12 +24,10 @@ module Subscribers
           @logger = subscriber_logger_for(:on_enroll_individual_enrollments_expire_coverages_expire)
           payload = JSON.parse(response, symbolize_names: true)
           enrollment_hbx_id = payload[:enrollment_hbx_id]
-
           @logger.info "ExpireCoveragesSubscriber on_expire, response: #{payload}"
           @logger.info "------------ Processing enrollment: #{enrollment_hbx_id} ------------"
           result = Operations::HbxEnrollments::Expire.new.call(payload)
           @logger.info "Processed enrollment: #{enrollment_hbx_id}"
-
           result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e

--- a/app/models/concerns/domain/operations/transmittable_concern.rb
+++ b/app/models/concerns/domain/operations/transmittable_concern.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Domain
+  module Operations
+    # This concern is designed for code reuse within domain operations(class that include Dry::Monads[:result, :do]).
+    # It provides a set of generic methods or steps specifically tailored for Transmittable 2.0 functionality.
+    # The methods within this concern are focused on the creation of Job, Transmission, Transaction, Error, and ProcessStatus objects, offering a modular and reusable solution for related operations within the domain.
+    module TransmittableConcern
+      extend ActiveSupport::Concern
+
+      included do
+        def add_errors(error_key, message, transmittable_objects)
+          ::Operations::Transmittable::AddError.new.call(
+            {
+              key: error_key,
+              message: message,
+              transmittable_objects: transmittable_objects
+            }
+          )
+        end
+
+        def create_job(job_params)
+          ::Operations::Transmittable::CreateJob.new.call(job_params)
+        end
+
+        def create_transaction(transaction_params, job)
+          result = ::Operations::Transmittable::CreateTransaction.new.call(transaction_params)
+          return result if result.success?
+
+          add_errors(
+            :create_request_transaction,
+            "Failed to create transaction due to #{result.failure}",
+            { job: job, transmission: transmission }
+          )
+          status_result = update_status(result.failure, :failed, { job: job, transmission: transmission })
+          status_result.failure? ? status_result : result
+        end
+
+        def create_transmission(transmission_params, job)
+          result = ::Operations::Transmittable::CreateTransmission.new.call(transmission_params)
+          return result if result.success?
+
+          add_errors(
+            :create_request_transmission,
+            "Failed to create transmission due to #{result.failure}",
+            { job: job }
+          )
+          status_result = update_status(result.failure, :failed, { job: job })
+          status_result.failure? ? status_result : result
+        end
+
+        def update_status(message, state, transmittable_objects)
+          ::Operations::Transmittable::UpdateProcessStatus.new.call(
+            {
+              message: message,
+              state: state,
+              transmittable_objects: transmittable_objects
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/domain/operations/transmittable_concern.rb
+++ b/app/models/concerns/domain/operations/transmittable_concern.rb
@@ -9,6 +9,12 @@ module Domain
       extend ActiveSupport::Concern
 
       included do
+        # @param [Hash] opts The options to add errors
+        # @option opts [Symbol, String, Hash]
+        #   :error_key The key to identify the transmittable object
+        #   :message The error message
+        #   :transmittable_objects The transmittable objects to add errors to
+        # @return [Dry::Monads::Result]
         def add_errors(error_key, message, transmittable_objects)
           ::Operations::Transmittable::AddError.new.call(
             {
@@ -19,11 +25,19 @@ module Domain
           )
         end
 
+        # @param [Hash] opts The options to create a transmittable job
+        # @option opts [Hash] :job_params The params to create a job
+        # @return [Dry::Monads::Result]
         def create_job(job_params)
           ::Operations::Transmittable::CreateJob.new.call(job_params)
         end
 
-        def create_transaction(transaction_params, job)
+        # @param [Hash] opts The options to create a request transmittable transaction
+        # @option opts [Hash, Transmittable::Job]
+        #   :transaction_params The params to create a transaction
+        #   :job The job to create a transaction for
+        # @return [Dry::Monads::Result]
+        def create_request_transaction(transaction_params, job)
           result = ::Operations::Transmittable::CreateTransaction.new.call(transaction_params)
           return result if result.success?
 
@@ -36,7 +50,12 @@ module Domain
           status_result.failure? ? status_result : result
         end
 
-        def create_transmission(transmission_params, job)
+        # @param [Hash] opts The options to create a request transmittable transmission
+        # @option opts [Hash, Transmittable::Job]
+        #   :transmission_params The params to create a transmission
+        #   :job The job to create a transmission for
+        # @return [Dry::Monads::Result]
+        def create_request_transmission(transmission_params, job)
           result = ::Operations::Transmittable::CreateTransmission.new.call(transmission_params)
           return result if result.success?
 
@@ -49,6 +68,12 @@ module Domain
           status_result.failure? ? status_result : result
         end
 
+        # @param [Hash] opts The options to update the transmittable process status
+        # @option opts [String, Symbol, Hash]
+        #   :message The message to update the process status with
+        #   :state The state to update the process status with
+        #   :transmittable_objects The transmittable objects to update the process status for
+        # @return [Dry::Monads::Result]
         def update_status(message, state, transmittable_objects)
           ::Operations::Transmittable::UpdateProcessStatus.new.call(
             {

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -1075,9 +1075,7 @@ class Family
     end
 
     def expire_individual_market_enrollments
-      initialize_ivl_enrollment_service.expire_individual_market_enrollments(
-        HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period
-      )
+      initialize_ivl_enrollment_service.expire_individual_market_enrollments
     end
 
     def begin_coverage_for_ivl_enrollments

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -1075,7 +1075,9 @@ class Family
     end
 
     def expire_individual_market_enrollments
-      initialize_ivl_enrollment_service.expire_individual_market_enrollments
+      initialize_ivl_enrollment_service.expire_individual_market_enrollments(
+        HbxProfile.current_hbx.benefit_sponsorship.current_benefit_coverage_period
+      )
     end
 
     def begin_coverage_for_ivl_enrollments

--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -19,6 +19,8 @@ class HbxEnrollment
 
   include FloatHelper
 
+  include Transmittable::Subject
+
   belongs_to :household
   # Override attribute accessor as well
   # Migrate all the family ids to that

--- a/app/models/services/ivl_enrollment_service.rb
+++ b/app/models/services/ivl_enrollment_service.rb
@@ -10,17 +10,17 @@ module Services
     end
 
     def process_enrollments(new_date)
-      expire_individual_market_enrollments(new_date)
+      expire_individual_market_enrollments
       begin_coverage_for_ivl_enrollments if new_date == new_date.beginning_of_year
       # Deprecate following methods when DC moved to new eligibilities model
       send_enr_or_dr_notice_to_ivl(new_date)
       send_reminder_notices_for_ivl(new_date)
     end
 
-    def expire_individual_market_enrollments(new_date)
+    def expire_individual_market_enrollments
       @logger.info "Started expire_individual_market_enrollments process at #{TimeKeeper.datetime_of_record}"
       if EnrollRegistry.feature_enabled?(:async_expire_and_begin_coverages)
-        process_async_expirations_request(new_date)
+        process_async_expirations_request
       else
         batch_size = 500
         offset = 0
@@ -44,12 +44,7 @@ module Services
       @logger.info "Ended expire_individual_market_enrollments process at #{TimeKeeper.datetime_of_record}"
     end
 
-    def process_async_expirations_request(new_date)
-      if new_date != new_date.beginning_of_year
-        @logger.info "Skipping expire coverages request for #{new_date} as it is not the beginning of the year."
-        return
-      end
-
+    def process_async_expirations_request
       @logger.info "Started process_async_expirations_request process at #{Time.now.strftime('%H:%M:%S.%L')}"
       result = ::Operations::HbxEnrollments::RequestExpirations.new.call({})
       if result.success?

--- a/app/models/transmittable/job.rb
+++ b/app/models/transmittable/job.rb
@@ -6,6 +6,11 @@ module Transmittable
     include Mongoid::Document
     include Mongoid::Timestamps
 
+    # A Global ID is an app wide URI that uniquely identifies a model instance:
+    #   gid://YourApp/Some::Model/id
+    #   Example: 'gid://enroll/Transmittable::Job/65739e355b4dc03a97f26c3b'
+    include GlobalID::Identification
+
     has_many :transmissions, class_name: 'Transmittable::Transmission'
     has_one :process_status, as: :statusable, class_name: 'Transmittable::ProcessStatus'
     accepts_nested_attributes_for :process_status

--- a/app/models/transmittable/transaction.rb
+++ b/app/models/transmittable/transaction.rb
@@ -36,5 +36,11 @@ module Transmittable
 
       transmittable_errors&.map {|error| "#{error.key}: #{error.message}"}&.join(";")
     end
+
+    def transmissions
+      ::Transmittable::Transmission.where(
+        :id.in => transactions_transmissions.pluck(:transmission_id)
+      )
+    end
   end
 end

--- a/app/models/transmittable/transaction.rb
+++ b/app/models/transmittable/transaction.rb
@@ -6,6 +6,8 @@ module Transmittable
     include Mongoid::Document
     include Mongoid::Timestamps
 
+    include GlobalID::Identification
+
     belongs_to :transactable, polymorphic: true, index: true
     has_many :transactions_transmissions, class_name: 'Transmittable::TransactionsTransmissions'
     has_one :process_status, as: :statusable, class_name: 'Transmittable::ProcessStatus'

--- a/app/models/transmittable/transmission.rb
+++ b/app/models/transmittable/transmission.rb
@@ -8,7 +8,7 @@ module Transmittable
 
     include GlobalID::Identification
 
-    belongs_to :job, class_name: 'Transmittable::Job', optional: true
+    belongs_to :job, class_name: 'Transmittable::Job', optional: true, index: true
     has_many :transactions_transmissions, class_name: 'Transmittable::TransactionsTransmissions'
     has_one :process_status, as: :statusable, class_name: 'Transmittable::ProcessStatus'
     accepts_nested_attributes_for :process_status

--- a/app/models/transmittable/transmission.rb
+++ b/app/models/transmittable/transmission.rb
@@ -6,6 +6,8 @@ module Transmittable
     include Mongoid::Document
     include Mongoid::Timestamps
 
+    include GlobalID::Identification
+
     belongs_to :job, class_name: 'Transmittable::Job', optional: true
     has_many :transactions_transmissions, class_name: 'Transmittable::TransactionsTransmissions'
     has_one :process_status, as: :statusable, class_name: 'Transmittable::ProcessStatus'

--- a/app/models/transmittable/transmission.rb
+++ b/app/models/transmittable/transmission.rb
@@ -30,5 +30,11 @@ module Transmittable
 
       transmittable_errors&.map {|error| "#{error.key}: #{error.message}"}&.join(";")
     end
+
+    def transactions
+      ::Transmittable::Transaction.where(
+        :id.in => transactions_transmissions.pluck(:transaction_id)
+      )
+    end
   end
 end

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
 
   # TODO: Refactor to get the logger content from subject.logger instead of hardcoding the path
   let(:logger_content) do
-    File.read("#{Rails.root}/log/expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+    File.read("#{Rails.root}/log/hbx_enrollments_expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
   end
 
   describe 'with invalid params' do

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
     }
   end
 
-  let(:result) { described_class.new.call(params) }
+  let(:result) { subject.call(params) }
 
   describe 'with invalid params' do
     context 'params is not a hash' do
@@ -50,9 +50,11 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
 
     context 'missing query criteria' do
       let(:params) { {} }
+      let(:failure_msg) { "Invalid query_criteria in params: #{params}. Expected a hash." }
 
       it 'fails due to missing query criteria' do
-        expect(result.failure).to eq("Invalid query_criteria in params: #{params}. Expected a hash.")
+        expect(result.failure).to eq(failure_msg)
+        expect(subject.logger)
       end
     end
 

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -38,7 +38,11 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
   end
 
   let(:result) { subject.call(params) }
-  let(:logger_content) { File.read(subject.logger.filename) }
+
+  # TODO: Refactor to get the logger content from subject.logger instead of hardcoding the path
+  let(:logger_content) do
+    File.read("#{Rails.root}/log/expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+  end
 
   describe 'with invalid params' do
     context 'params is not a hash' do
@@ -116,5 +120,10 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
       expect(logger_content).to include(enr_success_msg)
       expect(logger_content).to include(success_msg)
     end
+  end
+
+  after :all do
+    file_path = "#{Rails.root}/log/expiration_handler_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+    File.delete(file_path) if File.file?(file_path)
   end
 end

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -87,21 +87,19 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
 
     context 'with no enrollments in previous year' do
       let(:effective_on) { TimeKeeper.date_of_record.beginning_of_year }
-      let(:failure_msg) { "No enrollments found for query criteria: #{query_criteria}" }
 
       it 'returns a failure moand with error message' do
-        expect(result.failure).to eq(failure_msg)
-        expect(logger_content).to match(failure_msg)
+        expect(result.failure).to eq("No enrollments found for query criteria: #{query_criteria}")
+        expect(logger_content).to match(/No enrollments found for query criteria:/)
       end
     end
 
     context 'with no active enrollments in previous year' do
       let(:aasm_state) { 'coverage_canceled' }
-      let(:failure_msg) { "No enrollments found for query criteria: #{query_criteria}" }
 
       it 'returns a failure moand with error message' do
-        expect(result.failure).to eq(failure_msg)
-        expect(logger_content).to match(failure_msg)
+        expect(result.failure).to eq("No enrollments found for query criteria: #{query_criteria}")
+        expect(logger_content).to match(/No enrollments found for query criteria:/)
       end
     end
   end

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -19,11 +19,13 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
   end
 
   let(:query_criteria) do
-    {
-      'aasm_state': { '$in': HbxEnrollment::ENROLLED_STATUSES - ['coverage_termination_pending'] },
-      'effective_on': { '$lt': start_on },
-      'kind': { '$in': ['individual', 'coverall'] }
-    }
+    JSON.parse(
+      {
+        'aasm_state': { '$in': HbxEnrollment::ENROLLED_STATUSES - ['coverage_termination_pending'] },
+        'effective_on': { '$lt': start_on },
+        'kind': { '$in': ['individual', 'coverall'] }
+      }.to_json
+    ).deep_symbolize_keys
   end
 
   let(:start_on) { TimeKeeper.date_of_record.beginning_of_year }

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
   end
 
   let(:result) { subject.call(params) }
-  let(:logger_content) { File.read(subject.logger) }
+  let(:logger_content) { File.read(subject.logger.filename) }
 
   describe 'with invalid params' do
     context 'params is not a hash' do
@@ -108,7 +108,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
     end
 
     let(:enr_success_msg) do
-      "Successfully published expiration event for enrollment hbx id: #{enrollment.hbx_id}"
+      "Successfully published expiration event: #{event.name} for enrollment with hbx_id: #{enrollment.hbx_id}."
     end
 
     it 'succeeds with message' do

--- a/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expiration_handler_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
 
       it 'returns failure monad due to invalid params type' do
         expect(result.failure).to eq(failure_msg)
-        expect(logger_content).to include(failure_msg)
+        expect(logger_content).to match(failure_msg)
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
 
       it 'fails due to missing query criteria' do
         expect(result.failure).to eq(failure_msg)
-        expect(logger_content).to include(failure_msg)
+        expect(logger_content).to match(failure_msg)
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
 
       it 'returns failure monad with error message' do
         expect(result.failure).to eq(failure_msg)
-        expect(logger_content).to include(failure_msg)
+        expect(logger_content).to match(failure_msg)
       end
     end
 
@@ -81,7 +81,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
 
       it 'returns failure monad with error message' do
         expect(result.failure).to eq(failure_msg)
-        expect(logger_content).to include(failure_msg)
+        expect(logger_content).to match(failure_msg)
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
 
       it 'returns a failure moand with error message' do
         expect(result.failure).to eq(failure_msg)
-        expect(logger_content).to include(failure_msg)
+        expect(logger_content).to match(failure_msg)
       end
     end
 
@@ -101,7 +101,7 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
 
       it 'returns a failure moand with error message' do
         expect(result.failure).to eq(failure_msg)
-        expect(logger_content).to include(failure_msg)
+        expect(logger_content).to match(failure_msg)
       end
     end
   end
@@ -112,13 +112,13 @@ RSpec.describe ::Operations::HbxEnrollments::ExpirationHandler, dbclean: :after_
     end
 
     let(:enr_success_msg) do
-      "Successfully published expiration event: #{event.name} for enrollment with hbx_id: #{enrollment.hbx_id}."
+      "Successfully published expiration event: events.individual.enrollments.expire_coverages.expire for enrollment with hbx_id: #{enrollment.hbx_id}."
     end
 
     it 'succeeds with message' do
       expect(result.success).to eq(success_msg)
-      expect(logger_content).to include(enr_success_msg)
-      expect(logger_content).to include(success_msg)
+      expect(logger_content).to match(enr_success_msg)
+      expect(logger_content).to match(success_msg)
     end
   end
 

--- a/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ::Operations::HbxEnrollments::PublishExpirationEvent, dbclean: :a
 
       it 'returns success' do
         expect(result.success).to eq(
-          "Published expiration event: events.individual.enrollments.expire_coverages.expire for enrollment with gid: #{enrollment.to_global_id.uri}."
+          "Successfully published expiration event: events.individual.enrollments.expire_coverages.expire for enrollment with hbx_id: #{enrollment.hbx_id}."
         )
       end
 

--- a/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
@@ -48,7 +48,9 @@ RSpec.describe ::Operations::HbxEnrollments::PublishExpirationEvent, dbclean: :a
     end
 
     context 'with valid params' do
-      before :each { result }
+      before :each do
+        result
+      end
 
       it 'returns success' do
         expect(result.success).to eq(

--- a/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
@@ -3,6 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe ::Operations::HbxEnrollments::PublishExpirationEvent, dbclean: :after_each do
+  include Dry::Monads[:result, :do]
+
+  before :each do
+    DatabaseCleaner.clean
+  end
+
   let(:family) { FactoryBot.create(:family, :with_primary_family_member) }
   let(:effective_on) { TimeKeeper.date_of_record.prev_year.beginning_of_year }
   let(:aasm_state) { 'coverage_selected' }
@@ -16,7 +22,23 @@ RSpec.describe ::Operations::HbxEnrollments::PublishExpirationEvent, dbclean: :a
     )
   end
 
-  let(:transmittable_job) { FactoryBot.create(:transmittable_job, :hbx_enrollments_expiration) }
+  let(:transmittable_job) do
+    ::Operations::Transmittable::CreateJob.new.call(
+      {
+        key: :hbx_enrollments_expiration,
+        title: "Request expiration of all active IVL enrollments.",
+        description: "Job that requests expiration of all active IVL enrollments.",
+        publish_on: DateTime.now,
+        started_at: DateTime.now
+      }
+    ).success
+  end
+
+  let(:job_process_status) { transmittable_job.process_status }
+
+  let(:transmission) { operation_instance.transmission }
+  let(:transmission_process_status) { transmission.process_status }
+
   let(:params) { { enrollment: enrollment, job: transmittable_job } }
 
   let(:operation_instance) { described_class.new }
@@ -45,6 +67,81 @@ RSpec.describe ::Operations::HbxEnrollments::PublishExpirationEvent, dbclean: :a
 
         it 'returns a failure' do
           expect(result.failure).to eq("Invalid input params: #{params}. Expected a hash.")
+        end
+      end
+
+      context 'when transmission creation fails' do
+        before :each do
+          allow(
+            ::Operations::Transmittable::CreateTransmission
+          ).to receive(:new).and_return(
+            double('CreateTransmission', call: Failure('Failed to create transmission due to invalid params.'))
+          )
+
+          result
+        end
+
+        it 'returns a failure monad' do
+          expect(result.failure).to eq('Failed to create transmission due to invalid params.')
+        end
+
+        it 'does not create transmission' do
+          expect(transmittable_job.transmissions.count).to eq(0)
+          expect(operation_instance.transmission).to be_nil
+          expect(Transmittable::Transmission.count).to eq(0)
+        end
+
+        it 'creates an error associated to the job' do
+          expect(transmittable_job.transmittable_errors.count).to eq(1)
+          expect(transmittable_job.transmittable_errors.first.key).to eq(:create_request_transmission)
+          expect(Transmittable::Error.all.count).to eq(1)
+          expect(Transmittable::Error.first.errorable).to eq(transmittable_job)
+        end
+
+        it 'updates the process status and creates new process state associated to the job' do
+          expect(job_process_status.latest_state).to eq(:failed)
+          expect(job_process_status.process_states.count).to eq(2)
+          expect(job_process_status.process_states.last.state_key).to eq(:failed)
+        end
+      end
+
+      context 'when transaction creation fails' do
+        before :each do
+          allow(
+            ::Operations::Transmittable::CreateTransaction
+          ).to receive(:new).and_return(
+            double('CreateTransaction', call: Failure('Failed to create transaction due to invalid params.'))
+          )
+
+          result
+        end
+
+        it 'returns a failure monad' do
+          expect(result.failure).to eq('Failed to create transaction due to invalid params.')
+        end
+
+        it 'does not create transaction' do
+          expect(transmission.transactions.count).to eq(0)
+          expect(operation_instance.transaction).to be_nil
+          expect(Transmittable::Transaction.count).to eq(0)
+        end
+
+        it 'creates an error associated to the job and transmission' do
+          expect(transmission.transmittable_errors.count).to eq(1)
+          expect(transmission.transmittable_errors.first.key).to eq(:create_request_transaction)
+          expect(transmittable_job.transmittable_errors.count).to eq(1)
+          expect(transmittable_job.transmittable_errors.first.key).to eq(:create_request_transaction)
+          expect(Transmittable::Error.all.count).to eq(2)
+          expect(Transmittable::Error.all.map(&:errorable).sort).to eq([transmission, transmittable_job].sort)
+        end
+
+        it 'updates the process status and creates new process state associated to the job' do
+          expect(job_process_status.latest_state).to eq(:failed)
+          expect(job_process_status.process_states.count).to eq(2)
+          expect(job_process_status.process_states.last.state_key).to eq(:failed)
+          expect(transmission_process_status.latest_state).to eq(:failed)
+          expect(transmission_process_status.process_states.count).to eq(2)
+          expect(transmission_process_status.process_states.last.state_key).to eq(:failed)
         end
       end
     end

--- a/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::Operations::HbxEnrollments::PublishExpirationEvent, dbclean: :after_each do
+  let(:family) { FactoryBot.create(:family, :with_primary_family_member) }
+  let(:effective_on) { TimeKeeper.date_of_record.prev_year.beginning_of_year }
+  let(:aasm_state) { 'coverage_selected' }
+  let!(:enrollment) do
+    FactoryBot.create(
+      :hbx_enrollment,
+      :individual_unassisted,
+      family: family,
+      aasm_state: aasm_state,
+      effective_on: effective_on
+    )
+  end
+
+  let(:transmittable_job) { FactoryBot.create(:transmittable_job, :hbx_enrollments_expiration) }
+  let(:params) { { enrollment: enrollment, job: transmittable_job } }
+  let(:result) { described_class.new.call(params) }
+
+  describe '#call' do
+    context 'with invalid params' do
+      context 'when params is not a hash' do
+        let(:params) { nil }
+
+        it 'returns a failure' do
+          expect(result.failure).to eq("Invalid input params: #{params}. Expected a hash.")
+        end
+      end
+
+      context 'when enrollment is not a valid object' do
+        let(:params) { { enrollment: 'enrollment' } }
+
+        it 'returns a failure' do
+          expect(result.failure).to eq("Invalid input params: #{params}. Expected a hash.")
+        end
+      end
+
+      context 'when job is not a valid object' do
+        let(:params) { { enrollment: enrollment, job: 'transmittable_job' } }
+
+        it 'returns a failure' do
+          expect(result.failure).to eq("Invalid input params: #{params}. Expected a hash.")
+        end
+      end
+    end
+
+    context 'with valid params' do
+      it 'returns success' do
+        expect(result.success).to eq(
+          "Published expiration event: events.individual.enrollments.expire_coverages.expire for enrollment with gid: #{enrollment.to_global_id.uri}."
+        )
+      end
+    end
+  end
+end
+
+__END__
+
+TODO:
+  1. Add specs to verify the creation of Transmittable::Job.
+  2. Add specs to verify the creation of Transmittable::Transmission.
+  3. Add specs to verify the creation of Transmittable::Transaction.
+  4. Add specs to verify the association of Subject to Transmittable::Transaction.
+  5. What is the use of ":transmission_id" on Transmittable::Transmission?
+  6. Why is ":transmission_id" a mandatory field on Transmittable::Transmission?
+  7. What is the use of ":correlation_id" on Transmittable::Transmission?

--- a/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
@@ -56,14 +56,3 @@ RSpec.describe ::Operations::HbxEnrollments::PublishExpirationEvent, dbclean: :a
     end
   end
 end
-
-__END__
-
-TODO:
-  1. Add specs to verify the creation of Transmittable::Job.
-  2. Add specs to verify the creation of Transmittable::Transmission.
-  3. Add specs to verify the creation of Transmittable::Transaction.
-  4. Add specs to verify the association of Subject to Transmittable::Transaction.
-  5. What is the use of ":transmission_id" on Transmittable::Transmission?
-  6. Why is ":transmission_id" a mandatory field on Transmittable::Transmission?
-  7. What is the use of ":correlation_id" on Transmittable::Transmission?

--- a/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/publish_expiration_event_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe ::Operations::HbxEnrollments::PublishExpirationEvent, dbclean: :a
 
       it 'creates transaction with correct associations' do
         expect(subject.transaction).to be_a(::Transmittable::Transaction)
-        expect(subject.transaction.job).to eq(subject.transmission)
         expect(
           ::Transmittable::TransactionsTransmissions.where(
             transaction_id: subject.transaction.id,

--- a/spec/domain/operations/hbx_enrollments/request_expirations_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/request_expirations_spec.rb
@@ -4,13 +4,9 @@ require 'rails_helper'
 
 RSpec.describe ::Operations::HbxEnrollments::RequestExpirations, dbclean: :after_each do
   describe '#call' do
-    let(:logger) do
-      "#{Rails.root}/log/request_expirations_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
-    end
-
-    let(:logger_content) { File.read(logger) }
-
     let(:result) { subject.call({}) }
+
+    let(:logger_content) { File.read(subject.logger.filename) }
 
     let(:hbx_profile) { FactoryBot.create(:hbx_profile, :open_enrollment_coverage_period) }
 

--- a/spec/domain/operations/hbx_enrollments/request_expirations_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/request_expirations_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe ::Operations::HbxEnrollments::RequestExpirations, dbclean: :after
   describe '#call' do
     let(:result) { subject.call({}) }
 
-    let(:logger_content) { File.read(subject.logger.filename) }
+    # TODO: Refactor to get the logger content from subject.logger instead of hardcoding the path
+    let(:logger_content) do
+      File.read("#{Rails.root}/log/request_expirations_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
+    end
 
     let(:hbx_profile) { FactoryBot.create(:hbx_profile, :open_enrollment_coverage_period) }
 

--- a/spec/domain/operations/hbx_enrollments/request_expirations_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/request_expirations_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::Operations::HbxEnrollments::RequestExpirations, dbclean: :after_each do
+  describe '#call' do
+    let(:logger) do
+      "#{Rails.root}/log/request_expirations_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+    end
+
+    let(:logger_content) { File.read(logger) }
+
+    let(:result) { subject.call({}) }
+
+    let(:hbx_profile) { FactoryBot.create(:hbx_profile, :open_enrollment_coverage_period) }
+
+    let(:start_on) do
+      hbx_profile.benefit_sponsorship.current_benefit_coverage_period.start_on
+    end
+
+    let(:event_name) { 'events.individual.enrollments.expire_coverages.request' }
+
+    let(:success_msg) do
+      "Successfully published event: #{event_name} to request expiration of all active IVL enrollments effective before #{start_on}."
+    end
+
+    context 'with valid params' do
+      before do
+        start_on
+        result
+      end
+
+      it 'returns success' do
+        expect(result.success).to eq(success_msg)
+      end
+
+      it 'logs success message' do
+        expect(logger_content).to include(success_msg)
+      end
+
+      it 'creates a job' do
+        expect(subject.job).to be_a(Transmittable::Job)
+      end
+    end
+
+    context 'with invalid params' do
+      context 'when params is not a hash' do
+        let(:params) { nil }
+
+        it 'returns a failure' do
+          expect(result.failure).to eq("Invalid input params: #{params}. Expected a hash.")
+        end
+      end
+
+      context 'when enrollment is not a valid object' do
+        let(:params) { { enrollment: 'enrollment' } }
+
+        it 'returns a failure' do
+          expect(result.failure).to eq("Invalid input params: #{params}. Expected a hash.")
+        end
+      end
+
+      context 'when job is not a valid object' do
+        let(:params) { { enrollment: enrollment, job: 'transmittable_job' } }
+
+        it 'returns a failure' do
+          expect(result.failure).to eq("Invalid input params: #{params}. Expected a hash.")
+        end
+      end
+    end
+  end
+
+  after :all do
+    file_path = "#{Rails.root}/log/request_expirations_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+    File.delete(file_path) if File.file?(file_path)
+  end
+end

--- a/spec/domain/operations/hbx_enrollments/request_expirations_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/request_expirations_spec.rb
@@ -44,27 +44,9 @@ RSpec.describe ::Operations::HbxEnrollments::RequestExpirations, dbclean: :after
     end
 
     context 'with invalid params' do
-      context 'when params is not a hash' do
-        let(:params) { nil }
-
-        it 'returns a failure' do
-          expect(result.failure).to eq("Invalid input params: #{params}. Expected a hash.")
-        end
-      end
-
-      context 'when enrollment is not a valid object' do
-        let(:params) { { enrollment: 'enrollment' } }
-
-        it 'returns a failure' do
-          expect(result.failure).to eq("Invalid input params: #{params}. Expected a hash.")
-        end
-      end
-
-      context 'when job is not a valid object' do
-        let(:params) { { enrollment: enrollment, job: 'transmittable_job' } }
-
-        it 'returns a failure' do
-          expect(result.failure).to eq("Invalid input params: #{params}. Expected a hash.")
+      context 'without hbx profile' do
+        it 'returns a failure moand with error message' do
+          expect(result.failure).to eq('Unable to find the start_on date for current benefit coverage period.')
         end
       end
     end

--- a/spec/factories/transmittable/jobs.rb
+++ b/spec/factories/transmittable/jobs.rb
@@ -6,5 +6,14 @@ FactoryBot.define do
     started_at {DateTime.now}
     publish_on {DateTime.now}
     job_id {"Job_123"}
+
+    trait :hbx_enrollments_expiration do
+      key { :hbx_enrollments_expiration }
+      title { "Request expiration of all active IVL enrollments before #{TimeKeeper.date_of_record.beginning_of_year}." }
+      description { "Job that requests expiration of all active IVL enrollments before #{TimeKeeper.date_of_record.beginning_of_year}." }
+      publish_on { DateTime.now }
+      started_at { DateTime.now }
+      job_id { nil }
+    end
   end
 end

--- a/spec/models/services/ivl_enrollment_service_spec.rb
+++ b/spec/models/services/ivl_enrollment_service_spec.rb
@@ -227,6 +227,11 @@ RSpec.describe Services::IvlEnrollmentService, type: :model, :dbclean => :after_
         it 'executes without raising any errors' do
           expect{ subject.expire_individual_market_enrollments(input_date) }.not_to raise_error
         end
+
+        it 'returns without requesting expirations' do
+          expect(::Operations::HbxEnrollments::RequestExpirations).not_to receive(:new)
+          subject.expire_individual_market_enrollments(input_date)
+        end
       end
 
       context 'when input date is beginning of the year' do

--- a/spec/models/services/ivl_enrollment_service_spec.rb
+++ b/spec/models/services/ivl_enrollment_service_spec.rb
@@ -397,4 +397,9 @@ RSpec.describe Services::IvlEnrollmentService, type: :model, :dbclean => :after_
       end
     end
   end
+
+  after :all do
+    file_path = "#{Rails.root}/log/family_advance_day_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+    File.delete(file_path) if File.file?(file_path)
+  end
 end

--- a/spec/models/services/ivl_enrollment_service_spec.rb
+++ b/spec/models/services/ivl_enrollment_service_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Services::IvlEnrollmentService, type: :model, :dbclean => :after_
     end
 
     it "should expire the cover all coverage_selected enrollment" do
-      subject.expire_individual_market_enrollments(TimeKeeper.date_of_record)
+      subject.expire_individual_market_enrollments
       expect(cover_coverage_enrolled_enrollment.reload.aasm_state).to eq "coverage_expired"
       expect(cover_coverage_enrolled_enrollment.workflow_state_transitions.first.event).to eq "expire_coverage!"
     end
@@ -210,7 +210,7 @@ RSpec.describe Services::IvlEnrollmentService, type: :model, :dbclean => :after_
     it "should not break when there is an error with one of the enrollments." do
       cover_coverage_enrolled_enrollment.unset(:family_id)
       cover_coverage_enrolled_enrollment.reload
-      subject.expire_individual_market_enrollments(TimeKeeper.date_of_record)
+      subject.expire_individual_market_enrollments
       expect(cover_coverage_enrolled_enrollment1.reload.aasm_state).to eq "coverage_expired"
       expect(cover_coverage_enrolled_enrollment1.workflow_state_transitions.first.event).to eq "expire_coverage!"
     end
@@ -221,25 +221,8 @@ RSpec.describe Services::IvlEnrollmentService, type: :model, :dbclean => :after_
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:async_expire_and_begin_coverages).and_return(true)
       end
 
-      context 'when input date is not beginning of the year' do
-        let(:input_date) { Date.new(TimeKeeper.date_of_record.year, 2, 1) }
-
-        it 'executes without raising any errors' do
-          expect{ subject.expire_individual_market_enrollments(input_date) }.not_to raise_error
-        end
-
-        it 'returns without requesting expirations' do
-          expect(::Operations::HbxEnrollments::RequestExpirations).not_to receive(:new)
-          subject.expire_individual_market_enrollments(input_date)
-        end
-      end
-
-      context 'when input date is beginning of the year' do
-        let(:input_date) { Date.new(TimeKeeper.date_of_record.year) }
-
-        it 'executes without raising any errors' do
-          expect{ subject.expire_individual_market_enrollments(input_date) }.not_to raise_error
-        end
+      it 'executes without raising any errors' do
+        expect{ subject.expire_individual_market_enrollments }.not_to raise_error
       end
     end
   end

--- a/spec/models/transmittable/job_spec.rb
+++ b/spec/models/transmittable/job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Transmittable::Job, type: :model, dbclean: :after_each do
-  let(:job) { create(:transmittable_job) }
+  let(:job) { FactoryBot.create(:transmittable_job) }
 
   describe '#before_create' do
     it 'populates message_id for the job' do
@@ -19,7 +19,7 @@ RSpec.describe Transmittable::Job, type: :model, dbclean: :after_each do
     it 'returns the GlobalID URI' do
       expect(
         job.to_global_id.uri.to_s
-      ).to eq("gid://enroll/Transmittable::Job/#{job.id}")
+      ).to eq("gid://enroll/#{described_class}/#{job.id}")
     end
   end
 end

--- a/spec/models/transmittable/job_spec.rb
+++ b/spec/models/transmittable/job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Transmittable::Job, type: :model, dbclean: :after_each do
       expect(job.respond_to?(:to_global_id)).to be_truthy
     end
 
-    it 'returns a GlobalID URI' do
+    it 'returns the GlobalID URI' do
       expect(
         job.to_global_id.uri.to_s
       ).to eq("gid://enroll/Transmittable::Job/#{job.id}")

--- a/spec/models/transmittable/job_spec.rb
+++ b/spec/models/transmittable/job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transmittable::Job, type: :model, dbclean: :after_each do
+  let(:job) { create(:transmittable_job) }
+
+  describe '#before_create' do
+    it 'populates message_id for the job' do
+      expect(job.message_id).to be_present
+    end
+  end
+
+  describe '#to_global_id' do
+    it 'responds to to_global_id' do
+      expect(job.respond_to?(:to_global_id)).to be_truthy
+    end
+
+    it 'returns a GlobalID URI' do
+      expect(
+        job.to_global_id.uri.to_s
+      ).to eq("gid://enroll/Transmittable::Job/#{job.id}")
+    end
+  end
+end

--- a/spec/models/transmittable/transaction_spec.rb
+++ b/spec/models/transmittable/transaction_spec.rb
@@ -35,4 +35,10 @@ RSpec.describe Transmittable::Transaction, type: :model, dbclean: :after_each do
       ).to eq("gid://enroll/#{described_class}/#{transaction.id}")
     end
   end
+
+  describe '#transmissions' do
+    it 'returns the transmissions' do
+      expect(transaction.transmissions.to_a).to eq([transmission])
+    end
+  end
 end

--- a/spec/models/transmittable/transaction_spec.rb
+++ b/spec/models/transmittable/transaction_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transmittable::Transaction, type: :model, dbclean: :after_each do
+  let(:transmission) { FactoryBot.create(:transmittable_transmission) }
+  let(:enrollment) do
+    FactoryBot.create(:hbx_enrollment, family: FactoryBot.create(:family, :with_primary_family_member))
+  end
+
+  let(:transaction) do
+    ::Operations::Transmittable::CreateTransaction.new.call(
+      {
+        transmission: transmission,
+        subject: enrollment,
+        key: :hbx_enrollments_expiration_request,
+        title: "Enrollment expiration request transaction for #{enrollment.hbx_id}.",
+        description: "Transaction request to expire enrollment with hbx id: #{enrollment.hbx_id}.",
+        publish_on: Date.today,
+        started_at: DateTime.now,
+        event: 'initial',
+        state_key: :initial
+      }
+    ).success
+  end
+
+  describe '#to_global_id' do
+    it 'responds to to_global_id' do
+      expect(transaction.respond_to?(:to_global_id)).to be_truthy
+    end
+
+    it 'returns the GlobalID URI' do
+      expect(
+        transaction.to_global_id.uri.to_s
+      ).to eq("gid://enroll/#{described_class}/#{transaction.id}")
+    end
+  end
+end

--- a/spec/models/transmittable/transmission_spec.rb
+++ b/spec/models/transmittable/transmission_spec.rb
@@ -16,4 +16,38 @@ RSpec.describe Transmittable::Transmission, type: :model, dbclean: :after_each d
       ).to eq("gid://enroll/#{described_class}/#{transmission.id}")
     end
   end
+
+  describe '#transactions' do
+    context 'when there are no transactions' do
+      it 'does not return any transactions' do
+        expect(transmission.transactions.to_a).to be_empty
+      end
+    end
+
+    context 'when there are transactions' do
+      let(:enrollment) do
+        FactoryBot.create(:hbx_enrollment, family: FactoryBot.create(:family, :with_primary_family_member))
+      end
+    
+      let!(:transaction) do
+        ::Operations::Transmittable::CreateTransaction.new.call(
+          {
+            transmission: transmission,
+            subject: enrollment,
+            key: :hbx_enrollments_expiration_request,
+            title: "Enrollment expiration request transaction for #{enrollment.hbx_id}.",
+            description: "Transaction request to expire enrollment with hbx id: #{enrollment.hbx_id}.",
+            publish_on: Date.today,
+            started_at: DateTime.now,
+            event: 'initial',
+            state_key: :initial
+          }
+        ).success
+      end
+
+      it 'returns the transactions' do
+        expect(transmission.transactions.to_a).to eq([transaction])
+      end
+    end
+  end
 end

--- a/spec/models/transmittable/transmission_spec.rb
+++ b/spec/models/transmittable/transmission_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Transmittable::Transmission, type: :model, dbclean: :after_each do
+  let(:transmission) { FactoryBot.create(:transmittable_transmission) }
+
+  describe '#to_global_id' do
+    it 'responds to to_global_id' do
+      expect(transmission.respond_to?(:to_global_id)).to be_truthy
+    end
+
+    it 'returns the GlobalID URI' do
+      expect(
+        transmission.to_global_id.uri.to_s
+      ).to eq("gid://enroll/#{described_class}/#{transmission.id}")
+    end
+  end
+end

--- a/spec/models/transmittable/transmission_spec.rb
+++ b/spec/models/transmittable/transmission_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Transmittable::Transmission, type: :model, dbclean: :after_each d
       let(:enrollment) do
         FactoryBot.create(:hbx_enrollment, family: FactoryBot.create(:family, :with_primary_family_member))
       end
-    
+
       let!(:transaction) do
         ::Operations::Transmittable::CreateTransaction.new.call(
           {

--- a/spec/shared_examples/transmittable.rb
+++ b/spec/shared_examples/transmittable.rb
@@ -7,7 +7,6 @@ RSpec.shared_context 'transmittable job transmission transaction', shared_contex
     job = FactoryBot.create(:transmittable_job)
     job.process_status = FactoryBot.create(:transmittable_process_status, statusable: job)
     job.process_status.process_states << FactoryBot.create(:transmittable_process_state, process_status: job.process_status)
-    job.generate_message_id
     job.save
     job
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186580328](https://www.pivotaltracker.com/story/show/186580328)

# A brief description of the changes

Current behavior: Currently, on the first of the year, the enrollments expire both synchronously and asynchronously based on the resource registry configuration.

New behavior: Transmittable models are created when the enrollments expire asynchronously when the resource registry `:async_expire_and_begin_coverages` is enabled for tracking purposes.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Resource Registry configuration -`:async_expire_and_begin_coverages`

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.