### PR TITLE
displays I am broker link for consumer account dashboard accordingly

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module ApplicationHelper
   include FloatHelper
   include ::FinancialAssistance::VerificationHelper

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
   include FloatHelper
   include ::FinancialAssistance::VerificationHelper
@@ -967,32 +969,7 @@ module ApplicationHelper
 
   def display_my_broker?(person, employee_role)
     employee_role ||= person.active_employee_roles.first
-    (person.has_active_employee_role? && employee_role.employer_profile.broker_agency_profile.present?) || display_i_am_broker_for_consumer?(person)
-  end
-
-  # @method display_i_am_broker_for_consumer?(person)
-  # Determines if the 'I am Broker' should be displayed for a given person with active Consumer Role.
-  #
-  # @param [Person] person The person for whom to check the broker status.
-  #
-  # @return [Boolean]
-  #   When the feature ':broker_role_consumer_enhancement' is enabled:
-  #     Returns true if person has an active consumer role, active broker role, active broker agency staff role, and both the active broker agency staff & active broker role have the same broker agency profile.
-  #   When the feature ':broker_role_consumer_enhancement' is disabled:
-  #     Returns true if person has an active consumer role and the primary family has a current broker agency.
-  #
-  # @example Check if 'I am Broker' should be displayed for a person with active Consumer Role
-  #   display_i_am_broker_for_consumer?(person) #=> true/false
-  def display_i_am_broker_for_consumer?(person)
-    if EnrollRegistry.feature_enabled?(:broker_role_consumer_enhancement)
-      broker_role = person.broker_role
-      matching_basr = person.broker_agency_staff_roles.where(
-        benefit_sponsors_broker_agency_profile_id: broker_role&.benefit_sponsors_broker_agency_profile_id
-      ).first
-      person.has_active_consumer_role? && broker_role.present? && broker_role.active? && matching_basr.present? && matching_basr.active?
-    else
-      person.has_active_consumer_role? && person.primary_family.current_broker_agency.present?
-    end
+    (person.has_active_employee_role? && employee_role.employer_profile.broker_agency_profile.present?) || (person.has_active_consumer_role? && person.primary_family.current_broker_agency.present?)
   end
 
   def display_family_members(family_members, primary_person)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -969,7 +969,32 @@ module ApplicationHelper
 
   def display_my_broker?(person, employee_role)
     employee_role ||= person.active_employee_roles.first
-    (person.has_active_employee_role? && employee_role.employer_profile.broker_agency_profile.present?) || (person.has_active_consumer_role? && person.primary_family.current_broker_agency.present?)
+    (person.has_active_employee_role? && employee_role.employer_profile.broker_agency_profile.present?) || display_i_am_broker_for_consumer?(person)
+  end
+
+  # @method display_i_am_broker_for_consumer?(person)
+  # Determines if the 'I am Broker' should be displayed for a given person with active Consumer Role.
+  #
+  # @param [Person] person The person for whom to check the broker status.
+  #
+  # @return [Boolean]
+  #   When the feature ':broker_role_consumer_enhancement' is enabled:
+  #     Returns true if person has an active consumer role, active broker role, active broker agency staff role, and both the active broker agency staff & active broker role have the same broker agency profile.
+  #   When the feature ':broker_role_consumer_enhancement' is disabled:
+  #     Returns true if person has an active consumer role and the primary family has a current broker agency.
+  #
+  # @example Check if 'I am Broker' should be displayed for a person with active Consumer Role
+  #   display_i_am_broker_for_consumer?(person) #=> true/false
+  def display_i_am_broker_for_consumer?(person)
+    if EnrollRegistry.feature_enabled?(:broker_role_consumer_enhancement)
+      broker_role = person.broker_role
+      matching_basr = person.broker_agency_staff_roles.where(
+        benefit_sponsors_broker_agency_profile_id: broker_role&.benefit_sponsors_broker_agency_profile_id
+      ).first
+      person.has_active_consumer_role? && broker_role.present? && broker_role.active? && matching_basr.present? && matching_basr.active?
+    else
+      person.has_active_consumer_role? && person.primary_family.current_broker_agency.present?
+    end
   end
 
   def display_family_members(family_members, primary_person)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,8 +1,17 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_market.rb"
 require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_application.rb"
 
 RSpec.describe ApplicationHelper, :type => :helper do
