### PR TITLE
update DC PO box address under Pay my bill section in employers billing tab

### DIFF
--- a/components/benefit_sponsors/app/helpers/benefit_sponsors/employers/pay_my_bill_helper.rb
+++ b/components/benefit_sponsors/app/helpers/benefit_sponsors/employers/pay_my_bill_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module BenefitSponsors
+  module Employers
+    # Helper methods for the PayMyBillTab on Employers Billing page
+    module PayMyBillHelper
+      # Retrieves the name associated with the PO lock box address from the EnrollRegistry.
+      # @return [String] The name corresponding to the PO lock box address.
+      def po_lock_box_name
+        EnrollRegistry[:po_lock_box_address].settings(:name).item
+      end
+
+      # Retrieves the number associated with the PO lock box address from the EnrollRegistry.
+      # @return [String] The number corresponding to the PO lock box address.
+      def po_lock_box_number
+        EnrollRegistry[:po_lock_box_address].settings(:number).item
+      end
+
+      # Retrieves the state associated with the PO lock box address from the EnrollRegistry.
+      # @return [String] The state corresponding to the PO lock box address.
+      def po_lock_box_state
+        EnrollRegistry[:po_lock_box_address].settings(:state).item
+      end
+
+      # Retrieves the city associated with the PO lock box address from the EnrollRegistry.
+      # @return [String] The city corresponding to the PO lock box address.
+      def po_lock_box_city
+        EnrollRegistry[:po_lock_box_address].settings(:city).item
+      end
+
+      # Retrieves the zip_code associated with the PO lock box address from the EnrollRegistry.
+      # @return [String] The zip_code corresponding to the PO lock box address.
+      def po_lock_box_zip_code
+        EnrollRegistry[:po_lock_box_address].settings(:zip_code).item
+      end
+    end
+  end
+end

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/accounts/_pay_my_bill.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/accounts/_pay_my_bill.html.erb
@@ -32,13 +32,13 @@
     </li>
     <li>Pay by Mail <i class="fa fa-info-circle" data-toggle="tooltip" data-placement="right" title="Slowest payment option – takes up to 2 weeks to process."></i>
       <div class="row col-md-offset-1">
-        <%= BenefitSponsorsRegistry[:enroll_app].settings(:short_name).item %>
+        <%= po_lock_box_name %>
       </div>
       <div class="row col-md-offset-1">
-        <%= EnrollRegistry[:enroll_app].setting(:contact_center_po_box).item %>
+        <%= po_lock_box_number %>
       </div>
       <div class="row col-md-offset-1">
-        <%= EnrollRegistry[:enroll_app].setting(:contact_center_city).item %>, <%= Settings.contact_center.state %> <%= EnrollRegistry[:enroll_app].setting(:contact_center_zip_code).item %>
+        <%= po_lock_box_city %>, <%= po_lock_box_state %> <%= po_lock_box_zip_code %>
       </div>
     </li>
   </ol>

--- a/config/client_config/dc/system/config/templates/features/enroll_app/contact_information.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/contact_information.yml
@@ -1,0 +1,19 @@
+---
+registry:
+  - namespace:
+      - :enroll_app
+      - :contact_information
+    features:
+      - key: :po_lock_box_address
+        is_enabled: true
+        settings:
+          - key: :name
+            item: "DC Government Health Benefit Exchange"
+          - key: :number
+            item: "PO Box 717023"
+          - key: :city
+            item: "Philadelphia"
+          - key: :state
+            item: "PA"
+          - key: :zip_code
+            item: "19171-7023"

--- a/config/client_config/me/system/config/templates/features/enroll_app/contact_information.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/contact_information.yml
@@ -1,0 +1,19 @@
+---
+registry:
+  - namespace:
+      - :enroll_app
+      - :contact_information
+    features:
+      - key: :po_lock_box_address
+        is_enabled: true
+        settings:
+          - key: :name
+            item: "CoverME.gov Health Benefit Exchange"
+          - key: :number
+            item: "PO Box 616"
+          - key: :city
+            item: "Augusta"
+          - key: :state
+            item: "ME"
+          - key: :zip_code
+            item: "04332-6626"

--- a/features/step_definitions/employers_steps.rb
+++ b/features/step_definitions/employers_steps.rb
@@ -1035,6 +1035,11 @@ end
 
 Then(/^the employer should see billing information$/) do
   expect(page).to have_content('The invoice includes next month')
+  expect(page).to have_content(EnrollRegistry[:po_lock_box_address].settings(:name).item)
+  expect(page).to have_content(EnrollRegistry[:po_lock_box_address].settings(:number).item)
+  expect(page).to have_content(EnrollRegistry[:po_lock_box_address].settings(:state).item)
+  expect(page).to have_content(EnrollRegistry[:po_lock_box_address].settings(:city).item)
+  expect(page).to have_content(EnrollRegistry[:po_lock_box_address].settings(:zip_code).item)
 end
 
 Then(/^the employer should see Download,Print Option/) do

--- a/system/config/templates/features/enroll_app/contact_information.yml
+++ b/system/config/templates/features/enroll_app/contact_information.yml
@@ -1,0 +1,19 @@
+---
+registry:
+  - namespace:
+      - :enroll_app
+      - :contact_information
+    features:
+      - key: :po_lock_box_address
+        is_enabled: true
+        settings:
+          - key: :name
+            item: "DC Government Health Benefit Exchange"
+          - key: :number
+            item: "PO Box 717023"
+          - key: :city
+            item: "Philadelphia"
+          - key: :state
+            item: "PA"
+          - key: :zip_code
+            item: "19171-7023"


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket:  https://redmine.priv.dchbx.org/issues/104371

# A brief description of the changes

Current behavior: Using old PO lockbox address on Employers Billing Page

New behavior: Use new PO lockbox address on on Employers Billing Page

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.