### PR TITLE
level aa contrast my broker page

### DIFF
--- a/app/assets/javascripts/keyboard_navigation.js
+++ b/app/assets/javascripts/keyboard_navigation.js
@@ -37,6 +37,10 @@ function handleButtonKeyDown(event, buttonId) {
   }
 }
 
+function handleSEPRadioButton(buttonId) {
+  document.getElementById(buttonId).click(); 
+}
+
 function handleCancelButtonKeyDown(event, buttonId, hideForm) {
   if (event.key === 'Enter') { 
     document.getElementById(buttonId).click(); 

--- a/app/assets/javascripts/qle.js.erb
+++ b/app/assets/javascripts/qle.js.erb
@@ -171,11 +171,15 @@ $(function () {
   });
 
   // Disable form submit on pressing Enter, instead click Submit link
-  $('#qle_form').on('keyup keypress', function(e) {
+  $('#qle_form').on('keydown', function(e) {
     var code = e.keyCode || e.which;
-    if (code == 13 && !$("div.n-radio-row").is(":focus")) {
+    if (code == 13 && !$("div.n-radio-row").is(":focus") && !$("a.btn-primary").is(":focus")) {
       e.preventDefault();
       $("#qle_submit").click();
+      return false;
+    } else if (code == 13 && $("div.n-radio-row").is(":focus")) {
+      e.preventDefault();
+      $("#qle_submit_reason").click();
       return false;
     }
   });
@@ -197,7 +201,7 @@ $(function () {
   $(document).on('click', '#qle_submit_reason', function() {
     var health_message = ($("#health-ending-expanded").length == 1 );
     var not_expected_response = ( health_message ) ? 'no' : 'yes';
-    
+
     if( $("input:radio[name=reason]:checked").val() != 'None of the Above' && $("input:radio[name=reason]:checked").val() != not_expected_response){
       get_qle_date();
     } else {
@@ -206,6 +210,10 @@ $(function () {
       $("#qle-details .error-text").html(errorNoticeAction);
       $('#qle-details .error-info').removeClass('hidden');
     }
+  });
+
+  $(document).ready(function() {
+    $('#qle_reason').hide();
   });
 
 	$(document).on('click', '#qle_continue_button', function() {

--- a/app/assets/stylesheets/insured.scss.erb
+++ b/app/assets/stylesheets/insured.scss.erb
@@ -527,7 +527,7 @@
 }
 
 #account-detail .popover {
-  background-color: var(--primary-white, $primary-black);
+  background-color: $primary-black;
   color: $primary-white;
   .arrow:after {
     border-right-color: $primary-black;

--- a/app/views/broker_agencies/profiles/_broker_help.html.erb
+++ b/app/views/broker_agencies/profiles/_broker_help.html.erb
@@ -78,9 +78,9 @@
 		        <br/>
 		       
              <p class="lg"> <b><%= l10n("broker_agencies.profiles.warning_for_existing_broker")%></b></p>
-               <button type="button" class="btn btn-primary btn-small help_button close_broker_select" data-broker='<%=@staff.id%>'><%= l10n("broker_agencies.profiles.select_this_broker")%></button>
+               <button type="button" id="broker-select" class="btn btn-primary btn-small help_button close_broker_select" data-broker='<%=@staff.id%>'><%= l10n("broker_agencies.profiles.select_this_broker")%></button>
              
-               <button type="button" class="btn btn-default btn-default btn-small"><%= l10n("close")%></button>
+               <button type="button" class="btn btn-default btn-default btn-small close_broker_select"><%= l10n("close")%></button>
             </div> 
           
       </div>

--- a/app/views/broker_agencies/profiles/_broker_help.html.erb
+++ b/app/views/broker_agencies/profiles/_broker_help.html.erb
@@ -78,7 +78,7 @@
 		        <br/>
 		       
              <p class="lg"> <b><%= l10n("broker_agencies.profiles.warning_for_existing_broker")%></b></p>
-               <button type="button" class="btn btn-primary btn-small help_button close_broker_select" data-broker='<%=@staff.id%>'><%= l10n("broker_agencies.profiles.select_this_broker")%></button>
+               <button type="button" id="broker-select" class="btn btn-primary btn-small help_button close_broker_select" data-broker='<%=@staff.id%>'><%= l10n("broker_agencies.profiles.select_this_broker")%></button>
              
                <button type="button" class="btn btn-default btn-default btn-small close_broker_select"><%= l10n("close")%></button>
             </div> 

--- a/app/views/broker_agencies/profiles/_broker_help.html.erb
+++ b/app/views/broker_agencies/profiles/_broker_help.html.erb
@@ -78,9 +78,9 @@
 		        <br/>
 		       
              <p class="lg"> <b><%= l10n("broker_agencies.profiles.warning_for_existing_broker")%></b></p>
-               <button type="button" id="broker-select" class="btn btn-primary btn-small help_button close_broker_select" data-broker='<%=@staff.id%>'><%= l10n("broker_agencies.profiles.select_this_broker")%></button>
+               <button type="button" class="btn btn-primary btn-small help_button close_broker_select" data-broker='<%=@staff.id%>'><%= l10n("broker_agencies.profiles.select_this_broker")%></button>
              
-               <button type="button" class="btn btn-default btn-default btn-small close_broker_select"><%= l10n("close")%></button>
+               <button type="button" class="btn btn-default btn-default btn-small"><%= l10n("close")%></button>
             </div> 
           
       </div>

--- a/app/views/insured/families/_broker_delete.html.erb
+++ b/app/views/insured/families/_broker_delete.html.erb
@@ -1,0 +1,21 @@
+<!-- Delete Modal -->
+<div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="deleteModalLabel"><%= l10n("confirmation") %>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <i aria-hidden="true" class="fas fa-times"><span class="hide"><%=l10n("close")%></span></i>
+          </button>
+        </h4>
+      </div>
+      <div class="modal-body">
+        <%= l10n("confirm_delete_msg") %>
+      </div>
+      <div class="modal-footer" style="display: flex;">
+        <%= button_to l10n("Delete"), delete_consumer_broker_insured_family_path(@family), method: :delete, class: 'btn btn-save', style: 'margin-right: 5px'%>
+        <button type="button" class="btn btn-default" data-dismiss="modal"><%= l10n("Cancel") %></button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/insured/families/_consumer_broker.html.erb
+++ b/app/views/insured/families/_consumer_broker.html.erb
@@ -6,7 +6,15 @@
       </h3>
     </div>
     <div class="text-right">
-      <%= link_to "#{l10n('insured.delete_broker')} &nbsp;<i class='fa fa-user-times' aria-hidden='true'></i>".html_safe, delete_consumer_broker_insured_family_path(@family) , method: :delete , data: { confirm: l10n("confirm_delete_msg") }, class: 'btn btn-default'+pundit_class(Family,:updateable?) %>
+      <% if EnrollRegistry.feature_enabled?(:contrast_level_aa) %>
+        <%= render "insured/families/broker_delete" %>
+        <a href="#" class="btn btn-default" data-toggle="modal" data-target="#deleteModal">
+          <%= l10n('insured.delete_broker') %>
+          <i class="fa fa-user-times" aria-hidden="true"></i>
+        </a>
+      <% else %>
+        <%= link_to "#{l10n('insured.delete_broker')} &nbsp;<i class='fa fa-user-times' aria-hidden='true'></i>".html_safe, delete_consumer_broker_insured_family_path(@family) , method: :delete , data: { confirm: l10n("confirm_delete_msg") }, class: 'btn btn-default'+pundit_class(Family,:updateable?) %>
+      <% end %>       
     </div>
   </div>
   <div class="panel-body">

--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -147,7 +147,7 @@
 
         <div class="plan-button-group">
             <button tabindex="0" onkeydown="handleButtonKeyDown(event, 'plan_doc_<%= hbx_enrollment.hbx_id %>')" class="btn btn-default">
-                <%= render partial: "shared/plan_shoppings/sbc_link", locals: { plan: product } %>
+                <%= render partial: "shared/plan_shoppings/sbc_link", locals: { plan: product, hbx_id: hbx_enrollment.hbx_id } %>
             </button>
 
             <button tabindex="0" onkeydown="handleContactInfoKeyDown(event, 'plan_contact_info-<%= hbx_enrollment.hbx_id%>', '<%= product.kind.to_s %>-<%= product.id %>-<%= hbx_enrollment.hbx_id%>')" class="btn btn-default">

--- a/app/views/insured/families/_insurance_fields.html.erb
+++ b/app/views/insured/families/_insurance_fields.html.erb
@@ -13,14 +13,14 @@
   </h4> <br/>
   <div class = 'moving_radio_btn'>
     <div class="n-radio-group">
-      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'reason_accept')" class="n-radio-row">
+      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept')" class="n-radio-row">
     	  <label class="n-radio vertically-aligned-row" for="reason_accept">
     	    <%= radio_button_tag :reason, "yes",  !EnrollRegistry.feature_enabled?(:default_is_your_health_coverage_ending_no), id: 'reason_accept', class: "n-radio" %>
     	    <span class = "n-radio"></span>
     	      <%= l10n("yes") %>
     	  </label>
       </div>
-      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'reason_accept1')" class="n-radio-row">
+      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept1')" class="n-radio-row">
         <label class="n-radio" for="reason_accept1">
         <%= radio_button_tag :reason, "no", EnrollRegistry.feature_enabled?(:default_is_your_health_coverage_ending_no), id: 'reason_accept1', class: "n-radio" %>
         <span class="n-radio"></span>

--- a/app/views/insured/families/_marriage_fields.html.erb
+++ b/app/views/insured/families/_marriage_fields.html.erb
@@ -2,14 +2,14 @@
   <h4> Did you or your spouse have health insurance for at least one day between <%= @qle_date_calc %> and <%= @qle_date %> ? </h4> <br/>
   <div class = 'moving_radio_btn'>
     <div class="n-radio-group">
-      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'reason_accept1')" class="n-radio-row">
+      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept1')" class="n-radio-row">
         <label class="n-radio vertically-aligned-row" for="reason_accept1">
           <%= radio_button_tag :reason, "no", false, id: 'reason_accept1', class: "n-radio" %>
           <span class = "n-radio"></span>
             yes
         </label>
       </div>
-      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'reason_accept')" class="n-radio-row">
+      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept')" class="n-radio-row">
         <label class="n-radio" for="reason_accept">
         <%= radio_button_tag :reason, "yes", true, id: 'reason_accept', class: "n-radio" %>
         <span class="n-radio"></span>

--- a/app/views/insured/families/_moving_fields.html.erb
+++ b/app/views/insured/families/_moving_fields.html.erb
@@ -2,21 +2,21 @@
   <h4><%= l10n("insured.indicate_following_circumstances_apply_to_you") %>: </h4> <br/>
   <div class = 'moving_radio_btn'>
     <div class="n-radio-group">
-      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'reason_accept')" class="n-radio-row">
+      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept')" class="n-radio-row">
     	  <label class="n-radio vertically-aligned-row" for="reason_accept">
           <%= radio_button_tag :reason, "",  true, id: 'reason_accept', class: "n-radio zip-check" %>
     	    <span class = "n-radio"></span>
     	    <span id="date-change"></span>
     	  </label>
       </div>
-      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'reason_accept1')" class="n-radio-row">
+      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept1')" class="n-radio-row">
         <label class="n-radio" for="reason_accept1">
           <%= radio_button_tag :reason, "I was living outside the US or in a US territory", false, id: 'reason_accept1', class: "n-radio" %>
           <span class="n-radio"></span>
           <span><%= l10n("insured.living_outside_the_US_or_in_US_territory") %></span>
         </label>
       </div>
-      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'reason_accept2')" class="n-radio-row">
+      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept2')" class="n-radio-row">
         <label class="n-radio vertically-aligned-row" for="reason_accept2">
           <%= radio_button_tag :reason, "I had income below 100% of the Federal Poverty Level and was living in a state that had not expanded Medicaid (tool-tip below)", false, id: 'reason_accept2', class: "n-radio zip-check"%>
           <span class="n-radio"></span>
@@ -25,7 +25,7 @@
           </span>
         </label>
       </div>
-      <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'reason_reject')" class="n-radio-row">
+      <div tabindex="0" onfocus="handleSEPRadioButton('reason_reject')" class="n-radio-row">
         <label class="n-radio" for="reason_reject">
           <%= radio_button_tag :reason, "None of the Above", false, id:'reason_reject', class: "n-radio" %>
           <span class="n-radio"></span>
@@ -60,12 +60,14 @@
 
 <script type="text/javascript">
   <% if EnrollRegistry[:enroll_app].setting(:sep_moved_out_zip_compare).item %>
-    $('#qle_submit_reason').on('click', function() {
-      if ($("input:radio[name=reason]:checked").hasClass('zip-check')) {
-        $('.special_qle_reasons').addClass('hidden');
-        $('.zip_compare').removeClass('hidden');
-        event.preventDefault();
-        event.stopImmediatePropagation();
+    $('#qle_submit_reason').on('click keydown', function(event) {
+      if (event.type === 'click' || (event.type === 'keydown' && event.keyCode === 13)) {
+        if ($("input:radio[name=reason]:checked").hasClass('zip-check')) {
+          $('.special_qle_reasons').addClass('hidden');
+          $('.zip_compare').removeClass('hidden');
+          event.preventDefault();
+          event.stopImmediatePropagation();
+        }
       }
     })
   <% end %>

--- a/app/views/insured/families/verification/_verification.html.erb
+++ b/app/views/insured/families/verification/_verification.html.erb
@@ -57,10 +57,10 @@
                   <div class="v-type-upload col-md-3">
                     <% if display_upload_for_verification?(verif_type) %>
                       <%= form_tag insured_verification_documents_upload_path, multipart: true, method: :post do %>
-                        <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'upload_identity')" class="btn btn-default btn-file">
+                        <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'upload_identity_<%= verif_type.id %>')" class="btn btn-default btn-file">
                           <i class="fa fa-upload" aria-hidden="true"></i>
                           <%= l10n('upload_documents') %>
-                          <%= file_field_tag "file[]", type: :file, accept: VlpDocument::ALLOWED_MIME_TYPES.join(','), id: "upload_identity", class: "doc-upload-file", tabindex:"-1", :multiple => true, value: "Upload Documents", onchange: "validateFileSize(this)"%>
+                          <%= file_field_tag "file[]", type: :file, accept: VlpDocument::ALLOWED_MIME_TYPES.join(','), id: "upload_identity_#{verif_type.id}", class: "doc-upload-file", tabindex:"-1", :multiple => true, value: "Upload Documents", onchange: "validateFileSize(this)"%>
                         </span  >
                         <%= hidden_field_tag 'docs_owner', person.id  %>
                         <%= hidden_field_tag 'verification_type', verif_type.id  %>

--- a/app/views/shared/plan_shoppings/_sbc_link.html.erb
+++ b/app/views/shared/plan_shoppings/_sbc_link.html.erb
@@ -11,7 +11,7 @@
 
   <% key, bucket = get_key_and_bucket(plan.sbc_document.identifier) %>
   <% plan_name = plan.try(:title) || plan.try(:name) %>
-  <% id = (defined? hbx_id) ? "plan_doc_#{hbx_id}" : "" %>
+  <% id = (defined? hbx_id) ? "plan_doc_#{hbx_id}" : "summary_benefits" %>
   <a href="<%= main_app.document_download_path(bucket, key) + "?content_type=application/pdf&filename=#{plan_name.gsub(/[^0-9a-z]/i,'')}.pdf&disposition=inline" %>" class="sbc_link <%= text_class %> vertically-aligned-row" target="_blank" tabindex="-1" id="<%= id %>">
     <% if custom_css.present? %>
       <i class="fa fa-file-pdf-o fa-2x pull-left" ></i>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/shared/profiles/broker_agency/_search.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/shared/profiles/broker_agency/_search.html.erb
@@ -8,7 +8,7 @@
       <% end %>
       <span class="input-group-btn">
           <button class="btn btn-default" type="submit">
-              <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+              <span class="glyphicon glyphicon-search" aria-hidden="true"><span class="hide"><%= l10n("search") %></span></span>
           </button>
       </span>
   </div>

--- a/features/insured/contrast_level_aa/my_expert_page.feature
+++ b/features/insured/contrast_level_aa/my_expert_page.feature
@@ -1,13 +1,33 @@
 # frozen_string_literal: true
 
 Feature: Contrast level AA is enabled - existing consumer visits the my expert page
-  Background:
+    Background:
     Given the contrast level aa feature is enabled
-    Given a consumer exists
-    And the consumer is logged in
-    And consumer has successful ridp
-    And consumer visits home page
+    And an IVL Broker Agency exists
+    And the broker Max Planck is primary broker for IVL Broker Agency
+    And Individual has not signed up as an HBX user
+    And the FAA feature configuration is enabled
+    When Individual visits the Consumer portal during open enrollment
+    Then Individual creates a new HBX account
+    Then Individual should see a successful sign up message
+    And Individual sees Your Information page
+    When user registers as an individual
+    When Individual clicks on continue
+    And Individual sees form to enter personal information
+    When Individual clicks on continue
+    And Individual agrees to the privacy agreeement
+    And Individual answers the questions of the Identity Verification page and clicks on submit
+    Then Individual is on the Help Paying for Coverage page
+    When Individual does not apply for assistance and clicks continue
+    And Individual clicks on the Continue button of the Family Information page
+    And Individual clicks on continue button on Choose Coverage page
+    And Individual clicks on the Help Me Sign Up link
 
   Scenario: the user visits the my expert page
-    Given individual clicks on the my expert button
+    And Individual clicks on the Help from an Expert link
+    And Individual selects a broker
+    And Individual clicks on Select this Broker button
+    And Individual clicks on close button
+    And the page is refreshed
+    And the Individual clicks on the My Broker tab
     Then the page passes minimum level aa contrast guidelines

--- a/features/insured/contrast_level_aa/my_expert_page.feature
+++ b/features/insured/contrast_level_aa/my_expert_page.feature
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Feature: Contrast level AA is enabled - existing consumer visits the my expert page
+  Background:
+    Given the contrast level aa feature is enabled
+    Given a consumer exists
+    And the consumer is logged in
+    And consumer has successful ridp
+    And consumer visits home page
+
+  Scenario: the user visits the my expert page
+    Given individual clicks on the my expert button
+    Then the page passes minimum level aa contrast guidelines

--- a/features/insured/contrast_level_aa/my_expert_page.feature
+++ b/features/insured/contrast_level_aa/my_expert_page.feature
@@ -3,10 +3,10 @@
 Feature: Contrast level AA is enabled - existing consumer visits the my expert page
     Background:
     Given the contrast level aa feature is enabled
+    And the FAA feature configuration is enabled
     And an IVL Broker Agency exists
     And the broker Max Planck is primary broker for IVL Broker Agency
     And Individual has not signed up as an HBX user
-    And the FAA feature configuration is enabled
     When Individual visits the Consumer portal during open enrollment
     Then Individual creates a new HBX account
     Then Individual should see a successful sign up message
@@ -17,11 +17,9 @@ Feature: Contrast level AA is enabled - existing consumer visits the my expert p
     When Individual clicks on continue
     And Individual agrees to the privacy agreeement
     And Individual answers the questions of the Identity Verification page and clicks on submit
-    Then Individual is on the Help Paying for Coverage page
-    When Individual does not apply for assistance and clicks continue
-    And Individual clicks on the Continue button of the Family Information page
-    And Individual clicks on continue button on Choose Coverage page
-    And Individual clicks on the Help Me Sign Up link
+    And Individual has broker assigned to them
+    And Individual visits home page
+    And Individual clicks on the Get Help Signing Up button
 
   Scenario: the user visits the my expert page
     And Individual clicks on the Help from an Expert link
@@ -29,5 +27,5 @@ Feature: Contrast level AA is enabled - existing consumer visits the my expert p
     And Individual clicks on Select this Broker button
     And Individual clicks on close button
     And the page is refreshed
-    And the Individual clicks on the My Broker tab
+    And Individual clicks on the My Broker link
     Then the page passes minimum level aa contrast guidelines

--- a/features/step_definitions/help_me_sign_up_steps.rb
+++ b/features/step_definitions/help_me_sign_up_steps.rb
@@ -19,3 +19,20 @@ end
 And(/Individual selects a broker?/) do
   find(".broker_select_button").click
 end
+
+And(/Individual clicks on Select this Broker button$/) do
+  find("#broker-select").click
+end
+
+And(/Individual clicks on close button$/) do
+  find(".interaction-click-control-×").click
+end
+
+And(/Individual clicks on the My Broker tab$/) do
+  path = delete_consumer_broker_insured_family_path
+  find("a[href='#{path}']").click
+end
+
+And(/the page is refreshed/) do
+  visit current_path
+end

--- a/features/step_definitions/help_me_sign_up_steps.rb
+++ b/features/step_definitions/help_me_sign_up_steps.rb
@@ -8,11 +8,11 @@ Given(/^an IVL Broker Agency exists$/) do
 end
 
 And(/Individual has broker assigned to them/) do
-    family = Family.first
-    broker_id = Person.where(:broker_role.exists => true).last.id
-    profile_id = BenefitSponsors::Organizations::GeneralOrganization.first.profiles.first.id
-    family.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: profile_id, writing_agent_id: broker_id, is_active: true, start_on: Date.today)
-    family.save!
+  family = Family.first
+  broker_id = Person.where(:broker_role.exists => true).last.id
+  profile_id = BenefitSponsors::Organizations::GeneralOrganization.first.profiles.first.id
+  family.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: profile_id, writing_agent_id: broker_id, is_active: true, start_on: Date.today)
+  family.save!
 end
 
 And(/^Individual clicks on the Help Me Sign Up link?/) do
@@ -45,7 +45,6 @@ And(/^the page is refreshed$/) do
 end
 
 And(/^Individual clicks on the My Broker link$/) do
-  binding.irb
   path = brokers_insured_families_path(tab: 'broker')
   find("a[href='#{path}']").click
 end

--- a/features/step_definitions/help_me_sign_up_steps.rb
+++ b/features/step_definitions/help_me_sign_up_steps.rb
@@ -4,35 +4,48 @@ Given(/^an IVL Broker Agency exists$/) do
   broker_name = "IVL Broker Agency"
   broker_agency_organization broker_name, legal_name: broker_name, dba: broker_name
 
-  broker_agency_profile(broker_name).update_attributes!(aasm_state: 'is_approved', market_kind: 'individual')
+  broker_agency_profile(broker_name).update_attributes!(aasm_state: 'is_approved', market_kind: 'individual', accept_new_clients: true)
 end
 
-And(/Individual clicks on the Help Me Sign Up link?/) do
+And(/Individual has broker assigned to them/) do
+    family = Family.first
+    broker_id = Person.where(:broker_role.exists => true).last.id
+    profile_id = BenefitSponsors::Organizations::GeneralOrganization.first.profiles.first.id
+    family.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: profile_id, writing_agent_id: broker_id, is_active: true, start_on: Date.today)
+    family.save!
+end
+
+And(/^Individual clicks on the Help Me Sign Up link?/) do
   find("#help_with_plan_shopping_btn").click
 end
 
-And(/Individual clicks on the Help from an Expert link?/) do
+And(/^Individual clicks on the Get Help Signing Up button?/) do
+  find(".interaction-click-control-get-help-signing-up").click
+end
+
+And(/^Individual clicks on the Help from an Expert link?/) do
   path = benefit_sponsors.staff_index_profiles_broker_agencies_broker_agency_profiles_path
   find("a[href='#{path}']").click
 end
 
-And(/Individual selects a broker?/) do
+And(/^Individual selects a broker?/) do
   find(".broker_select_button").click
 end
 
-And(/Individual clicks on Select this Broker button$/) do
+And(/^Individual clicks on Select this Broker button$/) do
   find(".help_button").click
 end
 
-And(/Individual clicks on close button$/) do
+And(/^Individual clicks on close button$/) do
   find(".interaction-click-control-×").click
 end
 
-And(/Individual clicks on the My Broker tab$/) do
-  path = delete_consumer_broker_insured_family_path
-  find("a[href='#{path}']").click
+And(/^the page is refreshed$/) do
+  visit current_path
 end
 
-And(/the page is refreshed/) do
-  visit current_path
+And(/^Individual clicks on the My Broker link$/) do
+  binding.irb
+  path = brokers_insured_families_path(tab: 'broker')
+  find("a[href='#{path}']").click
 end

--- a/features/step_definitions/help_me_sign_up_steps.rb
+++ b/features/step_definitions/help_me_sign_up_steps.rb
@@ -21,7 +21,7 @@ And(/Individual selects a broker?/) do
 end
 
 And(/Individual clicks on Select this Broker button$/) do
-  find(".close_broker_select").click
+  find(".help_button").click
 end
 
 And(/Individual clicks on close button$/) do

--- a/features/step_definitions/help_me_sign_up_steps.rb
+++ b/features/step_definitions/help_me_sign_up_steps.rb
@@ -21,7 +21,7 @@ And(/Individual selects a broker?/) do
 end
 
 And(/Individual clicks on Select this Broker button$/) do
-  find("#broker-select").click
+  find(".close_broker_select").click
 end
 
 And(/Individual clicks on close button$/) do

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -1112,6 +1112,7 @@ end
 
 When(/.+ visits home page/) do
   visit "/families/home"
+  binding.irb
 end
 
 When(/^\w+ checks? the Insured portal open enrollment dates$/) do
@@ -1210,6 +1211,10 @@ end
 
 When(/Individual clicks on continue button on Choose Coverage page$/) do
   find(IvlChooseCoverage.continue_btn).click
+end
+
+And(/Individual clicks the Back to My Account button$/) do
+  find(".interaction-click-control-back-to-my-account")
 end
 
 And(/Individual signed in to resume enrollment$/) do

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -1112,7 +1112,6 @@ end
 
 When(/.+ visits home page/) do
   visit "/families/home"
-  binding.irb
 end
 
 When(/^\w+ checks? the Insured portal open enrollment dates$/) do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186868938 && https://www.pivotaltracker.com/story/show/186499229 && https://www.pivotaltracker.com/story/show/186499314 && https://www.pivotaltracker.com/story/show/186499313 && https://www.pivotaltracker.com/story/show/186499312 && https://www.pivotaltracker.com/story/show/186657157

# A brief description of the changes

Current behavior: No coverage on my broker page, bug fixes on older tickets

New behavior: Cucumber added, new modal added for ME, bug fixes for previous tickets

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

![Screenshot 2024-01-18 at 2 53 06 PM](https://github.com/ideacrew/enroll/assets/45053146/424d8c5a-8880-4f8d-9591-dfb63b60ff8d)

![Screenshot 2024-01-18 at 2 54 01 PM](https://github.com/ideacrew/enroll/assets/45053146/73424e00-f916-4509-a879-158db2e2e3c1)


# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.