### PR TITLE
audit log bugfixes: reset filters before searching, properly limit csvs

### DIFF
--- a/app/controllers/event_logs_controller.rb
+++ b/app/controllers/event_logs_controller.rb
@@ -4,16 +4,8 @@
 class EventLogsController < ApplicationController
   before_action :check_hbx_staff_role
   def index
-    if params[:group] && params[:type]
-      if params[:type] == "consumer"
-        family = Family.find(params[:group])
-        hbxes = family.family_members.map {|fm| fm.person.hbx_id}&.uniq
-        group_logs = EventLogs::MonitoredEvent.where(:subject_hbx_id.in => hbxes)
-      else
-        group_logs = EventLogs::MonitoredEvent.where(subject_hbx_id: params[:group])
-      end
-    end
-    @event_logs = group_logs || EventLogs::MonitoredEvent.all
+    events = params[:events]
+    @event_logs = events ? EventLogs::MonitoredEvent.where(:_id.in => params[:events]) : EventLogs::MonitoredEvent.all
     respond_to do |format|
       format.js
       format.csv do
@@ -26,7 +18,7 @@ class EventLogsController < ApplicationController
   private
 
   def event_log_params
-    params.permit(:family)
+    params.permit(:family, :events)
   end
 
   def check_hbx_staff_role

--- a/app/models/event_logs/monitored_event.rb
+++ b/app/models/event_logs/monitored_event.rb
@@ -37,7 +37,7 @@ module EventLogs
       details = JSON.parse(self.attributes.to_json, symbolize_names: true)
       datetime = parsed.dig(:state_histories, 0, :effective_on)
       effective_on = DateTime.parse(datetime.to_s)&.strftime("%d/%m/%Y") if datetime
-      subject = Person.by_hbx_id(self.subject_hbx_id)&.first&.full_name
+      subject = get_subject_name(log.subject_gid)
       detail = log.event_name&.match(/[^.]+\z/)&.to_s&.titleize
       build_details(parsed, details, effective_on, detail, subject)
     end
@@ -49,6 +49,12 @@ module EventLogs
       details[:effective_on] = effective_on || ""
       details[:detail] = detail || ""
       details
+    end
+
+    def get_subject_name(gid)
+      subject = GlobalID::Locator.locate(gid)
+      return subject.full_name if subject.instance_of?(Person)
+      subject&.legal_name
     end
 
     def self.fetch_event_logs(params)

--- a/app/views/event_logs/_event_log_tab.html.erb
+++ b/app/views/event_logs/_event_log_tab.html.erb
@@ -1,5 +1,4 @@
 <div class="event-log-tab">
-  <% group = @family || @employer_profile %>
   <div>
     <h1><b><%= l10n("audit_log") %></b></h1>
     <h3><b><%= name %></b></h3>
@@ -8,6 +7,7 @@
     <% else %>
     <% if type == 'consumer' %>
       <p><b><%= l10n("Account") %> <%= l10n("Primary") %>:</b> <%= l10n("Self") %></p>
+      <p><b><%= l10n("event_log.hbx_id_text") %></b> <%= hbx_id %></p>
       <p><%= l10n("event_log.ivl_action") %></p>
     <% else %>
       <p><b><%= l10n("event_log.hbx_id_text") %></b> <%= hbx_id %></p>
@@ -23,7 +23,7 @@
         <h2><%= l10n("event_log.eligibility") %> <%= l10n("Details") %></h2>
         <div class="filter-row">
           <% if type == 'consumer' %>
-          <div class="filter">
+          <div class="filter" id="subjectFilter">
             <label for="<%= l10n("subject").downcase %>"><%= l10n("Subject") %></label>
             <dl class="dropdown">
               <dt>
@@ -125,7 +125,7 @@
     <div class="event-log-header">
       <div class="event-log-export-text">
         <h3><b><%= type === "consumer" ? l10n("event_log.table_label_consumer") + hbx_id : l10n("event_log.table_label_employer")%></b></h3>
-        <a href="/event_logs.csv?group=<%= group.id %>?type=<%= type %>" id="export-table" class="button button-primary"><%= l10n("Export") %> <%= l10n("to") %> CSV</a>
+        <a href="/event_logs.csv?<% @event_logs.each do |event| %>&events[]=<%= event[:_id] %><% end %>" id="export-table" class="button button-primary"><%= l10n("Export") %> <%= l10n("to") %> CSV</a>
       </div>
     </div>
     <div id="event-table-data">
