### PR TITLE
fix 'Login' email text.

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -116,11 +116,19 @@ class UserMailer < ApplicationMailer
     end
   end
 
-  def broker_or_broker_staff_linked_invitation_email(email, person_name)
+  def broker_linked_invitation_email(email, person_name)
     return if email.blank?
 
-    mail({to: email, subject: l10n("user_mailer.broker_or_broker_staff_linked_notification_email.subject")}) do |format|
-      format.html { render "broker_or_broker_staff_linked_notification_email", :locals => { :person_name => person_name, :login_url => site_main_web_address_url }}
+    mail({to: email, subject: l10n("user_mailer.broker_staff_linked_notification_email.subject")}) do |format|
+      format.html { render "broker_staff_linked_notification_email", :locals => { :person_name => person_name, :login_url => site_main_web_address_url }}
+    end
+  end
+
+  def broker_staff_linked_invitation_email(email, person_name)
+    return if email.blank?
+
+    mail({to: email, subject: l10n("user_mailer.broker_staff_linked_notification_email.subject")}) do |format|
+      format.html { render "broker_staff_linked_notification_email", :locals => { :person_name => person_name, :login_url => site_main_web_address_url }}
     end
   end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -300,7 +300,7 @@ class Invitation
       invitation.send_broker_invitation!(broker_role.parent.full_name)
       invitation
     elsif should_notify_linked_broker?(broker_role)
-      UserMailer.broker_or_broker_staff_linked_invitation_email(broker_role.email_address, broker_role.parent.full_name).deliver_now
+      UserMailer.broker_linked_invitation_email(broker_role.email_address, broker_role.parent.full_name).deliver_now
     end
   end
 
@@ -315,7 +315,7 @@ class Invitation
       invitation.send_broker_staff_invitation!(broker_role.parent.full_name, broker_role.parent.id)
       invitation
     elsif should_notify_linked_broker_staff?(broker_role)
-      UserMailer.broker_or_broker_staff_linked_invitation_email(broker_role.email_address, broker_role.parent.full_name).deliver_now
+      UserMailer.broker_staff_linked_invitation_email(broker_role.email_address, broker_role.parent.full_name).deliver_now
     end
   end
 

--- a/app/views/user_mailer/broker_linked_notification_email.html.erb
+++ b/app/views/user_mailer/broker_linked_notification_email.html.erb
@@ -1,5 +1,5 @@
 
