### PR TITLE
creates broker agency staff role in broker_agency_pending state

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1326,7 +1326,6 @@ class Person
   def create_broker_agency_staff_role(basr_params)
     basr = broker_agency_staff_roles.build(
       {
-        aasm_state: basr_params[:aasm_state],
         benefit_sponsors_broker_agency_profile_id: basr_params[:benefit_sponsors_broker_agency_profile_id]
       }
     )

--- a/components/benefit_sponsors/app/models/benefit_sponsors/organizations/factories/profile_factory.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/organizations/factories/profile_factory.rb
@@ -440,10 +440,7 @@ module BenefitSponsors
             return unless EnrollRegistry.feature_enabled?(:broker_role_consumer_enhancement)
 
             matched_person.create_broker_agency_staff_role(
-              {
-                aasm_state: 'active',
-                benefit_sponsors_broker_agency_profile_id: bap_id
-              }
+              benefit_sponsors_broker_agency_profile_id: bap_id
             )
           end
 

--- a/components/benefit_sponsors/spec/dummy/app/models/person.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/person.rb
@@ -1225,7 +1225,6 @@ class Person
   def create_broker_agency_staff_role(basr_params)
     basr = broker_agency_staff_roles.build(
       {
-        aasm_state: basr_params[:aasm_state],
         benefit_sponsors_broker_agency_profile_id: basr_params[:benefit_sponsors_broker_agency_profile_id]
       }
     )

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/organizations/factories/profile_factory_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/organizations/factories/profile_factory_spec.rb
@@ -707,6 +707,12 @@ module BenefitSponsors
             it 'creates broker agency staff role for the person' do
               expect(person.reload.broker_agency_staff_roles.count).to eq(1)
             end
+
+            it 'creates broker agency staff role in the initial aasm_state' do
+              expect(
+                person.reload.broker_agency_staff_roles.first.aasm_state
+              ).to eq('broker_agency_pending')
+            end
           end
 
           context 'person without user' do

--- a/spec/models/person_broker_agency_staff_role_spec.rb
+++ b/spec/models/person_broker_agency_staff_role_spec.rb
@@ -7,12 +7,18 @@ RSpec.describe Person, type: :model, dbclean: :after_each do
 
   describe '#create_broker_agency_staff_role' do
     context 'with valid params' do
-      let(:basr_params) { { aasm_state: 'active', benefit_sponsors_broker_agency_profile_id: BSON::ObjectId.new } }
+      let(:basr_params) { { benefit_sponsors_broker_agency_profile_id: BSON::ObjectId.new } }
 
       it 'creates a broker agency staff role' do
         expect(
           person.create_broker_agency_staff_role(basr_params)
         ).to be_a(BrokerAgencyStaffRole)
+      end
+
+      it 'creates a broker agency staff role in initial aasm_state' do
+        expect(
+          person.create_broker_agency_staff_role(basr_params).aasm_state
+        ).to eq('broker_agency_pending')
       end
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: Ticket: [IVL Product Development - 186693256](https://www.pivotaltracker.com/story/show/186693256)

# A brief description of the changes

Current behavior: When the feature is enabled and the broker registers, there is a corresponding person with a user in the system and then the system creates a broker agency staff role in the `active` aasm state.

New behavior: When the feature is enabled and the broker registers, there is a corresponding person with a user in the system and then the system creates a broker agency staff role in the initial `broker_agency_pending` aasm state.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

Feature Key: `:broker_role_consumer_enhancement`
Environment Variable: `'BROKER_ROLE_CONSUMER_ENHANCEMENT_IS_ENABLED'`
Description: `Enhancements for Brokers acting as consumers under the same account`

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.