### PR TITLE
check for prospective year enrollments when rating area is changed in December

### DIFF
--- a/app/domain/operations/families/relocate_enrolled_products.rb
+++ b/app/domain/operations/families/relocate_enrolled_products.rb
@@ -64,6 +64,7 @@ module Operations
 
       def filter_enrollments(all_enrollments, primary_family_id, _person_hbx_id)
         all_enrollments = all_enrollments.where(family_id: primary_family_id, kind: "individual")
+        all_enrollments = all_enrollments.by_year(TimeKeeper.date_of_record.next_year.year) if TimeKeeper.date_of_record.month == 12
         return Failure("RelocateEnrolledProducts: No enrollments found for a given criteria") if all_enrollments.blank?
 
         Success(all_enrollments)

--- a/spec/domain/operations/families/relocate_enrolled_products_spec.rb
+++ b/spec/domain/operations/families/relocate_enrolled_products_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe ::Operations::Families::RelocateEnrolledProducts, dbclean: :after_each do
   before :all do
     DatabaseCleaner.clean
+    TimeKeeper.set_date_of_record_unprotected!(Date.new(TimeKeeper.date_of_record.year, 10, 1))
   end
 
   let!(:person) { FactoryBot.create(:person, :with_consumer_role) }
@@ -205,9 +206,18 @@ RSpec.describe ::Operations::Families::RelocateEnrolledProducts, dbclean: :after
         }
         @result = subject.call(@params)
       end
+
       it "should return success" do
         expect(@result).to be_success
       end
+
+      it "should have prospective year enrollment" do
+        expect(@result.success[enrollment_3.hbx_id][:enrollment_hbx_id]).to eql(enrollment_3.hbx_id)
+      end
     end
+  end
+
+  after :all do
+    TimeKeeper.set_date_of_record_unprotected!(Date.today)
   end
 end

--- a/spec/domain/operations/families/relocate_enrolled_products_spec.rb
+++ b/spec/domain/operations/families/relocate_enrolled_products_spec.rb
@@ -137,4 +137,77 @@ RSpec.describe ::Operations::Families::RelocateEnrolledProducts, dbclean: :after
       expect(@result.failure).to eq "RelocateEnrolledProducts: address_set should be of kind home"
     end
   end
+
+  describe "when the system date is in December" do
+
+    before :all do
+      TimeKeeper.set_date_of_record_unprotected!(Date.new(TimeKeeper.date_of_record.year, 12, 1))
+    end
+
+    context "when the family only has enrollments in the current plan year" do
+      before do
+        allow(EnrollRegistry[:enroll_app].setting(:geographic_rating_area_model)).to receive(:item).and_return('county')
+        allow(EnrollRegistry[:enroll_app].setting(:rating_areas)).to receive(:item).and_return('county')
+        BenefitMarkets::Locations::RatingArea.update_all(covered_states: nil)
+        BenefitMarkets::Locations::RatingArea.where(:exchange_provided_code.nin => ["R-ME004"]).first.update_attributes(covered_states: nil, active_year: start_date.year, county_zip_ids: [county_zip.id], exchange_provided_code: "R-ME001")
+        BenefitMarkets::Locations::ServiceArea.update_all(covered_states: ['ME'])
+        rating_area = ::BenefitMarkets::Locations::RatingArea.rating_area_for(person.home_address)
+        enrollment.update_attributes!(rating_area_id: rating_area.id)
+        enrollment2.update_attributes!(rating_area_id: rating_area.id)
+        person.home_address.update_attributes(zip: "04771", county: "Aroostook", state: "ME")
+        modified_address = person.home_address.attributes.slice("address_1", "address_2", "address_3", "county", "kind", "city", "state", "zip").transform_keys(&:to_sym)
+        @params = {
+          address_set: {original_address: original_address,
+                        modified_address: modified_address},
+          change_set: {"old_set": {zip: county_zip.zip, county: county_zip.county_name},"new_set": {zip: "04771", county: "Aroostook"}},
+          person_hbx_id: person.hbx_id,
+          primary_family_id: person.primary_family.id,
+          is_primary: person.primary_family.present?
+        }
+        @result = subject.call(@params)
+      end
+
+      it "should return failure" do
+        expect(@result).to be_failure
+      end
+
+      it "should return error message" do
+        expect(@result.failure).to eq "RelocateEnrolledProducts: No enrollments found for a given criteria"
+      end
+    end
+
+    context "when the family has an enrollment in the current plan year and an enrollment in the prospective year" do
+      let!(:enrollment_3) do
+        FactoryBot.create(:hbx_enrollment, family: family, household: family.active_household, coverage_kind: "health", kind: "individual",
+                                           aasm_state: "coverage_selected", effective_on: Date.new(TimeKeeper.date_of_record.next_year.year), :product => product)
+      end
+
+      before do
+        allow(EnrollRegistry[:enroll_app].setting(:geographic_rating_area_model)).to receive(:item).and_return('county')
+        allow(EnrollRegistry[:enroll_app].setting(:rating_areas)).to receive(:item).and_return('county')
+        BenefitMarkets::Locations::RatingArea.update_all(covered_states: nil)
+        BenefitMarkets::Locations::RatingArea.where(:exchange_provided_code.nin => ["R-ME004"]).first.update_attributes(covered_states: nil, active_year: start_date.year, county_zip_ids: [county_zip.id], exchange_provided_code: "R-ME001")
+        BenefitMarkets::Locations::ServiceArea.update_all(covered_states: ['ME'])
+
+        rating_area = ::BenefitMarkets::Locations::RatingArea.rating_area_for(person.home_address)
+        enrollment.update_attributes!(rating_area_id: rating_area.id)
+        enrollment2.update_attributes!(rating_area_id: rating_area.id)
+        enrollment_3.update_attributes!(rating_area_id: rating_area.id)
+        person.home_address.update_attributes(zip: "04771", county: "Aroostook", state: "ME")
+        modified_address = person.home_address.attributes.slice("address_1", "address_2", "address_3", "county", "kind", "city", "state", "zip").transform_keys(&:to_sym)
+        @params = {
+          address_set: {original_address: original_address,
+                        modified_address: modified_address},
+          change_set: {"old_set": {zip: county_zip.zip, county: county_zip.county_name},"new_set": {zip: "04771", county: "Aroostook"}},
+          person_hbx_id: person.hbx_id,
+          primary_family_id: person.primary_family.id,
+          is_primary: person.primary_family.present?
+        }
+        @result = subject.call(@params)
+      end
+      it "should return success" do
+        expect(@result).to be_success
+      end
+    end
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-186863833](https://www.pivotaltracker.com/n/projects/2640060/stories/186863833)

# A brief description of the changes

Current behavior: If there is a rating area change in December, current year enrollments are being terminated and new enrollments are being generated.

New behavior:  If there is a rating area change in December, no action should be made to current year enrollments and no new enrollments should generate unless there is already a prospective year enrollment.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.