### PR TITLE
correct padding for FAA income save buttons

### DIFF
--- a/components/financial_assistance/app/assets/stylesheets/financial_assistance/financial_assistance.scss
+++ b/components/financial_assistance/app/assets/stylesheets/financial_assistance/financial_assistance.scss
@@ -32,7 +32,7 @@ input[type="radio"]:checked + label span {
     background:url(https://s3-us-west-2.amazonaws.com/s.cdpn.io/210284/check_radio_sheet.png) -57px top no-repeat;
 }
 
-.deductions, .job_income, .new-other-income-form, .new-income-form, .new-unemployment-income-form, .edit-unemployment-income-form,
+.deductions, .job_income, .new-other-income-form, .new-unemployment-income-form, .edit-unemployment-income-form,
 .new-ai-an-income-form, .edit-ai-an-income-form {
   .col-md-3, input {
     padding-left: 0px !important;


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640057/stories/186499200

# A brief description of the changes

Current behavior: The save button on new incomes takes in a padding that it doesn't need, whereas the save button for editing existing incomes doesn't use the padding.

New behavior: Removed use of the padding.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

![Screenshot 2023-12-29 at 2 48 20 PM](https://github.com/ideacrew/enroll/assets/45053146/c1fce4aa-12ff-412b-95e4-8ff6d506c2fe)


# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.