### PR TITLE
checks if enr purchase event was previously published to publish term event

### DIFF
--- a/app/models/hbx_enrollment.rb
+++ b/app/models/hbx_enrollment.rb
@@ -184,6 +184,13 @@ class HbxEnrollment
   # Currently, this is only used in IVL Renewals context.
   field :successor_creation_failure_reasons, type: Array
 
+  # @!attribute purchase_event_published_at
+  #   @note This field is currently only used in Individual Market's context.
+  #     This field gets populated when the purchase event is published to the bus via acapi in IVlSepQuery.
+  #     This field is used in IVlSepQuery to determine if the purchase event is published to the bus or not.
+  #   @return [DateTime] the date and time when the purchase event was published.
+  field :purchase_event_published_at, type: DateTime
+
   track_history   :modifier_field_optional => true,
                   :on => [:kind,
                           :enrollment_kind,
@@ -3009,6 +3016,13 @@ class HbxEnrollment
     return nil unless predecessor_enrollment_id
 
     HbxEnrollment.where(id: predecessor_enrollment_id).first
+  end
+
+  def mark_purchase_event_as_published!
+    return if purchase_event_published_at.present?
+
+    self.purchase_event_published_at = DateTime.now
+    save!
   end
 
   private

--- a/app/models/queries/ivl_sep_events.rb
+++ b/app/models/queries/ivl_sep_events.rb
@@ -90,5 +90,11 @@ module Queries
 
       matching_cancel && matching_selection
     end
+
+    def skip_termination?(enrollment)
+      return true unless EnrollRegistry.feature_enabled?(:silent_transition_enrollment)
+
+      enrollment.purchase_event_published_at.blank?
+    end
   end
 end

--- a/script/ivl_sep_query.rb
+++ b/script/ivl_sep_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 start_time = Time.now - 17.minutes
 end_time = Time.now
 
@@ -29,16 +31,6 @@ def is_retro_renewal_enrollment?(enrollment)
   enrollment.workflow_state_transitions.where(from_state: 'auto_renewing', to_state: 'coverage_selected').present?
 end
 
-# TODO - Refactor this and move this into event source
-# def publish_cv3_family(event_name, hbx_enrollment)
-#   ::Operations::HbxEnrollments::PublishChangeEvent.new.call({
-#     event_name: event_name,
-#     enrollment: hbx_enrollment
-#   })
-# rescue StandardError => e
-#   Rails.logger.info "Error while publishing cv3_family for #{event_name} enrollment #{enrollment.id}  - #{e}"
-# end
-
 def can_transmit?(enrollment)
   # We need to replace this.
   # It currently checks if we offer the plan attached to the enrollment.
@@ -63,8 +55,8 @@ query = Queries::IvlSepEvents.new(start_time, end_time)
 purchases = query.selections_during_window
 terms = query.terminations_during_window
 
-puts purchases.count
-puts terms.count
+puts purchases.count unless Rails.env.test?
+puts terms.count unless Rails.env.test?
 
 purchase_event = "acapi.info.events.hbx_enrollment.coverage_selected"
 purchases.to_a.each do |rec|
@@ -76,6 +68,7 @@ purchases.to_a.each do |rec|
     Rails.logger.info "0$ premium issue - cannot transmit purchase #{pol_id}"
     next
   end
+
   if query.purchase_and_cancel_in_same_window?(enrollment)
     Rails.logger.info "Purchase and cancel in same window, ignoring initial event for #{pol_id}"
     next
@@ -88,13 +81,12 @@ purchases.to_a.each do |rec|
 
   if rec["enrollment_state"] == 'auto_renewing' || is_retro_renewal_enrollment?(enrollment)
     IvlEnrollmentsPublisher.publish_action(purchase_event, pol_id, "urn:openhbx:terms:v1:enrollment#auto_renew")
-    # TODO - Refactor this and move this into event source
-    # publish_cv3_family('auto_renew', enrollment)
   else
     IvlEnrollmentsPublisher.publish_action(purchase_event, pol_id, "urn:openhbx:terms:v1:enrollment#initial")
-    # TODO - Refactor this and move this into event source
-    # publish_cv3_family('initial_purchase', enrollment)
   end
+
+  Rails.logger.info "Published event: #{purchase_event} for enrollment hbx_id: #{pol_id}"
+  enrollment.mark_purchase_event_as_published!
 rescue StandardError => e
   Rails.logger.info "Error while processing purchase #{rec['_id']} - #{e}"
 end
@@ -109,7 +101,7 @@ terms.to_a.each do |rec|
     Rails.logger.info "0$ premium issue - cannot trasmit term #{pol_id}"
     next
   end
-  if query.purchase_and_cancel_in_same_window?(enrollment)
+  if query.purchase_and_cancel_in_same_window?(enrollment) && query.skip_termination?(enrollment)
     Rails.logger.info "Purchase and cancel in same window, ignoring term event for #{pol_id}"
     next
   end
@@ -122,8 +114,7 @@ terms.to_a.each do |rec|
   end
   Rails.logger.info "-----publishing #{pol_id}"
   IvlEnrollmentsPublisher.publish_action(term_event, pol_id, "urn:openhbx:terms:v1:enrollment#terminate_enrollment")
-  # TODO - Refactor this and move this into event source
-  # publish_cv3_family('terminated', enrollment)
+  Rails.logger.info "Published event: #{term_event} for enrollment hbx_id: #{pol_id}"
 rescue StandardError => e
   Rails.logger.info "Error while processing term #{rec['_id']} - #{e}"
 end

--- a/spec/models/hbx_enrollment_spec_5.rb
+++ b/spec/models/hbx_enrollment_spec_5.rb
@@ -14,11 +14,13 @@ RSpec.describe HbxEnrollment, type: :model do
   let(:family) { create(:family, :with_primary_family_member, person: person) }
   let(:aasm_state) { 'coverage_selected' }
   let(:predecessor_enrollment_id) { nil }
+  let(:purchase_event_published_at) { nil }
   let(:hbx_enrollment) do
     create(:hbx_enrollment, :individual_aptc, :with_silver_health_product, aasm_state: aasm_state,
                                                                            applied_aptc_amount: applied_aptc_amount,
                                                                            elected_aptc_pct: elected_aptc_pct,
                                                                            family: family,
+                                                                           purchase_event_published_at: purchase_event_published_at,
                                                                            predecessor_enrollment_id: predecessor_enrollment_id,
                                                                            consumer_role_id: person.consumer_role.id,
                                                                            ehb_premium: enrollment_ehb_premium)
@@ -701,6 +703,27 @@ RSpec.describe HbxEnrollment, type: :model do
     context 'without predecessor_enrollment_id' do
       it 'returns nil' do
         expect(hbx_enrollment.predecessor_enrollment).to be_nil
+      end
+    end
+  end
+
+  describe '#mark_purchase_event_as_published!' do
+    context 'with purchase_event_published_at' do
+      let(:purchase_event_published_at) { DateTime.now }
+
+      it 'returns without modifying the published at' do
+        expect(hbx_enrollment.purchase_event_published_at).to eq(purchase_event_published_at)
+        hbx_enrollment.mark_purchase_event_as_published!
+        expect(hbx_enrollment.purchase_event_published_at).to eq(purchase_event_published_at)
+      end
+    end
+
+    context 'without purchase_event_published_at' do
+
+      it 'populates published at' do
+        expect(hbx_enrollment.purchase_event_published_at).to be_nil
+        hbx_enrollment.mark_purchase_event_as_published!
+        expect(hbx_enrollment.purchase_event_published_at).not_to be_nil
       end
     end
   end

--- a/spec/script/ivl_sep_query_spec.rb
+++ b/spec/script/ivl_sep_query_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'ivl_sep_query', dbclean: :after_each do
+  before :all do
+    DatabaseCleaner.clean
+  end
+
+  let(:product) do
+    FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health)
+  end
+
+  let(:family) do
+    FactoryBot.create(
+      :family, :with_primary_family_member,
+      person: FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role)
+    )
+  end
+
+  let(:purchase_event_published_at) { nil }
+
+  let(:enrollment) do
+    FactoryBot.create(
+      :hbx_enrollment,
+      :individual_shopping,
+      :with_enrollment_members,
+      effective_on: TimeKeeper.date_of_record.beginning_of_month,
+      household: family.households.first,
+      family: family,
+      product: product,
+      coverage_kind: 'health',
+      rating_area_id: 'ME0',
+      purchase_event_published_at: purchase_event_published_at,
+      enrollment_members: family.active_family_members,
+      consumer_role_id: family.primary_person.consumer_role.id
+    )
+  end
+
+  let(:purchases) { [] }
+  let(:terms) { [] }
+  let(:query) { double('Queries::IvlSepEvents', selections_during_window: purchases, terminations_during_window: terms) }
+  let(:decorated_hbx_enrollment) { double('HbxEnrollmentDecorator', total_premium: 1000.0) }
+  let(:enabled_or_disabled) { false }
+  let(:purchase_and_cancel_in_same_window_true_or_false) { false }
+  let(:skip_termination_true_or_false) { false }
+  let(:has_silent_cancel_true_or_false) { false }
+  let(:logger_content) { File.read(File.join(Rails.root, 'log', 'test.log')) }
+
+  before :each do
+    allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+    allow(EnrollRegistry).to receive(:feature_enabled?).with(:silent_transition_enrollment).and_return(enabled_or_disabled)
+    allow(Queries::IvlSepEvents).to receive(:new).with(any_args).and_return(query)
+    allow(HbxEnrollment).to receive(:where).and_call_original
+    allow(HbxEnrollment).to receive(:where).with(hbx_id: input_enrollment.hbx_id).and_return([input_enrollment])
+    allow(input_enrollment).to receive(:decorated_hbx_enrollment).and_return(decorated_hbx_enrollment)
+    allow(query).to receive(:purchase_and_cancel_in_same_window?).with(input_enrollment).and_return(
+      purchase_and_cancel_in_same_window_true_or_false
+    )
+    allow(query).to receive(:skip_termination?).with(input_enrollment).and_return(
+      skip_termination_true_or_false
+    )
+    allow(query).to receive(:has_silent_cancel?).with(input_enrollment).and_return(
+      has_silent_cancel_true_or_false
+    )
+    invoke_ivl_sep_query
+  end
+
+  context 'acapi.info.events.hbx_enrollment.coverage_selected' do
+    let(:input_enrollment) do
+      enrollment.select_coverage!
+      enrollment
+    end
+
+    let(:purchases) { [{ '_id' => input_enrollment.hbx_id, 'created_at' => input_enrollment.created_at.to_s, 'enrollment_state' => 'coverage_selected' }] }
+
+    it 'updates purchase_event_published_at' do
+      expect(input_enrollment.reload.purchase_event_published_at).to be_present
+    end
+
+    it 'logs message' do
+      expect(logger_content).to include(
+        "Published event: acapi.info.events.hbx_enrollment.coverage_selected for enrollment hbx_id: #{input_enrollment.hbx_id}"
+      )
+    end
+  end
+
+  context 'acapi.info.events.hbx_enrollment.terminated' do
+    let(:input_enrollment) do
+      enrollment.select_coverage!
+      enrollment.terminate_coverage!
+      enrollment
+    end
+
+    let(:terms) { [{ '_id' => input_enrollment.hbx_id, 'created_at' => input_enrollment.created_at.to_s }] }
+
+    context 'when query.skip_termination returns true' do
+      let(:purchase_event_published_at) { DateTime.now }
+      let(:enabled_or_disabled) { true }
+      let(:purchase_and_cancel_in_same_window_true_or_false) { true }
+      let(:skip_termination_true_or_false) { true }
+
+      it 'returns without publishing the event' do
+        expect(IvlEnrollmentsPublisher).not_to receive(:publish_action).with(
+          'acapi.info.events.hbx_enrollment.terminated',
+          input_enrollment.hbx_id,
+          'urn:openhbx:terms:v1:enrollment#terminate_enrollment'
+        )
+
+        invoke_ivl_sep_query
+      end
+    end
+
+    context 'when publish is invoked' do
+      let(:purchase_event_published_at) { DateTime.now }
+      let(:enabled_or_disabled) { true }
+      let(:purchase_and_cancel_in_same_window_true_or_false) { false }
+
+      it 'returns without publishing the event' do
+        expect(logger_content).to include(
+          "Published event: acapi.info.events.hbx_enrollment.terminated for enrollment hbx_id: #{input_enrollment.hbx_id}"
+        )
+      end
+    end
+  end
+end
+
+def invoke_ivl_sep_query
+  load File.join(Rails.root, 'script/ivl_sep_query.rb')
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186670692](https://www.pivotaltracker.com/story/show/186670692)

# A brief description of the changes

Current behavior: Currently, the IvlSepQuery, does not publish purchase and termination events if they happened in the same window and does not check if the purchase event was published in the previous window.

New behavior: With the new implementation, the IvlSepQuery will check if the enrollment's purchase event was published in the past and will publish the terminated event if exists.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

- Resource Registry Configuration - `:silent_transition_enrollment`
- Environment Variable - `'SILENT_TRANSITION_ENROLLMENT_IS_ENABLED'`

This feature is currently enabled to ME and disabled to DC.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.