### PR TITLE
aa contrast fixes to success green color

### DIFF
--- a/vendor/assets/stylesheets/bootstrap-theme.scss.erb
+++ b/vendor/assets/stylesheets/bootstrap-theme.scss.erb
@@ -94,10 +94,10 @@
   background-image: none;
 }
 .btn-success {
-  background-image: -webkit-linear-gradient(top, #5cb85c 0%, #419641 100%);
-  background-image:      -o-linear-gradient(top, #5cb85c 0%, #419641 100%);
-  background-image: -webkit-gradient(linear, left top, left bottom, from(#5cb85c), to(#419641));
-  background-image:         linear-gradient(to bottom, #5cb85c 0%, #419641 100%);
+  background-image: -webkit-linear-gradient(top, var(--primary-green, #5cb85c) 0%, #419641 100%);
+  background-image:      -o-linear-gradient(top, var(--primary-green, #5cb85c) 0%, #419641 100%);
+  background-image: -webkit-gradient(linear, left top, left bottom, from(var(--primary-green, #5cb85c)), to(#419641));
+  background-image:         linear-gradient(to bottom, var(--primary-green, #5cb85c) 0%, #419641 100%);
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff5cb85c', endColorstr='#ff419641', GradientType=0);
   filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
   background-repeat: repeat-x;
@@ -346,10 +346,10 @@
   background-repeat: repeat-x;
 }
 .progress-bar-success {
-  background-image: -webkit-linear-gradient(top, #5cb85c 0%, #449d44 100%);
-  background-image:      -o-linear-gradient(top, #5cb85c 0%, #449d44 100%);
-  background-image: -webkit-gradient(linear, left top, left bottom, from(#5cb85c), to(#449d44));
-  background-image:         linear-gradient(to bottom, #5cb85c 0%, #449d44 100%);
+  background-image: -webkit-linear-gradient(top, var(--primary-green, #5cb85c) 0%, #449d44 100%);
+  background-image:      -o-linear-gradient(top, var(--primary-green, #5cb85c) 0%, #449d44 100%);
+  background-image: -webkit-gradient(linear, left top, left bottom, from(var(--primary-green, #5cb85c)), to(#449d44));
+  background-image:         linear-gradient(to bottom, var(--primary-green, #5cb85c) 0%, #449d44 100%);
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff5cb85c', endColorstr='#ff449d44', GradientType=0);
   background-repeat: repeat-x;
 }

--- a/vendor/assets/stylesheets/bootstrap.css.erb
+++ b/vendor/assets/stylesheets/bootstrap.css.erb
@@ -3180,8 +3180,8 @@ fieldset[disabled] .btn-primary.focus {
 }
 .btn-success {
   color: #fff;
-  background-color: #5cb85c;
-  border-color: #4cae4c;
+  background-color: var(--primary-green, #5cb85c);
+  border-color: var(--secondary-green,#4cae4c);
 }
 .btn-success:focus,
 .btn-success.focus {
@@ -3228,11 +3228,11 @@ fieldset[disabled] .btn-success:focus,
 .btn-success.disabled.focus,
 .btn-success[disabled].focus,
 fieldset[disabled] .btn-success.focus {
-  background-color: #5cb85c;
-  border-color: #4cae4c;
+  background-color: var(--primary-green, #5cb85c);
+  border-color: var(--secondary-green,#4cae4c);
 }
 .btn-success .badge {
-  color: #5cb85c;
+  color: var(--primary-green, #5cb85c);
   background-color: #fff;
 }
 .btn-info {
@@ -4891,7 +4891,7 @@ a.label:focus {
   background-color: #286090;
 }
 .label-success {
-  background-color: #5cb85c;
+  background-color: var(--primary-green, #5cb85c);
 }
 .label-success[href]:hover,
 .label-success[href]:focus {
@@ -5171,7 +5171,7 @@ a.thumbnail.active {
   animation: progress-bar-stripes 2s linear infinite;
 }
 .progress-bar-success {
-  background-color: #5cb85c;
+  background-color: var(--primary-green, #5cb85c);
 }
 .progress-striped .progress-bar-success {
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);

--- a/vendor/assets/stylesheets/bootstrap_3.css.erb
+++ b/vendor/assets/stylesheets/bootstrap_3.css.erb
@@ -2888,8 +2888,8 @@ fieldset[disabled] .btn-primary.active {
 }
 .btn-success {
   color: #fff;
-  background-color: #5cb85c;
-  border-color: #4cae4c;
+  background-color: var(--primary-green, #5cb85c);
+  border-color: var(--secondary-green,#4cae4c);
 }
 .btn-success:hover,
 .btn-success:focus,
@@ -2924,11 +2924,11 @@ fieldset[disabled] .btn-success:active,
 .btn-success.disabled.active,
 .btn-success[disabled].active,
 fieldset[disabled] .btn-success.active {
-  background-color: #5cb85c;
-  border-color: #4cae4c;
+  background-color: var(--primary-green, #5cb85c);
+  border-color: var(--secondary-green,#4cae4c);
 }
 .btn-success .badge {
-  color: #5cb85c;
+  color: var(--primary-green, #5cb85c);
   background-color: #fff;
 }
 .btn-info {
@@ -4541,7 +4541,7 @@ a.label:focus {
   background-color: #286090;
 }
 .label-success {
-  background-color: #5cb85c;
+  background-color: var(--primary-green, #5cb85c);
 }
 .label-success[href]:hover,
 .label-success[href]:focus {
@@ -4815,7 +4815,7 @@ a.thumbnail.active {
           animation: progress-bar-stripes 2s linear infinite;
 }
 .progress-bar-success {
-  background-color: #5cb85c;
+  background-color: var(--primary-green, #5cb85c);
 }
 .progress-striped .progress-bar-success {
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186426730

# A brief description of the changes

Current behavior: When admin approves documents from user, green does not pass contrast

New behavior: Green now passes contrast

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CR97_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

Cucumber tests will be added via ticket at the end of the workflow (https://www.pivotaltracker.com/story/show/186580246)

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.