### PR TITLE
create broker agency staff role after broker application is approved

### DIFF
--- a/app/controllers/exchanges/broker_applicants_controller.rb
+++ b/app/controllers/exchanges/broker_applicants_controller.rb
@@ -101,7 +101,7 @@ class Exchanges::BrokerApplicantsController < ApplicationController
   def create_and_approve_staff_role_and_approve_agency(broker_role)
     return unless broker_role.is_primary_broker?
 
-    basr = broker_role.create_basr_for_person_with_consumer_role
+    basr = broker_role.create_basr_for_person
     agency = broker_role.broker_agency_profile
     agency.approve! if agency.may_approve?
 

--- a/app/models/broker_role.rb
+++ b/app/models/broker_role.rb
@@ -353,13 +353,11 @@ class BrokerRole
     aasm_state == 'active'
   end
 
-  # @method create_basr_for_person_with_consumer_role
-  # Creates a Broker Agency Staff Role (BASR) for a person with a consumer role.
+  # @method create_basr_for_person
+  # Creates a Broker Agency Staff Role (BASR) for a person.
   #
   # This method checks:
   #   - if the 'broker_role_consumer_enhancement' feature is enabled
-  #   - if the person has a consumer role
-  #   - if the person has a user
   #   - if the person already has a BASR for the current broker agency profile.
   #   If all these conditions are met, it creates a new BASR for the person with the current broker agency profile.
   #
@@ -367,11 +365,9 @@ class BrokerRole
   #   Returns the newly created BrokerAgencyStaffRole if it was created, or nil if no role was created.
   #
   # @example Create a BASR for a person with a consumer role
-  #   create_basr_for_person_with_consumer_role
-  def create_basr_for_person_with_consumer_role
+  #   create_basr_for_person
+  def create_basr_for_person
     return unless EnrollRegistry.feature_enabled?(:broker_role_consumer_enhancement)
-    return if person.consumer_role.blank?
-    return if person.user.blank?
     return if person.pending_basr_by_profile_id(benefit_sponsors_broker_agency_profile_id)
 
     person.create_broker_agency_staff_role(

--- a/db/seedfiles/translations/en/me/shared.rb
+++ b/db/seedfiles/translations/en/me/shared.rb
@@ -71,7 +71,7 @@ SHARED_TRANSLATIONS = {
 
     "en.previous_step" => "Previous Step",
     "en.save_and_exit" => "Log Out",
-    "en.help_sign_up" => "Help Me Sign Up"
+    "en.help_sign_up" => "Help Me Sign Up",
     # event log
     "en.event_log.eligibility" => "Eligibility",
     "en.event_log.outcome" => "Outcome",

--- a/spec/models/broker_role_broker_agency_staff_role_spec.rb
+++ b/spec/models/broker_role_broker_agency_staff_role_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
-  describe '#create_basr_for_person_with_consumer_role' do
+  describe '#create_basr_for_person' do
     let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
     let(:broker_role) { FactoryBot.create(:broker_role, person: person) }
     let(:user) { FactoryBot.create(:user, person: person) }
@@ -35,7 +35,7 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
       let(:brce_feature_enabled) { false }
 
       it 'returns nil without creating a new BrokerAgencyStaffRole' do
-        expect(broker_role.create_basr_for_person_with_consumer_role).to be_nil
+        expect(broker_role.create_basr_for_person).to be_nil
         expect(person.broker_agency_staff_roles.to_a).to be_empty
       end
     end
@@ -48,10 +48,16 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         - person has a broker role' do
 
         let(:person) { FactoryBot.create(:person) }
+        let(:broker_role) { FactoryBot.create(:broker_role, person: person) }
 
-        it 'returns nil without creating a new BrokerAgencyStaffRole' do
-          expect(broker_role.create_basr_for_person_with_consumer_role).to be_nil
-          expect(person.broker_agency_staff_roles.to_a).to be_empty
+        before do
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+        end
+
+        it 'returns newly created BrokerAgencyStaffRole' do
+          result = broker_role.create_basr_for_person
+          expect(result).to be_a(BrokerAgencyStaffRole)
+          expect(person.broker_agency_staff_roles.count).to eq(1)
         end
       end
 
@@ -60,9 +66,17 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         - person has a broker role
         - person does not have a user role' do
 
-        it 'returns nil without creating a new BrokerAgencyStaffRole' do
-          expect(broker_role.create_basr_for_person_with_consumer_role).to be_nil
-          expect(person.broker_agency_staff_roles.to_a).to be_empty
+        let(:person) { FactoryBot.create(:person, :with_consumer_role) }
+        let(:broker_role) { FactoryBot.create(:broker_role, person: person) }
+
+        before do
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+        end
+
+        it 'returns newly created BrokerAgencyStaffRole' do
+          result = broker_role.create_basr_for_person
+          expect(result).to be_a(BrokerAgencyStaffRole)
+          expect(person.broker_agency_staff_roles.count).to eq(1)
         end
       end
 
@@ -85,7 +99,7 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         end
 
         it 'returns nil without creating a new BrokerAgencyStaffRole' do
-          expect(broker_role.create_basr_for_person_with_consumer_role).to be_nil
+          expect(broker_role.create_basr_for_person).to be_nil
           expect(person.broker_agency_staff_roles.to_a).to eq([matching_basr])
         end
       end
@@ -109,7 +123,7 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         end
 
         it 'returns newly created BrokerAgencyStaffRole' do
-          result = broker_role.create_basr_for_person_with_consumer_role
+          result = broker_role.create_basr_for_person
           expect(result).to be_a(BrokerAgencyStaffRole)
           expect(result.broker_agency_pending?).to be_truthy
           expect(person.broker_agency_staff_roles.count).to eq(2)
@@ -135,7 +149,7 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         end
 
         it 'returns newly created BrokerAgencyStaffRole' do
-          result = broker_role.create_basr_for_person_with_consumer_role
+          result = broker_role.create_basr_for_person
           expect(result).to be_a(BrokerAgencyStaffRole)
           expect(result.broker_agency_pending?).to be_truthy
           expect(person.broker_agency_staff_roles.count).to eq(2)
@@ -154,7 +168,7 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         end
 
         it 'returns newly created BrokerAgencyStaffRole' do
-          result = broker_role.create_basr_for_person_with_consumer_role
+          result = broker_role.create_basr_for_person
           expect(result).to be_a(BrokerAgencyStaffRole)
           expect(result.broker_agency_pending?).to be_truthy
           expect(person.broker_agency_staff_roles.count).to eq(1)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640059/stories/186910897

# A brief description of the changes

Current behavior: Creating a broker staff role only when a person has a user and consumer role associated after a broker application is approved

New behavior: Create broker staff role when a broker application is approved irrespective if  person has consumer_role and user associated.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.