### PR TITLE
contrast level aa qle page

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -329,7 +329,7 @@ span.red{
 }
 
 a.btn.add{
-  color: var(--theme-primary-100, #008ecd);
+  color: var(--theme-primary-blue, #008ecd);
 }
 .next{
   margin-top: 30px;
@@ -1426,14 +1426,14 @@ a.close-1, a.close-2{
     &.form-action {
       margin: 8px 0 20px;
       display: inline-block;
-      color: var(--theme-primary-100, #007bc4);
+      color: var(--theme-primary-blue, #007bc4);
       font-size: 14px;
       font-weight: bold;
       border-radius: 4px;
       border: solid 1px #b2b2b2;
       background-color: transparent;
       &:hover {
-        border: solid 1px var(--theme-primary-100, #007bc4);
+        border: solid 1px var(--theme-primary-blue, #007bc4);
         background-color: #ffffff;
       }
     }
@@ -4602,7 +4602,7 @@ table.table.table-no-sytle td {
     padding-left: 15%;
     font-weight: 400;
     padding-bottom: 8px;
-    color: #7b7b7b;
+    color: var(--secondary-font-color, #7b7b7b);
 
   }
 
@@ -4613,11 +4613,12 @@ table.table.table-no-sytle td {
 }
 
 .carousel-indicators li {
-  border-color: $brand-primary;
+  border-color: var(--theme-primary-blue, $brand-primary);
 }
 
 .carousel-indicators .active {
-  background-color: $brand-primary;
+  background-color: var(--theme-primary-blue, $brand-primary);
+
 }
 
 .carousel-control {
@@ -4625,7 +4626,7 @@ table.table.table-no-sytle td {
 }
 
 .carousel-control .fa {
-  color:<%= EnrollRegistry[:cancel_plan_border].settings(:color).item %>;
+  color:var(--theme-primary-blue, <%= EnrollRegistry[:cancel_plan_border].settings(:color).item %>);
   position: absolute;
   top: 35%;
   z-index: 5;
@@ -4667,8 +4668,7 @@ table.table.table-no-sytle td {
   padding-left: 10%;
   font-weight: 400;
   padding-bottom: 8px;
-  color: #7b7b7b;
-
+  color: var(--secondary-font-color, #7b7b7b);
 }
 
 #carousel-qles a.qle-menu-item {

--- a/app/assets/stylesheets/family_relationships.scss.erb
+++ b/app/assets/stylesheets/family_relationships.scss.erb
@@ -97,7 +97,7 @@
 
 
 .fa, .knowmore h4 {
-  color: var(--theme-primary-100, #007bc4);
+  color: var(--theme-primary-blue, #007bc4);
 }
 
 .tribe-area-clone {

--- a/app/assets/stylesheets/insured.scss.erb
+++ b/app/assets/stylesheets/insured.scss.erb
@@ -59,7 +59,7 @@
       background-color: transparent;
       background-image: none;
       h3 {
-        color: $primary-panel !important;
+        color: var(--theme-primary-blue, $primary-panel) !important;
         font-weight: $primary-bold;
         text-transform: uppercase;
         font-size: 18px;

--- a/app/assets/stylesheets/left_nav.scss.erb
+++ b/app/assets/stylesheets/left_nav.scss.erb
@@ -12,7 +12,7 @@
   }
 
   .applicant-nav a:visited {
-    color: var(--theme-primary-100, #0079C0);
+    color: var(--theme-primary-blue, #0079C0);
     font-size: 14px;
   }
 
@@ -40,11 +40,11 @@
   }
 
   li:not(.activer) a:not(.disabled) {
-    color: var(--theme-primary-100, #0079C0);
+    color: var(--theme-primary-blue, #0079C0);
   }
 
   .active {
-    border-left: 7px solid var(--theme-primary-100, #0079C0) !important;
+    border-left: 7px solid var(--theme-primary-blue, #0079C0) !important;
     a
     {
       padding-left: 10px;
@@ -148,7 +148,7 @@
 
 .nav > li.no-hover > a:hover, .nav > li.no-hover > a:focus {
   text-decoration: none;
-  background-color: var(--theme-primary-100, #007bc4) !important;
+  background-color: var(--theme-primary-blue, #007bc4) !important;
 }
 
 .nav > li.no-hover-disable > a:hover, .nav > li.no-hover-disable > a:focus {
@@ -158,7 +158,7 @@
 
 .nav > li.activer.no-hover-disable > a:hover, .nav > li.activer.no-hover-disable > a:focus {
   text-decoration: none;
-  background-color: var(--theme-primary-100, #007bc4) !important;
+  background-color: var(--theme-primary-blue, #007bc4) !important;
 }
 .mr-top {
   margin-top: 0px !important;
@@ -206,12 +206,12 @@
 }
 
 .activer {
-  background: var(--theme-primary-100, #007bc4);
+  background: var(--theme-primary-blue, #007bc4);
   color: white;
   font-weight: 600;
 }
 .activer > a {
-  background: var(--theme-primary-100, #007bc4);
+  background: var(--theme-primary-blue, #007bc4);
   font-weight: 600;
 }
 

--- a/app/assets/stylesheets/text_styles.scss.erb
+++ b/app/assets/stylesheets/text_styles.scss.erb
@@ -1,6 +1,6 @@
 @import "variables";
 .blue {
-  color: var(--theme-primary-100, #007bc4);
+  color: var(--theme-primary-blue, #007bc4);
 }
 .darkblue {
   color: var(--theme-secondary, #003260);

--- a/app/assets/stylesheets/ui-components/mahc-theme.scss
+++ b/app/assets/stylesheets/ui-components/mahc-theme.scss
@@ -76,7 +76,7 @@ h1,h2,h3,h4,h5,h6 {
           line-height: 50px;
           padding: 23px 15px;
           font-weight: 600;
-          color: #487ba2;
+          color: var(--theme-primary-blue, #487ba2);
           &:hover {
             background-color: $background-hover;
             text-decoration: none;
@@ -242,7 +242,7 @@ h1,h2,h3,h4,h5,h6 {
 .btn-min:hover,
 .btn-min:focus,
 .btn-min.focus {
-  color: #487ba2;
+  color: var(--theme-primary-blue, #487ba2);
   transform: scale(1.1);
 }
 .btn:active,
@@ -264,9 +264,9 @@ fieldset[disabled] .btn {
 }
 
 .btn-default {
-  color: var(--theme-primary-100, $secondary-button-text);
+  color: var(--theme-primary-blue, $secondary-button-text);
   background-color: $secondary-button-background;
-  border-color: var(--theme-primary-100, $secondary-button-border);
+  border-color: var(--theme-primary-blue, $secondary-button-border);
   text-transform: $secondary-button-text-casing;
   font-weight: $primary-bold;
   box-sizing: border-box;
@@ -356,7 +356,7 @@ thead {
     padding-right: 6px;
   }
   ul.progress-wrapper li.complete .vertical-line-progress {
-    background-color: #487ba2;
+    background-color: var(--theme-primary-blue, #487ba2);
   }
   .vertical-line-progress {
     background-color: #cacaca;
@@ -379,17 +379,17 @@ thead {
     padding: 5px 0px;
     list-style: none;
     padding-left: 35px;
-    color: #487ba2;
+    color: var(--theme-primary-blue, #487ba2);
   }
   ul.progress-wrapper li.active {
     padding: 5px 0px;
     list-style: none;
     padding-left: 35px;
     font-weight: bold;
-    color: #487ba2;
+    color: var(--theme-primary-blue, #487ba2);
   }
   ul.progress-wrapper li.complete span.circle-progress {
-    background-color: #487ba2;
+    background-color: var(--theme-primary-blue, #487ba2);
     border: none;
     width: 14px;
     left: 9px;
@@ -560,11 +560,11 @@ thead {
 }
 
 .fa-arrow-down:before {
-  color: var(--theme-primary-100, #007bc4);
+  color: var(--theme-primary-blue, #007bc4);
 }
 
 .fa-info-circle:before {
-  color: var(--theme-primary-100, #007bc4);
+  color: var(--theme-primary-blue, #007bc4);
 }
 
 #datatable_filter_source_kind {

--- a/app/javascript/css/admin_navbar.scss
+++ b/app/javascript/css/admin_navbar.scss
@@ -1,5 +1,5 @@
 #uic-primary-nav {
-  background: var(--theme-primary-100, #007bc4);
+  background: var(--theme-primary-blue, #007bc4);
 
   ul {
     padding: 20px 0;

--- a/app/javascript/css/contrast_level_aa.scss
+++ b/app/javascript/css/contrast_level_aa.scss
@@ -1,7 +1,7 @@
 :root {
     --secondary-font-color: #676C72; //secondary text gray
     --bold-font-color: #323130; //bold text
-    --theme-primary-100: #3B6B90; //primary blue
+    --theme-primary-blue: #3B6B90; //primary blue
     --theme-secondary: #425C6E; //secondary dark blue
     --primary-red: #D42537; //primary red
     --unfocused-red: #D4403A; //soft red color

--- a/app/javascript/css/main.scss
+++ b/app/javascript/css/main.scss
@@ -38,7 +38,7 @@ body {
 footer {
   font-size: 14px;
   color: var(--grey-000);
-  background-color: var(--theme-primary-100, #007bc4);
+  background-color: var(--theme-primary-blue, #007bc4);
   position: absolute;
   left: 0;
   bottom: 0;

--- a/app/javascript/css/theme.scss
+++ b/app/javascript/css/theme.scss
@@ -1,17 +1,17 @@
 .btn-outline-primary {
-  color: var(--theme-primary-100, #007bc4);
-  border-color: var(--theme-primary-100, #007bc4);
+  color: var(--theme-primary-blue, #007bc4);
+  border-color: var(--theme-primary-blue, #007bc4);
   font-weight: 600;
   text-transform: capitalize;
 
   &:hover {
     background-color: var(--grey-000);
-    color: var(--theme-primary-100, #007bc4);
+    color: var(--theme-primary-blue, #007bc4);
   }
 
   &:not(:disabled):not(:disabled):active {
     background-color: var(--grey-000);
-    color: var(--theme-primary-100, #007bc4);
+    color: var(--theme-primary-blue, #007bc4);
   }
 }
 
@@ -56,16 +56,16 @@
 }
 
 .btn-link {
-  color: var(--theme-primary-100, #007bc4) !important;
+  color: var(--theme-primary-blue, #007bc4) !important;
 }
 
 .swal2-styled.swal2-confirm {
-  background-color: var(--theme-primary-100, #3085D6) !important;
+  background-color: var(--theme-primary-blue, #3085D6) !important;
 }
 
 .heading-text {
   font-weight: 400;
-  color: var(--theme-primary-100, #007bc4);
+  color: var(--theme-primary-blue, #007bc4);
 }
 
 .invalid-feedback {
@@ -79,7 +79,7 @@
 
 .navbar-main {
   background-color: var(--grey-000);
-  border-bottom: solid 3px var(--theme-primary-100, #007bc4);
+  border-bottom: solid 3px var(--theme-primary-blue, #007bc4);
   .navbar-brand {
     border-right: solid 1px var(--grey-050);
     img {
@@ -101,7 +101,7 @@
     border: none;
   }
   .fa-phone {
-    color: var(--theme-primary-100, #007bc4);
+    color: var(--theme-primary-blue, #007bc4);
   }
   .cc-number {
     color: var(--grey-120);
@@ -110,7 +110,7 @@
 
 .sub-text {
   font-weight: 200;
-  color: var(--theme-primary-100, #007bc4);
+  color: var(--theme-primary-blue, #007bc4);
 }
 
 // This is for conditional styles used only in

--- a/app/javascript/css/tooltips.scss
+++ b/app/javascript/css/tooltips.scss
@@ -1,5 +1,5 @@
 .tooltip > .tooltip-inner {
-  background-color: var( --primary-white, var(--theme-primary-100, #007bc4));
+  background-color: var( --primary-white, var(--theme-primary-blue, #007bc4));
   color: var( --primary-black, var(--grey-000));
 }
 
@@ -11,17 +11,17 @@
 }
 
 .tooltip.bs-tooltip-right .arrow:before {
-  border-right-color: var(--theme-primary-100, #007bc4);
+  border-right-color: var(--theme-primary-blue, #007bc4);
 }
 
 .tooltip.bs-tooltip-left .arrow:before {
-  border-left-color: var(--theme-primary-100, #007bc4);
+  border-left-color: var(--theme-primary-blue, #007bc4);
 }
 
 .tooltip .tooltip-inner {
   border-style: solid;
   border-width: 2px;
-  border-color: var(--theme-primary-100, #007bc4);
+  border-color: var(--theme-primary-blue, #007bc4);
 }
 
 .pwHelper {

--- a/app/views/insured/families/_qle_detail.html.erb
+++ b/app/views/insured/families/_qle_detail.html.erb
@@ -5,7 +5,7 @@
         <h3 class="no-buffer"><%= l10n("insured.report_life_changes").to_s.upcase %></h3>
         <div class="text-right">
           <a class="close-popup" href="javascript:void(0);">
-            <i aria-hidden="true" class="fas fa-times"></i>
+            <i aria-hidden="true" class="fas fa-times"><span class="hide"><%=l10n("close")%></span></i>
           </a>
         </div>
       </div>
@@ -51,7 +51,7 @@
               <div class="spec_reasons">
               </div>
               <div class="text-center <%= pundit_class Family,:updateable? %>">
-                <%= submit_tag l10n('.continue'), class: 'btn btn-primary', data: { disable_with: false } %>
+                <%= submit_tag l10n('.continue'), id: 'sep_continue', class: 'btn btn-primary', data: { disable_with: false }, onkeydown: "handleButtonKeyDown(event, 'sep_continue')"  %>
                 <br/>
                 <br/>
               </div>

--- a/app/views/insured/families/_qles_carousel.html.erb
+++ b/app/views/insured/families/_qles_carousel.html.erb
@@ -54,10 +54,11 @@
     <!-- Controls -->
     <% color = EnrollRegistry[:qle_carousel].settings(:color).item %>
     <a class="left carousel-control" href="#carousel-qles" role="button" data-slide="prev" style="background-image: none;color:<%= color %>">
-      <i class="fa fa-angle-left left fa-2x" aria-hidden="true"></i>
+      <i class="fa fa-angle-left left fa-2x" aria-hidden="true"><span class="hide"><%=l10n("previous")%></span></i>
     </a>
+    &nbsp
     <a class="right carousel-control" href="#carousel-qles" role="button" data-slide="next" style="background-image: none;color:<%= color %>">
-      <i class="fa fa-angle-right right fa-2x" aria-hidden="true"></i>
+      <i class="fa fa-angle-right right fa-2x" aria-hidden="true"><span class="hide"><%=l10n("next")%></span></i>
     </a>
   <% end %>
 </div>

--- a/components/financial_assistance/app/assets/stylesheets/financial_assistance/financial_assistance.scss
+++ b/components/financial_assistance/app/assets/stylesheets/financial_assistance/financial_assistance.scss
@@ -52,7 +52,7 @@ input[type="radio"]:checked + label span {
 }
 
 .fa, .knowmore h4 {
-  color: var(--theme-primary-100, #007BC4);
+  color: var(--theme-primary-blue, #007BC4);
 }
 
 #backModal {

--- a/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/eligibility_results.scss
+++ b/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/eligibility_results.scss
@@ -74,7 +74,7 @@
   font-size: 1.5em;
 }
 .fa, .knowmore h4 {
-  color: var(--theme-primary-100, #007bc4);
+  color: var(--theme-primary-blue, #007bc4);
 }
 .fa-2x {
   font-size: 2em;

--- a/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/fa_income.scss
+++ b/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/fa_income.scss
@@ -53,7 +53,7 @@ div.disabled {
 }
 
 .deducticon-rectangle {
-  border: 3px solid var(--theme-primary-100, #007bc4);
+  border: 3px solid var(--theme-primary-blue, #007bc4);
   padding: 0 4px 2px 3px;
   border-radius: 4px;
   }
@@ -123,7 +123,7 @@ div.disabled {
   width: 100%;
 }
 .row-edit-border {
-  border: 2px solid var(--theme-primary-100, #007bc4);
+  border: 2px solid var(--theme-primary-blue, #007bc4);
 }
 .deduction-kind > .row {
   padding: 10px 0px;

--- a/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/family_relationships.scss
+++ b/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/family_relationships.scss
@@ -48,7 +48,7 @@
 }
 .icn-out {
   -webkit-text-stroke-width: 1px;
-  -webkit-text-stroke-color: var(--theme-primary-100, #007bc4);
+  -webkit-text-stroke-color: var(--theme-primary-blue, #007bc4);
   color: transparent;
 }
 .relation {

--- a/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/financial_assistance.scss
+++ b/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/financial_assistance.scss
@@ -52,7 +52,7 @@ input[type="radio"]:checked + label span {
 }
 
 .fa, .knowmore h4 {
-  color: var(--theme-primary-100, #007bc4);
+  color: var(--theme-primary-blue, #007bc4);
 }
 
 #backModal {
@@ -192,7 +192,7 @@ input.radio-yml {
 .title-text {
   margin-bottom: 0px;
   margin-top: 20px;
-  color: var(--theme-primary-100, #007bc4);
+  color: var(--theme-primary-blue, #007bc4);
 }
 .fa-text-color {
   font-weight: lighter;
@@ -260,7 +260,7 @@ div#add-more-link {
 }
 .help-to-decide {
   display: inline-block;
-  border-left: 1px solid var(--theme-primary-100, #007bc4);
+  border-left: 1px solid var(--theme-primary-blue, #007bc4);
   padding-left: 12px;
   margin-left: 10px;
 }

--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -94,6 +94,8 @@ How to find the SEVIS ID: On the DS-2019, the number is on the top right hand si
   :'en.delete' => "Delete",
   :'en.deleted' => "Deleted",
   :'en.info' => "Info",
+  :'en.next' => "Next Page",
+  :'en.previous' => "Previous Page",
   :'en.insured.families.medicaid_and_tax_credits' => "Medicaid & Tax Credits",
   :'en.insured.families.apply_for_medicaid_widget' => "Apply, renew, read notices or find out what documents are needed for Medicaid or tax credit assisted coverage",
   :'en.insured.families.aptc_or_csr_enrollments' => "APTC / CSR Enrollments",

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -118,6 +118,8 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.delete' => "Delete",
   :'en.deleted' => "Deleted",
   :'en.info' => "Info",
+  :'en.next' => "Next Page",
+  :'en.previous' => "Previous Page",
   :'en.insured.families.medicaid_and_tax_credits' => "Go to District Direct",
   :'en.insured.families.apply_for_medicaid_widget' => "Want to apply for Medicaid? Go to District Direct to apply, recertify benefits, and view notices.",
   :'en.insured.families.aptc_or_csr_enrollments' => "APTC / CSR Enrollments",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -118,6 +118,8 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.delete' => "Delete",
   :'en.deleted' => "Deleted",
   :'en.info' => "Info",
+  :'en.next' => "Next Page",
+  :'en.previous' => "Previous Page",
   :'en.insured.families.medicaid_and_tax_credits' => "Medicaid & Tax Credits",
   :'en.insured.families.apply_for_medicaid_widget' => "Apply, renew, read notices or find out what documents are needed for Medicaid or tax credit assisted coverage",
   :'en.insured.families.aptc_or_csr_enrollments' => "APTC / CSR Enrollments",

--- a/features/insured/contrast_level_aa/individual_sep_signup.feature
+++ b/features/insured/contrast_level_aa/individual_sep_signup.feature
@@ -1,0 +1,24 @@
+Feature: Contrast level AA is enabled - Insured Plan Shopping on Individual market
+  Background:
+    Given the contrast level aa feature is enabled
+    And the FAA feature configuration is enabled
+    Given individual Qualifying life events are present
+    Given Individual has not signed up as an HBX user
+    When Individual visits the Insured portal outside of open enrollment
+    And Individual creates a new HBX account
+    Then Individual should see a successful sign up message
+    And Individual sees Your Information page
+    When user registers as an individual
+    And Individual clicks on continue
+    And Individual sees form to enter personal information
+
+ Scenario: New insured user purchases on individual market thru qualifying life event
+    When Individual clicks on continue
+    And Individual agrees to the privacy agreeement
+    And Individual answers the questions of the Identity Verification page and clicks on submit
+    Then Individual is on the Help Paying for Coverage page
+    Then Individual does not apply for assistance and clicks continue
+    And Individual clicks on the Continue button of the Family Information page
+    When Individual click the "Had a baby" in qle carousel
+    And Individual selects a current qle date
+    Then the page should be axe clean excluding "a[disabled], .disabled" according to: wcag2aa; checking only: color-contrast

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -386,7 +386,7 @@ Then(/^Individual should be on verification page/) do
 end
 
 When(/^.+ clicks on the Continue button of the Family Information page$/) do
-  find(IvlFamilyInformation.continue_btn).click
+  find('.interaction-click-control-continue').click
   sleep 10
 end
 

--- a/vendor/assets/stylesheets/bootstrap.css.erb
+++ b/vendor/assets/stylesheets/bootstrap.css.erb
@@ -1366,7 +1366,7 @@ a.text-danger:focus {
 }
 .bg-primary {
   color: #fff;
-  background-color: var(--theme-primary-100, #337ab7);
+  background-color: var(--theme-primary-blue, #337ab7);
 }
 a.bg-primary:hover,
 a.bg-primary:focus {


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186499229

# A brief description of the changes

Current behavior: Contrast issues on headers, subheaders, and right side navigation, no cucumber, no fallback values for navigation

New behavior: Behaviors improved or fixed throughout page

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

![Screenshot 2024-01-08 at 10 00 51 AM](https://github.com/ideacrew/enroll/assets/45053146/f52f1b01-fa3d-49d2-83a9-985f4c63b456)
![Screenshot 2024-01-08 at 10 05 40 AM](https://github.com/ideacrew/enroll/assets/45053146/b126fa62-5fd2-4751-a7af-8fb30fb2640c)


The color variable `--theme-primary-100` was changed to be `theme-primary-blue` in order to have accurate fallbacks for some DC colors. This variable existed in both DC's and ME's future styling sheets and would never use the fallback colors.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.