### PR TITLE
CR-95: Prevent duplicate 'invitation' emails for brokers.

### DIFF
--- a/app/controllers/exchanges/broker_applicants_controller.rb
+++ b/app/controllers/exchanges/broker_applicants_controller.rb
@@ -101,7 +101,7 @@ class Exchanges::BrokerApplicantsController < ApplicationController
   def create_and_approve_staff_role_and_approve_agency(broker_role)
     return unless broker_role.is_primary_broker?
 
-    basr = broker_role.create_basr_for_person
+    basr = broker_role.create_basr_for_person_with_consumer_role
     agency = broker_role.broker_agency_profile
     agency.approve! if agency.may_approve?
 

--- a/app/controllers/exchanges/broker_applicants_controller.rb
+++ b/app/controllers/exchanges/broker_applicants_controller.rb
@@ -99,14 +99,7 @@ class Exchanges::BrokerApplicantsController < ApplicationController
   # @example Create a BASR and approve both the agency and the staff role for a primary broker role
   #   create_and_approve_staff_role_and_approve_agency(broker_role)
   def create_and_approve_staff_role_and_approve_agency(broker_role)
-    return unless broker_role.is_primary_broker?
-
-    basr = broker_role.create_basr_for_person_with_consumer_role
-    agency = broker_role.broker_agency_profile
-    agency.approve! if agency.may_approve?
-
-    basr ||= broker_role.person.pending_basr_by_profile_id(broker_role.benefit_sponsors_broker_agency_profile_id)
-    basr.broker_agency_accept! if basr&.may_broker_agency_accept?
+    Operations::EnsureBrokerStaffRoleForPrimaryBroker.new(:application_approved).call(broker_role)
   end
 
   def broker_role_update_params

--- a/app/domain/operations/ensure_broker_staff_role_for_primary_broker.rb
+++ b/app/domain/operations/ensure_broker_staff_role_for_primary_broker.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Operations
+  # Ensure that a primary broker has a broker staff role when the broker role
+  # is 'activated'.
+  #
+  # There are multiple ways for broker roles to be 'activated':
+  #
+  # * acceptance of a broker role invitation when no other roles exist on that
+  #   person
+  # * approval of a broker role for a person who already has a consumer role
+  # * successfully linking a person who already has a broker role via broker
+  #   application approval
+  #
+  # Each of these have different rules for when and which roles we should
+  # create, which states the staff role should transition through, and
+  # if the agency needs some form of broker agency application manipulated.
+  #
+  # This class is designed to encapsulate all these different entry points and
+  # present a common location for manipulation of these roles.  It is not
+  # designed to solve the problem that we invoke this in multiple areas - only
+  # to provide a single place for the logic until we can perform a more
+  # comprehensive refactor of the behaviour.
+  class EnsureBrokerStaffRoleForPrimaryBroker
+    include Dry::Monads[:result, :do]
+
+    VALID_SCENARIOS = [
+      :application_approved,
+      :consumer_role_linked,
+      :invitation_claimed
+    ].freeze
+
+    def initialize(scenario)
+      @scenario = scenario
+      validate_scenario
+    end
+
+    def call(broker_role)
+      case @scenario
+      when :application_approved
+        process_application_approved(broker_role)
+      when :invitation_claimed
+        process_invitation_claimed(broker_role)
+      when :consumer_role_linked
+        process_consumer_role_linked(broker_role)
+      end
+    end
+
+    private
+
+    def process_consumer_role_linked(broker_role)
+      return if broker_role.blank?
+      return unless broker_role.active?
+      person = broker_role.person
+      # Unless they are previously linked, and have a broker role, bail.
+      return if person.consumer_role.blank?
+      return if person.user.blank?
+      # Otherwise, treat it like they 'claimed' an invitation.
+      # At this point, they should have broker role in the correct status,
+      # they merely needs us to check the staff roles.
+      process_invitation_claimed(broker_role)
+    end
+
+    # Notice that we have introduced a duplicate check here.  Previously it
+    # was possible to get 'double staff roles' via a combination of not
+    # claiming the invitation and linking to a consumer role.
+    def process_invitation_claimed(broker_role)
+      person = broker_role.person
+      broker_agency_profile = broker_role.broker_agency_profile
+      existing_broker_staff_role = person.broker_agency_staff_roles.detect do |basr|
+        basr.broker_agency_profile.id == broker_agency_profile.id
+      end
+      if existing_broker_staff_role
+        existing_broker_staff_role.aasm_state = "active"
+        existing_broker_staff_role.save!
+      else
+        person.broker_agency_staff_roles << ::BrokerAgencyStaffRole.new({
+                                                                          :broker_agency_profile => broker_agency_profile,
+                                                                          :aasm_state => 'active'
+                                                                        })
+      end
+      person.save!
+    end
+
+    def process_application_approved(broker_role)
+      return unless broker_role.is_primary_broker?
+
+      basr = broker_role.create_basr_for_person_with_consumer_role
+      agency = broker_role.broker_agency_profile
+      agency.approve! if agency.may_approve?
+
+      basr ||= broker_role.person.pending_basr_by_profile_id(broker_role.benefit_sponsors_broker_agency_profile_id)
+      basr.broker_agency_accept! if basr&.may_broker_agency_accept?
+    end
+
+    def validate_scenario
+      raise ArgumentError, "Scenario must be one of: #{VALID_SCENARIOS}" unless VALID_SCENARIOS.include?(@scenario)
+    end
+  end
+end

