### PR TITLE
change individual enrollment due day of month to 16

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -96,7 +96,7 @@ aca:
   qle:
     with_in_sixty_days: 60
   individual_market:
-    monthly_enrollment_due_on: 15
+    monthly_enrollment_due_on: 16
     verification_outstanding_window:
       days: 0
     verification_due:

--- a/spec/models/benefit_coverage_period_spec.rb
+++ b/spec/models/benefit_coverage_period_spec.rb
@@ -152,10 +152,9 @@ RSpec.describe BenefitCoveragePeriod, type: :model, dbclean: :after_each do
 
         context "and today is the last day to obtain benefits starting first of next month" do
           before do
-            # Need to revert the monthly_effective_date_deadline with following changes back on 5/1/2020
-            # monthly_effective_date_deadline = HbxProfile::IndividualEnrollmentDueDayOfMonth
-            monthly_effective_date_deadline = 15
-            TimeKeeper.set_date_of_record_unprotected!(Date.new(2015, 9, monthly_effective_date_deadline))
+            TimeKeeper.set_date_of_record_unprotected!(
+              Date.new(2015, 9, HbxProfile::IndividualEnrollmentDueDayOfMonth)
+            )
           end
 
           it "should determine the earliest effective date is next month" do
@@ -165,16 +164,13 @@ RSpec.describe BenefitCoveragePeriod, type: :model, dbclean: :after_each do
 
         context "and today is past the deadline to obtain benefits starting first of next month" do
           before do
-            # Need to revert the monthly_effective_date_deadline with following changes back on 5/1/2020
-            # monthly_effective_date_deadline = HbxProfile::IndividualEnrollmentDueDayOfMonth
-            monthly_effective_date_deadline = 15
-            TimeKeeper.set_date_of_record_unprotected!(Date.new(2015, 9, (monthly_effective_date_deadline + 1)))
+            TimeKeeper.set_date_of_record_unprotected!(
+              Date.new(2015, 9, HbxProfile::IndividualEnrollmentDueDayOfMonth).next_day
+            )
           end
 
           it "should determine the earliest effective date is month after next" do
-            # Need to revert the Date.new(2015, 10, 1) with following changes back on 5/1/2020
             expect(benefit_coverage_period.earliest_effective_date).to eq Date.new(2015, 11, 1)
-            # expect(benefit_coverage_period.earliest_effective_date).to eq Date.new(2015, 10, 1)
           end
         end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)
- [x] Configuration Updates(Resource Registry, legacy Settings)

# What is the ticket # detailing the issue?

Ticket: [Pod of War - 186745384](https://www.pivotaltracker.com/story/show/186745384)

# A brief description of the changes

Current behavior: The default effective date for IVL customer shopping without a SEP is 2/1/2024 through **1/15/2024** and starting **1/16/2024** the default effective date should switch to 3/1/2024.

New behavior: The default effective date for IVL customer shopping without a SEP is 2/1/2024 through **1/16/2024** and starting **1/17/2024** the default effective date should switch to 3/1/2024.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.