+
+  let(:brce_enabled_or_disabled) { false }
+
+  before :each do
+    allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+    allow(EnrollRegistry).to receive(:feature_enabled?).with(:broker_role_consumer_enhancement).and_return(brce_enabled_or_disabled)
+  end
 
   describe "#can_employee_shop??" do
     it "should return false if date is empty" do
@@ -1106,6 +1115,173 @@ describe "Enabled/Disabled IVL market" do
           it 'returns false' do
             expect(helper.insured_role_exists?(user)).to eq(false)
           end
+        end
+      end
+    end
+  end
+
+  describe '#display_i_am_broker_for_consumer?' do
+    let(:site) do
+      FactoryBot.create(
+        :benefit_sponsors_site,
+        :with_benefit_market,
+        :as_hbx_profile,
+        site_key: ::EnrollRegistry[:enroll_app].settings(:site_key).item
+      )
+    end
+
+    let(:broker_agency_organization) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+    let(:broker_agency_profile) { broker_agency_organization.broker_agency_profile }
+    let(:broker_agency_id) { broker_agency_profile.id }
+
+    let(:broker_agency_organization2) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+    let(:broker_agency_profile2) { broker_agency_organization2.broker_agency_profile }
+
+    let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role, :with_broker_role) }
+    let(:broker_role) { person.broker_role }
+
+    let(:broker_agency_staff_role) do
+      person.create_broker_agency_staff_role(
+        benefit_sponsors_broker_agency_profile_id: broker_agency_id
+      )
+    end
+
+    context 'resource registry feature is enabled' do
+      let(:brce_enabled_or_disabled) { true }
+
+      context 'when:
+      - person does not have active consumer role' do
+
+        let(:person) { FactoryBot.create(:person) }
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+      - person has an active consumer role
+      - person does not have a broker role' do
+
+        let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+      - person has an active consumer role
+      - person has a broker role
+      - person does not have an active broker role' do
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+      - person has an active consumer role
+      - person has a broker role
+      - broker_role is a primary broker for an agency
+      - person has an active broker role
+      - person does not have broker_agency_staff_role' do
+
+        before do
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+          broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id)
+          broker_role.approve!
+        end
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+      - person has an active consumer role
+      - person has a broker role
+      - broker_role is a primary broker for an agency
+      - person has an active broker role
+      - person has a broker_agency_staff_role
+      - person does not have an active broker_agency_staff_role' do
+
+        let(:broker_agency_id) { broker_agency_profile2.id }
+
+        before do
+          broker_agency_staff_role
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+          broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id)
+          broker_role.approve!
+        end
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+      - person has an active consumer role
+      - person has a broker role
+      - broker_role is a primary broker for an agency
+      - person has an active broker role
+      - person has a broker_agency_staff_role
+      - person has an active broker_agency_staff_role
+      - both broker_agency_staff_role and broker_role are not linked to the same Broker Agency Profile' do
+
+        let(:broker_agency_id) { broker_agency_profile.id }
+
+        before do
+          broker_agency_staff_role.broker_agency_accept!
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_profile2.id)
+          broker_agency_profile2.update_attributes!(primary_broker_role_id: broker_role.id)
+          broker_role.approve!
+        end
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+      - person has an active consumer role
+      - person has a broker role
+      - broker_role is a primary broker for an agency
+      - person has an active broker role
+      - person has a broker_agency_staff_role
+      - person does not have a matching active broker_agency_staff_role
+      - both broker_agency_staff_role and broker_role are linked to the same Broker Agency Profile' do
+
+        before do
+          broker_agency_staff_role
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+          broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id)
+          broker_role.approve!
+        end
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+      - person has an active consumer role
+      - person has a broker role
+      - broker_role is a primary broker for an agency
+      - person has an active broker role
+      - person has a broker_agency_staff_role
+      - person has an active broker_agency_staff_role
+      - both broker_agency_staff_role and broker_role are linked to the same Broker Agency Profile' do
+
+        before do
+          broker_agency_staff_role.broker_agency_accept!
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+          broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id)
+          broker_role.approve!
+        end
+
+        it 'returns true' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(true)
         end
       end
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,17 +1,8 @@
-# frozen_string_literal: true
-
 require "rails_helper"
 require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_market.rb"
 require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_application.rb"
 
 RSpec.describe ApplicationHelper, :type => :helper do
