### PR TITLE
extract applicant params and check presence of dob

### DIFF
--- a/app/domain/operations/families/create_or_update_member.rb
+++ b/app/domain/operations/families/create_or_update_member.rb
@@ -23,13 +23,13 @@ module Operations
 
       def validate(params)
         Failure("family id is required") unless params[:family_id].present?
-        Success([params[:family_id], params.except(:family_id)])
+        Success([params[:family_id], params[:applicant_params]])
       end
 
       def sanitize_params(applicant_params)
         dob_value = applicant_params[:dob]
 
-        applicant_params.merge!(dob: dob_value.strftime('%d/%m/%Y')) unless dob_value.is_a?(String)
+        applicant_params.merge!(dob: dob_value&.strftime('%d/%m/%Y')) unless dob_value&.is_a?(String)
         Success(applicant_params)
       end
 

--- a/app/domain/operations/families/create_or_update_member.rb
+++ b/app/domain/operations/families/create_or_update_member.rb
@@ -28,8 +28,9 @@ module Operations
 
       def sanitize_params(applicant_params)
         dob_value = applicant_params[:dob]
+        return Failure("dob is required") unless dob_value.present?
 
-        applicant_params.merge!(dob: dob_value&.strftime('%d/%m/%Y')) unless dob_value&.is_a?(String)
+        applicant_params.merge!(dob: dob_value.strftime('%d/%m/%Y')) unless dob_value.is_a?(String)
         Success(applicant_params)
       end
 

--- a/components/financial_assistance/app/domain/financial_assistance/operations/application/relationship_handler.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/application/relationship_handler.rb
@@ -42,7 +42,7 @@ module FinancialAssistance
             create_or_update_member_params = { applicant_params: @dependent.attributes_for_export, family_id: @application.family_id }
 
             if FinancialAssistanceRegistry[:avoid_dup_hub_calls_on_applicant_create_or_update].enabled?
-              create_or_update_member_params.merge!(is_primary_applicant: @dependent.is_primary_applicant?, skip_consumer_role_callbacks: true, skip_person_updated_event_callback: true)
+              create_or_update_member_params[:applicant_params].merge!(is_primary_applicant: @dependent.is_primary_applicant?, skip_consumer_role_callbacks: true, skip_person_updated_event_callback: true)
               ::Operations::Families::CreateOrUpdateMember.new.call(create_or_update_member_params)
             else
               ::FinancialAssistance::Operations::Families::CreateOrUpdateMember.new.call(params: create_or_update_member_params)

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1310,7 +1310,7 @@ module FinancialAssistance
       save!
     end
 
-    # rubocop:disable Metrics/Naming/AccessorMethodName
+    # rubocop:disable Naming/AccessorMethodName
     def set_evidence_verified(evidence)
       evidence.verification_outstanding = false
       evidence.is_satisfied = true
@@ -1363,7 +1363,7 @@ module FinancialAssistance
       evidence.move_to_rejected
       save!
     end
-    # rubocop:enable Metrics/Naming/AccessorMethodName
+    # rubocop:enable Naming/AccessorMethodName
 
     class << self
       def find(id)

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -1621,7 +1621,7 @@ module FinancialAssistance
       if is_active && !callback_update
         create_or_update_member_params = { applicant_params: self.attributes_for_export, family_id: application.family_id }
         create_or_update_result = if FinancialAssistanceRegistry[:avoid_dup_hub_calls_on_applicant_create_or_update].enabled?
-                                    create_or_update_member_params.merge!(is_primary_applicant: is_primary_applicant?, skip_consumer_role_callbacks: true, skip_person_updated_event_callback: true)
+                                    create_or_update_member_params[:applicant_params].merge!(is_primary_applicant: is_primary_applicant?, skip_consumer_role_callbacks: true, skip_person_updated_event_callback: true)
                                     ::Operations::Families::CreateOrUpdateMember.new.call(create_or_update_member_params)
                                   else
                                     ::FinancialAssistance::Operations::Families::CreateOrUpdateMember.new.call(params: create_or_update_member_params)

--- a/spec/domain/operations/families/create_or_update_member_spec.rb
+++ b/spec/domain/operations/families/create_or_update_member_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Operations::Families::CreateOrUpdateMember, type: :model, dbclean
 
   context '#update member' do
     let(:params) do
