### PR TITLE
displays insured portal for users without RIDP verification and redirects accordingly

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1026,4 +1026,52 @@ module ApplicationHelper
   def individual_osse_eligibility_years_for_display
     ::BenefitCoveragePeriod.osse_eligibility_years_for_display.sort.reverse
   end
+
+  # => START: Broker Role Consumer Role(Dual Roles) Enhancement.
+
+  # Method: eligible_to_redirect_to_home_page?
+  #
+  # This method checks if a user is eligible to be redirected to the family home page.
+  #
+  # @param [User] user The user to check for eligibility.
+  #
+  # @return [Boolean]
+  #   returns true if the user has an employee role
+  #   returns true if the 'broker_role_consumer_enhancement' feature is not enabled
+  #   returns true if the user has a consumer role and their identity is verified.
+  #   Otherwise, it returns false.
+  #
+  # @example
+  #   eligible_to_redirect_to_home_page?(user) #=> true/false
+  def eligible_to_redirect_to_home_page?(user)
+    return true if user.has_employee_role?
+    return true unless EnrollRegistry.feature_enabled?(:broker_role_consumer_enhancement)
+
+    user.has_consumer_role? && user.consumer_identity_verified?
+  end
+
+  # @method insured_role_exists?(user)
+  # Checks if the user has an insured role.
+  #
+  # @param [User] user The user to check for insured roles.
+  #
+  # @return [Boolean]
+  #   returns true if the user has an employee role.
+  #   returns true if the user has a consumer role and the 'broker_role_consumer_enhancement' feature is enabled.
+  #   returns true if the user has a consumer role and their identity is verified when the 'broker_role_consumer_enhancement' feature is disabled enabled.
+  #   Otherwise, it returns false.
+  #
+  # @example Check if a user has an insured role
+  #   insured_role_exists?(user) #=> true/false
+  def insured_role_exists?(user)
+    return true if user.has_employee_role?
+
+    if EnrollRegistry.feature_enabled?(:broker_role_consumer_enhancement)
+      user.has_consumer_role?
+    else
+      user.has_consumer_role? && user.consumer_identity_verified?
+    end
+  end
+
+  # => END: Broker Role Consumer Role(Dual Roles) Enhancement
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1322,7 +1322,8 @@ class Person
   #
   # @param [Hash] basr_params.
   #   The acceptable keys: :aasm_state, :benefit_sponsors_broker_agency_profile_id, :reason
