### PR TITLE
update structure of verification_doc_size_limit_in_mb FF

### DIFF
--- a/app/controllers/insured/verification_documents_controller.rb
+++ b/app/controllers/insured/verification_documents_controller.rb
@@ -121,7 +121,7 @@ class Insured::VerificationDocumentsController < ApplicationController
   def validate_file_type
     return unless params[:file]
 
-    doc_limit_mb = EnrollRegistry[:verification_doc_size_limit_in_mb].item.to_i || 100
+    doc_limit_mb = EnrollRegistry[:verification_doc_size_limit_in_mb].item.to_i
     max_file_size_in_bytes = doc_limit_mb * 1024 * 1024
     params[:file].each do |file|
       file_path = file.path

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -117,7 +117,7 @@ registry:
         item: ^(?!666|000|9\d{2})\d{3}[- ]{0,1}(?!00)\d{2}[- ]{0,1}(?!0{4})\d{4}$
         is_enabled: <%= ENV['VALIDATE_SSN_IS_ENABLED'] || false %>
       - key: :verification_doc_size_limit_in_mb
-        item: 100
+        item: <%= ENV['VERIFICATION_DOC_SIZE_LIMIT_IN_MB'] || 100 %>
         is_enabled: true
   - namespace:
     - :enroll_app

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -120,7 +120,7 @@ registry:
         item: ^(?!666|000|9\d{2})\d{3}[- ]{0,1}(?!00)\d{2}[- ]{0,1}(?!0{4})\d{4}$
         is_enabled: <%= ENV['VALIDATE_SSN_IS_ENABLED'] || false %>
       - key: :verification_doc_size_limit_in_mb
-        item: 100
+        item: <%= ENV['VERIFICATION_DOC_SIZE_LIMIT_IN_MB'] || 100 %>
         is_enabled: true
   - namespace:
     - :enroll_app

--- a/system/config/templates/features/aca_individual_market/aca_individual_market.yml
+++ b/system/config/templates/features/aca_individual_market/aca_individual_market.yml
@@ -117,7 +117,7 @@ registry:
         item: ^(?!666|000|9\d{2})\d{3}[- ]{0,1}(?!00)\d{2}[- ]{0,1}(?!0{4})\d{4}$
         is_enabled: <%= ENV['VALIDATE_SSN_IS_ENABLED'] || false %>
       - key: :verification_doc_size_limit_in_mb
-        item: 100
+        item: <%= ENV['VERIFICATION_DOC_SIZE_LIMIT_IN_MB'] || 100 %>
         is_enabled: true
   - namespace:
     - :enroll_app


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes
Current behavior:
Fix the structure of verification_doc_size_limit_in_mb FF defined in parent PR https://github.com/ideacrew/enroll/pull/3361.

New behavior:
Fixed the structure of verification_doc_size_limit_in_mb FF.
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:
`verification_doc_size_limit_in_mb`
- [X] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.