### PR TITLE
fix defects tied with level aa contrast uplift

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -2367,7 +2367,7 @@ ul.navbar-nav.top-menu li {
 }
 
 .page-header h4 {
-    color: #7b7b7b;
+    color: var(--secondary-font-text, #7b7b7b);
     display: inline-block;
     font-weight: 600;
     margin-top: 0;

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -2367,7 +2367,7 @@ ul.navbar-nav.top-menu li {
 }
 
 .page-header h4 {
-    color: var(--secondary-font-text, #7b7b7b);
+    color: var(--secondary-font-color, #7b7b7b);
     display: inline-block;
     font-weight: 600;
     margin-top: 0;

--- a/app/views/insured/families/_insurance_fields.html.erb
+++ b/app/views/insured/families/_insurance_fields.html.erb
@@ -13,14 +13,14 @@
   </h4> <br/>
   <div class = 'moving_radio_btn'>
     <div class="n-radio-group">
-      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept')" class="n-radio-row">
+      <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'qle_submit_reason')" onfocus="handleSEPRadioButton('reason_accept')" class="n-radio-row">
     	  <label class="n-radio vertically-aligned-row" for="reason_accept">
     	    <%= radio_button_tag :reason, "yes",  !EnrollRegistry.feature_enabled?(:default_is_your_health_coverage_ending_no), id: 'reason_accept', class: "n-radio" %>
     	    <span class = "n-radio"></span>
     	      <%= l10n("yes") %>
     	  </label>
       </div>
-      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept1')" class="n-radio-row">
+      <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'qle_submit_reason')" onfocus="handleSEPRadioButton('reason_accept1')" class="n-radio-row">
         <label class="n-radio" for="reason_accept1">
         <%= radio_button_tag :reason, "no", EnrollRegistry.feature_enabled?(:default_is_your_health_coverage_ending_no), id: 'reason_accept1', class: "n-radio" %>
         <span class="n-radio"></span>

--- a/app/views/insured/families/_marriage_fields.html.erb
+++ b/app/views/insured/families/_marriage_fields.html.erb
@@ -2,14 +2,14 @@
   <h4> Did you or your spouse have health insurance for at least one day between <%= @qle_date_calc %> and <%= @qle_date %> ? </h4> <br/>
   <div class = 'moving_radio_btn'>
     <div class="n-radio-group">
-      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept1')" class="n-radio-row">
+      <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'qle_submit_reason')" onfocus="handleSEPRadioButton('reason_accept1')" class="n-radio-row">
         <label class="n-radio vertically-aligned-row" for="reason_accept1">
           <%= radio_button_tag :reason, "no", false, id: 'reason_accept1', class: "n-radio" %>
           <span class = "n-radio"></span>
             yes
         </label>
       </div>
-      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept')" class="n-radio-row">
+      <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'qle_submit_reason')" onfocus="handleSEPRadioButton('reason_accept')" class="n-radio-row">
         <label class="n-radio" for="reason_accept">
         <%= radio_button_tag :reason, "yes", true, id: 'reason_accept', class: "n-radio" %>
         <span class="n-radio"></span>

--- a/app/views/insured/families/_moving_fields.html.erb
+++ b/app/views/insured/families/_moving_fields.html.erb
@@ -2,21 +2,21 @@
   <h4><%= l10n("insured.indicate_following_circumstances_apply_to_you") %>: </h4> <br/>
   <div class = 'moving_radio_btn'>
     <div class="n-radio-group">
-      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept')" class="n-radio-row">
+      <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'qle_submit_reason')" onfocus="handleSEPRadioButton('reason_accept')" class="n-radio-row">
     	  <label class="n-radio vertically-aligned-row" for="reason_accept">
           <%= radio_button_tag :reason, "",  true, id: 'reason_accept', class: "n-radio zip-check" %>
     	    <span class = "n-radio"></span>
     	    <span id="date-change"></span>
     	  </label>
       </div>
-      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept1')" class="n-radio-row">
+      <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'qle_submit_reason')" onfocus="handleSEPRadioButton('reason_accept1')" class="n-radio-row">
         <label class="n-radio" for="reason_accept1">
           <%= radio_button_tag :reason, "I was living outside the US or in a US territory", false, id: 'reason_accept1', class: "n-radio" %>
           <span class="n-radio"></span>
           <span><%= l10n("insured.living_outside_the_US_or_in_US_territory") %></span>
         </label>
       </div>
-      <div tabindex="0" onfocus="handleSEPRadioButton('reason_accept2')" class="n-radio-row">
+      <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'qle_submit_reason')" onfocus="handleSEPRadioButton('reason_accept2')" class="n-radio-row">
         <label class="n-radio vertically-aligned-row" for="reason_accept2">
           <%= radio_button_tag :reason, "I had income below 100% of the Federal Poverty Level and was living in a state that had not expanded Medicaid (tool-tip below)", false, id: 'reason_accept2', class: "n-radio zip-check"%>
           <span class="n-radio"></span>
@@ -25,7 +25,7 @@
           </span>
         </label>
       </div>
-      <div tabindex="0" onfocus="handleSEPRadioButton('reason_reject')" class="n-radio-row">
+      <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'qle_submit_reason')" onfocus="handleSEPRadioButton('reason_reject')" class="n-radio-row">
         <label class="n-radio" for="reason_reject">
           <%= radio_button_tag :reason, "None of the Above", false, id:'reason_reject', class: "n-radio" %>
           <span class="n-radio"></span>

--- a/app/views/insured/families/verification/_verification.html.erb
+++ b/app/views/insured/families/verification/_verification.html.erb
@@ -60,7 +60,7 @@
                         <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'upload_identity_<%= verif_type.id %>')" class="btn btn-default btn-file">
                           <i class="fa fa-upload" aria-hidden="true"></i>
                           <%= l10n('upload_documents') %>
-                          <%= file_field_tag "file[]", type: :file, accept: VlpDocument::ALLOWED_MIME_TYPES.join(','), id: "upload_identity_#{verif_type.id}", class: "doc-upload-file", tabindex:"-1", :multiple => true, value: "Upload Documents", onchange: "validateFileSize(this)"%>
+                          <%= file_field_tag "file[]", type: :file, accept: VlpDocument::ALLOWED_MIME_TYPES.join(','), id: "upload_identity_#{verif_type.id}", class: "doc-upload-file", :multiple => true, value: "Upload Documents", onchange: "validateFileSize(this)"%>
                         </span  >
                         <%= hidden_field_tag 'docs_owner', person.id  %>
                         <%= hidden_field_tag 'verification_type', verif_type.id  %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186499307

# A brief description of the changes

Current behavior: Enter button not responding on manage family, small contrast miss

New behavior: Added onkeydown, fixed contrast

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.