### PR TITLE
fix display issues on sign up password tooltip

### DIFF
--- a/app/javascript/controllers/signup_controller.js
+++ b/app/javascript/controllers/signup_controller.js
@@ -32,7 +32,7 @@ emailTooltip() {
 }
 
 passwordTooltip() {
-  let passwordLength = $('#user_password').minLength;
+  let passwordLength = document.getElementById("user_password").minLength;
   const passwordHelper =
     `<p>Your password must:</p>
      <ul class="list-group pwHelper">
@@ -61,7 +61,7 @@ validateInput() {
   // Password text must be present
   if (this.passwordFieldTarget.value.length > 0 && document.querySelector('.pwHelper')) {
     const value = this.passwordFieldTarget.value;
-    const minLength = $('#user_password').minLength;
+    const minLength = document.getElementById("user_password").minLength;
     this.validateLength(value, minLength);
     this.validateNumber(value);
     this.validateSpecialCharacters(value);

--- a/features/insured/individual_account_creation.feature
+++ b/features/insured/individual_account_creation.feature
@@ -70,3 +70,8 @@ Feature: UI validations for Email, Username, SSN already in use, and weak Passwo
     When Individual visits the Consumer portal during open enrollment
     When Individual creates a new HBX account with a weak password
     Then Individual should see a minimum password length of 8
+
+  Scenario: Password field tooltip is displayed on focus and strong password length feature is disabled
+    Given the strong password length feature is disabled
+    When Individual focus on the password field
+    Then Individual should see the password tooltip with text minimum characters 8

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -504,6 +504,14 @@ When(/I click on none of the situations listed above apply checkbox$/) do
   expect(page).to have_content 'To enroll before open enrollment'
 end
 
+When(/Individual focus on the password field$/) do
+  page.execute_script("document.getElementById('user_password').focus()")
+end
+
+Then(/^Individual should see the password tooltip with text minimum characters (.+)$/) do |length|
+  expect(page).to have_content("Be at least #{length} characters")
+end
+
 And(/I click on back to my account button$/) do
   expect(page).to have_content "To enroll before open enrollment, you must qualify for a special enrollment period"
   find('.interaction-click-control-back-to-my-account').click


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640059/stories/186720273

# A brief description of the changes

Current behavior: Sign up page password tool tip is displaying incorrect text and also the validations are not working properly.

New behavior: Fix incorrect text on password tool tip and also fix validations.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
<img width="1217" alt="Screenshot 2024-02-07 at 9 01 30 AM" src="https://github.com/ideacrew/enroll/assets/15880971/b53f51e0-f3d1-458e-94c8-ea4dfd1b3727">


# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.