### PR TITLE
implements response transmittable for enrollments begin coverage

### DIFF
--- a/app/domain/operations/hbx_enrollments/begin_coverage.rb
+++ b/app/domain/operations/hbx_enrollments/begin_coverage.rb
@@ -112,9 +112,7 @@ module Operations
             "No HbxEnrollment found with given global ID: #{@hbx_enrollment_gid}"
           )
         elsif !hbx_enrollment.is_ivl_by_kind?
-          Failure(
-            "Failed to expire enrollment hbx id #{hbx_enrollment.hbx_id} - #{hbx_enrollment.kind} is not a valid IVL enrollment kind"
-          )
+          Failure("Invalid Enrollment kind: #{hbx_enrollment.kind}. Expected an IVL enrollment kinds.")
         else
           Success(hbx_enrollment)
         end
@@ -161,6 +159,9 @@ module Operations
           Success(msg)
         else
           msg = "Invalid Transition request. Failed to begin coverage for enrollment hbx id #{hbx_enrollment.hbx_id}."
+          add_errors(:enrollment_begin_coverage, msg, { transaction: response_transaction, transmission: response_transmission })
+          status_result = update_status(msg, :failed, { transaction: response_transaction, transmission: response_transmission })
+          return status_result if status_result.failure?
           logger.error msg
           Failure(msg)
         end

--- a/app/domain/operations/hbx_enrollments/begin_coverage.rb
+++ b/app/domain/operations/hbx_enrollments/begin_coverage.rb
@@ -4,37 +4,167 @@ module Operations
   module HbxEnrollments
     # Begin IVL enrollment coverage
     class BeginCoverage
-      include Dry::Monads[:result, :do]
+      include ::Operations::Transmittable::TransmittableUtils
+
+      attr_reader :logger, :hbx_enrollment, :job, :request_transaction, :request_transmission, :response_transaction, :response_transmission
 
       # @param [Hash] params
-      # @option params [String] :enrollment_hbx_id
+      # @option params [Hash] :enrollment_gid
+      # @option params [Hash] :transmittable_identifiers
       # @return [Dry::Monads::Result]
+      # @example params: {
+      #   enrollment_gid: 'gid://enroll/HbxEnrollment/65739e355b4dc03a97f26c3b',
+      #   enrollment_hbx_id: '123456',
+      #   transmittable_identifiers: {
+      #    job_gid: 'gid://enroll/Transmittable::Job/65739e355b4dc03a97f26c3b',
+      #    transmission_gid: 'gid://enroll/Transmittable::Transmission/65739e355b4dc03a97f26c3b',
+      #    transaction_gid: 'gid://enroll/Transmittable::Transaction/65739e355b4dc03a97f26c3b',
+      #    subject_gid: 'gid://enroll/HbxEnrollment/65739e355b4dc03a97f26c3b'
+      #   }
+      # }
       def call(params)
-        enrollment_hbx_id = yield validate(params)
-        hbx_enrollment    = yield find_enrollment(enrollment_hbx_id)
-        result            = yield begin_coverage(hbx_enrollment)
+        _params                   = yield validate(params)
+        @hbx_enrollment           = yield find_enrollment
+        @job                      = yield find_job_by_global_id(@job_gid)
+        @request_transmission     = yield find_transmission_by_global_id(@request_transmission_gid)
+        _updated_result           = yield update_status("Transmittable::Transmission found with given global ID: #{@request_transmission_gid}",
+                                                        :succeeded,
+                                                        { transmission: @request_transmission })
+        @request_transaction      = yield find_transaction_by_global_id(@request_transaction_gid)
+        _updated_result           = yield update_status("Transmittable::Transaction found with given global ID: #{@request_transaction_gid}",
+                                                        :succeeded,
+                                                        { transaction: @request_transaction })
+        transmission_params       = yield construct_response_transmission_params
+        @response_transmission    = yield create_response_transmission(transmission_params, { job: job, transmission: request_transmission })
+        transaction_params        = yield construct_response_transaction_params
+        @response_transaction     = yield create_response_transaction(transaction_params, { job: job, transaction: request_transaction})
+        begin_coverage_msg        = yield begin_coverage
+        _response_updated_result  = yield update_status(begin_coverage_msg,
+                                                        :succeeded,
+                                                        { transaction: response_transaction, transmission: response_transmission })
 
