### PR TITLE
CR 95 - Add notification email for already linked brokers and staff.

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -116,6 +116,14 @@ class UserMailer < ApplicationMailer
     end
   end
 
+  def broker_or_broker_staff_linked_invitation_email(email, person_name)
+    return if email.blank?
+
+    mail({to: email, subject: l10n("user_mailer.broker_or_broker_staff_linked_notification_email.subject")}) do |format|
+      format.html { render "broker_or_broker_staff_linked_notification_email", :locals => { :person_name => person_name, :login_url => site_main_web_address_url }}
+    end
+  end
+
   def message_to_broker(person, broker, params)
     if broker.email_address.present?
       mail({to: broker.email_address, subject: params[:subject], from: person.user.email}) do |format|

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -290,29 +290,33 @@ class Invitation
   end
 
   def self.invite_broker!(broker_role)
-    return nil unless should_invite_broker_or_broker_staff_role?(broker_role)
-
-    invitation = self.create(
-      :role => "broker_role",
-      :source_kind => "broker_role",
-      :source_id => broker_role.id,
-      :invitation_email => broker_role.email_address
-    )
-    invitation.send_broker_invitation!(broker_role.parent.full_name)
-    invitation
+    if should_invite_broker_or_broker_staff_role?(broker_role)
+      invitation = self.create(
+        :role => "broker_role",
+        :source_kind => "broker_role",
+        :source_id => broker_role.id,
+        :invitation_email => broker_role.email_address
+      )
+      invitation.send_broker_invitation!(broker_role.parent.full_name)
+      invitation
+    elsif should_notify_linked_broker_or_broker_staff_role?(broker_role)
+      UserMailer.broker_or_broker_staff_linked_invitation_email(broker_role.email_address, broker_role.parent.full_name)
+    end
   end
 
   def self.invite_broker_agency_staff!(broker_role)
-    return nil unless should_invite_broker_or_broker_staff_role?(broker_role)
-
-    invitation = self.create(
-      :role => "broker_agency_staff_role",
-      :source_kind => "broker_agency_staff_role",
-      :source_id => broker_role.id,
-      :invitation_email => broker_role.email_address
-    )
-    invitation.send_broker_staff_invitation!(broker_role.parent.full_name, broker_role.parent.id)
-    invitation
+    if should_invite_broker_or_broker_staff_role?(broker_role)
+      invitation = self.create(
+        :role => "broker_agency_staff_role",
+        :source_kind => "broker_agency_staff_role",
+        :source_id => broker_role.id,
+        :invitation_email => broker_role.email_address
+      )
+      invitation.send_broker_staff_invitation!(broker_role.parent.full_name, broker_role.parent.id)
+      invitation
+    elsif should_notify_linked_broker_or_broker_staff_role?(broker_role)
+      UserMailer.broker_or_broker_staff_linked_invitation_email(broker_role.email_address, broker_role.parent.full_name)
+    end
   end
 
   def self.invite_general_agency_staff!(staff_role)
@@ -381,8 +385,17 @@ class Invitation
   def self.should_invite_broker_or_broker_staff_role?(role)
     has_email = !role.email_address.blank?
     return has_email unless EnrollRegistry.feature_enabled?(:broker_role_consumer_enhancement)
+    has_email && !claimed_consumer_role_with_login?(role)
+  end
+
+  def self.should_notify_linked_broker_or_broker_staff_role?(role)
+    return false unless EnrollRegistry.feature_enabled?(:broker_role_consumer_enhancement)
+    return false if role.email_address.blank?
+    claimed_consumer_role_with_login?(role)
+  end
+
+  def self.claimed_consumer_role_with_login?(role)
     person = role.person
-    claimed_consumer_role_with_login = person.user.present? && person.consumer_role.present?
-    has_email && !claimed_consumer_role_with_login
+    person.user.present? && person.consumer_role.present?
   end
 end

--- a/app/views/user_mailer/broker_or_broker_staff_linked_notification_email.html.erb
+++ b/app/views/user_mailer/broker_or_broker_staff_linked_notification_email.html.erb
@@ -1,0 +1,13 @@
+
+<%= l10n("user_mailer.broker_or_broker_staff_linked_notification_email.full_text",
+      first_name: person_name,
+      person_name: person_name,
+      site_short_name: site_short_name,
+      contact_center_phone_number: EnrollRegistry[:enroll_app].setting(:contact_center_short_number).item,
+      site_home_business_url: site_home_business_url,
+      site_user_sign_in_url: EnrollRegistry[:enroll_app].setting(:user_sign_in_url).item,
+      contact_center_tty_number: EnrollRegistry[:enroll_app].settings(:contact_center_tty_number).item,
+      site_title: EnrollRegistry[:enroll_app].setting(:site_title).item,
+      broker_agreement_url: EnrollRegistry[:broker_agreement_url].item,
+      login_url: login_url
+).html_safe %>