-  # @return [Boolean] true if the Broker Agency Staff Role is created successfully.
+  #   Currently, we only create Broker Agency Staff Role with benefit_sponsors_broker_agency_profile_id
+  # @return [BrokerAgencyStaffRole] broker_agency_staff_role if the Broker Agency Staff Role is created successfully.
   def create_broker_agency_staff_role(basr_params)
     basr = broker_agency_staff_roles.build(
       {

--- a/app/views/shared/_my_portal_links.html.erb
+++ b/app/views/shared/_my_portal_links.html.erb
@@ -1,4 +1,4 @@
-<% insured = (current_user.try(:has_consumer_role?) && current_user.consumer_identity_verified?) || current_user.try(:has_employee_role?) %>
+<% insured = insured_role_exists?(current_user) %>
 <% employer_staff =  (current_user.person && current_user.person.active_employer_staff_roles) || []%>
 <% employer = employer_staff.first %>
 <% broker_staff_roles =  (current_user.person && current_user.person.active_broker_staff_roles) || []%>
@@ -10,6 +10,9 @@
     <span>
       <%= link_to l10n(".my_insured_portal"), main_app.family_account_path(tab: 'home'), class: 'header-text' if insured %>
       <%= link_to l10n('.my_employer_portal'), benefit_sponsors.new_profiles_registration_path(:profile_type => :benefit_sponsor), class: 'header-text' if employer_staff.present? %>
+
+      <!-- The text for the Broker Agency Portal link should display the name of the Broker Agency. -->
+      <!-- The redirection link should go to the Broker Agency Portal home page instead of the Broker Agency Registration page. -->
       <%= link_to l10n('.my_broker_agency_portal'), benefit_sponsors.new_profiles_registration_path(:profile_type => :broker_agency), class: 'header-text' if broker_staff_roles.any? %>
       <%= link_to l10n('.my_general_agency_portal'), benefit_sponsors.profiles_general_agencies_general_agency_profile_path(ga_staff_roles.first.general_agency_profile, tab:'home'), class: 'header-text' if ga_staff_roles.any? %>
       <span> | </span>
@@ -28,7 +31,11 @@
             </li>
           <% end %>
           <% if insured %>
-            <li><%= link_to l10n('.my_insured_portal'), main_app.family_account_path(tab: 'home'), class: 'header-text' %></li>
+            <% if eligible_to_redirect_to_home_page?(current_user) %>
+              <li><%= link_to l10n('.my_insured_portal'), main_app.family_account_path(tab: 'home'), class: 'header-text' %></li>
+            <% else %>
+              <li><%= sanitize link_to l10n('.my_insured_portal'), main_app.ridp_agreement_insured_consumer_role_index_path, class: 'header-text' %></li>
+            <% end %>
           <% end %>
           <% employer_staff.each do |employer_staff_role|  %>
             <% id = employer_staff_role.benefit_sponsor_employer_profile_id %>

--- a/features/insured/step_definitions/dual_role_steps.rb
+++ b/features/insured/step_definitions/dual_role_steps.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+Given(/^a person exists with a user$/) do
+  @dual_role_person = FactoryBot.create(
+    :person,
+    :with_consumer_role,
+    first_name: 'Dual',
+    last_name: 'Role'
+  )
+
+  FactoryBot.create(:user, person: @dual_role_person)
+end
+
+And(/^this person has a consumer role with failed or pending RIDP verification$/) do
+  @dual_role_person.user.update_attributes(identity_verified_date: nil)
+  @dual_role_person.consumer_role.move_identity_documents_to_outstanding
+end
+
+And(/^the last visited page is RIDP agreement$/) do
+  @dual_role_person.consumer_role.update_attributes!(
+    bookmark_url: "#{Rails.application.routes.url_helpers.root_url}insured/consumer_role/ridp_agreement"
+  )
+end
+
+And(/^this person has an approved broker role, broker agency staff role associated to a broker agency profile$/) do
+  broker_role = FactoryBot.create(:broker_role, person: @dual_role_person)
+  site = FactoryBot.create(:benefit_sponsors_site, :with_benefit_market, :as_hbx_profile, site_key: ::EnrollRegistry[:enroll_app].settings(:site_key).item)
+  broker_agency_organization = FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, legal_name: 'First Legal Name', site: site)
+  @broker_agency_profile = broker_agency_organization.broker_agency_profile
+  broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: @broker_agency_profile.id)
+  @broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id)
+  broker_role.approve!
+  @dual_role_person.create_broker_agency_staff_role(benefit_sponsors_broker_agency_profile_id: @broker_agency_profile.id).broker_agency_accept!
+end
+
+Given(/^broker_role_consumer_enhancement feature is enabled/) do
+  enable_feature :broker_role_consumer_enhancement
+end
+
+Given(/^broker_role_consumer_enhancement feature is disabled/) do
+  disable_feature :broker_role_consumer_enhancement
+end
+
+And(/^the Dual Role user logs into their account$/) do
+  login_as(@dual_role_person.user, scope: :user)
+end
+
+And(/^lands on RIDP agreement page$/) do
+  visit 'insured/consumer_role/ridp_agreement'
+end
+
+Then(/^the user will be able to see My Portals dropdown$/) do
+  expect(page).to have_content('MY PORTALS')
+end
+
+And(/^the user clicks My Portals dropdown$/) do
+  find('a', text: 'MY PORTALS', wait: 5).click
+end
+
+Then(/^the user will see My Insured Portal Link and My Broker Agency Portal Link$/) do
+  expect(page).to have_text('MY INSURED PORTAL')
+  expect(page).to have_text(@broker_agency_profile.legal_name.upcase)
+end
+
+And(/^the user clicks the Broker Agency Profile link with legal name$/) do
+  click_link(@broker_agency_profile.legal_name, wait: 5)
+end
+
+Then(/^the user navigates to the Broker Agency Profile$/) do
+  expect(page).to have_text(@broker_agency_profile.legal_name)
+end
+
+And(/^the user clicks the My Insured Portal link$/) do
+  find_all('li', text: 'My Insured Portal'.upcase)[1].click
+end
+
+And(/^the user navigates to Consumer Role account to RIDP agreeement page$/) do
+  expect(page).to have_text('Authorization and Consent')
+end
+
+Then(/^the user will be able to see My Broker Agency Portal Link$/) do
+  expect(page).to have_text('MY BROKER AGENCY PORTAL')
+end
+
+And(/^the user clicks the Broker Agency Profile link$/) do
+  find('a', text: 'MY BROKER AGENCY PORTAL', wait: 5).click
+end
+
+Then(/^the user does not see My Insured Portal Link$/) do
+  expect(page).not_to have_content('MY PORTALS')
+  expect(page).not_to have_text('MY INSURED PORTAL')
+end

