### PR TITLE
set evidence due on to nil when transition to NRR

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1338,13 +1338,13 @@ module FinancialAssistance
     end
 
     def set_evidence_to_negative_response(evidence)
-      if evidence.may_negative_response_received?
-        evidence.verification_outstanding = false
-        evidence.is_satisfied = true
-        evidence.due_on = nil
-        evidence.negative_response_received!
-        save!
-      end
+      return unless evidence.may_negative_response_received?
+
+      evidence.verification_outstanding = false
+      evidence.is_satisfied = true
+      evidence.due_on = nil
+      evidence.negative_response_received!
+      save!
     end
 
     def set_evidence_unverified(evidence)

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1338,8 +1338,13 @@ module FinancialAssistance
     end
 
     def set_evidence_to_negative_response(evidence)
-      evidence.negative_response_received! if evidence.may_negative_response_received?
-      save!
+      if evidence.may_negative_response_received?
+        evidence.verification_outstanding = false
+        evidence.is_satisfied = true
+        evidence.due_on = nil
+        evidence.negative_response_received!
+        save!
+      end
     end
 
     def set_evidence_unverified(evidence)

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Ifsv::H9t::IfsvE
         expect(income_evidence.outstanding?).to be_falsey
         expect(income_evidence.verification_outstanding).to be_falsey
         expect(income_evidence.negative_response_received?).to be_truthy
-        expect(income_evidence.is_satisfied).to eq false
+        expect(income_evidence.is_satisfied).to eq true
         expect(income_evidence.request_results.present?).to eq true
         expect(@result.success).to eq('Successfully updated Applicant with evidence')
       end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/pvc/medicare/add_pvc_medicare_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/pvc/medicare/add_pvc_medicare_determination_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Pvc::Medicare::A
 
         it 'should not update due_on on local mec evidence' do
           @applicant.reload
-          expect(@applicant.non_esi_evidence.due_on).to eq TimeKeeper.date_of_record
+          expect(@applicant.non_esi_evidence.due_on).to eq nil
         end
       end
     end

--- a/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
+++ b/components/financial_assistance/spec/models/financial_assistance/applicant_spec.rb
@@ -1552,6 +1552,38 @@ RSpec.describe ::FinancialAssistance::Applicant, type: :model, dbclean: :after_e
         end
       end
 
+      context 'for outstanding income evidence with due on' do
+        before do
+          applicant.create_income_evidence(key: :income, title: "Income", aasm_state: 'outstanding', verification_outstanding: true, is_satisfied: false, due_on: Date.today + 2.months)
+        end
+
+        let(:current_evidence) { applicant.income_evidence }
+
+        it 'should transition evidence tonegative_response_received and due on to nil' do
+          expect(current_evidence.outstanding?).to be_truthy
+          expect(current_evidence.due_on.present?).to be_truthy
+          applicant.set_evidence_to_negative_response(current_evidence)
+          expect(current_evidence.reload.negative_response_received?).to be_truthy
+          expect(current_evidence.due_on.present?).to be_falsey
+        end
+      end
+
+      context 'for outstanding esi evidence with due on' do
+        before do
+          applicant.create_esi_evidence(key: :esi_mec, title: "Esi", aasm_state: 'outstanding', verification_outstanding: true, is_satisfied: false, due_on: Date.today + 2.months)
+        end
+
+        let(:current_evidence) { applicant.esi_evidence }
+
+        it 'should transition evidence to negative_response_received and due on to nil' do
+          expect(current_evidence.outstanding?).to be_truthy
+          expect(current_evidence.due_on.present?).to be_truthy
+          applicant.set_evidence_to_negative_response(current_evidence)
+          expect(current_evidence.reload.negative_response_received?).to be_truthy
+          expect(current_evidence.due_on.present?).to be_falsey
+        end
+      end
+
       context 'for esi mec evidence' do
         before do
           applicant.create_esi_evidence(key: :esi_mec, title: "Esi", aasm_state: 'pending', verification_outstanding: false, is_satisfied: true)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [pivotal-186611817](https://www.pivotaltracker.com/n/projects/2640060/stories/186611817#)

# A brief description of the changes

Current behavior: When evidence is transitioned to NRR from outstanding, due on is not removed.

New behavior: Set due on to nil when evidence is transition to NRR.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.