### PR TITLE
adjust ridp header name

### DIFF
--- a/app/domain/operations/fdsh/ridp/request_secondary_determination.rb
+++ b/app/domain/operations/fdsh/ridp/request_secondary_determination.rb
@@ -60,7 +60,7 @@ module Operations
 
         def publish(payload, interactive_verification)
           session_id = interactive_verification&.session_id
-          transmission_id = interactive_verification&.transmission_id
+          transmission_id = interactive_verification&.transaction_id
           Operations::Fdsh::Ridp::PublishSecondaryRequest.new.call(payload, session_id, transmission_id)
         end
       end

--- a/app/domain/operations/transformers/interactive_verification_to/attestation.rb
+++ b/app/domain/operations/transformers/interactive_verification_to/attestation.rb
@@ -33,7 +33,7 @@ module Operations
 
         def construct_ridp_attestation_hash(interactive_verification)
           secondary_request = construct_secondary_request(interactive_verification)
-          request_payload[:secondary_request][:DSHReferenceNumber] = interactive_verification.transmission_id if EnrollRegistry[:ridp_h139].setting(:payload_format).item == "json"
+          secondary_request[:secondary_request][:DSHReferenceNumber] = interactive_verification.transaction_id if EnrollRegistry[:ridp_h139].setting(:payload_format).item == "json"
           {
             is_satisfied: false,
             is_self_attested: true,


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2581014/stories/186800952#

# A brief description of the changes

Current behavior: the header name is transmission_id, it looks for the transmission_id on the interactive_verification, which doesn't exist

New behavior: the header name is transmission_id, it looks for the transactionn_id on the interactive_verification, which does exist

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.