--- a/features/insured/user_with_consumer_and_broker_roles.feature
+++ b/features/insured/user_with_consumer_and_broker_roles.feature
@@ -1,0 +1,33 @@
+Feature: Person with Dual Role(Broker and Consumer Role) navigation using My Portals link on top right.
+
+  Background: A person with consumer role and broker role exists
+    Given a person exists with a user
+    And this person has a consumer role with failed or pending RIDP verification
+    And the last visited page is RIDP agreement
+    And this person has an approved broker role, broker agency staff role associated to a broker agency profile
+
+  Scenario: User logs into the account when the RR feature is enabled
+    Given broker_role_consumer_enhancement feature is enabled
+    And the Dual Role user logs into their account
+    And lands on RIDP agreement page
+    Then the user will be able to see My Portals dropdown
+    And the user clicks My Portals dropdown
+    Then the user will see My Insured Portal Link and My Broker Agency Portal Link
+    And the user clicks the Broker Agency Profile link with legal name
+    Then the user navigates to the Broker Agency Profile
+    And the user clicks My Portals dropdown
+    Then the user will see My Insured Portal Link and My Broker Agency Portal Link
+    And the user clicks the My Insured Portal link
+    And the user navigates to Consumer Role account to RIDP agreeement page
+    And Individual logs out
+
+  Scenario: User logs into the account when the RR feature is disabled
+    Given broker_role_consumer_enhancement feature is disabled
+    And the Dual Role user logs into their account
+    And lands on RIDP agreement page
+    Then the user will be able to see My Broker Agency Portal Link
+    And the user clicks the Broker Agency Profile link
+    And the user navigates to the Broker Agency Profile
+    Then the user will be able to see My Broker Agency Portal Link
+    Then the user does not see My Insured Portal Link
+    And Individual logs out

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -173,6 +173,10 @@ def people
       broker_census_employee: true,
       password: 'aA1!aA1!aA1!',
       ssn: "222335220"
+    },
+    'Dual Role' => {
+      first_name: 'Dual',
+      last_name: 'Role'
     }
   }
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186693254](https://www.pivotaltracker.com/story/show/186693254)

# A brief description of the changes

Current behavior: Currently, when a Consumer Role exists without RIDP verification we do not display the "My Insured Portal" link.

New behavior: When a Consumer Role exists without RIDP verification and the RR configuration is enabled the "My Insured Portal" link will be displayed and the user will be redirected to the RIDP Failed Validation page.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

Feature Key: `:broker_role_consumer_enhancement`
Environment Variable: `'BROKER_ROLE_CONSUMER_ENHANCEMENT_IS_ENABLED'`
Description: `Enhancements for Brokers acting as consumers under the same account`

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.