### PR TITLE
call value on result prior to passing to PublishCloseCaseRequest

### DIFF
--- a/app/event_source/subscribers/fdsh_gateway/vlp_verifications_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/vlp_verifications_subscriber.rb
@@ -3,12 +3,12 @@
 module Subscribers
   module FdshGateway
   # Subscriber will receive response payload from FDSH gateway
-    class VlpverificationsSubscriber
+    class VlpVerificationsSubscriber
       include EventSource::Logging
       include ::EventSource::Subscriber[amqp: 'fdsh.eligibilities.vlp']
 
       subscribe(:on_initial_verification_complete) do |delivery_info, metadata, response|
-        logger.info "Vlp::VlpverificationsSubscriber: invoked on_initial_verification_complete with delivery_info: #{delivery_info.inspect}, response: #{response.inspect}"
+        logger.info "Vlp::VlpVerificationsSubscriber: invoked on_initial_verification_complete with delivery_info: #{delivery_info.inspect}, response: #{response.inspect}"
         payload = JSON.parse(response, :symbolize_names => true)
 
         verification_payload = { person_hbx_id: metadata.correlation_id, metadata: metadata, response: payload }
@@ -16,17 +16,17 @@ module Subscribers
         result = Operations::Fdsh::Vlp::H92::InitialResponseProcessor.new.call(verification_payload)
 
         if result.success?
-          logger.info "Vlp::VlpverificationsSubscriber: on_initial_verification_complete acked with success: #{result.success}"
+          logger.info "Vlp::VlpVerificationsSubscriber: on_initial_verification_complete acked with success: #{result.success}"
           correlation_id = metadata.correlation_id
-          Operations::Fdsh::Vlp::Rx142::CloseCase::PublishCloseCaseRequest.new.call(result, correlation_id) if EnrollRegistry.feature_enabled?(:send_close_case_request)
+          Operations::Fdsh::Vlp::Rx142::CloseCase::PublishCloseCaseRequest.new.call(result.value!, correlation_id) if EnrollRegistry.feature_enabled?(:send_close_case_request)
         else
           errors = result.failure&.errors&.to_h
-          logger.info "Vlp::VlpverificationsSubscriber: on_initial_verification_complete acked with failure, errors: #{errors}"
+          logger.info "Vlp::VlpVerificationsSubscriber: on_initial_verification_complete acked with failure, errors: #{errors}"
         end
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.error "Vlp::VlpverificationsSubscriber: on_initial_verification_complete error_message: #{e.message}, backtrace: #{e.backtrace}"
+        logger.error "Vlp::VlpVerificationsSubscriber: on_initial_verification_complete error_message: #{e.message}, backtrace: #{e.backtrace}"
       end
     end
   end

--- a/app/event_source/subscribers/fdsh_gateway/vlp_verifications_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/vlp_verifications_subscriber.rb
@@ -20,7 +20,7 @@ module Subscribers
           correlation_id = metadata.correlation_id
           Operations::Fdsh::Vlp::Rx142::CloseCase::PublishCloseCaseRequest.new.call(result.value!, correlation_id) if EnrollRegistry.feature_enabled?(:send_close_case_request)
         else
-          errors = result.failure&.errors&.to_h
+          errors = result.failure
           logger.info "Vlp::VlpVerificationsSubscriber: on_initial_verification_complete acked with failure, errors: #{errors}"
         end
         ack(delivery_info.delivery_tag)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [#186623185](https://www.pivotaltracker.com/story/show/186623185)

# A brief description of the changes

Current behavior: passing a dry monad into CloseCase's PublishRequest publisher instead of the value

New behavior: passing the value from initial_verification_requested into CloseCase's PublishRequest publisher

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.