### PR TITLE
update waived_under logic to check specifically bga health enrollment

### DIFF
--- a/app/models/census_employee.rb
+++ b/app/models/census_employee.rb
@@ -1729,7 +1729,7 @@ class CensusEmployee < CensusMember
     end
     return false if assignment_by_application.blank?
 
-    health_enrollment = assignment_by_application.hbx_enrollments.detect{|a|a.coverage_kind == 'health'}
+    health_enrollment = assignment_by_application.hbx_enrollments.detect{|a| a.coverage_kind == 'health'}
     health_enrollment&.is_coverage_waived?
   end
 

--- a/app/models/census_employee.rb
+++ b/app/models/census_employee.rb
@@ -1727,8 +1727,10 @@ class CensusEmployee < CensusMember
     assignment_by_application = [renewal_benefit_group_assignment, active_benefit_group_assignment].compact.detect do |assignment|
       assignment.benefit_application && (assignment.benefit_application == benefit_application)
     end
-    return false if assignment_by_application.blank? || assignment_by_application.hbx_enrollment.blank?
-    assignment_by_application.hbx_enrollment.is_coverage_waived?
+    return false if assignment_by_application.blank?
+
+    health_enrollment = assignment_by_application.hbx_enrollments.detect{|a|a.coverage_kind == 'health'}
+    health_enrollment&.is_coverage_waived?
   end
 
   def ssn=(new_ssn)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[RM-104090](https://redmine.priv.dchbx.org/issues/104090)

# A brief description of the changes

Current behavior:
census_employee's is_waived_under? method is checking the bga's default hbx_enrollment regardless of coverage_kind

New behavior:
is_waived_under? will ensure it check's the bga's health enrollment if it exists

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.