### PR TITLE
level aa contrast fix document download button

### DIFF
--- a/app/views/insured/families/verification/_verification.html.erb
+++ b/app/views/insured/families/verification/_verification.html.erb
@@ -60,7 +60,7 @@
                         <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'upload_identity_<%= verif_type.id %>')" class="btn btn-default btn-file">
                           <i class="fa fa-upload" aria-hidden="true"></i>
                           <%= l10n('upload_documents') %>
-                          <%= file_field_tag "file[]", type: :file, accept: VlpDocument::ALLOWED_MIME_TYPES.join(','), id: "upload_identity_#{verif_type.id}", class: "doc-upload-file", :multiple => true, value: "Upload Documents", onchange: "validateFileSize(this)"%>
+                          <%= file_field_tag "file[]", type: :file, accept: VlpDocument::ALLOWED_MIME_TYPES.join(','), id: "upload_identity_#{verif_type.id}", class: "doc-upload-file", tabindex:"-1", :multiple => true, value: "Upload Documents", onchange: "validateFileSize(this)"%>
                         </span  >
                         <%= hidden_field_tag 'docs_owner', person.id  %>
                         <%= hidden_field_tag 'verification_type', verif_type.id  %>

--- a/app/views/shared/plan_shoppings/_sbc_link.html.erb
+++ b/app/views/shared/plan_shoppings/_sbc_link.html.erb
@@ -12,7 +12,7 @@
   <% key, bucket = get_key_and_bucket(plan.sbc_document.identifier) %>
   <% plan_name = plan.try(:title) || plan.try(:name) %>
   <% id = (defined? hbx_id) ? "plan_doc_#{hbx_id}" : "summary_benefits" %>
-  <a href="<%= main_app.document_download_path(bucket, key) + "?content_type=application/pdf&filename=#{plan_name.gsub(/[^0-9a-z]/i,'')}.pdf&disposition=inline" %>" class="sbc_link <%= text_class %> vertically-aligned-row" target="_blank" tabindex="-1" id="<%= id %>">
+  <a href="<%= main_app.document_download_path(bucket, key) + "?content_type=application/pdf&filename=#{plan_name.gsub(/[^0-9a-z]/i,'')}.pdf&disposition=inline" %>" class="sbc_link <%= text_class %> vertically-aligned-row" target="_blank" id="<%= id %>">
     <% if custom_css.present? %>
       <i class="fa fa-file-pdf-o fa-2x pull-left" ></i>
       <div class="fa-icon-label <%= text_class %> col-xs-11 enrollment-tile-summary" style="display: inline; font-size: 10px;"><%= link_text %></div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186499314

# A brief description of the changes

Current behavior: Document link not accessible on certain pages where a button is not used. Solution is to have both text and button clickable for download

New behavior: Text and button clickable for download

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.