-<%= l10n("user_mailer.broker_or_broker_staff_linked_notification_email.full_text",
+<%= l10n("user_mailer.broker_linked_notification_email.full_text",
       first_name: person_name,
       person_name: person_name,
       site_short_name: site_short_name,

--- a/app/views/user_mailer/broker_staff_linked_notification_email.html.erb
+++ b/app/views/user_mailer/broker_staff_linked_notification_email.html.erb
@@ -1,0 +1,13 @@
+
+<%= l10n("user_mailer.broker_staff_linked_notification_email.full_text",
+      first_name: person_name,
+      person_name: person_name,
+      site_short_name: site_short_name,
+      contact_center_phone_number: EnrollRegistry[:enroll_app].setting(:contact_center_short_number).item,
+      site_home_business_url: site_home_business_url,
+      site_user_sign_in_url: EnrollRegistry[:enroll_app].setting(:user_sign_in_url).item,
+      contact_center_tty_number: EnrollRegistry[:enroll_app].settings(:contact_center_tty_number).item,
+      site_title: EnrollRegistry[:enroll_app].setting(:site_title).item,
+      broker_agreement_url: EnrollRegistry[:broker_agreement_url].item,
+      login_url: login_url
+).html_safe %>

--- a/config/locales/user_mailer.en.yml
+++ b/config/locales/user_mailer.en.yml
@@ -1,11 +1,20 @@
 en:
   user_mailer:
-    broker_or_broker_staff_linked_notification_email:
+    broker_linked_notification_email:
       subject: Access your expert portal
       full_text: |
         <p>Hi %{first_name},</p>
-        <p>Your application to assist consumers on %{site_short_name} has been approved.</p><br>
-        <p>You will need to claim your access to your expert portal to assist consumers. You can do this by pressing the 'Login' button in the email and entering the username and password you use to login to your personal account. You can move between your personal and expert portals by selecting ‘My Portals’ on the upper right-hand corner of your screen. By accessing your expert portal, you affirm that you have read and agreed to the %{site_short_name} broker agreement available at %{broker_agreement_url}.</p>
+        <p>Your application to assist consumers on %{site_short_name} has been approved.</p>
+        <p>You will need to claim your access to your expert portal to assist consumers. You can do this by pressing the 'Login' button in the email and entering the username and password you use to login to your personal account.</p>
+        <p>You can move between your personal and expert portals by selecting ‘My Portals’ on the upper right-hand corner of your screen. By accessing your expert portal, you affirm that you have read and agreed to the %{site_short_name} broker agreement available at <a href="%{broker_agreement_url}">%{broker_agreement_url}</a>.</p>
+        <a href=%{login_url} class='button-link'>Login</a><br>
+        <p>Questions? Call us at %{contact_center_phone_number}.</p>
+        <p>The %{site_short_name} Team</p>
+    broker_staff_linked_notification_email:
+      subject: Access your expert portal
+      full_text: |
+        <p>Hi %{first_name},</p>
+        <p>Your application to assist consumers on %{site_short_name} has been approved. You can move between your personal and expert portals by selecting ‘My Portals’ on the upper right-hand corner of your screen.</p>
         <a href=%{login_url} class='button-link'>Login</a><br>
         <p>Questions? Call us at %{contact_center_phone_number}.</p>
         <p>The %{site_short_name} Team</p>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -141,13 +141,30 @@ RSpec.describe UserMailer do
   end
 end
 
-RSpec.describe UserMailer, "sending a approval linked notification email for a broker or broker staff" do
+RSpec.describe UserMailer, "sending an approval linked notification email for a broker" do
   include Config::SiteHelper
 
   let(:email) { "some-broker@adomain.com"}
   let(:name) { "Broker Name"}
 
-  subject { UserMailer.broker_or_broker_staff_linked_invitation_email(email, name) }
+  subject { UserMailer.broker_linked_invitation_email(email, name) }
+
+  it "has the login link" do
+    expect(subject.body.raw_source.include?("href=#{site_main_web_address_url}")).to be_truthy
+  end
+
+  it "has the greeting" do
+    expect(subject.body.raw_source.include?("Hi #{name},")).to be_truthy
+  end
+end
+
+RSpec.describe UserMailer, "sending an approval linked notification email for broker staff" do
+  include Config::SiteHelper
+
+  let(:email) { "some-broker@adomain.com"}
+  let(:name) { "Broker Name"}
+
+  subject { UserMailer.broker_staff_linked_invitation_email(email, name) }
 
   it "has the login link" do
     expect(subject.body.raw_source.include?("href=#{site_main_web_address_url}")).to be_truthy

--- a/spec/mailers/user_mailer_translations_spec.rb
+++ b/spec/mailers/user_mailer_translations_spec.rb
@@ -3,16 +3,32 @@
 require 'rails_helper'
 
 describe "translations for: en.user_mailer" do
-  describe "the user_mailer.broker_or_broker_staff_linked_notification_email.full_text translation" do
-    let(:key) { "user_mailer.broker_or_broker_staff_linked_notification_email.full_text" }
+  describe "the user_mailer.broker_linked_notification_email.full_text translation" do
+    let(:key) { "user_mailer.broker_linked_notification_email.full_text" }
 
     it "exists" do
       expect(I18n.exists?(key)).to be_truthy
     end
   end
 
-  describe "the user_mailer.broker_or_broker_staff_linked_notification_email.subject translation" do
-    let(:key) { "user_mailer.broker_or_broker_staff_linked_notification_email.subject" }
+  describe "the user_mailer.broker_linked_notification_email.subject translation" do
+    let(:key) { "user_mailer.broker_linked_notification_email.subject" }
+
+    it "exists" do
+      expect(I18n.exists?(key)).to be_truthy
+    end
+  end
+
+  describe "the user_mailer.broker_staff_linked_notification_email.full_text translation" do
+    let(:key) { "user_mailer.broker_staff_linked_notification_email.full_text" }
+
+    it "exists" do
+      expect(I18n.exists?(key)).to be_truthy
+    end
+  end
+
+  describe "the user_mailer.broker_staff_linked_notification_email.subject translation" do
+    let(:key) { "user_mailer.broker_staff_linked_notification_email.subject" }
 
     it "exists" do
       expect(I18n.exists?(key)).to be_truthy


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186853876

# A brief description of the changes

Current behavior:  The broker and broker staff 'Login' invitation emails had incorrect text.

New behavior: Correct text for the broker and broker staff 'Login' invitation emails.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

**Failure Kind**: Ruby Cross Site Scripting
**Code Flagged**:
 line 2 of `app/views/user_mailer/broker_staff_linked_notification_email.html.erb`
```ruby
<%= l10n("user_mailer.broker_staff_linked_notification_email.full_text",
      first_name: person_name,
      person_name: person_name,
      site_short_name: site_short_name,
      contact_center_phone_number: EnrollRegistry[:enroll_app].setting(:contact_center_short_number).item,
      site_home_business_url: site_home_business_url,
      site_user_sign_in_url: EnrollRegistry[:enroll_app].setting(:user_sign_in_url).item,
      contact_center_tty_number: EnrollRegistry[:enroll_app].settings(:contact_center_tty_number).item,
      site_title: EnrollRegistry[:enroll_app].setting(:site_title).item,
      broker_agreement_url: EnrollRegistry[:broker_agreement_url].item,
      login_url: login_url
).html_safe %>
```
**Exception Justification**:
While normally dynamic, unsanitized usage of HTML in a Rails template is a vector for XSS, this case is different from the usual usage of raw HTML in a rails template, as:
1. This does not generate a client facing page - this generation is used to send emails.  This means this template would never be rendered to a client in the process of traversing our application.
2. The portion of the data which comes from data entry by a user (and thus could be used to inject malicious content) is limited to the a name field of a person record - a field already sanitized for HTML.