### PR TITLE
cucumber coverage for other questions page

### DIFF
--- a/features/financial_assistance/family_info.feature
+++ b/features/financial_assistance/family_info.feature
@@ -36,6 +36,6 @@ Feature: Start a new Financial Assistance Application
     When a consumer visits the Get Help Paying for coverage page
     And selects yes they would like help paying for coverage
     Then they should see a new finanical assistance application
-    Then They should see the application assistance year above Info Needed\
+    Then They should see the application assistance year above Info Needed
     And the browser has finished rendering the page
     Then the page should be axe clean excluding "a[disabled]" according to: wcag2aa; checking only: color-contrast

--- a/features/financial_assistance/other_questions_contrast_level_aa.feature
+++ b/features/financial_assistance/other_questions_contrast_level_aa.feature
@@ -1,0 +1,27 @@
+Feature: Start a new Financial Assistance Application and answers questions on Other Questions page - contrast level aa is enabled
+
+  Background: User logs in and visits applicant's other questions page
+    Given the contrast level aa feature is enabled
+    And the FAA feature configuration is enabled
+    And the primary caretaker question configuration is enabled
+    And FAA student_follow_up_questions feature is enabled
+    When a consumer, with a family, exists
+    And is logged in
+    And the user SSN is nil
+    And the user has an eligible immigration status
+    And the user has an age between 18 and 19 years old
+    And the user will navigate to the FAA Household Info page
+    And all applicants fill all pages except other questions
+    And the user clicks Other Questions section on the left navigation
+    And the user will navigate to the Other Questions page for the corresponding applicant
+
+  Scenario: Before answering any questions
+    Then the page should be axe clean excluding "a[disabled]" according to: wcag2aa; checking only: color-contrast
+
+  Scenario: Currently pregnant response with Yes with information filled and submitted
+    Given the user answers yes to being pregnant
+    Then the due date question should display
+    And the user enters a pregnancy due date of one month from today
+    And how many children question should display
+    And the user answers two for how many children
+    Then the page should be axe clean excluding "a[disabled]" according to: wcag2aa; checking only: color-contrast

--- a/features/financial_assistance/other_questions_page.feature
+++ b/features/financial_assistance/other_questions_page.feature
@@ -38,4 +38,3 @@ Feature: Start a new Financial Assistance Application and answers questions on O
   Scenario: User gives no answer to blind, daily help, help with bills, and physically disabled
     Given the user fills out the required other questions and submits it
     Then the user should see text that the info is complete
- 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186499196

# A brief description of the changes

Current behavior:
There is no automated test coverage for level AA contrast accessibility standards on the FAA Other Questions section of the UI.

New behavior:
Automated test coverage is present for level AA contrast accessibility standards on the FAA Other Questions section of the UI.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.