### PR TITLE
add more graceful error handling for VLP without individual responses key

### DIFF
--- a/app/domain/operations/fdsh/vlp/rx142/close_case/request_close_case.rb
+++ b/app/domain/operations/fdsh/vlp/rx142/close_case/request_close_case.rb
@@ -27,9 +27,11 @@ module Operations
             private
 
             def get_case_number(payload)
-              verification_response = payload.dig(:InitialVerificationResponseSet, :InitialVerificationIndividualResponses).first
-              case_number = verification_response.dig(:InitialVerificationIndividualResponseSet, :CaseNumber)
-              return Failure('No case number') unless case_number
+              verification_response = payload&.dig(:InitialVerificationResponseSet, :InitialVerificationIndividualResponses)&.first
+              return Failure('No individual responses found in CMS response') unless verification_response
+
+              case_number = verification_response&.dig(:InitialVerificationIndividualResponseSet, :CaseNumber)
+              return Failure('No case number found in CMS response') unless case_number
 
               Success(case_number)
             end


### PR DESCRIPTION
… InitialVerificationIndividualResponses

# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [186865469](https://www.pivotaltracker.com/story/show/186865469)

# A brief description of the changes

Current behavior: No error handling for CMS VLP initial verification responses without InitialVerificationIndividualResponses

New behavior: Adds handling for CMS VLP initial verification responses without InitialVerificationIndividualResponses

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.