-
-  let(:brce_enabled_or_disabled) { false }
-
-  before :each do
-    allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
-    allow(EnrollRegistry).to receive(:feature_enabled?).with(:broker_role_consumer_enhancement).and_return(brce_enabled_or_disabled)
-  end
 
   describe "#can_employee_shop??" do
     it "should return false if date is empty" do
@@ -960,6 +951,7 @@ describe "Enabled/Disabled IVL market" do
   describe '#eligible_to_redirect_to_home_page?' do
     let(:user) { FactoryBot.create(:user, person: person) }
     let(:person) { FactoryBot.create(:person, :with_consumer_role) }
+
     let(:brce_enabled_or_disabled) { false }
 
     before :each do
@@ -1064,8 +1056,9 @@ describe "Enabled/Disabled IVL market" do
   end
 
   describe '#insured_role_exists?' do
-    let(:brce_enabled_or_disabled) { false }
     let(:user) { FactoryBot.create(:user, person: person) }
+
+    let(:brce_enabled_or_disabled) { false }
 
     before :each do
       allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
@@ -1077,6 +1070,7 @@ describe "Enabled/Disabled IVL market" do
       let(:employee_role) { person.employee_roles.first }
 
       before do
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:aca_shop_market).and_return(true)
         allow(person).to receive(:active_employee_roles).and_return([employee_role])
       end
 
@@ -1146,11 +1140,18 @@ describe "Enabled/Disabled IVL market" do
       )
     end
 
+    let(:brce_enabled_or_disabled) { false }
+
+    before :each do
+      allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:broker_role_consumer_enhancement).and_return(brce_enabled_or_disabled)
+    end
+
     context 'resource registry feature is enabled' do
       let(:brce_enabled_or_disabled) { true }
 
       context 'when:
-      - person does not have active consumer role' do
+        - person does not have active consumer role' do
 
         let(:person) { FactoryBot.create(:person) }
 
@@ -1160,8 +1161,8 @@ describe "Enabled/Disabled IVL market" do
       end
 
       context 'when:
-      - person has an active consumer role
-      - person does not have a broker role' do
+        - person has an active consumer role
+        - person does not have a broker role' do
 
         let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
 
@@ -1171,9 +1172,9 @@ describe "Enabled/Disabled IVL market" do
       end
 
       context 'when:
-      - person has an active consumer role
-      - person has a broker role
-      - person does not have an active broker role' do
+        - person has an active consumer role
+        - person has a broker role
+        - person does not have an active broker role' do
 
         it 'returns false' do
           expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
@@ -1181,11 +1182,11 @@ describe "Enabled/Disabled IVL market" do
       end
 
       context 'when:
-      - person has an active consumer role
-      - person has a broker role
-      - broker_role is a primary broker for an agency
-      - person has an active broker role
-      - person does not have broker_agency_staff_role' do
+        - person has an active consumer role
+        - person has a broker role
+        - broker_role is a primary broker for an agency
+        - person has an active broker role
+        - person does not have broker_agency_staff_role' do
 
         before do
           broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
@@ -1199,12 +1200,12 @@ describe "Enabled/Disabled IVL market" do
       end
 
       context 'when:
-      - person has an active consumer role
-      - person has a broker role
-      - broker_role is a primary broker for an agency
-      - person has an active broker role
-      - person has a broker_agency_staff_role
-      - person does not have an active broker_agency_staff_role' do
+        - person has an active consumer role
+        - person has a broker role
+        - broker_role is a primary broker for an agency
+        - person has an active broker role
+        - person has a broker_agency_staff_role
+        - person does not have an active broker_agency_staff_role' do
 
         let(:broker_agency_id) { broker_agency_profile2.id }
 
