### PR TITLE
level AA contrast sep signup cucumber fix

### DIFF
--- a/app/assets/stylesheets/jquery-ui/theme.css.erb
+++ b/app/assets/stylesheets/jquery-ui/theme.css.erb
@@ -122,7 +122,7 @@ a.ui-button:active,
 .ui-button:active,
 .ui-button.ui-state-active:hover {
 	border: 1px solid #003eff/*{borderColorActive}*/;
-	background: #007fff/*{bgColorActive}*/ /*{bgImgUrlActive}*/ /*{bgActiveXPos}*/ /*{bgActiveYPos}*/ /*{bgActiveRepeat}*/;
+	background: var(--theme-primary-blue, #007fff)/*{bgColorActive}*/ /*{bgImgUrlActive}*/ /*{bgActiveXPos}*/ /*{bgActiveYPos}*/ /*{bgActiveRepeat}*/;
 	font-weight: normal/*{fwDefault}*/;
 	color: #ffffff/*{fcActive}*/;
 }
@@ -145,7 +145,7 @@ a.ui-button:active,
 .ui-widget-header .ui-state-highlight {
 	border: 1px solid #dad55e/*{borderColorHighlight}*/;
 	background: #fffa90/*{bgColorHighlight}*/ /*{bgImgUrlHighlight}*/ /*{bgHighlightXPos}*/ /*{bgHighlightYPos}*/ /*{bgHighlightRepeat}*/;
-	color: #777620/*{fcHighlight}*/;
+	color: var(--primary-black, #777620)/*{fcHighlight}*/;
 }
 .ui-state-checked {
 	border: 1px solid #dad55e/*{borderColorHighlight}*/;
@@ -154,7 +154,7 @@ a.ui-button:active,
 .ui-state-highlight a,
 .ui-widget-content .ui-state-highlight a,
 .ui-widget-header .ui-state-highlight a {
-	color: #777620/*{fcHighlight}*/;
+	color: var(--primary-black, #777620)/*{fcHighlight}*/;
 }
 .ui-state-error,
 .ui-widget-content .ui-state-error,

--- a/config/client_config/me/app/assets/stylesheets/ui-components/jquery-ui.scss.erb
+++ b/config/client_config/me/app/assets/stylesheets/ui-components/jquery-ui.scss.erb
@@ -980,7 +980,7 @@ a.ui-button:active,
 .ui-button:active,
 .ui-button.ui-state-active:hover {
   border: 1px solid #003eff;
-  background: #007fff;
+  background: var(--theme-primary-blue, #007fff);
   font-weight: normal;
   color: #ffffff;
 }

--- a/features/insured/contrast_level_aa/individual_sep_signup.feature
+++ b/features/insured/contrast_level_aa/individual_sep_signup.feature
@@ -21,4 +21,5 @@ Feature: Contrast level AA is enabled - Insured Plan Shopping on Individual mark
     And Individual clicks on the Continue button of the Family Information page
     When Individual click the "Had a baby" in qle carousel
     And Individual selects a current qle date
+    And the browser has finished rendering the page
     Then the page should be axe clean excluding "a[disabled], .disabled" according to: wcag2aa; checking only: color-contrast


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/186817885

# A brief description of the changes

Current behavior: This test had passed locally and on it's original PR due to the page not fully rendering prior to the contrast check running, leading to false positive builds. This was also the first test to show the datepicker when checking contrast, leading to finding out it doesn't pass guidelines when either the current date or another date is selected.

New behavior: Cucumber test now has a sleep step to allow the page to fully render before testing the contrast. On top of this, the colors have been modified so that they pass contrast level aa checks.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

**Old Look**
![Screenshot 2024-01-10 at 9 37 49 AM](https://github.com/ideacrew/enroll/assets/45053146/b34ddc9b-4336-4d55-9e89-378257e52dfc)

**New Look**
![Screenshot 2024-01-10 at 9 38 36 AM](https://github.com/ideacrew/enroll/assets/45053146/4497a6f3-14ee-45d9-a3c0-97e4bd42fc78)

**DC will not be affected by this change**

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.