### PR TITLE
set monitored event login_session_id if session available

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: b282e4771b7a820a1ab03b64cc624d74b0ef2e5f
+  revision: 94d9e34088076814be513be7d97f1e9cf2e8b646
   branch: trunk
   specs:
     aca_entities (0.10.0)
@@ -35,7 +35,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/event_source.git
-  revision: e368d614f37c5cf4e4a17a81ae71c49376d96ff6
+  revision: f4e83cbdf124c4d48e469e239f36261191ee61c9
   branch: trunk
   specs:
     event_source (0.5.8)

--- a/app/domain/operations/event_logs/store.rb
+++ b/app/domain/operations/event_logs/store.rb
@@ -58,7 +58,7 @@ module Operations
         options[:session_detail] = account[:session]
         # TODO: Work with @raghuram to understand why login_session_id is not available in session object in some cases.
         # substitute login_session_id with session_id token for now.
-        options[:session_detail][:login_session_id] = options[:session_detail][:login_session_id] || options[:session_detail][:session_id]
+        options[:session_detail][:login_session_id] ||= account[:session][:session_id] if account[:session]
         options[:account_id] = account[:id]
         options[:monitored_event] = construct_monitored_event(payload, headers)
         options[:payload] = payload.to_json
@@ -74,7 +74,7 @@ module Operations
         user_account = account_with(account[:id])
         options[:account_hbx_id] = user_account.person.hbx_id
         options[:account_username] = user_account.oim_id || user_account.email
-        options[:login_session_id] = account[:session][:login_session_id]
+        options[:login_session_id] = account[:session][:login_session_id] if account[:session]
         options[:event_category] = event_category_for(headers[:event_name])
         options.merge(
           {

--- a/app/domain/operations/event_logs/store.rb
+++ b/app/domain/operations/event_logs/store.rb
@@ -56,8 +56,6 @@ module Operations
         account = headers[:account]
         options[:event_time] = formated_time(headers[:event_time])
         options[:session_detail] = account[:session]
-        # TODO: Work with @raghuram to understand why login_session_id is not available in session object in some cases.
-        # substitute login_session_id with session_id token for now.
         options[:session_detail][:login_session_id] ||= account[:session][:session_id] if account[:session]
         options[:account_id] = account[:id]
         options[:monitored_event] = construct_monitored_event(payload, headers)

--- a/app/event_source/subscribers/eligible/eligibility_subscriber.rb
+++ b/app/event_source/subscribers/eligible/eligibility_subscriber.rb
@@ -54,7 +54,7 @@ module Subscribers
         subscriber_logger.info "EligibilitySubscriber#on_enroll_enterprise_events, response: #{payload}"
 
         subject = GlobalID::Locator.locate(payload[:subject_gid])
-        eligibility_date = TimeKeeper.date_of_record
+        eligibility_date = payload[:eligibility_date].to_date || TimeKeeper.date_of_record
         effective_date = payload[:effective_date].to_date
         evidence_key = payload[:evidence_key].to_sym
 

--- a/spec/domain/operations/ivl_osse_eligibilities/create_ivl_osse_eligibility_spec.rb
+++ b/spec/domain/operations/ivl_osse_eligibilities/create_ivl_osse_eligibility_spec.rb
@@ -46,9 +46,13 @@ RSpec.describe ::Operations::IvlOsseEligibilities::CreateIvlOsseEligibility,
   end
 
   let(:evidence_value) { "false" }
+  let!(:system_user) { FactoryBot.create(:user, email: "admin@dc.gov") }
+  let(:trackable_event_instance) { Operations::EventLogs::TrackableEvent.new}
 
   before do
     allow(EnrollRegistry).to receive(:feature_enabled?).and_return(true)
+    allow(trackable_event_instance).to receive(:publish).and_return(Dry::Monads::Success(true))
+    allow(Operations::EventLogs::TrackableEvent).to receive(:new).and_return(trackable_event_instance)
     catalog_eligibility
   end
 

--- a/spec/models/services/ivl_osse_eligibility_service_spec.rb
+++ b/spec/models/services/ivl_osse_eligibility_service_spec.rb
@@ -19,13 +19,16 @@ RSpec.describe Services::IvlOsseEligibilityService, type: :model, :dbclean => :a
   let(:person) { FactoryBot.create(:person, :with_consumer_role)}
   let(:role) { person.consumer_role }
   let(:current_date) { TimeKeeper.date_of_record }
-
+  let!(:system_user) { FactoryBot.create(:user, email: "admin@dc.gov") }
   let(:params) { { person_id: person.id, osse: { current_date.year.to_s => "true", current_date.last_year.year.to_s => "false" } } }
+  let(:trackable_event_instance) { Operations::EventLogs::TrackableEvent.new}
 
   subject { described_class.new(params) }
 
   before do
     allow(EnrollRegistry).to receive(:feature_enabled?).and_return(true)
+    allow(trackable_event_instance).to receive(:publish).and_return(Dry::Monads::Success(true))
+    allow(Operations::EventLogs::TrackableEvent).to receive(:new).and_return(trackable_event_instance)
     catalog_eligibility
   end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186780742

# A brief description of the changes

Current behavior: Getting a nil error while assigning monitored event login session id under event_log store operation

New behavior:  Add condition to verify presence of the session since system triggered events will not have live session.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.