@@ -1221,13 +1222,13 @@ describe "Enabled/Disabled IVL market" do
       end
 
       context 'when:
-      - person has an active consumer role
-      - person has a broker role
-      - broker_role is a primary broker for an agency
-      - person has an active broker role
-      - person has a broker_agency_staff_role
-      - person has an active broker_agency_staff_role
-      - both broker_agency_staff_role and broker_role are not linked to the same Broker Agency Profile' do
+        - person has an active consumer role
+        - person has a broker role
+        - broker_role is a primary broker for an agency
+        - person has an active broker role
+        - person has a broker_agency_staff_role
+        - person has an active broker_agency_staff_role
+        - both broker_agency_staff_role and broker_role are not linked to the same Broker Agency Profile' do
 
         let(:broker_agency_id) { broker_agency_profile.id }
 
@@ -1244,13 +1245,13 @@ describe "Enabled/Disabled IVL market" do
       end
 
       context 'when:
-      - person has an active consumer role
-      - person has a broker role
-      - broker_role is a primary broker for an agency
-      - person has an active broker role
-      - person has a broker_agency_staff_role
-      - person does not have a matching active broker_agency_staff_role
-      - both broker_agency_staff_role and broker_role are linked to the same Broker Agency Profile' do
+        - person has an active consumer role
+        - person has a broker role
+        - broker_role is a primary broker for an agency
+        - person has an active broker role
+        - person has a broker_agency_staff_role
+        - person does not have a matching active broker_agency_staff_role
+        - both broker_agency_staff_role and broker_role are linked to the same Broker Agency Profile' do
 
         before do
           broker_agency_staff_role
@@ -1265,13 +1266,13 @@ describe "Enabled/Disabled IVL market" do
       end
 
       context 'when:
-      - person has an active consumer role
-      - person has a broker role
-      - broker_role is a primary broker for an agency
-      - person has an active broker role
-      - person has a broker_agency_staff_role
-      - person has an active broker_agency_staff_role
-      - both broker_agency_staff_role and broker_role are linked to the same Broker Agency Profile' do
+        - person has an active consumer role
+        - person has a broker role
+        - broker_role is a primary broker for an agency
+        - person has an active broker role
+        - person has a broker_agency_staff_role
+        - person has an active broker_agency_staff_role
+        - both broker_agency_staff_role and broker_role are linked to the same Broker Agency Profile' do
 
         before do
           broker_agency_staff_role.broker_agency_accept!

--- a/spec/helpers/portal_header_helper_spec.rb
+++ b/spec/helpers/portal_header_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe PortalHeaderHelper, :type => :helper, dbclean: :after_each do
@@ -95,5 +97,165 @@ RSpec.describe PortalHeaderHelper, :type => :helper, dbclean: :after_each do
       end
     end
 
