### PR TITLE
update for initial verification request header for CMS 37.1

### DIFF
--- a/app/domain/operations/fdsh/vlp/h92/request_initial_verification.rb
+++ b/app/domain/operations/fdsh/vlp/h92/request_initial_verification.rb
@@ -29,7 +29,7 @@ module Operations
           end
 
           def build_event(payload)
-            payload_type = EnrollRegistry[:vlp_h92].setting(:payload_type).item
+            payload_type = EnrollRegistry[:vlp_rx142].setting(:payload_type).item
             event('events.fdsh.vlp.h92.initial_verification_requested', attributes: payload, headers: { correlation_id: payload[:hbx_id], payload_type: payload_type })
           end
 

--- a/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -18,8 +18,8 @@ registry:
       - key: :vlp_rx142
         is_enabled: true
         settings:
-        - key: :payload_type
-          item: <%= ENV['VLP_RX142_PAYLOAD_TYPE'] || "xml" %>
+          - key: :payload_type
+            item: <%= ENV['VLP_RX142_PAYLOAD_TYPE'] || "xml" %>
       - key: :ssa_h3
         is_enabled: true
         settings:

--- a/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -15,6 +15,11 @@ registry:
         settings:
           - key: :payload_type
             item: <%= ENV['VLP_PAYLOAD_TYPE'] || "xml" %>
+      - key: :vlp_rx142
+        is_enabled: true
+        settings:
+        - key: :payload_type
+          item: <%= ENV['VLP_RX142_PAYLOAD_TYPE'] || "xml" %>
       - key: :ssa_h3
         is_enabled: true
         settings:

--- a/config/client_config/me/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -15,6 +15,11 @@ registry:
         settings:
           - key: :payload_type
             item: <%= ENV['VLP_PAYLOAD_TYPE'] || "xml" %>
+      - key: :vlp_rx142
+        is_enabled: true
+        settings:
+        - key: :payload_type
+          item: <%= ENV['VLP_RX142_PAYLOAD_TYPE'] || "xml" %>
       - key: :ssa_h3
         is_enabled: true
         settings:

--- a/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -15,6 +15,11 @@ registry:
         settings:
           - key: :payload_type
             item: <%= ENV['VLP_PAYLOAD_TYPE'] || "xml" %>
+      - key: :vlp_rx142
+        is_enabled: true
+        settings:
+          - key: :payload_type
+            item: <%= ENV['VLP_RX142_PAYLOAD_TYPE'] || "xml" %>
       - key: :ssa_h3
         is_enabled: true
         settings:


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior: Missing payload_type header when making initial_verification request 

New behavior: has payload_type header set when making initial_verification request 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [x] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.