### PR TITLE
contrast level aa verify doc fix

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/applications/verifications/_verification_card.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/verifications/_verification_card.html.erb
@@ -20,10 +20,10 @@
     <div class="v-type-upload col-md-3">
       <% if display_upload_for_evidence?(evidence) %>
         <%= form_tag financial_assistance.application_applicant_verification_documents_upload_path(application, applicant), multipart: true, method: :post do %>
-          <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'upload_evidence')" class="btn btn-default btn-file">
+          <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'upload_evidence_<%= evidence.id %>')" class="btn btn-default btn-file">
             <i class="fa fa-upload" aria-hidden="true"></i>
             <%= l10n('upload_documents') %>
-            <%= file_field_tag "file[]", type: :file, accept: 'image/png,image/gif,image/jpeg,application/pdf', class: "doc-upload-file", :multiple => true, value: "Upload Documents", tabindex: "-1", id: "upload_evidence" %>
+            <%= file_field_tag "file[]", type: :file, accept: 'image/png,image/gif,image/jpeg,application/pdf', class: "doc-upload-file", :multiple => true, value: "Upload Documents", tabindex: "-1", id: "upload_evidence_#{evidence.id}" %>
           </span>
             <%= hidden_field_tag 'applicant_id', applicant.id  %>
             <%= hidden_field_tag 'evidence', evidence.id  %>

--- a/features/financial_assistance/step_definitions/financial_assistance_steps.rb
+++ b/features/financial_assistance/step_definitions/financial_assistance_steps.rb
@@ -791,3 +791,11 @@ And(/^all applicants are not medicaid chip eligible and are non magi medicaid el
     applicant.update_attributes(is_non_magi_medicaid_eligible: false)
   end
 end
+
+And(/^there is a (.*) evidence present with the option to upload a document$/) do |evidence_type|
+  evidence = application.applicants.first.send("#{evidence_type}_evidence".to_sym)
+  # confirm evidence is visible
+  find("#evidence_kind_#{evidence_type}_evidence")
+  # confirm id on hidden input for upload is present
+  find(:xpath, "//input[@id='upload_evidence_#{evidence.id}']", :visible => false)
+end

--- a/features/insured/contrast_level_aa/documents_page.feature
+++ b/features/insured/contrast_level_aa/documents_page.feature
@@ -1,9 +1,17 @@
-Feature: Consumer goes to the Documents page
+Feature: Contrast level AA is enabled - Documents page
 
-  Scenario: Consumer can see the text on left to the Navigation Button
+  Scenario: Consumer goes to the Documents page
     Given the contrast level aa feature is enabled
-    Given a consumer exists
+    And a consumer exists
     And the consumer is logged in
     When the consumer visits verification page
-    And the user navigates to the DOCUMENTS tab
+    Then the page passes minimum level aa contrast guidelines
+
+  Scenario: Consumer has an FAA Application and income evidence present
+    Given the contrast level aa feature is enabled
+    And the FAA feature configuration is enabled
+    And a family with financial application and applicants in determined state exists with evidences
+    And the consumer is logged in
+    When the consumer visits verification page
+    And there is a income evidence present with the option to upload a document
     Then the page passes minimum level aa contrast guidelines

--- a/features/step_definitions/verification_process_steps.rb
+++ b/features/step_definitions/verification_process_steps.rb
@@ -38,7 +38,7 @@ Given(/^the consumer is logged in$/) do
 end
 
 Then(/^the consumer visits verification page$/) do
-  visit verification_insured_families_path
+  visit verification_insured_families_path(tab: 'verification')
   find(".interaction-click-control-documents", wait: 5).click
 end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186499312

# A brief description of the changes

Current behavior: When evidence for financial assistance upload button is clicked from the Documents page, it uploads the document to the first section.

New behavior: Uploads document to correct section

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CONTRAST_LEVEL_AA_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

![Screenshot 2024-01-20 at 8 49 34 AM](https://github.com/ideacrew/enroll/assets/45053146/9e0bf998-0fcc-478d-98dc-5290a3aa9fff)


# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.