### PR TITLE
Fix staff invitation not sent when added by broker.

### DIFF
--- a/components/benefit_sponsors/app/models/benefit_sponsors/services/staff_role_service.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/services/staff_role_service.rb
@@ -172,8 +172,12 @@ module BenefitSponsors
         if terminated_brokers_with_same_profile.present?
           terminated_brokers_with_same_profile.broker_agency_active!
         else
-          broker_agency_staff_role = BrokerAgencyStaffRole.new(person: person.first, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, aasm_state: "active")
-          broker_agency_staff_role.save
+          broker_agency_staff_role = person.first.create_broker_agency_staff_role(
+            {
+              benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id
+            }
+          )
+          broker_agency_staff_role.broker_agency_accept!
         end
         [true, person.first]
       end

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/services/staff_role_service_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/services/staff_role_service_spec.rb
@@ -394,6 +394,17 @@ module BenefitSponsors
         it 'returns the person' do
           expect(@result).to eq person1
         end
+
+        it 'places the person into the active state, after transitioning from the initial state' do
+          person1.reload
+          broker_agency_staff_role = person1.broker_agency_staff_roles.first
+          transition = broker_agency_staff_role.workflow_state_transitions.detect do |wst|
+            wst.from_state == "broker_agency_pending" &&
+              wst.to_state == "active" &&
+              wst.event == "broker_agency_accept!"
+          end
+          expect(transition).not_to be_nil
+        end
       end
 
       context 'person already has broker role with this broker agency' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186817778

# A brief description of the changes

Current behavior: 

When the broker staff is created by the broker (not via broker staff self-registration), the broker staff model is created DIRECTLY in the 'active' state - this means the 'accepted' trigger, which is how the invitation mail is sent, is skipped.

New behavior:  Pass through the correct states when a broker staff role is added directly in the staff UI.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

