### PR TITLE
level aa contrast for FAA family relationships page

### DIFF
--- a/components/financial_assistance/app/assets/stylesheets/financial_assistance/family_relationships.scss
+++ b/components/financial_assistance/app/assets/stylesheets/financial_assistance/family_relationships.scss
@@ -6,7 +6,7 @@
 }
 .usercard .card-detail-titles {
   font-weight: bold;
-	color: #909090;
+	color: var(--secondary-font-color, #909090);
 }
 
 .household .card-detail-titles {
@@ -91,7 +91,7 @@
 
 .review-relations .review-relation-headers {
   font-weight: bold;
-  color: #909090;
+  color: var(--secondary-font-color, #909090);
   font-size: 10px;
 }
 

--- a/features/financial_assistance/family_relationships_page_contrast_level_aa.feature
+++ b/features/financial_assistance/family_relationships_page_contrast_level_aa.feature
@@ -1,0 +1,26 @@
+Feature: Functionality for the Family Relationships page - contrast level aa is enabled
+
+  Background: Family Relationships page
+    Given the contrast level aa feature is enabled
+    And a consumer exists
+    And a benchmark plan exists
+    And the FAA feature configuration is enabled
+    And a financial assistance application and two applicants in info completed state exist
+    And financial assistance primary applicant logs in
+    And user clicks CONTINUE
+    Then the user will navigate to Family Relationships page
+    Given that the user is on the FAA Family Relationships page
+
+  Scenario: Continue button enabled when all relationships are entered
+    And there is a nil value for at least one relationship
+    When the user populates the drop down with a value
+    And the relationship is saved
+    And the browser has finished rendering the page
+    Then the page should be axe clean excluding "a[disabled], .disabled" according to: wcag2aa; checking only: color-contrast
+
+
+  Scenario: Missing value is highlighted
+    And there is a nil value for at least one relationship
+    And the family member row will be highlighted
+    And the browser has finished rendering the page
+    Then the page should be axe clean excluding "a[disabled], .disabled" according to: wcag2aa; checking only: color-contrast


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186499194

# A brief description of the changes

Current behavior:
There are three identified contrast violations on the FAA family relationships page when the contrast_level_aa feature is enabled.

New behavior:
There are zero contrast violations on the FAA family relationships page when the contrast_level_aa feature is enabled.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: `CONTRAST_LEVEL_AA_IS_ENABLED`

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.