### PR TITLE
revert 12 character password minimum length

### DIFF
--- a/.docker/config/devise.rb
+++ b/.docker/config/devise.rb
@@ -145,7 +145,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 12..20
+  config.password_length = 8..20
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/app/javascript/controllers/signup_controller.js
+++ b/app/javascript/controllers/signup_controller.js
@@ -35,7 +35,7 @@ passwordTooltip() {
   const passwordHelper =
     `<p>Your password must:</p>
      <ul class="list-group pwHelper">
-      <li id="length" class="invalid"><i class="fa fa-times mr-3 length"></i>Be at least 12 characters</li>
+      <li id="length" class="invalid"><i class="fa fa-times mr-3 length"></i>Be at least 8 characters</li>
       <li id="longer" class="invalid"><i class="fa fa-times mr-3 longer"></i>Not be longer than 20 characters</li>
       <li id="lower" class="invalid"><i class="fa fa-times mr-3 lower"></i>Include at least one lowercase letter</li>
       <li id="upper" class="invalid"><i class="fa fa-times mr-3 upper"></i>Include at least one uppercase letter</li>
@@ -87,10 +87,10 @@ resetIcons() {
 }
 
 validateLength(value) {
-  if (value.length >= 12 && value.length < 20) {
+  if (value.length >= 8 && value.length < 20) {
     document.querySelector('.length').classList.add('fa-check');
     document.querySelector('.longer').classList.add('fa-check');
-  } else if (value.length < 12 && this.usernameFieldTarget.value.length > 0) {
+  } else if (value.length < 8 && this.usernameFieldTarget.value.length > 0) {
     this.resetIcons();
   }
 }
@@ -180,7 +180,7 @@ validateUserIdMatch(value) {
 }
 
 passwordComplexity(value) {
-  const minPasswordLength = 12;
+  const minPasswordLength = 8;
   const num = {};
   num.Excess = 0;
   num.Upper = 0;
@@ -223,7 +223,7 @@ passwordComplexity(value) {
   //   To keep the same scoring logic, strongPasswordBonus accounts for the
   //   4 characters' worth of "bonus.Excess" points (3 each) that would be
   //   added to the final score of a 12 character password with minPasswordLength set to 8.
-  let strongPasswordBonus = 12;
+  let strongPasswordBonus = 0;
 
   score = baseScore + (num.Excess*bonus.Excess) + (num.Upper*bonus.Upper) + (num.Numbers*bonus.Numbers) + (num.Symbols*bonus.Symbols) + bonus.Combo + bonus.FlatLower + bonus.FlatNumber + strongPasswordBonus;
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -13,7 +13,7 @@
       <div id="pswd_info" class="tooltip_box" style="display: none;">
         <p>Your password must:</p>
         <ul>
-          <li id="length" class="valid">Be at least 12 characters</li>
+          <li id="length" class="valid">Be at least 8 characters</li>
           <li id="longer" class="invalid">Not be longer than 20 characters</li>
           <li id="lower" class="valid">Include at least one lowercase letter</li>
           <li id="upper" class="invalid">Include at least one uppercase letter</li>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -39,9 +39,9 @@
               </div>
             </div>
           </div>
-          <%= f.password_field :password, autocomplete: "off", class: "form-control", minlength:"12", maxlength:"20", required: true, data: { action: "focus->signup#passwordTooltip", toggle: "tooltip", placement: "right", trigger: 'click', html: true, target: 'signup.passwordField' } %>
+          <%= f.password_field :password, autocomplete: "off", class: "form-control", minlength:"8", maxlength:"20", required: true, data: { action: "focus->signup#passwordTooltip", toggle: "tooltip", placement: "right", trigger: 'click', html: true, target: 'signup.passwordField' } %>
           <div class="invalid-feedback">
-            Must be at least 12 characters and cannot contain username
+            Must be at least 8 characters and cannot contain username
           </div>
         </div>
         <div class="form-group">
@@ -56,9 +56,9 @@
               </div>
             </div>
           </div>
-          <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control", minlength:"12", required: true, data: {action: "focus->signup#hideTooltips click->signup#hideTooltips keyup->signup#checkMatch blur->signup#validatePassword", target: 'signup.passwordConfirmationField'} %>
+          <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control", minlength:"8", required: true, data: {action: "focus->signup#hideTooltips click->signup#hideTooltips keyup->signup#checkMatch blur->signup#validatePassword", target: 'signup.passwordConfirmationField'} %>
           <div class="invalid-feedback">
-            Must be at least 12 characters and cannot contain username
+            Must be at least 8 characters and cannot contain username
           </div>
         </div>
         <div class="form-group d-none" id="optionalEmail">

--- a/components/benefit_sponsors/spec/dummy/config/initializers/devise.rb
+++ b/components/benefit_sponsors/spec/dummy/config/initializers/devise.rb
@@ -148,7 +148,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 12..20
+  config.password_length = 8..20
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/components/financial_assistance/spec/dummy/app/models/concerns/config/initializers/devise.rb
+++ b/components/financial_assistance/spec/dummy/app/models/concerns/config/initializers/devise.rb
@@ -150,7 +150,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 12..20
+  config.password_length = 8..20
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/components/financial_assistance/spec/dummy/config/initializers/devise.rb
+++ b/components/financial_assistance/spec/dummy/config/initializers/devise.rb
@@ -150,7 +150,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 12..20
+  config.password_length = 8..20
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/components/sponsored_benefits/spec/dummy/config/initializers/devise.rb
+++ b/components/sponsored_benefits/spec/dummy/config/initializers/devise.rb
@@ -148,7 +148,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 12..20
+  config.password_length = 8..20
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -174,7 +174,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 12..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe User, :type => :model, dbclean: :after_each do
       it 'does not match' do
         expect(User.create(**params).errors[:password].any?).to be_truthy
         expect(User.create(**params).errors[:password_confirmation].any?).to be_truthy
-        expect(User.create(**params).errors[:password]).to eq ["Password must have at least 4 alphabetical characters", "is too short (minimum is 12 characters)"]
+        expect(User.create(**params).errors[:password]).to eq ["Password must have at least 4 alphabetical characters", "is too short (minimum is 8 characters)"]
         expect(User.create(**params).errors[:password_confirmation]).to eq ["doesn't match Password"]
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[186720273](https://www.pivotaltracker.com/n/projects/2640063/stories/186720273)

# A brief description of the changes

Current behavior:
Devise config is set to have 12 characters for minimum password length.

New behavior:
Reverting back to 8 for client deployment.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.