### PR TITLE
audit log ui: reduce filter accordion width

### DIFF
--- a/app/views/event_logs/_event_log_tab.html.erb
+++ b/app/views/event_logs/_event_log_tab.html.erb
@@ -15,9 +15,11 @@
     <% end %>
 
     <div class="filters-container">
-      <div id="filters-toggle" class="filters-toggle">
-        <span class="glyphicon glyphicon-chevron-right" id="filters-arrow"></span>
-        <span class="filters-text"><%= l10n("event_log.filters") %></span>
+      <div>
+        <span id="filters-toggle" class="filters-toggle">
+          <span class="glyphicon glyphicon-chevron-right" id="filters-arrow"></span>
+          <span class="filters-text" ><%= l10n("event_log.filters") %></span>
+        </span>
       </div>
       <form class="filters" id="filters">
         <h2><%= l10n("event_log.eligibility") %> <%= l10n("Details") %></h2>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2659995/stories/186986518

# A brief description of the changes

Current behavior: The clickable area for the filter accordion spans the width of the page, leading to misclicks

New behavior: The clickable area only contains the word and icon

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.