### PR TITLE
level aa contrast manage family page

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -1355,17 +1355,17 @@ a.close-1, a.close-2{
   background: #fff;
   padding: 20px;
   text-align: center;
-  color: red;
+  color: var(--status-red, red);
   border: 1px solid #b7b7b7;
   border-top: none;
 }
 
 #remove_confirm a.cancel {
-  color: red;
+  color: var(--status-red, red);
 }
 
 #remove_confirm a.confirm {
-  color: black;
+  color: var(--primary-black, black);
 }
 /* New address flow start */
 
@@ -2412,7 +2412,7 @@ ul.navbar-nav.top-menu li {
 }
 
 #profile-content .panel .info-wrapper h3 {
-    color: <%= EnrollRegistry[:qle_carousel].settings(:color).item %>;
+    color: var(--theme-primary-blue, #007bc4);
     font-weight: bold;
     margin-top: 0;
     text-transform: uppercase;
@@ -2428,7 +2428,7 @@ ul.list-qle li {
 }
 
 ul.list-qle li a {
-    color: #0079c7;
+    color: var(--theme-primary-blue, #0079c7);
     font-size: 17px;
     font-weight: 400;
 }
@@ -3821,7 +3821,7 @@ ul.list-right-section li a img {
 
 
 .my-account-page h1{
-    color: <%= EnrollRegistry[:cancel_plan_border].settings(:color).item %>;
+    color: var(--theme-primary-blue, #003260);
     font-size: 36px;
     margin-bottom: 10px;
     margin-top: 0;

--- a/app/views/insured/family_members/_dependent.html.erb
+++ b/app/views/insured/family_members/_dependent.html.erb
@@ -27,9 +27,9 @@
           <label class="static_label label-floatlabel"><%= l10n("relationship").to_s.upcase %></label>
           <span class="field_value floatlabel form-control active-floatlabel"> <%= dependent.relationship.try(:humanize) %> </span>
           <div class="text-right">
-            <%= link_to main_app.edit_insured_family_member_path(dependent), remote: true, class: 'close close-2' do %>
+            <a href="<%= main_app.edit_insured_family_member_path(dependent) %>" data-remote="true" class="close close-2">
               <i class="fas fa-pencil-alt"><span class="hide"><%= l10n("edit") %></span></i>
-            <% end %>
+            </a>
           </div>
         </div>
       </div>

--- a/app/views/insured/family_members/_dependent.html.erb
+++ b/app/views/insured/family_members/_dependent.html.erb
@@ -27,11 +27,9 @@
           <label class="static_label label-floatlabel"><%= l10n("relationship").to_s.upcase %></label>
           <span class="field_value floatlabel form-control active-floatlabel"> <%= dependent.relationship.try(:humanize) %> </span>
           <div class="text-right">
-            <%=
-              link_to main_app.edit_insured_family_member_path(dependent), remote: true, class: 'close close-2' do
-                '<i class="fas fa-pencil-alt"></i>'.html_safe
-              end
-            %>
+            <%= link_to main_app.edit_insured_family_member_path(dependent), remote: true, class: 'close close-2' do %>
+              <i class="fas fa-pencil-alt"><span class="hide"><%= l10n("edit") %></span></i>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/insured/family_members/_dependent_form.html.erb
+++ b/app/views/insured/family_members/_dependent_form.html.erb
@@ -73,7 +73,7 @@
               <%= f.text_field :last_name, value: dependent.last_name ,class: "home required floatlabel form-control", required: true, placeholder: "#{l10n("last_name").to_s.upcase} *" %>
               <div class="text-right">
                 <% if !dependent.persisted? %>
-                  <a href="#" class="close close-1 remove-new-employee-dependent" onclick="$('#btn-continue').removeClass('disabled');" data-target="#new_employee_dependent_form"><%= image_tag "member-close.png" %></a>
+                  <a href="#" class="close close-1 remove-new-employee-dependent" onclick="$('#btn-continue').removeClass('disabled');" data-target="#new_employee_dependent_form"><%= image_tag "member-close.png" %><span class="hide"><%=l10n("delete")%></span></a>
                 <% else %>
                   <%= link_to insured_family_member_path(dependent), class: 'close close-2', :method => :delete, :remote => true, data: {confirm: l10n("confirm_remove_dependent"), ok: l10n("yes"), cancel: l10n("no")} do
                     '<i class="fa fa-times"><span class="hide">Delete</span></i>'.html_safe

--- a/app/views/insured/family_members/_dependent_resident_form.html.erb
+++ b/app/views/insured/family_members/_dependent_resident_form.html.erb
@@ -46,9 +46,9 @@
                 <% if !dependent.persisted? %>
                   <a href="#" class="close close-1 remove-new-employee-dependent" onclick="$('#btn-continue').removeClass('disabled');" data-target="#new_employee_dependent_form"><%= image_tag "member-close.png" %><span class="hide"><%=l10n("delete")%></span></a>
                 <% else %>
-                  <%= link_to insured_family_member_path(dependent), class: 'close close-2', :method => :delete, :remote => true, data: {confirm: l10n("confirm_remove_dependent"), ok: l10n("yes"), cancel: l10n("no")} do %>
-                      <i class="fa fa-times"><span class="hide"><%=l10n("delete")%></span></i>
-                  <% end %>
+                  <a href="<%= insured_family_member_path(dependent) %>" class="close close-2" data-method="delete" data-remote="true" data-confirm="<%= l10n('confirm_remove_dependent') %>" data-ok="<%= l10n('yes') %>" data-cancel="<%= l10n('no') %>">
+                    <i class="fa fa-times"><span class="hide"><%= l10n('delete') %></span></i>
+                  </a>
                 <% end %>
               </div>
             </div>

--- a/app/views/insured/family_members/_dependent_resident_form.html.erb
+++ b/app/views/insured/family_members/_dependent_resident_form.html.erb
@@ -44,11 +44,11 @@
               <%= f.text_field :last_name, value: dependent.last_name ,class: "home required floatlabel form-control", required: true, placeholder: "#{l10n("last_name").to_s.upcase} *" %>
               <div class="text-right">
                 <% if !dependent.persisted? %>
-                  <a href="#" class="close close-1 remove-new-employee-dependent" onclick="$('#btn-continue').removeClass('disabled');" data-target="#new_employee_dependent_form"><%= image_tag "member-close.png" %></a>
+                  <a href="#" class="close close-1 remove-new-employee-dependent" onclick="$('#btn-continue').removeClass('disabled');" data-target="#new_employee_dependent_form"><%= image_tag "member-close.png" %><span class="hide"><%=l10n("delete")%></span></a>
                 <% else %>
-                  <%= link_to insured_family_member_path(dependent), class: 'close close-2', :method => :delete, :remote => true, data: {confirm: l10n("confirm_remove_dependent"), ok: l10n("yes"), cancel: l10n("no")} do
-                      '<i class="fa fa-times"></i>'.html_safe
-                    end %>
+                  <%= link_to insured_family_member_path(dependent), class: 'close close-2', :method => :delete, :remote => true, data: {confirm: l10n("confirm_remove_dependent"), ok: l10n("yes"), cancel: l10n("no")} do %>
+                      <i class="fa fa-times"><span class="hide"><%=l10n("delete")%></span></i>
+                  <% end %>
                 <% end %>
               </div>
             </div>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
@@ -74,9 +74,9 @@
                   <% if !@applicant.persisted? %>
                       <a href="#" class="close close-1 remove-new-employee-dependent" onclick="$('#btn-continue').removeClass('disabled');" data-target="#new_employee_dependent_form"><%= image_tag "member-close.png" %><span class="hide"><%=l10n("delete")%></span></a>
                   <% else %>
-                    <%= link_to insured_family_member_path(@applicant), class: 'close close-2', :method => :delete, :remote => true, data: {confirm: l10n("confirm_remove_dependent"), ok: l10n("yes"), cancel: l10n("no")} do %>
-                      <i class="fa fa-times"><span class="hide"><%=l10n("delete")%></span></i>
-                    <% end %>
+                    <a href="<%= insured_family_member_path(@applicant) %>" class="close close-2" data-method="delete" data-remote="true" data-confirm="<%= l10n('confirm_remove_dependent') %>" data-ok="<%= l10n('yes') %>" data-cancel="<%= l10n('no') %>">
+                      <i class="fa fa-times"><span class="hide"><%= l10n('delete') %></span></i>
+                    </a>
                   <% end %>
                 </div>
               </div>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
@@ -72,11 +72,11 @@
                 <%= f.text_field :last_name, value: @applicant.last_name ,class: "home required floatlabel form-control", required: true, placeholder: "#{l10n("last_name").to_s.upcase} *" %>
                 <div class="text-right">
                   <% if !@applicant.persisted? %>
-                      <a href="#" class="close close-1 remove-new-employee-dependent" onclick="$('#btn-continue').removeClass('disabled');" data-target="#new_employee_dependent_form"><%= image_tag "member-close.png" %></a>
+                      <a href="#" class="close close-1 remove-new-employee-dependent" onclick="$('#btn-continue').removeClass('disabled');" data-target="#new_employee_dependent_form"><%= image_tag "member-close.png" %><span class="hide"><%=l10n("delete")%></span></a>
                   <% else %>
-                      <%= link_to insured_family_member_path(@applicant), class: 'close close-2', :method => :delete, :remote => true, data: {confirm: l10n("confirm_remove_dependent"), ok: l10n("yes"), cancel: l10n("no")} do
-                        '<i class="fa fa-times"></i>'.html_safe
-                      end %>
+                    <%= link_to insured_family_member_path(@applicant), class: 'close close-2', :method => :delete, :remote => true, data: {confirm: l10n("confirm_remove_dependent"), ok: l10n("yes"), cancel: l10n("no")} do %>
+                      <i class="fa fa-times"><span class="hide"><%=l10n("delete")%></span></i>
+                    <% end %>
                   <% end %>
                 </div>
               </div>

--- a/features/insured/contrast_level_aa/manage_family_page.feature
+++ b/features/insured/contrast_level_aa/manage_family_page.feature
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Feature: Contrast level AA is enabled - existing consumer visits the manage family page
+  Background:
+    Given the contrast level aa feature is enabled
+    Given a consumer exists
+    And the consumer is logged in
+    And consumer has successful ridp
+    And consumer visits home page
+
+  Scenario: the user visits the family tab
+    Given individual clicks on the Manage Family button
+    Then the page passes minimum level aa contrast guidelines
+
+  Scenario: the user visits the personal tab
+    Given individual clicks on the Manage Family button
+    Then individual clicks on the Personal portal
+    And the consumer should see tribal name textbox without text

--- a/features/insured/contrast_level_aa/manage_family_page.feature
+++ b/features/insured/contrast_level_aa/manage_family_page.feature
@@ -15,4 +15,4 @@ Feature: Contrast level AA is enabled - existing consumer visits the manage fami
   Scenario: the user visits the personal tab
     Given individual clicks on the Manage Family button
     Then individual clicks on the Personal portal
-    And the consumer should see tribal name textbox without text
+    Then the page passes minimum level aa contrast guidelines


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186499307 && https://www.pivotaltracker.com/story/show/186499306

# A brief description of the changes

Current behavior No cucumbers, no fallback for icons, some contrast issues

New behavior: Cucumber test added, functionality improved, l10n added in places for fallbacks

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

![Screenshot 2024-01-14 at 4 52 00 PM](https://github.com/ideacrew/enroll/assets/45053146/bb858c0b-c417-434f-a7bd-961010590162)
![Screenshot 2024-01-14 at 4 52 35 PM](https://github.com/ideacrew/enroll/assets/45053146/ac257d0a-b771-44af-ab24-c73f1db87e3f)
![Screenshot 2024-01-14 at 4 52 45 PM](https://github.com/ideacrew/enroll/assets/45053146/5d7842b9-9ded-4bb4-b5a6-0310914f6c9a)
![Screenshot 2024-01-14 at 4 52 58 PM](https://github.com/ideacrew/enroll/assets/45053146/279094c5-f239-4f2c-9594-ff619e078aa2)
![Screenshot 2024-01-14 at 4 55 04 PM](https://github.com/ideacrew/enroll/assets/45053146/ff954b82-1f3f-45ac-9a0b-624d0566d6a9)


# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.