### PR TITLE
level aa contrast ai button fixes

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/benefits/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/index.html.erb
@@ -270,7 +270,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <span class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
+          <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'benefits-delete')" id="benefits-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
           <h4 class="modal-title darkblue" id="myModalLabel">Permanently Remove This Info?</h4>
         </div>
         <div class="modal-body">
@@ -291,7 +291,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <span class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
+          <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'all-benefits-delete')" id="all-benefits-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
           <h4 class="modal-title darkblue" id="myModalLabel">Permanently Remove This Info?</h4>
         </div>
         <div class="modal-body">

--- a/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
@@ -107,7 +107,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <span class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
+          <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'deductions-delete')" id="deductions-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
           <h4 class="modal-title darkblue" id="myModalLabel">Permanently Remove This Info?</h4>
         </div>
         <div class="modal-body">
@@ -126,7 +126,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <span class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
+          <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'all-deductions-delete')" id="all-deductions-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
           <h4 class="modal-title darkblue" id="myModalLabel">Permanently Remove This Info?</h4>
         </div>
         <div class="modal-body">

--- a/components/financial_assistance/app/views/financial_assistance/incomes/_ai_an_income.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/incomes/_ai_an_income.html.erb
@@ -22,8 +22,8 @@
         <span class="field_value floatlabel form-control active-floatlabel" id="name"><%= income.end_on %></span>
       </div>
       <div class="col-md-1 form-group-lg class-fa-household no-pd fa-adjustment">
-        <a class="ai-an-income-edit edit-pr"><i class="fa fa-pencil fa-lg" aria-hidden="true"></i></a>
-        <a class="ai-an-income-delete"><i class="fa fa-trash-o fa-lg" aria-hidden="true"></i></a>
+        <a tabindex="0" onkeydown="handleButtonKeyDown(event, 'ai-income-edit-<%= dom_id income %>')" id="ai-income-edit-<%= dom_id income %>" class="ai-an-income-edit edit-pr"><i class="fa fa-pencil fa-lg" aria-hidden="true"><span class="hide"><%=l10n("edit")%></span></i></a>
+        <a tabindex="0" onkeydown="handleButtonKeyDown(event, 'ai-income-delete-<%= dom_id income %>')" id="ai-income-delete-<%= dom_id income %>" class="ai-an-income-delete"><i class="fa fa-trash-o fa-lg" aria-hidden="true"><span class="hide"><%=l10n("delete")%></span></i></a>
       </div>
     </div>
   </div>

--- a/components/financial_assistance/app/views/financial_assistance/incomes/_ai_an_income_form.erb
+++ b/components/financial_assistance/app/views/financial_assistance/incomes/_ai_an_income_form.erb
@@ -25,8 +25,8 @@
     </div>
     <div class="row">
       <div class="col-md-3 pull-right">
-        <a class="btn btn-default ai-an-income-cancel">Cancel</a>
-        <%= f.submit 'Save', class: "btn btn-danger #{'disabled' if disabled }", onclick: "checkDate('#{income.id}')" %>
+        <a tabindex="0" onkeydown="handleButtonKeyDown(event, 'income-cancel-<%= income_id %>')" id="income-cancel-<%= income.id %>" class="btn btn-default ai-an-income-cancel">Cancel</a>
+        <%= f.submit 'Save', class: "btn btn-save #{'disabled' if disabled }", onclick: "checkDate('#{income.id}')" %>
       </div>
     </div>
   </div>

--- a/components/financial_assistance/app/views/financial_assistance/incomes/other.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/incomes/other.html.erb
@@ -187,7 +187,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <span tabindex="0" tabindex="0" onkeydown="handleButtonKeyDown(event, 'other-income-delete')" id="other-income-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
+          <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'other-income-delete')" id="other-income-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
           <h4 class="modal-title darkblue" id="myModalLabel">Permanently Remove This Info?</h4>
         </div>
         <div class="modal-body">

--- a/components/financial_assistance/app/views/financial_assistance/incomes/other.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/incomes/other.html.erb
@@ -142,7 +142,7 @@
           <% end %>
         </div>
 
-        <a class='new-ai-an-income'> <span class="fa-icon fa-stack plus-mr"><i class="fa fa-circle-thin fa-stack-2x"></i><i class="fa fa-plus fa-stack-1x"></i></span></span> <b> Add Another</b> American Indian/Alaskan Native Income </a>
+        <a tabindex="0" onkeydown="handleButtonKeyDown(event, 'new-ai-income')" id="new-ai-income" class='new-ai-an-income'> <span class="fa-icon fa-stack plus-mr"><i class="fa fa-circle-thin fa-stack-2x"></i><i class="fa fa-plus fa-stack-1x"></i></span></span> <b> Add Another</b> American Indian/Alaskan Native Income </a>
 
         <div class='new-ai-an-income-form hidden'>
           <%= render partial: 'financial_assistance/incomes/ai_an_income_form', locals: { income: @applicant.incomes.build(kind: 'american_indian_and_alaskan_native'), disabled: false } %>
@@ -166,7 +166,7 @@
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
-            <span class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
+            <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'unsaved-delete')" id="unsaved-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
             <h4 class="modal-title darkblue" id="myModalLabel">You Have Unsaved Changes</h4>
           </div>
           <div class="modal-body">
@@ -187,7 +187,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <span class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
+          <span tabindex="0" tabindex="0" onkeydown="handleButtonKeyDown(event, 'other-income-delete')" id="other-income-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
           <h4 class="modal-title darkblue" id="myModalLabel">Permanently Remove This Info?</h4>
         </div>
         <div class="modal-body">
@@ -207,7 +207,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <span class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
+          <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'all-other-income-delete')" id="all-other-income-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
           <h4 class="modal-title darkblue" id="myModalLabel">Permanently Remove This Info?</h4>
         </div>
         <div class="modal-body">
@@ -227,7 +227,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <span class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
+          <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'other-existing-income-delete')" id="other-existing-income-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
           <h4 class="modal-title darkblue" id="myModalLabel">Permanently Remove This Info?</h4>
         </div>
         <div class="modal-body">
@@ -247,7 +247,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <span class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
+          <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'unemployment-delete')" id="unemployment-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
           <h4 class="modal-title darkblue" id="myModalLabel">Permanently Remove This Info?</h4>
         </div>
         <div class="modal-body">
@@ -286,7 +286,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <span class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
+          <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'ai-delete')" id="ai-delete" class="glyphicon glyphicon-remove close" aria-hidden="true" data-dismiss="modal" aria-label="Close"></span>
           <h4 class="modal-title darkblue" id="myModalLabel">Permanently Remove This Info?</h4>
         </div>
         <div class="modal-body">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186499199

# A brief description of the changes

Current behavior: When American Indian is selected earlier in the registration workflow, a conditional question will appear on this page. This question was not supported in recent changes. On top of this, the close button on modals was found to not have keyboard support

New behavior: All issues found from QA addressed.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

**Tests have not been added for this ticket as we do not currently have tests designed for ensuring tab functionality. This will be discussed later on after the main code reaches UAT**

![Screenshot 2024-01-08 at 5 30 25 PM](https://github.com/ideacrew/enroll/assets/45053146/f92ab93f-9353-4ab3-b9ce-6c69b15743a0)
![Screenshot 2024-01-08 at 5 30 44 PM](https://github.com/ideacrew/enroll/assets/45053146/d151078f-da28-4ccd-a47c-20c19542af78)
![Screenshot 2024-01-08 at 5 31 17 PM](https://github.com/ideacrew/enroll/assets/45053146/61e5dbb2-f1f7-4b6e-aae0-fd88c1cf21ac)



# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.