### PR TITLE
creates broker agency staff role if person matches during broker registration

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1316,6 +1316,24 @@ class Person
     end
   end
 
+  # Creates a new Broker Agency Staff Role with given input params.
+  #
+  # @note This method may raise an exception if the Broker Agency Staff Role is not created successfully.
+  #
+  # @param [Hash] basr_params.
+  #   The acceptable keys: :aasm_state, :benefit_sponsors_broker_agency_profile_id, :reason
+  # @return [Boolean] true if the Broker Agency Staff Role is created successfully.
+  def create_broker_agency_staff_role(basr_params)
+    basr = broker_agency_staff_roles.build(
+      {
+        aasm_state: basr_params[:aasm_state],
+        benefit_sponsors_broker_agency_profile_id: basr_params[:benefit_sponsors_broker_agency_profile_id]
+      }
+    )
+    save!
+    basr
+  end
+
   private
 
   def assign(collection, association)

--- a/components/benefit_sponsors/app/models/benefit_sponsors/organizations/factories/profile_factory.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/organizations/factories/profile_factory.rb
@@ -436,6 +436,7 @@ module BenefitSponsors
           # @return [Boolean] true if the Broker Agency Staff Role is created successfully.
           def create_broker_agency_staff_role(bap_id)
             return if matched_person.blank?
+            return if matched_person.user.blank?
             return unless EnrollRegistry.feature_enabled?(:broker_role_consumer_enhancement)
 
             matched_person.create_broker_agency_staff_role(

--- a/components/benefit_sponsors/spec/dummy/app/models/person.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/person.rb
@@ -1215,6 +1215,24 @@ class Person
     end
   end
 
+  # Creates a new Broker Agency Staff Role with given input params.
+  #
+  # @note This method may raise an exception if the Broker Agency Staff Role is not created successfully.
+  #
+  # @param [Hash] basr_params.
+  #   The acceptable keys: :aasm_state, :benefit_sponsors_broker_agency_profile_id, :reason
+  # @return [Boolean] true if the Broker Agency Staff Role is created successfully.
+  def create_broker_agency_staff_role(basr_params)
+    basr = broker_agency_staff_roles.build(
+      {
+        aasm_state: basr_params[:aasm_state],
+        benefit_sponsors_broker_agency_profile_id: basr_params[:benefit_sponsors_broker_agency_profile_id]
+      }
+    )
+    save!
+    basr
+  end
+
   private
 
   def is_ssn_composition_correct?

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/organizations/factories/profile_factory_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/organizations/factories/profile_factory_spec.rb
@@ -683,11 +683,12 @@ module BenefitSponsors
 
     context 'BrokerAgency persist_representative!' do
       context 'when matching person exists' do
-        let(:person) { FactoryBot.create(:person) }
-        let(:first_name) { person.first_name }
-        let(:last_name) { person.last_name }
-        let(:person_date_of_birth) { person.dob }
-        let(:profile_factory) { profile_factory_class.call(valid_broker_params) }
+        let(:person)                { FactoryBot.create(:person) }
+        let(:user)                  { FactoryBot.create(:user, person: person) }
+        let(:first_name)            { user.person.first_name }
+        let(:last_name)             { user.person.last_name }
+        let(:person_date_of_birth)  { user.person.dob }
+        let(:profile_factory)       { profile_factory_class.call(valid_broker_params) }
 
         before do
           allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
@@ -702,8 +703,20 @@ module BenefitSponsors
             expect(profile_factory.matched_person).to eq(person)
           end
 
-          it 'creates broker agency staff role for the person' do
-            expect(person.reload.broker_agency_staff_roles.count).to eq(1)
+          context 'person with user' do
+            it 'creates broker agency staff role for the person' do
+              expect(person.reload.broker_agency_staff_roles.count).to eq(1)
+            end
+          end
+
+          context 'person without user' do
+            let(:first_name)            { person.first_name }
+            let(:last_name)             { person.last_name }
+            let(:person_date_of_birth)  { person.dob }
+
+            it 'does not create broker agency staff role for the person' do
+              expect(person.reload.broker_agency_staff_roles.count).not_to eq(1)
+            end
           end
         end
 

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/organizations/factories/profile_factory_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/organizations/factories/profile_factory_spec.rb
@@ -85,6 +85,11 @@ module BenefitSponsors
         }
       }
     end
