### PR TITLE
aa compliance on red alerts and labels

### DIFF
--- a/app/assets/stylesheets/admin.scss.erb
+++ b/app/assets/stylesheets/admin.scss.erb
@@ -3,7 +3,7 @@
   &.household-header {
     input.error-styling {
       color: #a94442;
-      background-color: #f2dede;
+      background-color: var(--background-light-red, #f2dede);
       border-color: #ebccd1;
     }
   } 
@@ -60,7 +60,7 @@
   &.enrollment-header {
     input.error-styling {
       color: #a94442;
-      background-color: #f2dede;
+      background-color: var(--background-light-red, #f2dede);
       border-color: #ebccd1;
     }
   }

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -121,7 +121,6 @@ a {
 
 .alert-error {
     background-color: var(--background-light-red, #f2dede);
-    border-bottom: .4mm solid var(--primary-red, transparent) !important;
     border-color: #eed3d7;
     color: var(--primary-red, var(--error-color, #b94a48));
     text-align: left;

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -128,7 +128,7 @@ a {
  }
 
 .alert-alert {
-    background-color: #f2dede;
+    background-color: var(--background-light-red, #f2dede);
     border-color: #eed3d7;
     color: var(--primary-red, var(--error-color, #b94a48));
     text-align: left;

--- a/app/assets/stylesheets/devise.css.erb
+++ b/app/assets/stylesheets/devise.css.erb
@@ -2,16 +2,18 @@
 /* Devise flash message coloring. Must be changed as per design.*/
 
 .alert-error {
-  background-color: #f2dede;
-  border-color: #eed3d7;
-  color: #b94a48;
+  background-color: var(--background-light-red, #f2dede);
+  border-bottom: .4mm solid var(--primary-red, transparent) !important;
+  border-color: var(--primary-red, #eed3d7);
+  color: var(--primary-red, var(--error-color, #b94a48));
   text-align: left;
 }
 
 .alert-alert {
-  background-color: #f2dede;
-  border-color: #eed3d7;
-  color: #b94a48;
+  background-color: var(--background-light-red, #f2dede);
+  border-bottom: .4mm solid var(--primary-red, transparent) !important;
+  border-color: var(--primary-red, #eed3d7);
+  color: var(--primary-red, var(--error-color, #b94a48));
   text-align: left;
 }
 

--- a/app/javascript/css/cr97.scss
+++ b/app/javascript/css/cr97.scss
@@ -8,10 +8,13 @@
     --background-light-red: #F9F1F1; //error notice background color
     --primary-green: #5A7334; //green continue buttons
     --secondary-green: #738C4A; //green for continue button hover
+    --success-green: #027314; //green for success notices
 
+    --primary-orange: #E5A900;
     --primary-white: #ffffff;
     --primary-black: #000000;
     --alert-notice-green: #62703E; //success notice green
+    --info-blue: #003260;
 
     --font: Barlow, sans-serif;
     --default-font-color: #323130;

--- a/vendor/assets/stylesheets/bootstrap.css.erb
+++ b/vendor/assets/stylesheets/bootstrap.css.erb
@@ -1394,7 +1394,7 @@ a.bg-warning:focus {
   background-color: #f7ecb5;
 }
 .bg-danger {
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
 }
 a.bg-danger:hover,
 a.bg-danger:focus {
@@ -2423,7 +2423,7 @@ table th[class*="col-"] {
 .table > thead > tr.danger > th,
 .table > tbody > tr.danger > th,
 .table > tfoot > tr.danger > th {
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
 }
 .table-hover > tbody > tr > td.danger:hover,
 .table-hover > tbody > tr > th.danger:hover,
@@ -2886,7 +2886,7 @@ select[multiple].input-lg {
 }
 .has-error .input-group-addon {
   color: #a94442;
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
   border-color: #a94442;
 }
 .has-error .form-control-feedback {
@@ -3293,8 +3293,8 @@ fieldset[disabled] .btn-info.focus {
   background-color: #fff;
 }
 .btn-warning {
-  color: #fff;
-  background-color: #f0ad4e;
+  color: var(--primary-black, #fff);
+  background-color: var(--primary-orange, #f0ad4e);
   border-color: #eea236;
 }
 .btn-warning:focus,
@@ -3342,11 +3342,11 @@ fieldset[disabled] .btn-warning:focus,
 .btn-warning.disabled.focus,
 .btn-warning[disabled].focus,
 fieldset[disabled] .btn-warning.focus {
-  background-color: #f0ad4e;
+  background-color: var(--primary-orange, #f0ad4e);
   border-color: #eea236;
 }
 .btn-warning .badge {
-  color: #f0ad4e;
+  color: var(--primary-orange, #f0ad4e);
   background-color: #fff;
 }
 .btn-danger {
@@ -4891,21 +4891,22 @@ a.label:focus {
   background-color: #286090;
 }
 .label-success {
-  background-color: var(--primary-green, #5cb85c);
+  background-color: var(--success-green, #5cb85c);
 }
 .label-success[href]:hover,
 .label-success[href]:focus {
   background-color: #449d44;
 }
 .label-info {
-  background-color: #5bc0de;
+  background-color: var(--info-blue, #5bc0de);
 }
 .label-info[href]:hover,
 .label-info[href]:focus {
   background-color: #31b0d5;
 }
 .label-warning {
-  background-color: #f0ad4e;
+  background-color: var(--primary-orange, #f0ad4e);
+  color: var(--primary-black, #ffffff);
 }
 .label-warning[href]:hover,
 .label-warning[href]:focus {
@@ -5099,7 +5100,7 @@ a.thumbnail.active {
 }
 .alert-danger {
   color: #a94442;
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
   border-color: #ebccd1;
 }
 .alert-danger hr {
@@ -5422,7 +5423,7 @@ button.list-group-item-warning.active:focus {
 }
 .list-group-item-danger {
   color: #a94442;
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
 }
 a.list-group-item-danger,
 button.list-group-item-danger {
@@ -5787,14 +5788,14 @@ button.list-group-item-danger.active:focus {
 }
 .panel-danger > .panel-heading {
   color: #a94442;
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
   border-color: #ebccd1;
 }
 .panel-danger > .panel-heading + .panel-collapse > .panel-body {
   border-top-color: #ebccd1;
 }
 .panel-danger > .panel-heading .badge {
-  color: #f2dede;
+  color: var(--background-light-red, #f2dede);
   background-color: #a94442;
 }
 .panel-danger > .panel-footer + .panel-collapse > .panel-body {

--- a/vendor/assets/stylesheets/bootstrap_3.css.erb
+++ b/vendor/assets/stylesheets/bootstrap_3.css.erb
@@ -3018,7 +3018,7 @@ fieldset[disabled] .btn-warning.active {
   border-color: #eea236;
 }
 .btn-warning .badge {
-  color: var(--primary-orange, #f0ad4e)
+  color: var(--primary-orange, #f0ad4e);
   background-color: #fff;
 }
 .btn-danger {

--- a/vendor/assets/stylesheets/bootstrap_3.css.erb
+++ b/vendor/assets/stylesheets/bootstrap_3.css.erb
@@ -1202,7 +1202,7 @@ a.bg-warning:hover {
   background-color: #f7ecb5;
 }
 .bg-danger {
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
 }
 a.bg-danger:hover {
   background-color: #e4b9b9;
@@ -2230,7 +2230,7 @@ table th[class*="col-"] {
 .table > thead > tr.danger > th,
 .table > tbody > tr.danger > th,
 .table > tfoot > tr.danger > th {
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
 }
 .table-hover > tbody > tr > td.danger:hover,
 .table-hover > tbody > tr > th.danger:hover,
@@ -2638,7 +2638,7 @@ select[multiple].form-group-lg .form-control {
 }
 .has-error .input-group-addon {
   color: #a94442;
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
   border-color: #a94442;
 }
 .has-error .form-control-feedback {
@@ -2889,7 +2889,7 @@ fieldset[disabled] .btn-primary.active {
 .btn-success {
   color: #fff;
   background-color: var(--primary-green, #5cb85c);
-  border-color: var(--secondary-green,#4cae4c);
+  border-color: var(--secondary-green, #4cae4c);
 }
 .btn-success:hover,
 .btn-success:focus,
@@ -2925,7 +2925,7 @@ fieldset[disabled] .btn-success:active,
 .btn-success[disabled].active,
 fieldset[disabled] .btn-success.active {
   background-color: var(--primary-green, #5cb85c);
-  border-color: var(--secondary-green,#4cae4c);
+  border-color: var(--secondary-green, #4cae4c);
 }
 .btn-success .badge {
   color: var(--primary-green, #5cb85c);
@@ -2977,8 +2977,8 @@ fieldset[disabled] .btn-info.active {
   background-color: #fff;
 }
 .btn-warning {
-  color: #fff;
-  background-color: #f0ad4e;
+  color: var(--primary-black, #fff);
+  background-color: var(--primary-orange, #f0ad4e);
   border-color: #eea236;
 }
 .btn-warning:hover,
@@ -3014,11 +3014,11 @@ fieldset[disabled] .btn-warning:active,
 .btn-warning.disabled.active,
 .btn-warning[disabled].active,
 fieldset[disabled] .btn-warning.active {
-  background-color: #f0ad4e;
+  background-color: var(--primary-orange, #f0ad4e);
   border-color: #eea236;
 }
 .btn-warning .badge {
-  color: #f0ad4e;
+  color: var(--primary-orange, #f0ad4e)
   background-color: #fff;
 }
 .btn-danger {
@@ -4541,21 +4541,22 @@ a.label:focus {
   background-color: #286090;
 }
 .label-success {
-  background-color: var(--primary-green, #5cb85c);
+  background-color: var(--success-green, #5cb85c);
 }
 .label-success[href]:hover,
 .label-success[href]:focus {
   background-color: #449d44;
 }
 .label-info {
-  background-color: #5bc0de;
+  background-color: var(--info-blue, #5bc0de);
 }
 .label-info[href]:hover,
 .label-info[href]:focus {
   background-color: #31b0d5;
 }
 .label-warning {
-  background-color: #f0ad4e;
+  background-color: var(--primary-orange, #f0ad4e);
+  text-color: var(--primary-black, #ffffff);
 }
 .label-warning[href]:hover,
 .label-warning[href]:focus {
@@ -4743,7 +4744,7 @@ a.thumbnail.active {
 }
 .alert-danger {
   color: #a94442;
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
   border-color: #ebccd1;
 }
 .alert-danger hr {
@@ -4831,7 +4832,7 @@ a.thumbnail.active {
   background-image:         linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
 }
 .progress-bar-warning {
-  background-color: #f0ad4e;
+  background-color: var(--primary-orange, #f0ad4e);
 }
 .progress-striped .progress-bar-warning {
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
@@ -5022,7 +5023,7 @@ a.list-group-item-warning.active:focus {
 }
 .list-group-item-danger {
   color: #a94442;
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
 }
 a.list-group-item-danger {
   color: #a94442;
@@ -5372,14 +5373,14 @@ a.list-group-item-danger.active:focus {
 }
 .panel-danger > .panel-heading {
   color: #a94442;
-  background-color: #f2dede;
+  background-color: var(--background-light-red, #f2dede);
   border-color: #ebccd1;
 }
 .panel-danger > .panel-heading + .panel-collapse > .panel-body {
   border-top-color: #ebccd1;
 }
 .panel-danger > .panel-heading .badge {
-  color: #f2dede;
+  color: var(--background-light-red, #f2dede);
   background-color: #a94442;
 }
 .panel-danger > .panel-footer + .panel-collapse > .panel-body {


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186426730
Ticket: https://www.pivotaltracker.com/story/show/186426729

# A brief description of the changes

Current behavior: Different label colors, error popup need contrast improvement

New behavior: labels are now passing

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CR97_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

<img width="700" alt="Screenshot 2023-12-14 at 2 10 45 PM" src="https://github.com/ideacrew/enroll/assets/45053146/4987bd75-b87f-4d40-901f-c38bc66b1737">
<img width="700" alt="Screenshot 2023-12-14 at 2 11 01 PM" src="https://github.com/ideacrew/enroll/assets/45053146/3640f36d-13ed-47ef-bc7d-afe2ca3d061e">
<img width="700" alt="Screenshot 2023-12-14 at 2 11 12 PM" src="https://github.com/ideacrew/enroll/assets/45053146/3f1348cd-65e1-4313-b15b-59ad35decce1">
<img width="1632" alt="Screenshot 2023-12-14 at 2 16 18 PM" src="https://github.com/ideacrew/enroll/assets/45053146/08d1b074-ec56-45c2-a32c-a804d2c85b39">


Cucumber tests will be added via ticket at the end of the workflow (https://www.pivotaltracker.com/story/show/186580246)

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.