### PR TITLE
add feature flag for ridp payload format

### DIFF
--- a/app/domain/operations/fdsh/ridp/publish_primary_request.rb
+++ b/app/domain/operations/fdsh/ridp/publish_primary_request.rb
@@ -22,7 +22,7 @@ module Operations
 
         def build_event(payload)
           hbx_id = payload.to_h[:family_members].detect{|fm| fm[:is_primary_applicant] == true}[:person][:hbx_id]
-          event('events.fdsh.ridp.primary_determination_requested', attributes: payload.to_h, headers: { correlation_id: hbx_id })
+          event('events.fdsh.ridp.primary_determination_requested', attributes: payload.to_h, headers: { correlation_id: hbx_id, payload_format: EnrollRegistry[:ridp_h139].setting(:payload_format).item })
         end
 
         def publish(event)

--- a/app/domain/operations/fdsh/ridp/publish_secondary_request.rb
+++ b/app/domain/operations/fdsh/ridp/publish_secondary_request.rb
@@ -22,7 +22,7 @@ module Operations
 
         def build_event(payload)
           hbx_id = payload.to_h[:family_members].detect{|fm| fm[:is_primary_applicant] == true}[:person][:hbx_id]
-          event('events.fdsh.ridp.secondary_determination_requested', attributes: payload.to_h, headers: { correlation_id: hbx_id })
+          event('events.fdsh.ridp.secondary_determination_requested', attributes: payload.to_h, headers: { correlation_id: hbx_id, payload_format: EnrollRegistry[:ridp_h139].setting(:payload_format).item })
         end
 
         def publish(event)

--- a/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -5,6 +5,9 @@ registry:
     features:
       - key: :ridp_h139
         is_enabled: true
+        settings:
+          - key: :payload_format
+            item: <%= ENV['RIDP_H139_PAYLOAD_FORMAT'] || "xml" %>
       - key: :paper_application_verification
         is_enabled: true
       - key: :vlp_h92

--- a/config/client_config/me/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -5,6 +5,9 @@ registry:
     features:
       - key: :ridp_h139
         is_enabled: true
+        settings:
+          - key: :payload_format
+            item: <%= ENV['RIDP_H139_PAYLOAD_FORMAT'] || "xml" %>
       - key: :paper_application_verification
         is_enabled: false
       - key: :vlp_h92

--- a/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -5,6 +5,9 @@ registry:
     features:
       - key: :ridp_h139
         is_enabled: true
+        settings:
+          - key: :payload_format
+            item: <%= ENV['RIDP_H139_PAYLOAD_FORMAT'] || "xml" %>
       - key: :paper_application_verification
         is_enabled: true
       - key: :vlp_h92


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/185698187

# A brief description of the changes

Current behavior: There is no payload_format associated with the RIDP

New behavior: There is now a feature flag to set the payload format and it will be sent as a header with the payloads for both primary and secondary requests

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: RIDP_H139_PAYLOAD_FORMAT

- [X] DC
- [X] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.