+
+    let(:first_name) { 'Tyrion' }
+    let(:last_name) { 'Lannister' }
+    let(:person_date_of_birth) { dob }
+
     let(:valid_broker_params) do
       site
       {
@@ -96,12 +101,12 @@ module BenefitSponsors
           0 =>
           {
             :npn => "3458947593",
-            :first_name => "Tyrion",
-            :last_name => "Lannister",
+            first_name: first_name,
+            last_name: last_name,
             :email => "tyrion@lannister.com",
             :phone => nil,
             :status => nil,
-            :dob => dob,
+            :dob => person_date_of_birth,
             :person_id => nil,
             :area_code => nil,
             :number => nil,
@@ -672,6 +677,46 @@ module BenefitSponsors
 
         it 'should update address' do
           expect(general_agency.general_agency_profile.primary_office_location.address.city).to eq city
+        end
+      end
+    end
+
+    context 'BrokerAgency persist_representative!' do
+      context 'when matching person exists' do
+        let(:person) { FactoryBot.create(:person) }
+        let(:first_name) { person.first_name }
+        let(:last_name) { person.last_name }
+        let(:person_date_of_birth) { person.dob }
+        let(:profile_factory) { profile_factory_class.call(valid_broker_params) }
+
+        before do
+          allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+          allow(EnrollRegistry).to receive(:feature_enabled?).with(:broker_role_consumer_enhancement).and_return(enabled_or_disabled)
+          profile_factory
+        end
+
+        context 'when the feature is enabled' do
+          let(:enabled_or_disabled) { true }
+
+          it 'sets the attribute reader with matched person record' do
+            expect(profile_factory.matched_person).to eq(person)
+          end
+
+          it 'creates broker agency staff role for the person' do
+            expect(person.reload.broker_agency_staff_roles.count).to eq(1)
+          end
+        end
+
+        context 'when the feature is disabled' do
+          let(:enabled_or_disabled) { false }
+
+          it 'sets the attribute reader with matched person record' do
+            expect(profile_factory.matched_person).to eq(person)
+          end
+
+          it 'creates broker agency staff role for the person' do
+            expect(person.reload.broker_agency_staff_roles.count).to eq(0)
+          end
         end
       end
     end

--- a/spec/models/person_broker_agency_staff_role_spec.rb
+++ b/spec/models/person_broker_agency_staff_role_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Person, type: :model, dbclean: :after_each do
+  let(:person) { FactoryBot.create(:person) }
+
+  describe '#create_broker_agency_staff_role' do
+    context 'with valid params' do
+      let(:basr_params) { { aasm_state: 'active', benefit_sponsors_broker_agency_profile_id: BSON::ObjectId.new } }
+
+      it 'creates a broker agency staff role' do
+        expect(
+          person.create_broker_agency_staff_role(basr_params)
+        ).to be_a(BrokerAgencyStaffRole)
+      end
+    end
+
+    context 'with invalid params' do
+      let(:basr_params) { { dummy_field: 'dummy' } }
+
+      it 'raises an error' do
+        expect do
+          person.create_broker_agency_staff_role(basr_params)
+        end.to raise_error(
+          Mongoid::Errors::Validations, /Validation of Person failed./
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186693256](https://www.pivotaltracker.com/story/show/186693256)

# A brief description of the changes

Current behavior: Currently, when a broker registers and a matching person exists in the system, the system will not create a broker agency staff role.

New behavior: When a broker registers and there is a corresponding person in the system, the system will create a broker agency staff role for that person moving forward when the feature is enabled.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:


Feature Key: `:broker_role_consumer_enhancement`
Environment Variable: `'BROKER_ROLE_CONSUMER_ENHANCEMENT_IS_ENABLED'`
Description: `Enhancements for Brokers acting as consumers under the same account`

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.