### PR TITLE
complete sanitization of plan titles

### DIFF
--- a/components/benefit_markets/app/models/benefit_markets/products/product.rb
+++ b/components/benefit_markets/app/models/benefit_markets/products/product.rb
@@ -196,7 +196,7 @@ module BenefitMarkets
         end
 
         def network_labels
-          ['Nationwide', EnrollRegistry[:enroll_app].setting(:statewide_area).item]
+          ['Nationwide', 'State/Regional']
         end
       end
 
@@ -212,7 +212,7 @@ module BenefitMarkets
 
       def network
         return 'Nationwide' if nationwide
-        return EnrollRegistry[:enroll_app].setting(:statewide_area).item if in_state_network
+        return 'State/Regional'
       end
 
       def can_use_aptc?

--- a/script/sanitize_plan_info.rb
+++ b/script/sanitize_plan_info.rb
@@ -1,0 +1,8 @@
+plans = BenefitMarkets::Products::Product.where(title: /maine/i)
+
+plans.each do |plan|
+  plan.title = plan.title.gsub(/maine/i, 'State')
+  plan.save
+end
+
+puts "All plan titles containing \'Maine\' successfully updated"

--- a/script/sanitize_plan_info.rb
+++ b/script/sanitize_plan_info.rb
@@ -1,3 +1,7 @@
+# This script is for the demo environment: it does two things
+# It changes all mentions of "Maine" to "State" in the titles of all instances of BenefitMarkets::Products::Product
+# It can be run with bundle exec rails r script/sanitize_plan_info.rb
+
 plans = BenefitMarkets::Products::Product.where(title: /maine/i)
 
 plans.each do |plan|

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Factory for products/plans
+FactoryBot.define do
+  factory :product,
+          :class => 'BenefitMarkets::Products::Product' do
+    title { "Clear Choice HMO Catastrophic 9450" }
+    description { "" }
+    product_package_kinds { [:metal_level, :single_issuer, :single_product] }
+    premium_ages { { min: 14, max: 64 } }
+    rating_method { "Age-Based Rates" }
+    benefit_market_kind { :aca_individual }
+    issuer_profile_id { BSON::ObjectId('60f5d94c2a6d4300fbedc98f') }
+    application_period { { min: DateTime.parse('2024-01-01'), max: DateTime.parse('2024-12-31') } }
+    deductible { "$9,450" }
+    family_deductible { "$9450 per person | $18900 per group" }
+    is_reference_plan_eligible { true }
+    kind { :health }
+    updated_at { DateTime.parse('2023-12-19 14:39:31') }
+    created_at { DateTime.parse('2023-12-19 14:39:31') }
+  end
+end

--- a/spec/script/sanatize_plan_info_spec.rb
+++ b/spec/script/sanatize_plan_info_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'applicant_outreach_report', :dbclean => :after_each do
+  before :all do
+    DatabaseCleaner.clean
+  end
+
+  let(:service_areas) { FactoryBot.create(:benefit_markets_locations_service_area).to_a }
+  let(:product_1) { FactoryBot.create(:product, title: "Maine's Choice Healthcare", service_area_id: service_areas.first.id) }
+  let(:product_2) { FactoryBot.create(:product, title: "Maine's Best Healthcare", service_area_id: service_areas.first.id) }
+  let(:product_3) { FactoryBot.create(:product, title: "State Healthcare", service_area_id: service_areas.first.id) }
+
+  context 'when sanitizing all plans' do
+    before do
+      invoke_plan_sanitization
+    end
+
+    it "should have no plans with titles containing the substring 'Maine'" do
+      maine_plans = BenefitMarkets::Products::Product.where(title: /maine/i)
+
+      expect(maine_plans.size).to eq(0)
+    end
+  end
+end
+
+def invoke_plan_sanitization
+  plan_sanitizationer = File.join(Rails.root, "script/sanitize_plan_info.rb")
+  load plan_sanitizationer
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [186966075](https://www.pivotaltracker.com/story/show/186966075)

# A brief description of the changes

Current behavior: Has plans

New behavior: Changes plan titles to omit "Maine"

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.