### PR TITLE
CR-95: Check the invitation claimant against the existing person user id

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -4,7 +4,7 @@ class InvitationsController < ApplicationController
   def claim
     @invitation = Invitation.find(params[:id])
 
-    if @invitation.may_claim?
+    if @invitation.may_claim? && @invitation.may_be_claimed_by?(current_user)
       @invitation.claim_invitation!(current_user, self)
     else
       flash[:error] = "Invalid invitation."

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe InvitationsController do
       allow(user).to receive(:person).and_return nil
       sign_in(user)
       allow(Invitation).to receive(:find).with(invitation_id).and_return(invitation)
+      allow(invitation).to receive(:may_be_claimed_by?).with(user).and_return(true)
     end
 
     describe "with an already claimed invitation" do

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -554,3 +554,267 @@ describe "A Broker Staff Invitation" do
     end
   end
 end
+
+describe Invitation, "for:
+  - a broker role
+  - when the associated person doesn't have a user yet" do
+
+  let(:current_user) do
+    instance_double(User)
+  end
+
+  let(:broker_role) do
+    instance_double(
+      BrokerRole,
+      :person => person
+    )
+  end
+
+  let(:person) do
+    instance_double(
+      Person,
+      :user_id => nil
+    )
+  end
+
+  subject do
+    Invitation.new(
+      :role => "broker_role",
+      :source_id => broker_role_id
+    )
+  end
+
+  let(:broker_role_id) { "SOME BROKER ROLE ID" }
+
+  before :each do
+    allow(BrokerRole).to receive(:find).with(broker_role_id).and_return(broker_role)
+  end
+
+  it "may be claimed by the current user" do
+    expect(subject.may_be_claimed_by?(current_user)).to be_truthy
+  end
+end
+
+describe Invitation, "for:
+  - a broker role
+  - when the associated person has the same user" do
+
+  let(:current_user) do
+    instance_double(
+      User,
+      :id => same_user_id
+    )
+  end
+
+  let(:broker_role) do
+    instance_double(
+      BrokerRole,
+      :person => person
+    )
+  end
+
+  let(:person) do
+    instance_double(
+      Person,
+      :user_id => same_user_id
+    )
+  end
+
+  subject do
+    Invitation.new(
+      :role => "broker_role",
+      :source_id => broker_role_id
+    )
+  end
+
+  let(:same_user_id) { "SOME USER ID" }
+
+  let(:broker_role_id) { "SOME BROKER ROLE ID" }
+
+  before :each do
+    allow(BrokerRole).to receive(:find).with(broker_role_id).and_return(broker_role)
+  end
+
+  it "may be claimed by the current user" do
+    expect(subject.may_be_claimed_by?(current_user)).to be_truthy
+  end
+end
+
+describe Invitation, "for:
+  - a broker role
+  - when the associated person has a different user" do
+
+  let(:current_user) do
+    instance_double(
+      User,
+      :id => broker_user_id
+    )
+  end
+
+  let(:broker_role) do
+    instance_double(
+      BrokerRole,
+      :person => person
+    )
+  end
+
+  let(:person) do
+    instance_double(
+      Person,
+      :user_id => person_user_id
+    )
+  end
+
+  subject do
+    Invitation.new(
+      :role => "broker_role",
+      :source_id => broker_role_id
+    )
+  end
+
+  let(:broker_user_id) { "BROKER USER ID" }
+
+  let(:person_user_id) { "PERSON USER ID" }
+
+  let(:broker_role_id) { "SOME BROKER ROLE ID" }
+
+  before :each do
+    allow(BrokerRole).to receive(:find).with(broker_role_id).and_return(broker_role)
+  end
+
+  it "may NOT be claimed by the current user" do
+    expect(subject.may_be_claimed_by?(current_user)).to be_falsey
+  end
+end
+
+describe Invitation, "for:
+  - a broker staff role
+  - when the associated person doesn't have a user yet" do
+
+  let(:current_user) do
+    instance_double(User)
+  end
+
+  let(:broker_agency_staff_role) do
+    instance_double(
+      BrokerAgencyStaffRole,
+      :person => person
+    )
+  end
+
+  let(:person) do
+    instance_double(
+      Person,
+      :user_id => nil
+    )
+  end
+
+  subject do
+    Invitation.new(
+      :role => "broker_agency_staff_role",
+      :source_id => broker_agency_staff_role_id
+    )
+  end
+
+  let(:broker_agency_staff_role_id) { "SOME BROKER STAFF ROLE ID" }
+
+  before :each do
+    allow(BrokerAgencyStaffRole).to receive(:find).with(broker_agency_staff_role_id).and_return(broker_agency_staff_role)
+  end
+
+  it "may be claimed by the current user" do
+    expect(subject.may_be_claimed_by?(current_user)).to be_truthy
+  end
+end
+
+describe Invitation, "for:
+  - a broker staff role
+  - when the associated person has the same user" do
+
+  let(:current_user) do
+    instance_double(
+      User,
+      :id => same_user_id
+    )
+  end
+
+  let(:broker_agency_staff_role) do
+    instance_double(
+      BrokerAgencyStaffRole,
+      :person => person
+    )
+  end
+
+  let(:person) do
+    instance_double(
+      Person,
+      :user_id => same_user_id
+    )
+  end
+
+  subject do
+    Invitation.new(
+      :role => "broker_agency_staff_role",
+      :source_id => broker_agency_staff_role_id
+    )
+  end
+
+  let(:same_user_id) { "SOME USER ID" }
+
+  let(:broker_agency_staff_role_id) { "SOME BROKER STAFF ROLE ID" }
+
+  before :each do
+    allow(BrokerAgencyStaffRole).to receive(:find).with(broker_agency_staff_role_id).and_return(broker_agency_staff_role)
+  end
+
+  it "may be claimed by the current user" do
+    expect(subject.may_be_claimed_by?(current_user)).to be_truthy
+  end
+end
+
+describe Invitation, "for:
+  - a broker staff role
+  - when the associated person a different user" do
+
+  let(:current_user) do
+    instance_double(
+      User,
+      :id => broker_staff_user_id
+    )
+  end
+
+  let(:broker_agency_staff_role) do
+    instance_double(
+      BrokerAgencyStaffRole,
+      :person => person
+    )
+  end
+
+  let(:person) do
+    instance_double(
+      Person,
+      :user_id => person_user_id
+    )
+  end
+
+  subject do
+    Invitation.new(
+      :role => "broker_agency_staff_role",
+      :source_id => broker_agency_staff_role_id
+    )
+  end
+
+  let(:broker_staff_user_id) { "BROKER STAFF USER ID" }
+
+  let(:person_user_id) { "PERSON USER ID" }
+
+  let(:broker_agency_staff_role_id) { "SOME BROKER STAFF ROLE ID" }
+
+  before :each do
+    allow(BrokerAgencyStaffRole).to receive(:find).with(broker_agency_staff_role_id).and_return(broker_agency_staff_role)
+  end
+
+  it "may be claimed by the current user" do
+    expect(subject.may_be_claimed_by?(current_user)).to be_falsey
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186910768

# A brief description of the changes

Current behavior:  If the user attempting to claim a broker or broker staff invitation was a different user than the user linked to the role, the application would issue a 500 error message.

New behavior: Do not allow different users to claim invitations on behalf of an already linked role.