### PR TITLE
cucumber coverage for your preferences page

### DIFF
--- a/features/financial_assistance/contrast_level_aa/other_questions.feature
+++ b/features/financial_assistance/contrast_level_aa/other_questions.feature
@@ -1,4 +1,4 @@
-Feature: Start a new Financial Assistance Application and answers questions on Other Questions page - contrast level aa is enabled
+Feature: Contrast level AA is enabled - Start a new Financial Assistance Application and answers questions on Other Questions page
 
   Background: User logs in and visits applicant's other questions page
     Given the contrast level aa feature is enabled

--- a/features/financial_assistance/contrast_level_aa/your_preferences_page.feature
+++ b/features/financial_assistance/contrast_level_aa/your_preferences_page.feature
@@ -1,4 +1,4 @@
-Feature: Contrast level aa is enabled - User data usage preferences and voter registration
+Feature: Contrast level AA is enabled - User data usage preferences and voter registration
 
   Background: Your Preferences Page
     Given the contrast level aa feature is enabled

--- a/features/financial_assistance/contrast_level_aa/your_preferences_page.feature
+++ b/features/financial_assistance/contrast_level_aa/your_preferences_page.feature
@@ -1,0 +1,23 @@
+Feature: Contrast level aa is enabled - User data usage preferences and voter registration
+
+  Background: Your Preferences Page
+    Given the contrast level aa feature is enabled
+    And a consumer exists
+    And is logged in
+    And the FAA feature configuration is enabled
+    And the user will navigate to the FAA Household Info page
+    And all applicants are in Info Completed state with all types of income
+    And the user clicks CONTINUE
+    And the user is on the Review Your Application page
+    And the user clicks CONTINUE
+    Then the user is on the Your Preferences page
+
+  Scenario: Defaulted to "I AGREE"
+    And the answer to "To make it easier to determine my eligibility..." is defaulted to "I AGREE"
+    Then the page should be axe clean excluding "a[disabled], .disabled" according to: wcag2aa; checking only: color-contrast
+
+  Scenario: User selects "I DISAGREE"
+    Given the user selects I DISAGREE
+    Then the "How long would you like your eligibility for premium reductions to be renewed? *" question displays
+    When the user selects 3 years for eligibility length question
+    Then the page should be axe clean excluding "a[disabled], .disabled" according to: wcag2aa; checking only: color-contrast

--- a/features/financial_assistance/step_definitions/your_preferences_page_steps.rb
+++ b/features/financial_assistance/step_definitions/your_preferences_page_steps.rb
@@ -26,5 +26,5 @@ Then(/^the "([^"]*)" question displays$/) do |question|
 end
 
 Given(/^the user selects I DISAGREE$/) do
-  find(:xpath, '//*[@id="eligibility_easier_no"]').set(true)
+  choose('eligibility_easier_no')
 end

--- a/features/financial_assistance/your_preferences_page.feature
+++ b/features/financial_assistance/your_preferences_page.feature
@@ -1,25 +1,24 @@
-Feature: This gives the user access to application level navigation for applicants
+Feature: User data usage preferences and voter registration
 
   Background: Your Preferences Page
-    Given the FAA feature configuration is enabled
-    Given the date is within open enrollment
-    And the user is on FAA Household Info: Family Members page
+    Given a consumer exists
+    And is logged in
+    And the FAA feature configuration is enabled
+    And the user will navigate to the FAA Household Info page
     And all applicants are in Info Completed state with all types of income
     And the user clicks CONTINUE
-    Then the user is on the Review Your Application page
-    Given the user clicks CONTINUE
+    And the user is on the Review Your Application page
+    And the user clicks CONTINUE
     Then the user is on the Your Preferences page
 
   Scenario: Defaulted to "I AGREE"
-    Given the user is on the Your Preferences page
-    Then the answer to "To make it easier to determine my eligibility..." is defaulted to "I AGREE"
+    And the answer to "To make it easier to determine my eligibility..." is defaulted to "I AGREE"
     When the user clicks CONTINUE
     Then the user is on the Submit Your Application page
 
-  @broken
   Scenario: User selects "I DISAGREE"
     Given the user selects I DISAGREE
-    Then the "How long would you like your eligibility for help paying for coverage to be renewed? *" question displays
+    Then the "How long would you like your eligibility for premium reductions to be renewed? *" question displays
     When the user selects 3 years for eligibility length question
     And the user clicks CONTINUE
     Then the user is on the Submit Your Application page


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: TT6-186499192

# A brief description of the changes

Current behavior:
Broken cucumber exists for Your Preferences page in the FAA flow.

New behavior:
Fixed cucumber coverage for Your Preferences page and added new cucumber to check for adherence to Level AA contrast minimums.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: `CONTRAST_LEVEL_AA_IS_ENABLED`
- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.