### PR TITLE
audit log ui: reset all rows to be visible on 2nd search

### DIFF
--- a/app/views/event_logs/_event_log_tab.html.erb
+++ b/app/views/event_logs/_event_log_tab.html.erb
@@ -320,7 +320,6 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
     } else {
       $(this).closest('.mutliSelect').find('input[value="all"]').removeClass('partial-all')
     }
-
     label.text(checked_count + " Selected");
   }
 });
@@ -330,10 +329,8 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
     event.preventDefault();
 
     // reset visibility before running a new search
-    $('#event-log-table tbody tr.primary-row').each(function( index ) {
+    $('#event-log-table tbody tr').each(function( index ) {
       $(this).show();
-    });
-    $('#event-log-table tbody tr.detail-row').each(function( index ) {
       $(this).removeClass("hidden-by-filters");
     });
 
@@ -509,8 +506,6 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
     $('.fake-select-label').text("All");
     $('#event-log-table tbody tr').each(function( index ) {
       $(this).removeClass("hidden-by-filters");
-    });
-    $('#event-log-table tbody tr.primary-row').each(function( index ) {
       $(this).show();
     });
   });


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187001687

# A brief description of the changes

Current behavior: After filtering once to narrow down detail rows, all filtered rows remain hidden even once the filters have been adjusted again

New behavior: After filtering once to narrow down detail rows, all the appropriate rows show

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.