### PR TITLE
level aa contrast improve info button

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/applications/review_and_submit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/review_and_submit.html.erb
@@ -78,7 +78,7 @@
                   <div class="row row-form-wrapper ptb no-buffer row-height form-content">
                     <div class="col-md-7 annual-income-row">
                       <%= applicant.first_name %>'s annual income for <%= @application.assistance_year %>
-                      <a href="#net_annual_income" data-toggle="modal" data-target="#net_annual_income"><i class="fa fa-info-circle"></i></a> :
+                      <a href="#net_annual_income" data-toggle="modal" data-target="#net_annual_income"><i class="fa fa-info-circle"><span class="hide"><%=l10n("info")%></span></i></a> :
                     </div>
                     <div class="col-md-5">
                       <%= number_to_currency(applicant.net_annual_income) %>

--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -93,6 +93,7 @@ How to find the SEVIS ID: On the DS-2019, the number is on the top right hand si
   :'en.insured.families.verification.documents_FAQ' => "Documents We Accept",
   :'en.delete' => "Delete",
   :'en.deleted' => "Deleted",
+  :'en.info' => "Info",
   :'en.insured.families.medicaid_and_tax_credits' => "Medicaid & Tax Credits",
   :'en.insured.families.apply_for_medicaid_widget' => "Apply, renew, read notices or find out what documents are needed for Medicaid or tax credit assisted coverage",
   :'en.insured.families.aptc_or_csr_enrollments' => "APTC / CSR Enrollments",

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -117,6 +117,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.families.verification.documents_FAQ' => "Documents We Accept",
   :'en.delete' => "Delete",
   :'en.deleted' => "Deleted",
+  :'en.info' => "Info",
   :'en.insured.families.medicaid_and_tax_credits' => "Go to District Direct",
   :'en.insured.families.apply_for_medicaid_widget' => "Want to apply for Medicaid? Go to District Direct to apply, recertify benefits, and view notices.",
   :'en.insured.families.aptc_or_csr_enrollments' => "APTC / CSR Enrollments",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -117,6 +117,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.families.verification.documents_FAQ' => "Documents We Accept",
   :'en.delete' => "Delete",
   :'en.deleted' => "Deleted",
+  :'en.info' => "Info",
   :'en.insured.families.medicaid_and_tax_credits' => "Medicaid & Tax Credits",
   :'en.insured.families.apply_for_medicaid_widget' => "Apply, renew, read notices or find out what documents are needed for Medicaid or tax credit assisted coverage",
   :'en.insured.families.aptc_or_csr_enrollments' => "APTC / CSR Enrollments",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186499193

# A brief description of the changes

Current behavior: Missing info icon fallback if all styling fails, ends up hiding modal text

New behavior: Behavior improved

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

![Screenshot 2024-01-08 at 11 28 33 AM](https://github.com/ideacrew/enroll/assets/45053146/714d7679-f577-407e-88bd-743cc0e0f57c)


# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.