-      {applicant_params: applicant_params.merge( gender: 'female', is_incarcerated: false, :ethnicity => ["Filipino", "Japanese", "Korean", "Vietnamese", "Other Asian"], i94_number: '45612378985', relationship: 'spouse'), family_id: family.id}
+      {applicant_params: applicant_params.merge(gender: 'female', is_incarcerated: false, :ethnicity => ["Filipino", "Japanese", "Korean", "Vietnamese", "Other Asian"], i94_number: '45612378985', relationship: 'spouse'), family_id: family.id}
     end
 
     let!(:create_spouse) do

--- a/spec/domain/operations/families/create_or_update_member_spec.rb
+++ b/spec/domain/operations/families/create_or_update_member_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Operations::Families::CreateOrUpdateMember, type: :model, dbclean
   let(:family) {FactoryBot.create(:family, :with_primary_family_member, person: person)}
 
   let(:params) do
-    applicant_params.merge(family_id: family.id, relationship: 'spouse')
+    {applicant_params: applicant_params.merge(relationship: 'spouse'), family_id: family.id}
   end
 
   it 'should be a container-ready operation' do
@@ -31,7 +31,7 @@ RSpec.describe Operations::Families::CreateOrUpdateMember, type: :model, dbclean
       before do
         @result = subject.call(params)
         family.reload
-        @person = Person.by_hbx_id(params[:person_hbx_id]).first
+        @person = Person.by_hbx_id(applicant_params[:person_hbx_id]).first
       end
 
       it 'returns a success result' do
@@ -67,7 +67,7 @@ RSpec.describe Operations::Families::CreateOrUpdateMember, type: :model, dbclean
       before do
         @result = subject.call(params.except(:family_id))
         family.reload
-        @person = Person.by_hbx_id(params[:person_hbx_id]).first
+        @person = Person.by_hbx_id(applicant_params[:person_hbx_id]).first
       end
 
       it 'should return failure' do
@@ -86,7 +86,7 @@ RSpec.describe Operations::Families::CreateOrUpdateMember, type: :model, dbclean
 
   context '#update member' do
     let(:params) do
-      applicant_params.merge(family_id: family.id, gender: 'female', is_incarcerated: false, :ethnicity => ["Filipino", "Japanese", "Korean", "Vietnamese", "Other Asian"], i94_number: '45612378985', relationship: 'spouse')
+      {applicant_params: applicant_params.merge( gender: 'female', is_incarcerated: false, :ethnicity => ["Filipino", "Japanese", "Korean", "Vietnamese", "Other Asian"], i94_number: '45612378985', relationship: 'spouse'), family_id: family.id}
     end
 
     let!(:create_spouse) do
@@ -98,7 +98,7 @@ RSpec.describe Operations::Families::CreateOrUpdateMember, type: :model, dbclean
       before do
         @result = subject.call(params)
         family.reload
-        @person = Person.by_hbx_id(params[:person_hbx_id]).first
+        @person = Person.by_hbx_id(applicant_params[:person_hbx_id]).first
       end
 
       it 'returns a success result' do
@@ -132,7 +132,7 @@ RSpec.describe Operations::Families::CreateOrUpdateMember, type: :model, dbclean
       before do
         @result = subject.call(params.except(:family_id))
         family.reload
-        @person = Person.by_hbx_id(params[:person_hbx_id]).first
+        @person = Person.by_hbx_id(applicant_params[:person_hbx_id]).first
       end
 
       it 'should return failure' do
@@ -145,6 +145,29 @@ RSpec.describe Operations::Families::CreateOrUpdateMember, type: :model, dbclean
 
       it 'should not create family member' do
         expect(family.family_members.count).to eq 1
+      end
+    end
+  end
+
+  context '#sanitize_params' do
+    let(:subject) { described_class.new }
+
+    context 'when dob is not present' do
+      it 'returns a failure result' do
+        result = subject.sanitize_params(applicant_params.except(:dob))
+        expect(result).to be_failure
+      end
+    end
+
+    context 'when dob is present' do
+      it 'returns a success result' do
+        result = subject.sanitize_params(applicant_params)
+        expect(result).to be_success
+      end
+
+      it 'converts dob to the desired format if it is not a string' do
+        result = subject.sanitize_params(applicant_params)
+        expect(result.value!).to eq(applicant_params.merge(dob: dob.strftime('%d/%m/%Y')))
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [pivotal-186201442](https://www.pivotaltracker.com/n/projects/2640060/stories/186201442)

# A brief description of the changes

Current behavior: The presence of the DOB key in a nested hash is causing a data flow failure when an attempt is made to fetch it from the top level.

New behavior: The current change is to stop excluding the family_id from the parameters. Instead, all other attributes is be merged into applicant_params, which is then be extracted as the top-level hash

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.