--- a/config/client_config/dc/system/config/templates/features/brokers/brokers.yml
+++ b/config/client_config/dc/system/config/templates/features/brokers/brokers.yml
@@ -24,6 +24,9 @@ registry:
       - key: :broker_training_link
         is_enabled: true
         item: ""
+      - key: broker_agreement_url
+        is_enabled: true
+        item: ""
       - key: :allow_edit_broker_email
         is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL_IS_ENABLED'] || false %>
       - key: :allow_edit_broker_npn

--- a/config/client_config/me/system/config/templates/features/brokers/brokers.yml
+++ b/config/client_config/me/system/config/templates/features/brokers/brokers.yml
@@ -24,6 +24,9 @@ registry:
       - key: :broker_training_link
         is_enabled: true
         item: "https://coverme.inquisiqlms.com/"
+      - key: broker_agreement_url
+        is_enabled: true
+        item: "https://coverme.gov/brokeragreement"
       - key: :allow_edit_broker_email
         is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL_IS_ENABLED'] || false %>
       - key: :allow_edit_broker_npn

--- a/config/locales/user_mailer.en.yml
+++ b/config/locales/user_mailer.en.yml
@@ -1,0 +1,11 @@
+en:
+  user_mailer:
+    broker_or_broker_staff_linked_notification_email:
+      subject: Access your expert portal
+      full_text: |
+        <p>Hi %{first_name},</p>
+        <p>Your application to assist consumers on %{site_short_name} has been approved.</p><br>
+        <p>You will need to claim your access to your expert portal to assist consumers. You can do this by pressing the 'Login' button in the email and entering the username and password you use to login to your personal account. You can move between your personal and expert portals by selecting ‘My Portals’ on the upper right-hand corner of your screen. By accessing your expert portal, you affirm that you have read and agreed to the %{site_short_name} broker agreement available at %{broker_agreement_url}.</p>
+        <a href=%{login_url} class='button-link'>Login</a><br>
+        <p>Questions? Call us at %{contact_center_phone_number}.</p>
+        <p>The %{site_short_name} Team</p>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UserMailer do
@@ -136,5 +138,22 @@ RSpec.describe UserMailer do
     it "should render the email with the proper text" do
       expect(identity_verification_denial.body.raw_source).to include(person_with_work_email.first_name)
     end
+  end
+end
+
+RSpec.describe UserMailer, "sending a approval linked notification email for a broker or broker staff" do
+  include Config::SiteHelper
+
+  let(:email) { "some-broker@adomain.com"}
+  let(:name) { "Broker Name"}
+
+  subject { UserMailer.broker_or_broker_staff_linked_invitation_email(email, name) }
+
+  it "has the login link" do
+    expect(subject.body.raw_source.include?("href=#{site_main_web_address_url}")).to be_truthy
+  end
+
+  it "has the greeting" do
+    expect(subject.body.raw_source.include?("Hi #{name},")).to be_truthy
   end
 end

--- a/spec/mailers/user_mailer_translations_spec.rb
+++ b/spec/mailers/user_mailer_translations_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe "translations for: en.user_mailer" do
+  describe "the user_mailer.broker_or_broker_staff_linked_notification_email.full_text translation" do
+    let(:key) { "user_mailer.broker_or_broker_staff_linked_notification_email.full_text" }
+
+    it "exists" do
+      expect(I18n.exists?(key)).to be_truthy
+    end
+  end
+
+  describe "the user_mailer.broker_or_broker_staff_linked_notification_email.subject translation" do
+    let(:key) { "user_mailer.broker_or_broker_staff_linked_notification_email.subject" }
+
+    it "exists" do
+      expect(I18n.exists?(key)).to be_truthy
+    end
+  end
+end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -225,6 +225,10 @@ describe "A Broker Invitation" do
     it "should not invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker)).to be_falsey
     end
+
+    it "should not notify the broker of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker)).to be_falsey
+    end
   end
 
   describe "when:
@@ -237,6 +241,10 @@ describe "A Broker Invitation" do
 
     it "should invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker)).to be_truthy
+    end
+
+    it "should not notify the broker of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker)).to be_falsey
     end
   end
 
@@ -251,6 +259,10 @@ describe "A Broker Invitation" do
     it "should not invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker)).to be_falsey
     end
+
+    it "should not notify the broker of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker)).to be_falsey
+    end
   end
 
   describe "when:
@@ -265,6 +277,10 @@ describe "A Broker Invitation" do
 
     it "should invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker)).to be_truthy
+    end
+
+    it "should not notify the broker of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker)).to be_falsey
     end
   end
 
@@ -281,6 +297,10 @@ describe "A Broker Invitation" do
     it "should invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker)).to be_truthy
     end
+
+    it "should not notify the broker of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker)).to be_falsey
+    end
   end
 
   describe "when:
@@ -295,6 +315,10 @@ describe "A Broker Invitation" do
 
     it "should invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker)).to be_truthy
+    end
+
+    it "should not notify the broker of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker)).to be_falsey
     end
   end
 