@@ -148,7 +148,7 @@
               <% if type == 'consumer' %>
                 <td class="subject"><%= event_log[0] %></td>
               <% else %>
-                <td class="subject"><%= name %></td>
+                <td class="subject"><%= event_log[0] %></td>
               <% end %>
               <td class="eligibility"><%= event_log[1]&.upcase %></td>
               <td class="status"><%= details[0][:current_state]&.titleize %></td>
@@ -326,6 +326,12 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
   // filter the data on the page
   $('#run-query').on('click', function(event) {
     event.preventDefault();
+
+    // reset visibility before running a new search
+    $('#event-log-table tbody tr.primary-row').each(function( index ) {
+      $(this).show();
+    });
+
     var subjects = [],
         eligibilities = [],
         statuses = [],
@@ -348,7 +354,9 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
     });
 
     // subject filter
-    if (!subjects.length === 0 && !subjects.includes("ALL")){
+    // have to check for visibilitiy so it doesn't filter out all rows automatically
+    // for employer flow
+    if ($('#subjectFilter').is(":visible") && !subjects.includes("ALL")){
       $('td.subject').each(function( index ) {
         var row = $(this).closest('tr').prop('id');
         var row_index = visible_rows.indexOf(row)

--- a/app/views/event_logs/_export_csv.csv.erb
+++ b/app/views/event_logs/_export_csv.csv.erb
@@ -1,4 +1,4 @@
-"Subject","Eligibility", "Eligibility Status", "Effective On", "Event Details","Performed By","Time"
+"Subject","Eligibility","Eligibility Status","Effective On","Event Details","Performed By","Time"
 <% event_logs.each do |event_log| %>
    <% performed_by = event_log[:account_username] + " (" + event_log[:account_hbx_id] + ")" %>
   <%= event_log[:subject] %>, <%= event_log[:title].to_s.upcase %>,<%= event_log[:current_state]&.titleize %>,<%= event_log[:effective_on] %>,<%= event_log[:detail] %>,<%= performed_by %>,<%= event_log[:event_time] %>

--- a/spec/controllers/event_logs_controller_spec.rb
+++ b/spec/controllers/event_logs_controller_spec.rb
@@ -20,12 +20,11 @@ RSpec.describe EventLogsController, :type => :controller do
   end
 
   context "#index" do
-    let(:event_log_params) { { "group" => family.id, "type" => "consumer" } }
 
     it "should assign event logs with params" do
-      FactoryBot.create(:monitored_event, account_username: user.email, monitorable: person_event_log, subject_hbx_id: person.hbx_id)
+      event1 = FactoryBot.create(:monitored_event, account_username: user.email, monitorable: person_event_log, subject_hbx_id: person.hbx_id)
       FactoryBot.create(:monitored_event, account_username: user.email, monitorable: person_event_log)
-      get :index, params: event_log_params, format: :js
+      get :index, params: {events: [event1.id]}, format: :js
       expect(assigns(:event_logs).count).to eq 1
       expect(assigns(:event_logs).first.subject_hbx_id).to eq person.hbx_id
     end
@@ -36,13 +35,13 @@ RSpec.describe EventLogsController, :type => :controller do
     end
 
     it "should render index" do
-      get :index, params: event_log_params, format: :js
+      get :index, params: {}, format: :js
       expect(response).to render_template(:index)
     end
 
     context "csv" do
       it "should render csv" do
-        get :index, params: event_log_params.merge(format: :csv)
+        get :index, params: {format: :csv}
         expect(response.header["Content-Type"]).to eq "text/csv"
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
Filters not working for a 2nd search without re-setting:
* https://www.pivotaltracker.com/n/projects/2659995/stories/186957336
* https://www.pivotaltracker.com/story/show/186957310
* https://www.pivotaltracker.com/n/projects/2659995/stories/186957277

HBX ID missing from consumer flow:
* https://www.pivotaltracker.com/n/projects/2659995/stories/186957204

CSV not showing subjects for employers and showing all events, not scoped events:
* https://www.pivotaltracker.com/story/show/186956835

# A brief description of the changes

Current behavior: Audit log filters do not work as expected when switching and re-running without resetting in the middle, HBX Id does not display on consumer audit log, audit log csv export shows all events rather than just the ones for that page, employer subject column in blank on the CSV export.

New behavior: Audit log filters work as expected when switching and re-running without resetting in the middle, HBX Id  displays on consumer audit log, audit log csv export shows only the ones for that page, employer subject column isn't blank on the CSV export.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.