### PR TITLE
aa contrast compliance for FAA checklist

### DIFF
--- a/app/assets/stylesheets/family_relationships.scss.erb
+++ b/app/assets/stylesheets/family_relationships.scss.erb
@@ -97,7 +97,7 @@
 
 
 .fa, .knowmore h4 {
-  color: <%= EnrollRegistry[:qle_carousel].settings(:color).item %>;
+  color: var(--theme-primary-100, #007bc4);
 }
 
 .tribe-area-clone {

--- a/app/assets/stylesheets/ui-components/mahc-theme.scss
+++ b/app/assets/stylesheets/ui-components/mahc-theme.scss
@@ -559,6 +559,13 @@ thead {
   padding-left: 0.5em;
 }
 
+.fa-arrow-down:before {
+  color: var(--theme-primary-100, #007bc4);
+}
+
+.fa-info-circle:before {
+  color: var(--theme-primary-100, #007bc4);
+}
 
 #datatable_filter_source_kind {
     width: 75px;

--- a/features/financial_assistance/application_checklist.feature
+++ b/features/financial_assistance/application_checklist.feature
@@ -35,9 +35,9 @@ Feature: A dedicated page that gives the user prior notice that that application
     Then the next time the user logs in the user will see Application checklist page
 
   Scenario: contrast level aa is enabled - User clicks previous or the back browser button with year selection enabled.
-    Given the iap year selection feature is enabled
+    Given the contrast_level_aa feature is enabled
+    And the iap year selection feature is enabled
     Given that the user is on the Application Checklist page
     When the user clicks the PREVIOUS link
     Then the user will navigate to the assistance year selection page
-    When the contrast_level_aa feature is enabled
     Then the page should be axe clean according to: wcag2aa; checking only: color-contrast

--- a/features/financial_assistance/application_checklist.feature
+++ b/features/financial_assistance/application_checklist.feature
@@ -35,7 +35,7 @@ Feature: A dedicated page that gives the user prior notice that that application
     Then the next time the user logs in the user will see Application checklist page
 
   Scenario: contrast level aa is enabled - User clicks previous or the back browser button with year selection enabled.
-    Given the contrast_level_aa feature is enabled
+    Given the contrast level aa feature is enabled
     And the iap year selection feature is enabled
     Given that the user is on the Application Checklist page
     When the user clicks the PREVIOUS link

--- a/features/financial_assistance/start_new_application.feature
+++ b/features/financial_assistance/start_new_application.feature
@@ -49,8 +49,6 @@ Feature: Cost Savings -  Start New Application
     Then consumer should see 'Start New Application' button
     When consumer click 'Start New Application' button
     Then the consumer is navigated to Application checklist page
-    And contrast_level_aa feature is enabled
-    Then the page should be axe clean according to: wcag2a; checking only: color-contrast
 
   Scenario: FAA is enabled - year selection disabled - OE ended - and consumer has a no existing FAA applications
     Given the iap year selection feature is enabled
@@ -67,8 +65,6 @@ Feature: Cost Savings -  Start New Application
     Then consumer should see 'Start New Application' button
     When consumer click 'Start New Application' button
     Then the consumer is navigated to Application checklist page
-    And contrast_level_aa feature is enabled
-    Then the page should be axe clean according to: wcag2a; checking only: color-contrast
 
   Scenario: FAA is enabled - year selection disabled - in OE - and consumer has a no existing FAA applications
     Given the iap year selection feature is enabled
@@ -101,3 +97,18 @@ Feature: Cost Savings -  Start New Application
     Then consumer should see 'Start New Application' button
     When consumer click 'Start New Application' button
     Then the user will navigate to the non-OE assistance year selection page
+
+  Scenario: FAA is enabled - year selection disabled - contrast level aa is enabled - and consumer has a no existing FAA applications
+    Given the iap year selection feature is disabled
+    Given a consumer exists
+    And the consumer is logged in
+    And consumer has successful ridp
+    And the FAA feature configuration is enabled
+    When consumer visits home page
+    And the Cost Savings link is visible
+    And the consumer clicks on Cost Savings link
+    Then consumer should see 'Start New Application' button
+    When consumer click 'Start New Application' button
+    Then the consumer is navigated to Application checklist page
+    And contrast_level_aa feature is enabled
+    Then the page should be axe clean according to: wcag2a; checking only: color-contrast

--- a/features/financial_assistance/start_new_application.feature
+++ b/features/financial_assistance/start_new_application.feature
@@ -116,3 +116,21 @@ Feature: Cost Savings -  Start New Application
     Then the user will navigate to the assistance year selection page with multiple options
     When the contrast_level_aa feature is enabled
     Then the page should be axe clean according to: wcag2aa; checking only: color-contrast
+
+  Scenario: FAA is enabled - year selection disabled - OE ended - contrast level aa is enabled - and consumer has a no existing FAA applications
+    Given the iap year selection feature is enabled
+    And the iap year selection form feature is disabled
+    And current hbx is not under open enrollment
+    Given the date is after open enrollment
+    Given a consumer exists
+    And the consumer is logged in
+    And consumer has successful ridp
+    And the FAA feature configuration is enabled
+    When consumer visits home page
+    And the Cost Savings link is visible
+    And the consumer clicks on Cost Savings link
+    Then consumer should see 'Start New Application' button
+    When consumer click 'Start New Application' button
+    Then the consumer is navigated to Application checklist page
+    When the contrast_level_aa feature is enabled
+    Then the page should be axe clean according to: wcag2aa; checking only: color-contrast

--- a/features/financial_assistance/start_new_application.feature
+++ b/features/financial_assistance/start_new_application.feature
@@ -49,6 +49,8 @@ Feature: Cost Savings -  Start New Application
     Then consumer should see 'Start New Application' button
     When consumer click 'Start New Application' button
     Then the consumer is navigated to Application checklist page
+    And contrast_level_aa feature is enabled
+    Then the page should be axe clean according to: wcag2a; checking only: color-contrast
 
   Scenario: FAA is enabled - year selection disabled - OE ended - and consumer has a no existing FAA applications
     Given the iap year selection feature is enabled
@@ -65,6 +67,8 @@ Feature: Cost Savings -  Start New Application
     Then consumer should see 'Start New Application' button
     When consumer click 'Start New Application' button
     Then the consumer is navigated to Application checklist page
+    And contrast_level_aa feature is enabled
+    Then the page should be axe clean according to: wcag2a; checking only: color-contrast
 
   Scenario: FAA is enabled - year selection disabled - in OE - and consumer has a no existing FAA applications
     Given the iap year selection feature is enabled

--- a/features/financial_assistance/start_new_application.feature
+++ b/features/financial_assistance/start_new_application.feature
@@ -119,7 +119,7 @@ Feature: Cost Savings -  Start New Application
 
   Scenario: FAA is enabled - year selection disabled - OE ended - contrast level aa is enabled - and consumer has a no existing FAA applications
     Given the contrast level aa feature is enabled
-    Given the iap year selection feature is enabled
+    And the iap year selection feature is enabled
     And the iap year selection form feature is disabled
     And current hbx is not under open enrollment
     Given the date is after open enrollment

--- a/features/financial_assistance/start_new_application.feature
+++ b/features/financial_assistance/start_new_application.feature
@@ -99,7 +99,8 @@ Feature: Cost Savings -  Start New Application
     Then the user will navigate to the non-OE assistance year selection page
 
   Scenario: FAA is enabled - year selection enabled - contrast level aa is enabled - and consumer has a no existing FAA applications
-    Given the iap year selection feature is enabled
+    Given the contrast level aa feature is enabled
+    And the iap year selection feature is enabled
     And the iap year selection form feature is enabled
     And current hbx is under open enrollment
     Given the date is within open enrollment
@@ -114,10 +115,10 @@ Feature: Cost Savings -  Start New Application
     Then consumer should see 'Start New Application' button
     When consumer click 'Start New Application' button
     Then the user will navigate to the assistance year selection page with multiple options
-    When the contrast_level_aa feature is enabled
     Then the page should be axe clean according to: wcag2aa; checking only: color-contrast
 
   Scenario: FAA is enabled - year selection disabled - OE ended - contrast level aa is enabled - and consumer has a no existing FAA applications
+    Given the contrast level aa feature is enabled
     Given the iap year selection feature is enabled
     And the iap year selection form feature is disabled
     And current hbx is not under open enrollment
@@ -132,5 +133,4 @@ Feature: Cost Savings -  Start New Application
     Then consumer should see 'Start New Application' button
     When consumer click 'Start New Application' button
     Then the consumer is navigated to Application checklist page
-    When the contrast_level_aa feature is enabled
     Then the page should be axe clean according to: wcag2aa; checking only: color-contrast

--- a/features/financial_assistance/start_new_application.feature
+++ b/features/financial_assistance/start_new_application.feature
@@ -110,5 +110,5 @@ Feature: Cost Savings -  Start New Application
     Then consumer should see 'Start New Application' button
     When consumer click 'Start New Application' button
     Then the consumer is navigated to Application checklist page
-    And contrast_level_aa feature is enabled
+    When the contrast_level_aa feature is enabled
     Then the page should be axe clean according to: wcag2a; checking only: color-contrast

--- a/features/financial_assistance/start_new_application.feature
+++ b/features/financial_assistance/start_new_application.feature
@@ -20,8 +20,9 @@ Feature: Cost Savings -  Start New Application
       | submitted |
       | determined |
 
-  Scenario: FAA is enabled - year selection enabled - and consumer has a no existing FAA applications
-    Given the iap year selection feature is enabled
+  Scenario: FAA is enabled - year selection enabled - contrast level aa is enabled - and consumer has a no existing FAA applications
+    Given the contrast level aa feature is enabled
+    And the iap year selection feature is enabled
     And the iap year selection form feature is enabled
     And current hbx is under open enrollment
     Given the date is within open enrollment
@@ -36,6 +37,7 @@ Feature: Cost Savings -  Start New Application
     Then consumer should see 'Start New Application' button
     When consumer click 'Start New Application' button
     Then the user will navigate to the assistance year selection page with multiple options
+    And the page should be axe clean according to: wcag2aa; checking only: color-contrast
 
   Scenario: FAA is enabled - year selection disabled - and consumer has a no existing FAA applications
     Given the iap year selection feature is disabled
@@ -82,8 +84,9 @@ Feature: Cost Savings -  Start New Application
     When consumer click 'Start New Application' button
     Then the consumer is navigated to year selection page
 
-  Scenario: FAA is enabled - year selection enabled - OE ended - year selection form enabled - and consumer has a no existing FAA applications
-    Given the iap year selection feature is enabled
+  Scenario: FAA is enabled - year selection enabled - OE ended - year selection form enabled - contrast level aa is enabled - and consumer has a no existing FAA applications
+    Given the contrast level aa feature is enabled
+    And the iap year selection feature is enabled
     And the iap year selection form feature is enabled
     And current hbx is not under open enrollment
     Given the date is after open enrollment
@@ -96,41 +99,5 @@ Feature: Cost Savings -  Start New Application
     And the consumer clicks on Cost Savings link
     Then consumer should see 'Start New Application' button
     When consumer click 'Start New Application' button
-    Then the user will navigate to the non-OE assistance year selection page
-
-  Scenario: FAA is enabled - year selection enabled - contrast level aa is enabled - and consumer has a no existing FAA applications
-    Given the contrast level aa feature is enabled
-    And the iap year selection feature is enabled
-    And the iap year selection form feature is enabled
-    And current hbx is under open enrollment
-    Given the date is within open enrollment
-    Given a consumer exists
-    And the consumer is logged in
-    And the date is within open enrollment
-    And consumer has successful ridp
-    And the FAA feature configuration is enabled
-    When consumer visits home page
-    And the Cost Savings link is visible
-    And the consumer clicks on Cost Savings link
-    Then consumer should see 'Start New Application' button
-    When consumer click 'Start New Application' button
-    Then the user will navigate to the assistance year selection page with multiple options
-    Then the page should be axe clean according to: wcag2aa; checking only: color-contrast
-
-  Scenario: FAA is enabled - year selection disabled - OE ended - contrast level aa is enabled - and consumer has a no existing FAA applications
-    Given the contrast level aa feature is enabled
-    And the iap year selection feature is enabled
-    And the iap year selection form feature is disabled
-    And current hbx is not under open enrollment
-    Given the date is after open enrollment
-    Given a consumer exists
-    And the consumer is logged in
-    And consumer has successful ridp
-    And the FAA feature configuration is enabled
-    When consumer visits home page
-    And the Cost Savings link is visible
-    And the consumer clicks on Cost Savings link
-    Then consumer should see 'Start New Application' button
-    When consumer click 'Start New Application' button
-    Then the consumer is navigated to Application checklist page
+    And the user will navigate to the non-OE assistance year selection page
     Then the page should be axe clean according to: wcag2aa; checking only: color-contrast

--- a/features/hbx_admin/step_definitions/ui_config_steps.rb
+++ b/features/hbx_admin/step_definitions/ui_config_steps.rb
@@ -148,3 +148,10 @@ end
 And(/^the user clicks the Admin tab$/) do
   page.find('.dropdown-toggle', text: 'Admin').click
 end
+
+And(/contrast_level_aa feature is enabled?/) do
+  # Assets are compiled for DC environment. Because of this, we need to reload the page
+  # in order to test our AA compliant styling changes for ME.
+  ENV["CONTRAST_LEVEL_AA_IS_ENABLED"] = "true"
+  page.reset!
+end

--- a/features/hbx_admin/step_definitions/ui_config_steps.rb
+++ b/features/hbx_admin/step_definitions/ui_config_steps.rb
@@ -149,9 +149,9 @@ And(/^the user clicks the Admin tab$/) do
   page.find('.dropdown-toggle', text: 'Admin').click
 end
 
-And(/contrast_level_aa feature is enabled?/) do
-  # Assets are compiled for DC environment. Because of this, we need to reload the page
-  # in order to test our AA compliant styling changes for ME.
+When(/the contrast_level_aa feature is enabled?/) do
+  # Assets are compiled after the page is loaded for cucumber tests. Because of this, we need to reload the page
+  # in order to test our AA compliant styling changes.
   ENV["CONTRAST_LEVEL_AA_IS_ENABLED"] = "true"
   page.reset!
 end

--- a/features/hbx_admin/step_definitions/ui_config_steps.rb
+++ b/features/hbx_admin/step_definitions/ui_config_steps.rb
@@ -28,6 +28,10 @@ Given(/notices feature is disabled?/) do
   disable_feature(:notices_tab)
 end
 
+Given(/^the contrast level aa feature is enabled$/) do
+  enable_feature :contrast_level_aa
+end
+
 Then(/^they should see the Notices tab$/) do
   expect(page).to have_content("Notices")
 end
@@ -147,11 +151,4 @@ end
 
 And(/^the user clicks the Admin tab$/) do
   page.find('.dropdown-toggle', text: 'Admin').click
-end
-
-When(/the contrast_level_aa feature is enabled?/) do
-  # Assets are compiled after the page is loaded for cucumber tests. Because of this, we need to reload the page
-  # in order to test our AA compliant styling changes.
-  ENV["CONTRAST_LEVEL_AA_IS_ENABLED"] = "true"
-  page.reset!
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186499203

# A brief description of the changes

Current behavior: Page functions normally, needs cucumber

New behavior: Cucumber tests added

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

<img width="1604" alt="Screenshot 2023-12-18 at 8 45 52 AM" src="https://github.com/ideacrew/enroll/assets/45053146/240b444d-18c6-4408-993f-6f0b0788bc8f">


# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.