### PR TITLE
fix audit log events intermittently failing to flow

### DIFF
--- a/app/domain/operations/event_logs/store.rb
+++ b/app/domain/operations/event_logs/store.rb
@@ -56,6 +56,8 @@ module Operations
         account = headers[:account]
         options[:event_time] = formated_time(headers[:event_time])
         options[:session_detail] = account[:session]
+        # TODO: Work with @raghuram to understand why login_session_id is not available in session object in some cases.
+        # substitute login_session_id with session_id token for now.
         options[:session_detail][:login_session_id] = options[:session_detail][:login_session_id] || options[:session_detail][:session_id]
         options[:account_id] = account[:id]
         options[:monitored_event] = construct_monitored_event(payload, headers)

--- a/app/domain/operations/event_logs/store.rb
+++ b/app/domain/operations/event_logs/store.rb
@@ -56,6 +56,7 @@ module Operations
         account = headers[:account]
         options[:event_time] = formated_time(headers[:event_time])
         options[:session_detail] = account[:session]
+        options[:session_detail][:login_session_id] = options[:session_detail][:login_session_id] || options[:session_detail][:session_id]
         options[:account_id] = account[:id]
         options[:monitored_event] = construct_monitored_event(payload, headers)
         options[:payload] = payload.to_json

--- a/app/event_source/subscribers/event_log_subscriber.rb
+++ b/app/event_source/subscribers/event_log_subscriber.rb
@@ -49,10 +49,8 @@ module Subscribers
             result.failure
           end
 
-        logger.info "$$ headers are #{headers}"
-        subscriber_logger.error "$$ headers are #{headers}"
-        logger.info "EventLogSubscriber: event failed1 to persist due to errors: #{errors.to_h}, #{errors.inspect}"
-        subscriber_logger.error "EventLogSubscriber: event failed1 to persist due to errors: #{errors.to_h}, #{errors.inspect}"
+        logger.error "EventLogSubscriber: event failed to persist due to errors: #{errors.to_h}"
+        subscriber_logger.error "EventLogSubscriber: event failed to persist due to errors: #{errors.to_h}"
       end
     end
 

--- a/app/event_source/subscribers/event_log_subscriber.rb
+++ b/app/event_source/subscribers/event_log_subscriber.rb
@@ -49,8 +49,10 @@ module Subscribers
             result.failure
           end
 
-        logger.info "EventLogSubscriber: event failed to persist due to errors: #{errors}"
-        subscriber_logger.error "EventLogSubscriber: event failed to persist due to errors: #{errors}"
+        logger.info "$$ headers are #{headers}"
+        subscriber_logger.error "$$ headers are #{headers}"
+        logger.info "EventLogSubscriber: event failed1 to persist due to errors: #{errors.to_h}, #{errors.inspect}"
+        subscriber_logger.error "EventLogSubscriber: event failed1 to persist due to errors: #{errors.to_h}, #{errors.inspect}"
       end
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2659995/stories/186916099

# A brief description of the changes

Current behavior:
In some cases Audi Log events intermittently fail to process.

New behavior:
Fix the issue so Audit Log events always process as expected. This is tested in PVT and things are working as expected now.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.