### PR TITLE
audit log ui: filter details rows in addition to primary rows

### DIFF
--- a/app/views/event_logs/_event_log_tab.html.erb
+++ b/app/views/event_logs/_event_log_tab.html.erb
@@ -266,7 +266,7 @@
 
   $('.primary-row').click(function(){
     $(this).find('.glyphicon-chevron-right, .glyphicon-chevron-down').toggleClass('glyphicon-chevron-right glyphicon-chevron-down')
-    $(this).nextAll('tr').each( function() {
+    $(this).nextAll('tr:not(.hidden-by-filters)').each( function() {
       if ($(this).hasClass('primary-row')) {
         return false;
       }
@@ -330,6 +330,9 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
     // reset visibility before running a new search
     $('#event-log-table tbody tr.primary-row').each(function( index ) {
       $(this).show();
+    });
+    $('#event-log-table tbody tr.detail-row').each(function( index ) {
+      $(this).removeClass("hidden-by-filters");
     });
 
     var subjects = [],
@@ -413,16 +416,11 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
     $('tr.primary-row').each(function( index ) {
       var row = $(this).prop('id');
       var row_index = visible_rows.indexOf(row);
-      var accounts = []
       var action_dates = []
-      $('td.user_id').each(function( index ) {
-        if ($(this).closest('tr').prop('id') === row) {
-          accounts.push($(this).prop('id').toUpperCase());
-          accounts.push($(this).text().toUpperCase());
-        }
-      });
+      var detail_rows = []
       $('td.event-time').each(function( index ) {
         if ($(this).closest('tr').prop('id') === row) {
+          detail_rows.push($(this).closest('tr'));
           action_dates.push(new Date($(this).text()).getTime());
         }
       });
@@ -430,8 +428,17 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
       if ($('#user-id').val()) {
         var row_index = visible_rows.indexOf(row);
         var value = $('#user-id').val().toUpperCase();
-        var value_index = accounts.indexOf(value);
-        if (value_index === -1 && row_index !== -1) {
+        var ok_rows = 0;
+        $.each( detail_rows, function( i, date ){
+          var user_id = $(this).find('td.user_id').prop('id').toUpperCase()
+          var user_email = $(this).find('td.user_id').text().toUpperCase()
+          if (user_id === value || user_email === value) {
+            ok_rows += 1
+          } else {
+            $(this).hide().addClass("hidden-by-filters");
+          }
+        });
+        if (ok_rows === 0 && row_index !== -1) {
           visible_rows.splice( row_index, 1 );
         }
       }
@@ -446,6 +453,8 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
         $.each( action_dates, function( i, date ){
           if (start.getTime() < date) {
             ok_rows += 1
+          } else {
+            detail_rows[i].hide().addClass("hidden-by-filters");
           }
         });
         if (ok_rows === 0 && row_index !== -1) {
@@ -463,6 +472,8 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
         $.each( action_dates, function( i, date ){
           if (end.getTime() > date) {
             ok_rows += 1
+          } else {
+            detail_rows[i].hide().addClass("hidden-by-filters");
           }
         });
         if (ok_rows === 0 && row_index !== -1) {


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[Filter the details rows in addition to the primary rows](https://www.pivotaltracker.com/story/show/186965610)
[Make sure user account search works the 2nd time around](https://www.pivotaltracker.com/story/show/186965676)

# A brief description of the changes

Current behavior: Searching by user account doesn't work the 2nd time you go to filter without resetting the filters. When using any of the detail row filters (account, action start and end date) the primary row filters but all actions remain below primary row.

New behavior: Searching by user account works the 2nd time you go to filter without resetting the filters. When using any of the detail row filters (account, action start and end date) the primary row filters and only applicable data rows show below the primary row.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.