### PR TITLE
check enrollment kind after redirecting from checkbook

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -126,7 +126,7 @@ class Insured::PlanShoppingsController < ApplicationController
     dependents_with_existing_coverage(@enrollment) if @market_kind == 'individual' && EnrollRegistry.feature_enabled?(:existing_coverage_warning)
     #flash.now[:error] = qualify_qle_notice unless @enrollment.can_select_coverage?(qle: @enrollment.is_special_enrollment?)
 
-    if EnrollRegistry.feature_enabled?(:enrollment_product_date_match) || (@plan.present? && @plan.application_period.cover?(@enrollment.effective_on)) || @market_kind == 'shop'
+    if EnrollRegistry.feature_enabled?(:enrollment_product_date_match) || (@plan.present? && @plan.application_period.cover?(@enrollment.effective_on)) || @enrollment.is_shop?
       respond_to do |format|
         format.html { render 'thankyou.html.erb' }
       end

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -732,7 +732,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
       shop_enrollment.update_attributes!(effective_on: Date.new(year, 1, 1))
       shop_enrollment.product.update_attributes!(application_period: Date.new(year - 1, 1, 1)..Date.new(year - 1, 12, 31))
       BenefitMarkets::Products::ProductRateCache.initialize_rate_cache!
-      allow(::BenefitMarkets::Products::ProductRateCache).to receive(:lookup_rate).and_return(100.00)#.with(
+      allow(::BenefitMarkets::Products::ProductRateCache).to receive(:lookup_rate).and_return(100.00)
       sign_in(user)
       get :thankyou, params: {id: shop_enrollment.id, plan_id: shop_enrollment.product.id, market_kind: 'shop'}
       expect(response).to render_template('insured/plan_shoppings/thankyou.html.erb')

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -700,6 +700,17 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
                         product: product)
     end
 
+    let(:shop_enrollment) do
+      FactoryBot.create(:hbx_enrollment, :with_product, sponsored_benefit_package_id: benefit_group_assignment.benefit_group.id,
+                                                        family: household.family,
+                                                        household: household,
+                                                        hbx_enrollment_members: [hbx_enrollment_member],
+                                                        coverage_kind: "health",
+                                                        external_enrollment: false,
+                                                        sponsored_benefit_id: sponsored_benefit.id,
+                                                        rating_area_id: rating_area.id)
+    end
+
     it 'should update the member coverage start on for continuous coverage' do
       sign_in(user)
       get :thankyou, params: { id: hbx_enrollment.id, plan_id: product.id }
@@ -718,10 +729,12 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
 
     it "should render thank you page if SHOP enrollment effective date doesn't match product dates" do
       allow(EnrollRegistry[:enrollment_product_date_match].feature).to receive(:is_enabled).and_return(false)
-      hbx_enrollment.update_attributes!(effective_on: Date.new(year, 1, 1))
-      product.update_attributes!(application_period: Date.new(year - 1, 1, 1)..Date.new(year - 1, 12, 31))
+      shop_enrollment.update_attributes!(effective_on: Date.new(year, 1, 1))
+      shop_enrollment.product.update_attributes!(application_period: Date.new(year - 1, 1, 1)..Date.new(year - 1, 12, 31))
+      BenefitMarkets::Products::ProductRateCache.initialize_rate_cache!
+      allow(::BenefitMarkets::Products::ProductRateCache).to receive(:lookup_rate).and_return(100.00)#.with(
       sign_in(user)
-      get :thankyou, params: {id: hbx_enrollment.id, plan_id: product.id, market_kind: 'shop'}
+      get :thankyou, params: {id: shop_enrollment.id, plan_id: shop_enrollment.product.id, market_kind: 'shop'}
       expect(response).to render_template('insured/plan_shoppings/thankyou.html.erb')
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
https://redmine.priv.dchbx.org/issues/104274?tab=history

# A brief description of the changes

Current behavior:
redirected back to the "Choose Coverage for Your Household" page when employees select plan in checkbook

New behavior:
redirects correctly when employees select plan in checkbook

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.