### PR TITLE
passing session id job identification

### DIFF
--- a/app/domain/operations/fdsh/ridp/publish_secondary_request.rb
+++ b/app/domain/operations/fdsh/ridp/publish_secondary_request.rb
@@ -11,8 +11,8 @@ module Operations
         send(:include, Dry::Monads[:result, :do, :try])
         include EventSource::Command
 
-        def call(payload, session_id)
-          event  = yield build_event(payload, session_id)
+        def call(payload, session_id, transmission_id)
+          event  = yield build_event(payload, session_id, transmission_id)
           result = yield publish(event)
 
           Success(result)
@@ -20,11 +20,12 @@ module Operations
 
         private
 
-        def build_event(payload, session_id)
+        def build_event(payload, session_id, transmission_id)
           hbx_id = payload.to_h[:family_members].detect{|fm| fm[:is_primary_applicant] == true}[:person][:hbx_id]
           event('events.fdsh.ridp.secondary_determination_requested', attributes: payload.to_h, headers: { correlation_id: hbx_id,
                                                                                                            payload_format: EnrollRegistry[:ridp_h139].setting(:payload_format).item,
-                                                                                                           session_id: session_id})
+                                                                                                           session_id: session_id,
+                                                                                                           transmission_id: transmission_id})
         end
 
         def publish(event)

--- a/app/domain/operations/fdsh/ridp/publish_secondary_request.rb
+++ b/app/domain/operations/fdsh/ridp/publish_secondary_request.rb
@@ -11,8 +11,8 @@ module Operations
         send(:include, Dry::Monads[:result, :do, :try])
         include EventSource::Command
 
-        def call(payload)
-          event  = yield build_event(payload)
+        def call(payload, session_id)
+          event  = yield build_event(payload, session_id)
           result = yield publish(event)
 
           Success(result)
@@ -20,9 +20,11 @@ module Operations
 
         private
 
-        def build_event(payload)
+        def build_event(payload, session_id)
           hbx_id = payload.to_h[:family_members].detect{|fm| fm[:is_primary_applicant] == true}[:person][:hbx_id]
-          event('events.fdsh.ridp.secondary_determination_requested', attributes: payload.to_h, headers: { correlation_id: hbx_id, payload_format: EnrollRegistry[:ridp_h139].setting(:payload_format).item })
+          event('events.fdsh.ridp.secondary_determination_requested', attributes: payload.to_h, headers: { correlation_id: hbx_id,
+                                                                                                           payload_format: EnrollRegistry[:ridp_h139].setting(:payload_format).item,
+                                                                                                           session_id: session_id})
         end
 
         def publish(event)

--- a/app/domain/operations/fdsh/ridp/request_secondary_determination.rb
+++ b/app/domain/operations/fdsh/ridp/request_secondary_determination.rb
@@ -19,7 +19,7 @@ module Operations
           payload_with_attestation = yield merge_attestation_to_user(family_hash, attestation_hash)
           payload_value = yield validate_payload(payload_with_attestation)
           payload_entity = yield create_payload_entity(payload_value)
-          payload = yield publish(payload_entity)
+          payload = yield publish(payload_entity, interactive_verification)
 
           Success(payload)
         end
@@ -58,8 +58,9 @@ module Operations
           Success(AcaEntities::Families::Family.new(value.to_h))
         end
 
-        def publish(payload)
-          Operations::Fdsh::Ridp::PublishSecondaryRequest.new.call(payload)
+        def publish(payload, interactive_verification)
+          session_id = interactive_verification&.session_id ? interactive_verification.session_id : nil
+          Operations::Fdsh::Ridp::PublishSecondaryRequest.new.call(payload, session_id)
         end
       end
     end

--- a/app/domain/operations/fdsh/ridp/request_secondary_determination.rb
+++ b/app/domain/operations/fdsh/ridp/request_secondary_determination.rb
@@ -59,8 +59,9 @@ module Operations
         end
 
         def publish(payload, interactive_verification)
-          session_id = interactive_verification&.session_id ? interactive_verification.session_id : nil
-          Operations::Fdsh::Ridp::PublishSecondaryRequest.new.call(payload, session_id)
+          session_id = interactive_verification&.session_id
+          transmission_id = interactive_verification&.transmission_id
+          Operations::Fdsh::Ridp::PublishSecondaryRequest.new.call(payload, session_id, transmission_id)
         end
       end
     end

--- a/app/domain/operations/transformers/interactive_verification_to/attestation.rb
+++ b/app/domain/operations/transformers/interactive_verification_to/attestation.rb
@@ -16,9 +16,7 @@ module Operations
         require 'securerandom'
 
         def call(interactive_verification)
-          request_payload = yield construct_payload(interactive_verification)
-
-          Success(request_payload)
+          construct_payload(interactive_verification)
         end
 
         private
@@ -34,12 +32,14 @@ module Operations
         end
 
         def construct_ridp_attestation_hash(interactive_verification)
+          secondary_request = construct_secondary_request(interactive_verification)
+          request_payload[:secondary_request][:DSHReferenceNumber] = interactive_verification.transmission_id if EnrollRegistry[:ridp_h139].setting(:payload_format).item == "json"
           {
             is_satisfied: false,
             is_self_attested: true,
             satisfied_at: nil,
             status: 'in_progress',
-            evidences: [construct_secondary_request(interactive_verification)]
+            evidences: [secondary_request]
           }
         end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)
Not needed as we are just adding a param on header
# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186478757

# A brief description of the changes

Current behavior: Currently we do not pass session for ridp secondary request since we do not bind primary and secondary calls.

New behavior: Passing session_id as a header to be able to find the primary job to bind with the secondary call.

# Feature Flag: Not needed.

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.