+  end
+
+  describe '#display_i_am_broker_for_consumer?' do
+    let(:site) do
+      FactoryBot.create(
+        :benefit_sponsors_site,
+        :with_benefit_market,
+        :as_hbx_profile,
+        site_key: ::EnrollRegistry[:enroll_app].settings(:site_key).item
+      )
+    end
+
+    let(:broker_agency_organization) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+    let(:broker_agency_profile) { broker_agency_organization.broker_agency_profile }
+    let(:broker_agency_id) { broker_agency_profile.id }
+
+    let(:broker_agency_organization2) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+    let(:broker_agency_profile2) { broker_agency_organization2.broker_agency_profile }
+
+    let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role, :with_broker_role) }
+    let(:broker_role) { person.broker_role }
+
+    let(:broker_agency_staff_role) do
+      person.create_broker_agency_staff_role(
+        benefit_sponsors_broker_agency_profile_id: broker_agency_id
+      )
+    end
+
+    before :each do
+      allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(:broker_role_consumer_enhancement).and_return(true)
+    end
+
+    context 'resource registry feature is enabled and person has an active consumer role' do
+      context 'when:
+        - person has an active consumer role
+        - person does not have a broker role' do
+
+        let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+        - person has an active consumer role
+        - person has a broker role
+        - person does not have an active broker role' do
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+        - person has an active consumer role
+        - person has a broker role
+        - broker_role is a primary broker for an agency
+        - person has an active broker role
+        - person does not have broker_agency_staff_role' do
+
+        before do
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+          broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id)
+          broker_role.approve!
+        end
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+        - person has an active consumer role
+        - person has a broker role
+        - broker_role is a primary broker for an agency
+        - person has an active broker role
+        - person has a broker_agency_staff_role
+        - person does not have an active broker_agency_staff_role' do
+
+        let(:broker_agency_id) { broker_agency_profile2.id }
+
+        before do
+          broker_agency_staff_role
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+          broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id)
+          broker_role.approve!
+        end
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+        - person has an active consumer role
+        - person has a broker role
+        - broker_role is a primary broker for an agency
+        - person has an active broker role
+        - person has a broker_agency_staff_role
+        - person has an active broker_agency_staff_role
+        - both broker_agency_staff_role and broker_role are not linked to the same Broker Agency Profile' do
+
+        let(:broker_agency_id) { broker_agency_profile.id }
+
+        before do
+          broker_agency_staff_role.broker_agency_accept!
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_profile2.id)
+          broker_agency_profile2.update_attributes!(primary_broker_role_id: broker_role.id)
+          broker_role.approve!
+        end
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+        - person has an active consumer role
+        - person has a broker role
+        - broker_role is a primary broker for an agency
+        - person has an active broker role
+        - person has a broker_agency_staff_role
+        - person does not have a matching active broker_agency_staff_role
+        - both broker_agency_staff_role and broker_role are linked to the same Broker Agency Profile' do
+
+        before do
+          broker_agency_staff_role
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+          broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id)
+          broker_role.approve!
+        end
+
+        it 'returns false' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(false)
+        end
+      end
+
+      context 'when:
+        - person has an active consumer role
+        - person has a broker role
+        - broker_role is a primary broker for an agency
+        - person has an active broker role
+        - person has a broker_agency_staff_role
+        - person has an active broker_agency_staff_role
+        - both broker_agency_staff_role and broker_role are linked to the same Broker Agency Profile' do
+
+        before do
+          broker_agency_staff_role.broker_agency_accept!
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+          broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id)
+          broker_role.approve!
+        end
+
+        it 'returns true' do
+          expect(helper.display_i_am_broker_for_consumer?(person)).to eq(true)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 186818196](https://www.pivotaltracker.com/story/show/186818196)

# A brief description of the changes

Current behavior: Currently, if a person has an active consumer role and the primary family has a current broker agency to display the 'I am Broker' link.

New behavior: Check if a person has an active consumer role, active broker role, active broker agency staff role, and both the active broker agency staff & active broker role have the same broker agency profile to display the 'I am Broker' link.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

Feature Key: `:broker_role_consumer_enhancement`
Environment Variable: `'BROKER_ROLE_CONSUMER_ENHANCEMENT_IS_ENABLED'`
Description: `Enhancements for Brokers acting as consumers under the same account`

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.

## Screenshots:

- When the feature is enabled, the Person has both a Consumer Role and an **UNAPPROVED** Broker Role.
-- <img width="1492" alt="image" src="https://github.com/ideacrew/enroll/assets/22556810/d37c0faf-2594-45e9-93fa-d1c0944aac95">
- When the feature is disabled, the Person has both a Consumer Role and an **UNAPPROVED** Broker Role.
-- <img width="1678" alt="image" src="https://github.com/ideacrew/enroll/assets/22556810/3801b47e-2e7f-46d5-a6db-f15046952777">
- When the feature is enabled, the Person has both a Consumer Role and an **APPROVED** Broker Role.
-- <img width="1671" alt="image" src="https://github.com/ideacrew/enroll/assets/22556810/e83053e6-38ed-4e1a-8128-6e16c62148bc">