-        Success(result)
+        Success(begin_coverage_msg)
       end
 
       private
 
       def validate(params)
-        return Failure('Missing enrollment_hbx_id') unless params.key?(:enrollment_hbx_id)
-        Success(params[:enrollment_hbx_id])
+        @logger = Logger.new(
+          "#{Rails.root}/log/begin_coverage_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+        )
+
+        logger.info "Processing begin coverage request with params: #{params}"
+
+        unless params.is_a?(Hash)
+          msg = "Invalid input params: #{params}. Expected a hash."
+          logger.error msg
+          return Failure(msg)
+        end
+
+        unless params[:transmittable_identifiers].is_a?(Hash)
+          msg = "Invalid transmittable_identifiers in params: #{params}. Expected a hash."
+          logger.error msg
+          return Failure(msg)
+        end
+
+        if params[:enrollment_gid].blank?
+          msg = "Missing enrollment_gid in params: #{params}."
+          logger.error msg
+          return Failure(msg)
+        end
+
+        if params[:transmittable_identifiers][:job_gid].blank?
+          msg = "Missing job_gid in transmittable_identifiers of params: #{params}."
+          logger.error msg
+          return Failure(msg)
+        end
+
+        if params[:transmittable_identifiers][:transmission_gid].blank?
+          msg = "Missing transmission_gid in transmittable_identifiers of params: #{params}."
+          logger.error msg
+          return Failure(msg)
+        end
+
+        if params[:transmittable_identifiers][:transaction_gid].blank?
+          msg = "Missing transaction_gid in transmittable_identifiers of params: #{params}."
+          logger.error msg
+          return Failure(msg)
+        end
+
+        if params[:transmittable_identifiers][:subject_gid].blank?
+          msg = "Missing subject_gid in transmittable_identifiers of params: #{params}."
+          logger.error msg
+          return Failure(msg)
+        end
+
+        @hbx_enrollment_gid       = params[:enrollment_gid]
+        @job_gid                  = params[:transmittable_identifiers][:job_gid]
+        @request_transmission_gid = params[:transmittable_identifiers][:transmission_gid]
+        @request_transaction_gid  = params[:transmittable_identifiers][:transaction_gid]
+
+        Success(params)
       end
 
-      def find_enrollment(enrollment_hbx_id)
-        Operations::HbxEnrollments::Find.new.call({hbx_id: enrollment_hbx_id})
+      def find_enrollment
+        hbx_enrollment = GlobalID::Locator.locate(@hbx_enrollment_gid)
+
+        if hbx_enrollment.blank?
+          Failure(
+            "No HbxEnrollment found with given global ID: #{@hbx_enrollment_gid}"
+          )
+        elsif !hbx_enrollment.is_ivl_by_kind?
+          Failure(
+            "Failed to expire enrollment hbx id #{hbx_enrollment.hbx_id} - #{hbx_enrollment.kind} is not a valid IVL enrollment kind"
+          )
+        else
+          Success(hbx_enrollment)
+        end
       end
 
-      def begin_coverage(enrollment)
-        return Failure("Failed to begin coverage for enrollment hbx id #{enrollment.hbx_id} - #{enrollment.kind} is not a valid IVL enrollment kind") unless enrollment.is_ivl_by_kind?
-        enrollment.begin_coverage!
+      def construct_response_transmission_params
+        Success(
+          {
+            job: job,
+            key: :hbx_enrollment_begin_coverage_response,
+            title: "Transmission response to begin coverage for enrollment with hbx id: #{hbx_enrollment.hbx_id}.",
+            description: "Transmission response to begin coverage for enrollment with hbx id: #{hbx_enrollment.hbx_id}.",
+            publish_on: Date.today,
+            started_at: DateTime.now,
+            event: 'received',
+            state_key: :received,
+            correlation_id: hbx_enrollment.hbx_id
+          }
+        )
+      end
 
-        Success("Successfully began coverage for enrollment hbx id #{enrollment.hbx_id}")
-      rescue StandardError => e
-        Failure("Failed to begin coverage for enrollment hbx id #{enrollment.hbx_id} - #{e.message}")
+      def construct_response_transaction_params
+        Success(
+          {
+            transmission: response_transmission,
+            subject: hbx_enrollment,
+            key: :hbx_enrollment_begin_coverage_response,
+            title: "Transaction response to begin coverage for enrollment with hbx id: #{hbx_enrollment.hbx_id}.",
+            description: "Transaction response to begin coverage for enrollment with hbx id: #{hbx_enrollment.hbx_id}.",
+            publish_on: Date.today,
+            started_at: DateTime.now,
+            event: 'received',
+            state_key: :received,
+            correlation_id: hbx_enrollment.hbx_id
+          }
+        )
+      end
+
+      def begin_coverage
+        if hbx_enrollment.may_begin_coverage?
+          hbx_enrollment.begin_coverage!
+          msg = "Successfully began coverage for enrollment hbx id #{hbx_enrollment.hbx_id}."
+          logger.info msg
+          Success(msg)
+        else
+          msg = "Invalid Transition request. Failed to begin coverage for enrollment hbx id #{hbx_enrollment.hbx_id}."
+          logger.error msg
+          Failure(msg)
+        end
       end
     end
   end

--- a/app/domain/operations/hbx_enrollments/begin_coverage.rb
+++ b/app/domain/operations/hbx_enrollments/begin_coverage.rb
@@ -14,7 +14,6 @@ module Operations
       # @return [Dry::Monads::Result]
       # @example params: {
       #   enrollment_gid: 'gid://enroll/HbxEnrollment/65739e355b4dc03a97f26c3b',
-      #   enrollment_hbx_id: '123456',
       #   transmittable_identifiers: {
       #    job_gid: 'gid://enroll/Transmittable::Job/65739e355b4dc03a97f26c3b',
       #    transmission_gid: 'gid://enroll/Transmittable::Transmission/65739e355b4dc03a97f26c3b',

--- a/app/domain/operations/hbx_enrollments/publish_begin_coverage_event.rb
+++ b/app/domain/operations/hbx_enrollments/publish_begin_coverage_event.rb
@@ -72,7 +72,6 @@ module Operations
           'events.individual.enrollments.begin_coverages.begin',
           attributes: {
             enrollment_gid: values[:enrollment].to_global_id.uri,
-            enrollment_hbx_id: values[:enrollment].hbx_id,
             transmittable_identifiers: {
               job_gid: values[:job].to_global_id.uri,
               transmission_gid: transmission.to_global_id.uri,

--- a/app/event_source/subscribers/individual/enrollments/begin_coverages_subscriber.rb
+++ b/app/event_source/subscribers/individual/enrollments/begin_coverages_subscriber.rb
@@ -25,12 +25,12 @@ module Subscribers
         subscribe(:on_begin) do |delivery_info, _metadata, response|
           @logger = subscriber_logger_for(:on_enroll_individual_enrollments_begin_coverages_begin)
           payload = JSON.parse(response, symbolize_names: true)
-          enrollment_hbx_id = payload[:enrollment_hbx_id]
+          enrollment_gid = payload[:enrollment_gid]
 
           @logger.info "BeginCoveragesSubscriber on_begin, response: #{payload}"
-          @logger.info "------------ Processing enrollment: #{enrollment_hbx_id} ------------"
+          @logger.info "------------ Processing enrollment: #{enrollment_gid} ------------"
           result = Operations::HbxEnrollments::BeginCoverage.new.call(payload)
-          @logger.info "Processed enrollment: #{enrollment_hbx_id}"
+          @logger.info "Processed enrollment: #{enrollment_gid}"
 
           result.success? ? @logger.info(result.value!) : @logger.error(result.failure)
           ack(delivery_info.delivery_tag)

--- a/spec/domain/operations/hbx_enrollments/begin_coverage_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/begin_coverage_spec.rb
@@ -168,6 +168,10 @@ RSpec.describe ::Operations::HbxEnrollments::BeginCoverage, dbclean: :after_each
   end
 
   describe 'with valid params' do
+    before :each do
+      result
+    end
+
     it 'returns success message' do
       msg = "Successfully began coverage for enrollment hbx id #{enrollment.hbx_id}."
       expect(result.success).to eq(msg)
@@ -176,12 +180,12 @@ RSpec.describe ::Operations::HbxEnrollments::BeginCoverage, dbclean: :after_each
 
     it 'creates transmission with correct association' do
       expect(operation_instance.response_transmission).to be_a(::Transmittable::Transmission)
-      expect(operation_instance.response_transmission.job).to eq(transmittable_job)
+      expect(operation_instance.response_transmission.job).to eq(job)
     end
 
     it 'associates newly created response transmission to job' do
-      expect(transmittable_job.transmissions.count).to eq(2)
-      expect(transmittable_job.transmissions.pluck(:key)).to include(:hbx_enrollment_begin_coverage_response)
+      expect(job.transmissions.count).to eq(2)
+      expect(job.transmissions.pluck(:key)).to include(:hbx_enrollment_begin_coverage_response)
     end
 
     it 'creates response transaction with correct associations' do
@@ -190,12 +194,10 @@ RSpec.describe ::Operations::HbxEnrollments::BeginCoverage, dbclean: :after_each
     end
 
     it 'creates join table record between transmission and transaction' do
+      expect(operation_instance.response_transaction.transmissions).to be_one
       expect(
-        ::Transmittable::TransactionsTransmissions.where(
-          transaction_id: operation_instance.response_transaction.id,
-          transmission_id: operation_instance.response_transmission.id
-        ).count
-      ).to eq(1)
+        operation_instance.response_transaction.transmissions.first
+      ).to eq(operation_instance.response_transmission)
     end
 
     it 'associates both request/response transmission and transaction to enrollment' do

--- a/spec/domain/operations/hbx_enrollments/begin_coverage_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/begin_coverage_spec.rb
@@ -5,63 +5,215 @@ require 'rails_helper'
 RSpec.describe ::Operations::HbxEnrollments::BeginCoverage, dbclean: :after_each do
 
   let(:family)      { FactoryBot.create(:family, :with_primary_family_member) }
-  let!(:enrollment) { FactoryBot.create(:hbx_enrollment, :individual_unassisted, family: family, aasm_state: 'auto_renewing') }
+  let(:effective_on) { TimeKeeper.date_of_record.beginning_of_year }
+  let(:aasm_state) { 'auto_renewing' }
+  let(:enrollment) { FactoryBot.create(:hbx_enrollment, :individual_unassisted, family: family, aasm_state: aasm_state, effective_on: effective_on) }
 
-  describe 'with invalid params' do
-    let(:params) { {} }
-    let(:result) { described_class.new.call(params) }
+  let(:enrollment_hbx_id) { enrollment.hbx_id }
 
-    it 'fails due to missing enrollment hbx id' do
-      expect(result.success?).to be_falsey
-      expect(result.failure).to eq('Missing enrollment_hbx_id')
-    end
+  let(:operation_instance)  { described_class.new }
+  let(:result)              { operation_instance.call(params) }
+
+  let(:logger) do
+    File.read("#{Rails.root}/log/begin_coverage_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log")
   end
 
-  describe 'with invalid enrollment' do
-    let(:params) { { enrollment_hbx_id: enrollment.hbx_id } }
-    let(:result) { described_class.new.call(params) }
+  let(:job) do
+    ::Operations::Transmittable::CreateJob.new.call(
+      {
+        key: :hbx_enrollments_begin_coverage,
+        title: "Request begin coverage of all renewal IVL enrollments.",
+        description: "Job that requests begin coverage of all renewal IVL enrollments.",
+        publish_on: DateTime.now,
+        started_at: DateTime.now
+      }
+    ).success
+  end
 
-    describe 'where enrollment is not an ivl enrollment' do
-      before do
-        enrollment.update(kind: 'employer_sponsored')
-      end
+  let(:request_transmission) do
+    ::Operations::Transmittable::CreateTransmission.new.call(
+      {
+        job: job,
+        key: :hbx_enrollment_begin_coverage_request,
+        title: "Transmission request to begin coverage enrollment with hbx id: #{enrollment.hbx_id}.",
+        description: "Transmission request to begin coverage enrollment with hbx id: #{enrollment.hbx_id}.",
+        publish_on: Date.today,
+        started_at: DateTime.now,
+        event: 'initial',
+        state_key: :initial,
+        correlation_id: enrollment.hbx_id
+      }
+    ).success
+  end
 
-      it 'fails due to invalid enrollment kind' do
-        expect(result.success?).to be_falsey
-        expect(result.failure).to eq("Failed to begin coverage for enrollment hbx id #{enrollment.hbx_id} - #{enrollment.kind} is not a valid IVL enrollment kind")
+  let(:request_transaction) do
+    ::Operations::Transmittable::CreateTransaction.new.call(
+      {
+        transmission: request_transmission,
+        subject: enrollment,
+        key: :hbx_enrollment_begin_coverage_request,
+        title: "Enrollment begin coverage request transaction for #{enrollment.hbx_id}.",
+        description: "Transaction request to begin coverage of enrollment with hbx id: #{enrollment.hbx_id}.",
+        publish_on: Date.today,
+        started_at: DateTime.now,
+        event: 'initial',
+        state_key: :initial,
+        correlation_id: enrollment.hbx_id
+      }
+    ).success
+  end
+
+  let(:params) do
+    {
+      enrollment_gid: enrollment.to_global_id.uri.to_s,
+      transmittable_identifiers: {
+        job_gid: job.to_global_id.uri.to_s,
+        transmission_gid: request_transmission.to_global_id.uri.to_s,
+        transaction_gid: request_transaction.to_global_id.uri.to_s,
+        subject_gid: enrollment.to_global_id.uri.to_s
+      }
+    }
+  end
+
+  describe 'with invalid params' do
+    context 'without params' do
+      let(:params) { nil }
+
+      it 'returns failure monad' do
+        expect(result.failure).to eq("Invalid input params: #{params}. Expected a hash.")
       end
     end
 
-    describe 'where enrollment fails the expiration guard clause' do
-      before do
-        enrollment.update_attributes(kind: "employer_sponsored")
+    context 'without transmittable_identifiers' do
+      let(:params) { { enrollment_gid: enrollment.to_global_id.uri.to_s } }
+
+      it 'returns failure monad' do
+        expect(result.failure).to eq("Invalid transmittable_identifiers in params: #{params}. Expected a hash.")
+      end
+    end
+
+    context 'without enrollment_gid' do
+      let(:params) do
+        {
+          transmittable_identifiers: {
+            job_gid: job.to_global_id.uri.to_s,
+            transmission_gid: request_transmission.to_global_id.uri.to_s,
+            transaction_gid: request_transaction.to_global_id.uri.to_s,
+            subject_gid: enrollment.to_global_id.uri.to_s
+          }
+        }
       end
 
-      it 'fails due to invalid state transition to coverage_expired' do
-        expect(result.success?).to be_falsey
-        expect(result.failure).to eq("Failed to begin coverage for enrollment hbx id #{enrollment.hbx_id} - #{enrollment.kind} is not a valid IVL enrollment kind")
+      it 'returns failure monad' do
+        expect(result.failure).to eq("Missing enrollment_gid in params: #{params}.")
+      end
+    end
+
+    context 'without job_gid' do
+      let(:params) { { enrollment_gid: enrollment.to_global_id.uri.to_s, transmittable_identifiers: {} } }
+
+      it 'returns failure monad' do
+        expect(result.failure).to eq("Missing job_gid in transmittable_identifiers of params: #{params}.")
+      end
+    end
+
+    context 'without transmission_gid' do
+      let(:params) do
+        {
+          enrollment_gid: enrollment.to_global_id.uri.to_s,
+          transmittable_identifiers: {
+            job_gid: job.to_global_id.uri.to_s,
+            transaction_gid: request_transaction.to_global_id.uri.to_s
+          }
+        }
+      end
+
+      it 'returns failure monad' do
+        expect(result.failure).to eq("Missing transmission_gid in transmittable_identifiers of params: #{params}.")
+      end
+    end
+
+    context 'without transaction_gid' do
+      let(:params) do
+        {
+          enrollment_gid: enrollment.to_global_id.uri.to_s,
+          transmittable_identifiers: {
+            job_gid: job.to_global_id.uri.to_s,
+            transmission_gid: request_transmission.to_global_id.uri.to_s
+          }
+        }
+      end
+
+      it 'returns failure monad' do
+        expect(result.failure).to eq("Missing transaction_gid in transmittable_identifiers of params: #{params}.")
+      end
+    end
+
+    context 'without subject_gid' do
+      let(:params) do
+        {
+          enrollment_gid: enrollment.to_global_id.uri.to_s,
+          transmittable_identifiers: {
+            job_gid: job.to_global_id.uri.to_s,
+            transmission_gid: request_transmission.to_global_id.uri.to_s,
+            transaction_gid: request_transaction.to_global_id.uri.to_s
+          }
+        }
+      end
+
+      it 'returns failure monad' do
+        expect(result.failure).to eq("Missing subject_gid in transmittable_identifiers of params: #{params}.")
       end
     end
   end
 
   describe 'with valid params' do
-    let(:params) { { enrollment_hbx_id: enrollment.hbx_id } }
-    let(:result) { described_class.new.call(params) }
-
-    it 'succeeds with message' do
-      expect(result.success?).to be_truthy
-      expect(result.value!).to eq("Successfully began coverage for enrollment hbx id #{enrollment.hbx_id}")
+    it 'returns success message' do
+      msg = "Successfully began coverage for enrollment hbx id #{enrollment.hbx_id}."
+      expect(result.success).to eq(msg)
+      expect(logger).to include(msg)
     end
 
-    describe 'where enrollment is a coverall enrollment' do
-      before do
-        enrollment.update_attributes(kind: 'coverall')
-      end
-
-      it 'succeeds with message' do
-        expect(result.success?).to be_truthy
-        expect(result.value!).to eq("Successfully began coverage for enrollment hbx id #{enrollment.hbx_id}")
-      end
+    it 'creates transmission with correct association' do
+      expect(operation_instance.response_transmission).to be_a(::Transmittable::Transmission)
+      expect(operation_instance.response_transmission.job).to eq(transmittable_job)
     end
+
+    it 'associates newly created response transmission to job' do
+      expect(transmittable_job.transmissions.count).to eq(2)
+      expect(transmittable_job.transmissions.pluck(:key)).to include(:hbx_enrollment_begin_coverage_response)
+    end
+
+    it 'creates response transaction with correct associations' do
+      expect(operation_instance.response_transaction).to be_a(::Transmittable::Transaction)
+      expect(operation_instance.response_transaction.transactable).to eq(enrollment)
+    end
+
+    it 'creates join table record between transmission and transaction' do
+      expect(
+        ::Transmittable::TransactionsTransmissions.where(
+          transaction_id: operation_instance.response_transaction.id,
+          transmission_id: operation_instance.response_transmission.id
+        ).count
+      ).to eq(1)
+    end
+
+    it 'associates both request/response transmission and transaction to enrollment' do
+      request_transmission_transmission_id = operation_instance.request_transmission.transmission_id
+      response_transmission_transmission_id = operation_instance.response_transmission.transmission_id
+      request_transaction_transaction_id = operation_instance.request_transaction.transaction_id
+      response_transaction_transaction_id = operation_instance.response_transaction.transaction_id
+      expect(request_transmission_transmission_id).to eq(response_transmission_transmission_id)
+      expect(request_transaction_transaction_id).to eq(response_transaction_transaction_id)
+      expect(request_transmission_transmission_id).to eq(enrollment_hbx_id)
+      expect(response_transmission_transmission_id).to eq(enrollment_hbx_id)
+      expect(request_transaction_transaction_id).to eq(enrollment_hbx_id)
+      expect(response_transaction_transaction_id).to eq(enrollment_hbx_id)
+    end
+  end
+
+  after :all do
+    file_path = "#{Rails.root}/log/begin_coverage_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+    File.delete(file_path) if File.file?(file_path)
   end
 end

--- a/spec/domain/operations/hbx_enrollments/expire_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/expire_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe ::Operations::HbxEnrollments::Expire, dbclean: :after_each do
 
       it 'fails due to invalid state transition to coverage_expired' do
         expect(result.success?).to be_falsey
-        expect(result.failure).to eq("Failed to expire enrollment hbx id #{enrollment.hbx_id} - Event 'expire_coverage' cannot transition from 'coverage_selected'. Failed callback(s): [:can_be_expired?].")
+        expect(result.failure).to match(
+          /Failed to expire enrollment hbx id #{enrollment.hbx_id} - Event 'expire_coverage' cannot transition from 'coverage_selected'./
+        )
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186674355](https://www.pivotaltracker.com/story/show/186674355)

# A brief description of the changes

Current behavior: Currently, on the first of the year, the enrollments begin coverage both synchronously and asynchronously based on the resource registry configuration.

New behavior: Response transmittable models are created when the enrollments begin coverage asynchronously when the resource registry `:async_expire_and_begin_coverages` is enabled for tracking purposes.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Resource Registry configuration -`:async_expire_and_begin_coverages`

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