@@ -310,6 +334,10 @@ describe "A Broker Invitation" do
 
     it "should not invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker)).to be_falsey
+    end
+
+    it "should notify the broker of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker)).to be_truthy
     end
   end
 end
@@ -337,6 +365,10 @@ describe "A Broker Staff Invitation" do
     it "should not invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker_staff)).to be_falsey
     end
+
+    it "should not notify the broker staff of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker_staff)).to be_falsey
+    end
   end
 
   describe "when:
@@ -349,6 +381,10 @@ describe "A Broker Staff Invitation" do
 
     it "should invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker_staff)).to be_truthy
+    end
+
+    it "should not notify the broker staff of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker_staff)).to be_falsey
     end
   end
 
@@ -363,6 +399,10 @@ describe "A Broker Staff Invitation" do
     it "should not invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker_staff)).to be_falsey
     end
+
+    it "should not notify the broker staff of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker_staff)).to be_falsey
+    end
   end
 
   describe "when:
@@ -377,6 +417,10 @@ describe "A Broker Staff Invitation" do
 
     it "should invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker_staff)).to be_truthy
+    end
+
+    it "should not notify the broker staff of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker_staff)).to be_falsey
     end
   end
 
@@ -393,6 +437,10 @@ describe "A Broker Staff Invitation" do
     it "should invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker_staff)).to be_truthy
     end
+
+    it "should not notify the broker staff of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker_staff)).to be_falsey
+    end
   end
 
   describe "when:
@@ -407,6 +455,10 @@ describe "A Broker Staff Invitation" do
 
     it "should invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker_staff)).to be_truthy
+    end
+
+    it "should not notify the broker staff of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker_staff)).to be_falsey
     end
   end
 
@@ -422,6 +474,10 @@ describe "A Broker Staff Invitation" do
 
     it "should not invite the broker" do
       expect(Invitation.should_invite_broker_or_broker_staff_role?(broker_staff)).to be_falsey
+    end
+
+    it "should notify the broker staff of being approved" do
+      expect(Invitation.should_notify_linked_broker_or_broker_staff_role?(broker_staff)).to be_truthy
     end
   end
 end

--- a/system/config/templates/features/brokers/brokers.yml
+++ b/system/config/templates/features/brokers/brokers.yml
@@ -26,7 +26,7 @@ registry:
         item: ""
       - key: broker_agreement_url
         is_enabled: true
-        item: "https://coverme.gov/brokeragreement"
+        item: ""
       - key: :allow_edit_broker_email
         is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL_IS_ENABLED'] || false %>
       - key: :allow_edit_broker_npn

--- a/system/config/templates/features/brokers/brokers.yml
+++ b/system/config/templates/features/brokers/brokers.yml
@@ -24,6 +24,9 @@ registry:
       - key: :broker_training_link
         is_enabled: true
         item: ""
+      - key: broker_agreement_url
+        is_enabled: true
+        item: "https://coverme.gov/brokeragreement"
       - key: :allow_edit_broker_email
         is_enabled: <%= ENV['ALLOW_EDIT_BROKER_EMAIL_IS_ENABLED'] || false %>
       - key: :allow_edit_broker_npn


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186693255

# A brief description of the changes

Current behavior:  Currently, brokers and broker staff already linked with a user and consumer role receive an 'invitation' email inviting them to come and create an account.  Creation of this account with an already existing user causes problems with account linkage and identity.

New behavior:  Don't create an invitation when these roles are approved, instead send a 'notification' email, inviting them to log in.

# Feature Flag

Variable name: :broker_role_consumer_enhancement
ENV name: BROKER_ROLE_CONSUMER_ENHANCEMENT_IS_ENABLED

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

**Failure Kind**: Ruby Cross Site Scripting
**Code Flagged**:
 line 2 in app/views/user_mailer/broker_or_broker_staff_linked_notification_email.html.erb:
```ruby
l10n("user_mailer.broker_or_broker_staff_linked_notification_email.full_text",
      first_name: person_name,
      person_name: person_name,
      site_short_name: site_short_name,
      contact_center_phone_number: EnrollRegistry[:enroll_app].setting(:contact_center_short_number).item,
      site_home_business_url: site_home_business_url,
      site_user_sign_in_url: EnrollRegistry[:enroll_app].setting(:user_sign_in_url).item,
      contact_center_tty_number: EnrollRegistry[:enroll_app].settings(:contact_center_tty_number).item,
      site_title: EnrollRegistry[:enroll_app].setting(:site_title).item,
      login_url: login_url
).html_safe %>
```
**Exception Justification**:
While normally dynamic, unsanitized usage of HTML in a Rails template is a vector for XSS, this case is different from the usual usage of raw HTML in a rails template, as:
1. This does not generate a client facing page - this generation is used to send emails.  This means this template would never be rendered to a client in the process of traversing our application.
2. The portion of the data which comes from data entry by a user (and thus could be used to inject malicious content) is limited to the a name field of a person record - a field already sanitized for HTML.