--- a/app/models/broker_role.rb
+++ b/app/models/broker_role.rb
@@ -353,11 +353,13 @@ class BrokerRole
     aasm_state == 'active'
   end
 
-  # @method create_basr_for_person
-  # Creates a Broker Agency Staff Role (BASR) for a person.
+  # @method create_basr_for_person_with_consumer_role
+  # Creates a Broker Agency Staff Role (BASR) for a person with a consumer role.
   #
   # This method checks:
   #   - if the 'broker_role_consumer_enhancement' feature is enabled
+  #   - if the person has a consumer role
+  #   - if the person has a user
   #   - if the person already has a BASR for the current broker agency profile.
   #   If all these conditions are met, it creates a new BASR for the person with the current broker agency profile.
   #
@@ -365,9 +367,11 @@ class BrokerRole
   #   Returns the newly created BrokerAgencyStaffRole if it was created, or nil if no role was created.
   #
   # @example Create a BASR for a person with a consumer role
-  #   create_basr_for_person
-  def create_basr_for_person
+  #   create_basr_for_person_with_consumer_role
+  def create_basr_for_person_with_consumer_role
     return unless EnrollRegistry.feature_enabled?(:broker_role_consumer_enhancement)
+    return if person.consumer_role.blank?
+    return if person.user.blank?
     return if person.pending_basr_by_profile_id(benefit_sponsors_broker_agency_profile_id)
 
     person.create_broker_agency_staff_role(

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -119,13 +119,11 @@ class Invitation
     redirection_obj.create_sso_account(user_obj, person, 15, "broker") do
       person.user = user_obj
       person.save!
+
       broker_agency_profile = broker_role.broker_agency_profile
 
-      person.broker_agency_staff_roles << ::BrokerAgencyStaffRole.new({
-        :broker_agency_profile => broker_agency_profile,
-        :aasm_state => 'active'
-      })
-      person.save!
+      Operations::EnsureBrokerStaffRoleForPrimaryBroker.new(:invitation_claimed).call(broker_role)
+
       user_obj.roles << "broker" unless user_obj.roles.include?("broker")
       if broker_role.is_primary_broker? && !user_obj.roles.include?("broker_agency_staff")
         user_obj.roles << "broker_agency_staff"

--- a/ci/rspec-split-config.json
+++ b/ci/rspec-split-config.json
@@ -1229,6 +1229,7 @@
       "spec/data_migrations/assign_attested_residency_state_spec.rb",
       "spec/models/factories/family_enrollment_clone_factory_spec.rb",
       "components/benefit_sponsors/spec/models/benefit_sponsors/model_events/generate_initial_invoice_spec.rb",
+      "components/financial_assistance/spec/domain/financial_assistance/operations/applications/pvc/medicare/add_pvc_medicare_determination_spec.rb",
       "spec/models/services/ivl_enrollment_renewal_service_spec.rb",
       "spec/domain/operations/families/create_or_update_family_member_spec.rb",
       "components/benefit_sponsors/spec/models/benefit_sponsors/model_events/renewal_employer_open_enrollment_completed_spec.rb",

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -888,7 +888,8 @@ When(/^.+ filters plans by Carrier/) do
 end
 
 Then(/^.+ should see plans filtered by Carrier/) do
-  find_all('.plan-row').each do |row|
+  sleep(2)
+  find_all('.plan-row', wait: 5).each do |row|
     expect(row.find('h3 small', wait: 5).text).to eq @carrier_selected
   end
 end

--- a/spec/domain/operations/ensure_broker_staff_role_for_primary_broker_spec.rb
+++ b/spec/domain/operations/ensure_broker_staff_role_for_primary_broker_spec.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Operations::EnsureBrokerStaffRoleForPrimaryBroker, "given an invalid scenario" do
+  subject do
+    described_class.new(:some_garbage)
+  end
+
+  it "raises an error" do
+    expect { subject }.to raise_error(ArgumentError)
+  end
+end
+
+describe Operations::EnsureBrokerStaffRoleForPrimaryBroker, "when:
+  - it is for the scenario of :consumer_role_linked
+  - the person has no broker role", dbclean: :after_each do
+
+  let(:operation) do
+    described_class.new(:consumer_role_linked)
+  end
+
+  let(:consumer_role) do
+    FactoryBot.create(:consumer_role)
+  end
+
+  let(:person) do
+    pers = consumer_role.person
+    pers.user = user
+    pers.save!
+    pers
+  end
+
+  let(:user) do
+    FactoryBot.create(:user)
+  end
+
+  before :each do
+    operation.call(nil)
+  end
+
+  it "does not add a staff role" do
+    expect(person.broker_agency_staff_roles).to eq []
+  end
+end
+
+describe Operations::EnsureBrokerStaffRoleForPrimaryBroker, "when:
+  - it is for the scenario of :consumer_role_linked
+  - the person has an unapproved broker role", dbclean: :after_each do
+
+  let(:operation) do
+    described_class.new(:consumer_role_linked)
+  end
+
+  let(:consumer_role) do
+    FactoryBot.create(:consumer_role)
+  end
+
+  let(:person) do
+    pers = consumer_role.person
+    pers.user = user
+    pers.save!
+    pers
+  end
+
+  let(:broker_agency_profile) do
+    FactoryBot.create(:benefit_sponsors_organizations_broker_agency_profile)
+  end
+
+  let(:user) do
+    FactoryBot.create(:user)
+  end
+
+  let(:existing_broker_staff_role) do
+    person.broker_agency_staff_roles.first
+  end
+
+  let(:broker_role) do
+    role = BrokerRole.new(
+      :broker_agency_profile => broker_agency_profile,
+      :aasm_state => "applicant",
+      :npn => "123456789",
+      :provider_kind => "broker"
+    )
+    person.broker_role = role
+    person.save!
+    person.broker_role
+  end
+
+  before :each do
+    operation.call(broker_role)
+  end
+
+  it "does not add a staff role" do
+    expect(person.broker_agency_staff_roles).to eq []
+  end
+end
+
+describe Operations::EnsureBrokerStaffRoleForPrimaryBroker, "when:
+  - it is for the scenario of :consumer_role_linked
+  - the person has an approved broker role
+  - the person already has a broker staff role for the same brokerage", dbclean: :after_each do
+  let(:operation) do
+    described_class.new(:consumer_role_linked)
+  end
+
+  let(:consumer_role) do
+    FactoryBot.create(:consumer_role)
+  end
+
+  let(:person) do
+    pers = consumer_role.person
+    pers.user = user
+    pers.broker_agency_staff_roles << BrokerAgencyStaffRole.new(
+      aasm_state: "broker_agency_pending",
+      broker_agency_profile: broker_agency_profile
+    )
+    pers.save!
+    pers
+  end
+
+  let(:broker_agency_profile) do
+    FactoryBot.create(:benefit_sponsors_organizations_broker_agency_profile)
+  end
+
+  let(:user) do
+    FactoryBot.create(:user)
+  end
+
+  let(:existing_broker_staff_role) do
+    person.broker_agency_staff_roles.first
+  end
+
+  let(:broker_role) do
+    role = BrokerRole.new(
+      :broker_agency_profile => broker_agency_profile,
+      :aasm_state => "active",
+      :npn => "123456789",
+      :provider_kind => "broker"
+    )
+    person.broker_role = role
+    person.save!
+    person.broker_role
+  end
+
+  before :each do
+    operation.call(broker_role)
+  end
+
+  it "doesn't add another broker staff role" do
+    expect(person.broker_agency_staff_roles.count).to eq 1
+  end
+
+  it "activates the broker staff role" do
+    expect(existing_broker_staff_role.aasm_state).to eq "active"
+  end
+end
+
+describe Operations::EnsureBrokerStaffRoleForPrimaryBroker, "when:
+  - it is for the scenario of :consumer_role_linked
+  - the person has an approved broker role
+  - the person doesn't have a broker staff role for the same brokerage", dbclean: :after_each do
+  let(:operation) do
+    described_class.new(:consumer_role_linked)
+  end
+
+  let(:consumer_role) do
+    FactoryBot.create(:consumer_role)
+  end
+
+  let(:person) do
+    pers = consumer_role.person
+    pers.user = user
+    pers.save!
+    pers
+  end
+
+  let(:broker_agency_profile) do
+    FactoryBot.create(:benefit_sponsors_organizations_broker_agency_profile)
+  end
+
+  let(:user) do
+    FactoryBot.create(:user)
+  end
+
+  let(:broker_role) do
+    role = BrokerRole.new(
+      :broker_agency_profile => broker_agency_profile,
+      :aasm_state => "active",
+      :npn => "123456789",
+      :provider_kind => "broker"
+    )
+    person.broker_role = role
+    person.save!
+    person.broker_role
+  end
+
+  before :each do
+    operation.call(broker_role)
+  end
+
+  it "creates a new broker staff role for the same brokerage" do
+    expect(person.broker_agency_staff_roles.first.broker_agency_profile.id).to eq broker_agency_profile.id
+  end
+
+  it "sets the new role to active" do
+    new_broker_staff_role = person.broker_agency_staff_roles.first
+    expect(new_broker_staff_role.aasm_state).to eq "active"
+  end
+end

--- a/spec/models/broker_role_broker_agency_staff_role_spec.rb
+++ b/spec/models/broker_role_broker_agency_staff_role_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
-  describe '#create_basr_for_person' do
+  describe '#create_basr_for_person_with_consumer_role' do
     let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
     let(:broker_role) { FactoryBot.create(:broker_role, person: person) }
     let(:user) { FactoryBot.create(:user, person: person) }
@@ -35,7 +35,7 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
       let(:brce_feature_enabled) { false }
 
       it 'returns nil without creating a new BrokerAgencyStaffRole' do
-        expect(broker_role.create_basr_for_person).to be_nil
+        expect(broker_role.create_basr_for_person_with_consumer_role).to be_nil
         expect(person.broker_agency_staff_roles.to_a).to be_empty
       end
     end
@@ -48,16 +48,10 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         - person has a broker role' do
 
         let(:person) { FactoryBot.create(:person) }
-        let(:broker_role) { FactoryBot.create(:broker_role, person: person) }
 
-        before do
-          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
-        end
-
-        it 'returns newly created BrokerAgencyStaffRole' do
-          result = broker_role.create_basr_for_person
-          expect(result).to be_a(BrokerAgencyStaffRole)
-          expect(person.broker_agency_staff_roles.count).to eq(1)
+        it 'returns nil without creating a new BrokerAgencyStaffRole' do
+          expect(broker_role.create_basr_for_person_with_consumer_role).to be_nil
+          expect(person.broker_agency_staff_roles.to_a).to be_empty
         end
       end
 
@@ -66,17 +60,9 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         - person has a broker role
         - person does not have a user role' do
 
-        let(:person) { FactoryBot.create(:person, :with_consumer_role) }
-        let(:broker_role) { FactoryBot.create(:broker_role, person: person) }
-
-        before do
-          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
-        end
-
-        it 'returns newly created BrokerAgencyStaffRole' do
-          result = broker_role.create_basr_for_person
-          expect(result).to be_a(BrokerAgencyStaffRole)
-          expect(person.broker_agency_staff_roles.count).to eq(1)
+        it 'returns nil without creating a new BrokerAgencyStaffRole' do
+          expect(broker_role.create_basr_for_person_with_consumer_role).to be_nil
+          expect(person.broker_agency_staff_roles.to_a).to be_empty
         end
       end
 
@@ -99,7 +85,7 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         end
 
         it 'returns nil without creating a new BrokerAgencyStaffRole' do
-          expect(broker_role.create_basr_for_person).to be_nil
+          expect(broker_role.create_basr_for_person_with_consumer_role).to be_nil
           expect(person.broker_agency_staff_roles.to_a).to eq([matching_basr])
         end
       end
@@ -123,7 +109,7 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         end
 
         it 'returns newly created BrokerAgencyStaffRole' do
-          result = broker_role.create_basr_for_person
+          result = broker_role.create_basr_for_person_with_consumer_role
           expect(result).to be_a(BrokerAgencyStaffRole)
           expect(result.broker_agency_pending?).to be_truthy
           expect(person.broker_agency_staff_roles.count).to eq(2)
@@ -149,7 +135,7 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         end
 
         it 'returns newly created BrokerAgencyStaffRole' do
-          result = broker_role.create_basr_for_person
+          result = broker_role.create_basr_for_person_with_consumer_role
           expect(result).to be_a(BrokerAgencyStaffRole)
           expect(result.broker_agency_pending?).to be_truthy
           expect(person.broker_agency_staff_roles.count).to eq(2)
@@ -168,7 +154,7 @@ RSpec.describe BrokerRole, type: :model, dbclean: :after_each do
         end
 
         it 'returns newly created BrokerAgencyStaffRole' do
-          result = broker_role.create_basr_for_person
+          result = broker_role.create_basr_for_person_with_consumer_role
           expect(result).to be_a(BrokerAgencyStaffRole)
           expect(result.broker_agency_pending?).to be_truthy
           expect(person.broker_agency_staff_roles.count).to eq(1)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186923065

# A brief description of the changes

Current behavior: If I approve a broker application for an unlinked user, I get both the 'Broker' and 'Broker Staff' invitation emails.  A duplicate broker staff record is also created.

New behavior: Send only the broker email, create only a single role.