### PR TITLE
level aa contrast plan shopping coverage

### DIFF
--- a/app/assets/javascripts/keyboard_navigation.js
+++ b/app/assets/javascripts/keyboard_navigation.js
@@ -4,7 +4,20 @@ function handleRadioKeyDown(event, radioId) {
     document.getElementById(radioId).click(); 
   }
 }
-  
+
+function handleCitizenKeyDown(event, radioIdBase) {
+  if (event.key === 'Enter') {
+    const personElement = document.getElementById(`person_${radioIdBase}`);
+    const dependentElement = document.getElementById(`dependent_${radioIdBase}`);
+
+    if (personElement) {
+      personElement.click();
+    } else if (dependentElement) {
+      dependentElement.click();
+    }
+  }
+}
+
 function handleButtonKeyDown(event, buttonId) {
   if (event.key === 'Enter') { 
     document.getElementById(buttonId).click(); 

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -3655,7 +3655,7 @@ ul.progress-wrapper li.complete {
     color: <%= EnrollRegistry[:qle_carousel].settings(:color).item %>;
 }
 ul.progress-wrapper li.complete span.circle-progress {
-    background-color: <%= EnrollRegistry[:qle_carousel].settings(:color).item %>;
+    background-color: var(--theme-primary-blue, <%= EnrollRegistry[:qle_carousel].settings(:color).item %>);
     border: none;
     width: 14px;
     left: 9px;
@@ -3664,14 +3664,14 @@ ul.progress-wrapper li.complete span.circle-progress {
 ul.progress-wrapper li.active {
     padding: 5px 0px;
     list-style: none;
-    /*border-left: 2px solid #007bc4;*/
+    /*border-left: 2px solid var(--theme-primary-blue, #007bc4);*/
     padding-left: 35px;
     font-weight: bold;
-    color: <%= EnrollRegistry[:qle_carousel].settings(:color).item %>;
+    color: var(--theme-primary-blue, <%= EnrollRegistry[:qle_carousel].settings(:color).item %>);
 }
 ul.progress-wrapper li.active span.circle-progress {
     background-color: #ffffff;
-    border: 2px solid <%= EnrollRegistry[:qle_carousel].settings(:color).item %>;
+    border: 2px solid var(--theme-primary-blue, <%= EnrollRegistry[:qle_carousel].settings(:color).item %>);
     width: 14px;
     left: 9px;
     height: 14px;
@@ -3686,7 +3686,7 @@ ul.progress-wrapper li.active span.circle-progress {
     margin-top: 5px;
 }
 ul.progress-wrapper li.complete .vertical-line-progress {
-    background-color: <%= EnrollRegistry[:qle_carousel].settings(:color).item %>;
+    background-color: var(--theme-primary-blue, <%= EnrollRegistry[:qle_carousel].settings(:color).item %>);
 }
 ul.progress-wrapper li.active .vertical-line-progress {
     background-color: #cacaca;

--- a/app/assets/stylesheets/ui-components/mahc-theme.scss
+++ b/app/assets/stylesheets/ui-components/mahc-theme.scss
@@ -574,3 +574,7 @@ thead {
 #fteEmployee, #pteEmployee, #medSecPayers {
   padding:0;
 }
+
+.white {
+  color: #ffffff !important;
+}

--- a/app/assets/stylesheets/ui-components/mahc-theme.scss
+++ b/app/assets/stylesheets/ui-components/mahc-theme.scss
@@ -578,3 +578,7 @@ thead {
 .white {
   color: #ffffff !important;
 }
+
+.black {
+  color: var(--primary-black, #ffffff) !important;
+}

--- a/app/views/insured/families/coverall/_family.html.erb
+++ b/app/views/insured/families/coverall/_family.html.erb
@@ -50,7 +50,7 @@
 <div id="dependent_buttons" class="focus_effect personal-info-row <%= pundit_class Family, :updateable?%>">
   <div class="col-md-12 no-pd col-sm-12 col-xs-12" id="add-member-btn">
     <%= link_to new_resident_dependent_insured_family_members_path(:family_id => @family.id), :remote => true, :class => "btn btn-primary " do
-      "<i class='fa fa-user-plus'></i> #{l10n('add_member')}".html_safe
+      "<i class='fa fa-user-plus white'></i> #{l10n('add_member')}".html_safe
     end
     %>
   </div>

--- a/app/views/insured/family_members/_dependent_form.html.erb
+++ b/app/views/insured/family_members/_dependent_form.html.erb
@@ -123,7 +123,12 @@
                     <%= f.label :no_ssn, :value => true do %>
                       <span class='no_ssn twelve'>&nbsp;<%= l10n("do_not_have_ssn") %></span>
                     <% end %>
-                    <span><i class='fa fa-question-circle' id="no_ssn_tooltip" data-toggle="tooltip" title="<%=l10n("insured.consumer_roles.search.no_ssn_tooltip")%>"></i></span>
+                    <span>
+                      <i tabindex="0" class='fa fa-question-circle' id="no_ssn_tooltip" data-toggle="tooltip" title="<%=l10n("insured.consumer_roles.search.no_ssn_tooltip")%>">
+                      <span class="hide"><%=l10n("open")%></span>
+                      </i>
+                      <span class="hide"> "<%=l10n("insured.consumer_roles.search.no_ssn_tooltip")%>"</span>
+                    </span>
                   </div>
                 </div>
               </div>
@@ -135,13 +140,13 @@
 
           <div class="col-md-3 col-sm-3 no-pd">
             <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-              <div class="radio">
+              <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_male')" class="radio">
                 <%= f.radio_button :gender, "male", class: "required floatlabel", id: 'radio_male' %>
                 <label for="radio_male"><span data-cuke="dependent_radio_male"><%= l10n("male").to_s.upcase %></span></label>
               </div>
             </div>
             <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-              <div class="radio">
+              <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_female')" class="radio">
                 <%= f.radio_button :gender, "female", class: "required floatlabel", id: 'radio_female'  %>
                 <label for="radio_female"><span><%= l10n("female").to_s.upcase %></span></label>
               </div>
@@ -241,7 +246,7 @@
           <%= l10n("confirm_member") %>
         <% end %>
 
-        <span id='confirm-dependent' class="btn btn-primary btn-br pull-right mz">
+        <span tabindex="0", onkeydown="handleButtonKeyDown(event, 'confirm-dependent')", id='confirm-dependent' class="btn btn-primary btn-br pull-right mz">
           <%= l10n("confirm_member") %>
         </span>
       </div>

--- a/app/views/insured/family_members/_family_members.html.erb
+++ b/app/views/insured/family_members/_family_members.html.erb
@@ -27,7 +27,7 @@
       <label class="static_label label-floatlabel" for="relation">RELATIONSHIP</label>
       <span class="field_value floatlabel form-control active-floatlabel" id="relation"><%= l10n(".self").to_s.upcase %></span>
       <%= link_to personal_insured_families_path, remote: true, class: 'close close-2' do %>
-        <i class="fas fa-pencil-alt"><span class="hide">Edit</span></i></i>
+        <i class="fas fa-pencil-alt"><span class="hide"><%= l10n("Edit") %></span></i></i>
       <% end %>
     </div>
   </div>

--- a/app/views/insured/family_members/_family_members.html.erb
+++ b/app/views/insured/family_members/_family_members.html.erb
@@ -27,7 +27,7 @@
       <label class="static_label label-floatlabel" for="relation">RELATIONSHIP</label>
       <span class="field_value floatlabel form-control active-floatlabel" id="relation"><%= l10n(".self").to_s.upcase %></span>
       <%= link_to personal_insured_families_path, remote: true, class: 'close close-2' do %>
-        <i class="fas fa-pencil-alt"></i>
+        <i class="fas fa-pencil-alt"><span class="hide">Edit</span></i></i>
       <% end %>
     </div>
   </div>
@@ -75,7 +75,7 @@
 
     <% if @change_plan.present? %>
       <%=
-        link_to '<i class="fa fa-user-plus"></i> Continue'.html_safe, group_selection_url,
+        link_to '<i class="fa fa-user-plus white"></i> Continue'.html_safe, group_selection_url,
                 class: 'btn btn-primary pull-right' + pundit_class(Family,:updateable?), id: 'btn_household_continue'
       %>
     <% end %>

--- a/app/views/insured/family_members/resident_index.html.erb
+++ b/app/views/insured/family_members/resident_index.html.erb
@@ -58,7 +58,7 @@
 
             <% if @change_plan.present? %>
               <%=
-                link_to "<i class='fa fa-user-plus'></i> #{l10n('.continue')}".html_safe, group_selection_url,
+                link_to "<i class='fa fa-user-plus white'></i> #{l10n('.continue')}".html_safe, group_selection_url,
                  class: 'btn btn-primary pull-right' + pundit_class(Family,:updateable?), id: 'btn_household_continue'
               %>
             <% end %>

--- a/app/views/insured/group_selection/_coverage_household.html.erb
+++ b/app/views/insured/group_selection/_coverage_household.html.erb
@@ -75,11 +75,11 @@
                     <label class="required no-pd"><%= l10n("insured.group_selection.is_tobacco_user") %> *</label>
                   </div>
                   <% member = @latest_enrollment.hbx_enrollment_members.where(applicant_id: family_member.id).first if @latest_enrollment %>
-                  <div class="col-xs-2 top-buffer pb-1">
+                  <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_tobacco_user_Y_<%= index %>')" class="col-xs-2 top-buffer pb-1">
                     <input id="is_tobacco_user_Y_<%= index %>" type="radio" value="Y" name="is_tobacco_user_<%= family_member.id %>" <%='checked' if member&.tobacco_use == 'Y' %>>
                     <label class="radio-label" for="is_tobacco_user_Y_<%= index %>"><span>Yes</span></label>
                   </div>
-                  <div class="col-md-2 col-xs-1 top-buffer pb-1">
+                  <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_tobacco_user_N_<%= index %>')" class="col-md-2 col-xs-1 top-buffer pb-1">
                     <input id="is_tobacco_user_N_<%= index %>" type="radio" value="N" name="is_tobacco_user_<%= family_member.id %>" <%='checked' if member&.tobacco_use != 'Y' %>>
                     <label class="radio-label" for="is_tobacco_user_N_<%= index %>"><span>No</span></label>
                   </div>

--- a/app/views/insured/group_selection/new.html.erb
+++ b/app/views/insured/group_selection/new.html.erb
@@ -39,17 +39,18 @@
               <% view_market_places(@person).each_with_index do |kind, index| %>
                 <div class="n-radio-row">
                   <label class="n-radio" for="market_kind_<%= kind %>">
+                  <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'market_kind_<%= kind %>')">
                     <%= radio_button_tag 'market_kind', kind, index == 0, id: "market_kind_#{kind}", required: true, class: "n-radio", checked: is_market_kind_checked?(kind, @person), disabled: is_market_kind_disabled?(kind, @person) %>
-                    <span class="n-radio">
-                </span>
-                  <% if kind == 'shop' %>
-                    <%= l10n("insured.group_selection.new.employee_sponsored_benefits") %>
-                  <% elsif kind=="individual"  %>
-                    <%= l10n("insured.group_selection.new.individual_benefits") %>
-                  <% elsif kind=="coverall"  %>
-                    <%= l10n("insured.group_selection.new.coverall_benefits") %>
-                  <% end %>
-                  </label>
+                    <span class="n-radio"></span>
+                    <% if kind == 'shop' %>
+                      <%= l10n("insured.group_selection.new.employee_sponsored_benefits") %>
+                    <% elsif kind=="individual"  %>
+                      <%= l10n("insured.group_selection.new.individual_benefits") %>
+                    <% elsif kind=="coverall"  %>
+                      <%= l10n("insured.group_selection.new.coverall_benefits") %>
+                    <% end %>
+                    </label>
+                  </div>
                 </div>
                 <div class="modal fade" id="WarningOnCoverAllSelection" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
                   <div class="modal-dialog" role="document">
@@ -101,16 +102,16 @@
           <h3><%= l10n("benefit_type") %></h3>
 
           <div class="n-radio-group">
-            <div class="n-radio-row">
+            <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'coverage_kind_health')" class="n-radio-row">
               <label class="n-radio" for="coverage_kind_health">
-                <%= radio_button_tag 'coverage_kind', 'health', is_coverage_kind_checked?("health"), disabled: is_coverage_kind_disabled?("health"),id: 'coverage_kind_health', class: 'n-radio' %>
+                <%= radio_button_tag 'coverage_kind', 'health', is_coverage_kind_checked?("health"), disabled: is_coverage_kind_disabled?("health"), id: 'coverage_kind_health', class: 'n-radio' %>
                 <span class="n-radio">
                   </span>
                 <%= l10n(".health") %>
               </label>
             </div>
 
-            <div id="dental-radio-button" class="n-radio-row <%= 'dn' if @adapter.can_shop_shop?(@person) && !@adapter.is_eligible_for_dental?(@employee_role, @change_plan, @hbx_enrollment, effective_date_for_display) %>">
+            <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'coverage_kind_dental')" id="dental-radio-button" class="n-radio-row <%= 'dn' if @adapter.can_shop_shop?(@person) && !@adapter.is_eligible_for_dental?(@employee_role, @change_plan, @hbx_enrollment, effective_date_for_display) %>">
               <label class="n-radio" for="coverage_kind_dental">
                 <%= radio_button_tag 'coverage_kind', 'dental', is_coverage_kind_checked?("dental"), disabled: is_coverage_kind_disabled?("dental"), id: 'coverage_kind_dental', class: 'n-radio' %>
                 <span class="n-radio">

--- a/app/views/people/landing_pages/_personal.html.erb
+++ b/app/views/people/landing_pages/_personal.html.erb
@@ -25,14 +25,14 @@
             <%=f.text_field :ssn, class: "person_ssn number floatlabel form-control", placeholder: "SOCIAL SECURITY", id: "", title: "8 digits", disabled: 'disabled' %>
           </div>
           <div class="col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd border_bottom_zero">
-            <div class="radio skinned-form-controls skinned-form-controls-mac">
-              <%= f.radio_button :gender, "male", class: "required floatlabel"  %>
+            <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_male')" class="radio skinned-form-controls skinned-form-controls-mac">
+              <%= f.radio_button :gender, "male", class: "required floatlabel", id: "radio_male" %>
               <label for="person_gender_male" data-cuke="primary_radio_male"><span>MALE</span></label>
             </div>
           </div>
           <div class="col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
-            <div class="radio skinned-form-controls skinned-form-controls-mac">
-              <%= f.radio_button :gender, "female", class: "required floatlabel"  %>
+            <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'radio_female')" class="radio skinned-form-controls skinned-form-controls-mac">
+              <%= f.radio_button :gender, "female", class: "required floatlabel", id: "radio_female" %>
               <label for="person_gender_female"><span>FEMALE</span></label>
             </div>
           </div>
@@ -127,8 +127,8 @@
   <% end %>
 
   <div class="row no-buffer <%= pundit_class Family, :updateable? %> ">
-    <button type="submit" class="btn btn-primary btn-br hidden"><i class="fa fa-user-plus"></i> Save</button>
-    <span class='btn btn-lg btn-primary btn-br' onclick='PersonValidations.manageRequiredValidations($(this));' data-cuke="personal-save"><i class="fa fa-user-plus"></i> Save</span>
+    <button type="submit" class="btn btn-primary btn-br hidden"><i class="fa fa-user-plus white"></i> Save</button>
+    <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'save_personal')" id="save_personal" class='btn btn-lg btn-primary btn-br' onclick='PersonValidations.manageRequiredValidations($(this));' data-cuke="personal-save"><i class="fa fa-user-plus white"></i> Save</span>
   </div>
 <% end %>
 <br>

--- a/app/views/shared/_consumer_fields.html.erb
+++ b/app/views/shared/_consumer_fields.html.erb
@@ -12,7 +12,7 @@
           <label>Is this person a US citizen or US national? *</label>
         </div>
         <div class="col-lg-3 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
-          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_us_citizen_true')" class="radio skinned-form-controls skinned-form-controls-mac">
+          <div tabindex="0" onkeydown="handleCitizenKeyDown(event, 'us_citizen_true')" class="radio skinned-form-controls skinned-form-controls-mac">
             <%= f.radio_button :us_citizen, true, required: true, class: "required floatlabel"%>
             <%= f.label :us_citizen, :value => true do %>
               <span class="yes_no_pair">Yes</span>
@@ -20,7 +20,7 @@
           </div>
         </div>
         <div class="col-lg-1 col-md-3 col-sm-3 col-xs-6 form-group form-group-lg no-pd">
-          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_us_citizen_false')" class="radio skinned-form-controls skinned-form-controls-mac">
+          <div tabindex="0" onkeydown="handleCitizenKeyDown(event, 'us_citizen_false')" class="radio skinned-form-controls skinned-form-controls-mac">
             <%= f.radio_button :us_citizen, false, required: true, class: "required floatlabel" %>
             <%= f.label :us_citizen, :value => false do %>
               <span class="yes_no_pair">No</span>
@@ -38,7 +38,7 @@
           <label> <%= l10n("insured.consumer_roles.naturalized_question") %> *</label>
         </div>
         <div class="col-lg-3 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_naturalized_citizen_true')" class="radio skinned-form-controls skinned-form-controls-mac">
+          <div tabindex="0" onkeydown="handleCitizenKeyDown(event, 'naturalized_citizen_true')" class="radio skinned-form-controls skinned-form-controls-mac">
             <%= f.radio_button :naturalized_citizen, true, required: true, class: "required floatlabel" %>
             <%= f.label :naturalized_citizen, :value => true do %>
               <span class="yes_no_pair">Yes</span>
@@ -46,7 +46,7 @@
           </div>
         </div>
         <div class="col-lg-1 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_naturalized_citizen_false')" class="radio skinned-form-controls skinned-form-controls-mac">
+          <div tabindex="0" onkeydown="handleCitizenKeyDown(event, 'naturalized_citizen_false')" class="radio skinned-form-controls skinned-form-controls-mac">
             <%= f.radio_button :naturalized_citizen, false, required: true, class: "required floatlabel" %>
             <%= f.label :naturalized_citizen, :value => false do %>
               <span class="yes_no_pair">No</span>
@@ -75,7 +75,7 @@
           </div>
         <% else %>
           <div class="col-lg-3 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-            <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_eligible_immigration_status_true')" class="radio skinned-form-controls skinned-form-controls-mac">
+            <div tabindex="0" onkeydown="handleCitizenKeyDown(event, 'eligible_immigration_status_true')" class="radio skinned-form-controls skinned-form-controls-mac">
               <%= f.radio_button :eligible_immigration_status, true, class: "required floatlabel" %>
               <%= f.label :eligible_immigration_status, :value => true do %>
                 <span class="yes_no_pair">Yes</span>
@@ -83,7 +83,7 @@
             </div>
           </div>
           <div class="col-lg-1 col-md-2 col-sm-6 col-xs-6 form-group form-group-lg no-pd">
-            <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'person_eligible_immigration_status_false')" class="radio skinned-form-controls skinned-form-controls-mac">
+            <div tabindex="0" onkeydown="handleCitizenKeyDown(event, 'eligible_immigration_status_false')" class="radio skinned-form-controls skinned-form-controls-mac">
               <%= f.radio_button :eligible_immigration_status, false, class: "required floatlabel" %>
               <%= f.label :eligible_immigration_status, :value => false do %>
                 <span class="yes_no_pair">No</span>

--- a/components/financial_assistance/app/assets/stylesheets/financial_assistance/application_indicator.scss
+++ b/components/financial_assistance/app/assets/stylesheets/financial_assistance/application_indicator.scss
@@ -68,10 +68,10 @@
 
 /*ready for review*/
 .ready-4-review .whitebox {
-  border-color: #69A30D;
+  border-color: var( --success-green, #69A30D);
 }
 .ready-4-review .note.purple::before {
-  border-color:#fff #eee #69A30D #69A30D;
+  border-color:#fff #eee var( --success-green, #69A30D) var( --success-green, #69A30D);
 }
 .whitebox {
   padding: 0;
@@ -90,7 +90,7 @@
 }
 .whitebox .info-needed span {
   font-weight: 600;
-  color: var(--primary-black, #ffffff);
+  color: var(--primary-white, #ffffff);
 }
 .whitebox .sub-desc {
   font-size: 12px;
@@ -112,9 +112,9 @@
   padding: .7em 1.5em 1em;
 }
 .ready-4-review .whitebox .info-needed {
-  border-top: 1px solid #69A30D;
-  border-bottom: 1px solid #69A30D;
-  background-color: #69A30D;
+  border-top: 1px solid var( --success-green, #69A30D);
+  border-bottom: 1px solid var( --success-green, #69A30D);
+  background-color: var( --success-green, #69A30D);
 }
 
 .app-year-header {

--- a/components/financial_assistance/app/assets/stylesheets/financial_assistance/financial_assistance.scss
+++ b/components/financial_assistance/app/assets/stylesheets/financial_assistance/financial_assistance.scss
@@ -174,7 +174,7 @@ span.span-text {
   border-top: 3px solid #ddd;
 }
 .complete-icon{
-  color: #69A30D;
+  color: var( --success-green, #69A30D);
   font-weight: bold;
 }
 .in-progress{
@@ -307,9 +307,9 @@ div#add-more-link {
 
 /*ready for review*/
 .ready-4-review .whitebox {
-  border-color: #69A30D;
+  border-color: var( --success-green, #69A30D);
 }
-.ready-4-review .note.purple::before { border-color:#fff #eee #69A30D #69A30D; }
+.ready-4-review .note.purple::before { border-color:#fff #eee var( --success-green, #69A30D) var( --success-green, #69A30D); }
 
 .margin-bottom-adjustment {
   margin-bottom:-25px;

--- a/components/financial_assistance/app/views/financial_assistance/shared/_status.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/shared/_status.html.erb
@@ -1,7 +1,7 @@
 <% if (application.present? && application.ready_for_attestation?) %>
   <div class="household-status ready-4-review">
   	<span class="note purple"> </span>
-    <div class="whitebox white">
+    <div class="whitebox">
       <% if FinancialAssistanceRegistry.feature_enabled?(:iap_assistance_year_display) %>
         <%= render partial: 'financial_assistance/shared/status_header', locals: {application: application} %>
       <% else %>
@@ -14,13 +14,13 @@
 <% else %>
 	<div class="household-status">
     <span class="note purple"> </span>
-    <div class="whitebox white">
+    <div class="whitebox">
       <% if FinancialAssistanceRegistry.feature_enabled?(:iap_assistance_year_display) %>
         <%= render partial: 'financial_assistance/shared/status_header', locals: {application: application} %>
       <% else %>
         <p>Your Application for Premium Reductions</p>
       <% end %>
-      <p class="info-needed"><i class="fa fa-refresh fa-refresh-faa fa-lg warning-status-hide" alt="warning" aria-hidden="true"></i><span>Info Needed</span></p>
+      <p class="info-needed"><i class="fa fa-refresh fa-refresh-faa fa-lg warning-status-hide" alt="warning" aria-hidden="true"></i><span class="black">Info Needed</span></p>
       <p class="sub-desc">You must enter all required information for everyone in your household.</p>
     </div>
   </div>

--- a/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/application_indicator.scss
+++ b/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/application_indicator.scss
@@ -68,10 +68,10 @@
 
 /*ready for review*/
 .ready-4-review .whitebox {
-  border-color: #69A30D;
+  border-color: var( --success-green, #69A30D);
 }
 .ready-4-review .note.purple::before { 
-  border-color:#fff #eee #69A30D #69A30D; 
+  border-color:#fff #eee var( --success-green, #69A30D) var( --success-green, #69A30D); 
 }
 .whitebox {
   padding: 0;
@@ -111,7 +111,8 @@
   padding: .7em 1.5em 1em;
 }
 .ready-4-review .whitebox .info-needed {
-  border-top: 1px solid #69A30D;
-  border-bottom: 1px solid #69A30D;
-  background-color: #69A30D;
+  border-top: 1px solid var( --success-green, #69A30D);
+  border-bottom: 1px solid var( --success-green, #69A30D);
+  background-color: var( --success-green, #69A30D);
+  color: #ffffff;
 }

--- a/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/financial_assistance.scss
+++ b/config/client_config/me/components/financial_assistance/app/asssets/stylesheets/financial_assistance/financial_assistance.scss
@@ -170,7 +170,7 @@ span.span-text {
   border-bottom: 3px solid #ddd;
 }
 .complete-icon{
-  color: #69A30D;
+  color: var( --success-green, #69A30D);
   font-weight: bold;
 }
 .in-progress{
@@ -303,9 +303,9 @@ div#add-more-link {
 
 /*ready for review*/
 .ready-4-review .whitebox {
-  border-color: #69A30D;
+  border-color: var( --success-green, #69A30D);
 }
-.ready-4-review .note.purple::before { border-color:#fff #eee #69A30D #69A30D; }
+.ready-4-review .note.purple::before { border-color:#fff #eee var( --success-green, #69A30D) var( --success-green, #69A30D); }
 
 .margin-bottom-adjustment {
   margin-bottom:-25px;

--- a/features/financial_assistance/contrast_level_aa/fa_not_applying.feature
+++ b/features/financial_assistance/contrast_level_aa/fa_not_applying.feature
@@ -1,0 +1,17 @@
+Feature: Contrast level AA is enabled - User is not applying for financial assistance
+  Background:
+    Given the contrast level aa feature is enabled
+    Given the FAA feature configuration is enabled
+    When the user is applying for a CONSUMER role
+    And the primary member has filled mandatory information required
+    And the primary member authorizes system to call EXPERIAN
+    And system receives a positive response from the EXPERIAN
+    And the user answers all the VERIFY IDENTITY  questions
+    When the user clicks on submit button
+    And the Experian returns a VERIFIED response
+    Then the user will navigate to the Help Paying for Coverage page
+
+  Scenario: Consumer is not applying for financial assistance
+    Given the user navigates to the "Household Info" page with "no" selected
+    When the user clicks on add member button
+    Then the page should be axe clean excluding "a[disabled], .disabled" according to: wcag2aa; checking only: color-contrast

--- a/features/insured/contrast_level_aa/family_information_sep_page.feature
+++ b/features/insured/contrast_level_aa/family_information_sep_page.feature
@@ -1,0 +1,25 @@
+Feature: Contrast level AA is enabled - Insured Plan Shopping with SEP
+  Background:
+    Given the contrast level aa feature is enabled
+    Given the FAA feature configuration is enabled
+    Given individual Qualifying life events are present
+    Given Individual has not signed up as an HBX user
+    When Individual visits the Insured portal outside of open enrollment
+    And Individual creates a new HBX account
+    Then Individual should see a successful sign up message
+    And Individual sees Your Information page
+    When user registers as an individual
+    And Individual clicks on continue
+    And Individual sees form to enter personal information
+
+ Scenario: New insured user purchases on individual market thru qualifying life event
+    When Individual clicks on continue
+    And Individual agrees to the privacy agreeement
+    And Individual answers the questions of the Identity Verification page and clicks on submit
+    Then Individual is on the Help Paying for Coverage page
+    Then Individual does not apply for assistance and clicks continue
+    And Individual clicks on the Continue button of the Family Information page
+    When Individual click the "Had a baby" in qle carousel
+    And Individual selects a current qle date
+    Then Individual should see confirmation and continue
+    Then the page should be axe clean excluding "a[disabled], .disabled" according to: wcag2aa; checking only: color-contrast

--- a/features/insured/contrast_level_aa/family_information_sep_page.feature
+++ b/features/insured/contrast_level_aa/family_information_sep_page.feature
@@ -22,4 +22,5 @@ Feature: Contrast level AA is enabled - Insured Plan Shopping with SEP
     When Individual click the "Had a baby" in qle carousel
     And Individual selects a current qle date
     Then Individual should see confirmation and continue
+    And the browser has finished rendering the page
     Then the page should be axe clean excluding "a[disabled], .disabled" according to: wcag2aa; checking only: color-contrast

--- a/features/insured/contrast_level_aa/household_coverage_page.feature
+++ b/features/insured/contrast_level_aa/household_coverage_page.feature
@@ -1,0 +1,29 @@
+Feature: Contrast level AA is enabled - Household Coverage Selection Page
+
+ Background: Individual market setup
+    Given the contrast level aa feature is enabled
+    And EnrollRegistry contact_method_via_dropdown feature is enabled
+    And the FAA feature configuration is enabled
+    Given EnrollRegistry extended_aptc_individual_agreement_message feature is enabled
+    Given an Individual has not signed up as an HBX user
+    Given the user visits the Consumer portal during open enrollment
+    When the user creates a Consumer role account
+    And the user sees Your Information page
+    And the user registers as an individual
+    And the individual clicks on the Continue button of the Account Setup page
+    And the individual sees form to enter personal information
+    And the individual clicks on the Continue button of the Account Setup page
+    And the individual agrees to the privacy agreeement
+    And the individual answers the questions of the Identity Verification page and clicks on submit
+    And the individual clicks on the Continue button of the Household Info page
+    When taxhousehold info is prepared for aptc user with selected eligibility
+    And has valid csr 73 benefit package without silver plans
+    And the individual does not apply for assistance and clicks continue
+    And the individual clicks on the Continue button of the Household Info page
+
+  Scenario: Contrast Validation of Household Coverage Page
+    Given EnrollRegistry temporary_configuration_enable_multi_tax_household_feature feature is enabled
+    Then multi tax household info is prepared for aptc user with selected eligibility
+    And the individual continues to the Choose Coverage page
+    And the browser has finished rendering the page
+    And the page should be axe clean excluding "a[disabled], .disabled" according to: wcag2aa; checking only: color-contrast

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -464,7 +464,7 @@ end
 And(/^.+ clicks on the Continue button of the Household Info page/) do
   screenshot("line 161")
   sleep 2
-  find(IvlIapFamilyInformation.continue_btn).click
+  find('.interaction-click-control-continue').click
 end
 
 Then(/consumer clicked on Go To My Account/) do
@@ -519,6 +519,9 @@ And(/I signed in$/) do
   find(SignIn.sign_in_btn).click
 end
 
+When(/^the individual continues to the Choose Coverage page$/) do
+  expect(page).to have_content IvlChooseCoverage.choose_coverage_for_your_household_text
+end
 
 When(/^the individual clicks the Continue button of the Group Selection page$/) do
   expect(page).to have_content IvlChooseCoverage.choose_coverage_for_your_household_text


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186499228 & https://www.pivotaltracker.com/story/show/186810399

# A brief description of the changes

Current behavior: There were contrast issues, navigation issues, and no fallback values for informational icons. On top of this, it was discovered that the button click handler introduced early on would not work well with the re-used consumer-fields form.

New behavior: All behaviors improved, along with a new handler for the radio buttons that were having issues with being used in dependent and person forms.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

**This PR includes work for 3 pages, but 2 of the pages use the same view partial.**

![Screenshot 2024-01-09 at 10 50 39 AM](https://github.com/ideacrew/enroll/assets/45053146/7034fda6-8d01-4406-b955-b4a217ce4bee)
![Screenshot 2024-01-09 at 11 26 19 AM](https://github.com/ideacrew/enroll/assets/45053146/2fc94e87-00ee-4ae6-a6f8-8f1b59df9105)
![Screenshot 2024-01-09 at 11 26 43 AM](https://github.com/ideacrew/enroll/assets/45053146/51e8e81e-3d6a-4f09-8594-937f9ef08d62)
![Screenshot 2024-01-09 at 11 27 04 AM](https://github.com/ideacrew/enroll/assets/45053146/22ca0b4a-e230-4e68-bebb-ca9fe0bc36f8)
![Screenshot 2024-01-09 at 1 11 10 PM](https://github.com/ideacrew/enroll/assets/45053146/aaf27543-1cdd-40d2-af02-65d8bcfdd51b)



# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.