### PR TITLE
check if primary is eligible for pediatric dental

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -267,7 +267,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
     return false if enrollment.is_health_enrollment?
     return false unless dental_renewal_product.allows_child_only_offering?
 
-    member.person.age_on(renewal_coverage_start) >= 19
+    member.person.age_on(member.coverage_start_on) < 19 && member.person.age_on(renewal_coverage_start) >= 19
   end
 
   # Find the dental product using renewal_product_id

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -277,7 +277,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
 
   # rubocop:disable Style/RedundantReturn
   def eligible_to_get_covered?(member)
-    valid_relations_for_pediatric_dental = %w[child ward foster_child adopted_child]
+    valid_relations_for_pediatric_dental = ["self", "child", "ward", "foster_child", "adopted_child"]
     return true unless valid_relations_for_pediatric_dental.include?(member.family_member.relationship)
 
     return false if turned_19_during_renewal_with_pediatric_only_qdp?(member)

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -279,10 +279,9 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   def eligible_to_get_covered?(member)
     valid_relations_for_pediatric_dental = ["self", "child", "ward", "foster_child", "adopted_child"]
     return true unless valid_relations_for_pediatric_dental.include?(member.family_member.relationship)
-    return true if member.family_member.relationship == "self" && member.person.age_on(member.coverage_start_on) > 19
+    return true if member.family_member.relationship == "self" && member.person.age_on(member.coverage_start_on) >= 19
 
     return false if turned_19_during_renewal_with_pediatric_only_qdp?(member)
-
     return true if member.family_member.age_off_excluded
 
     if EnrollRegistry.feature_enabled?(:age_off_relaxed_eligibility)

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -277,8 +277,8 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
 
   # rubocop:disable Style/RedundantReturn
   def eligible_to_get_covered?(member)
-    child_relations = %w[child ward foster_child adopted_child]
-    return true unless child_relations.include?(member.family_member.relationship)
+    valid_relations_for_pediatric_dental = %w[child ward foster_child adopted_child]
+    return true unless valid_relations_for_pediatric_dental.include?(member.family_member.relationship)
 
     return false if turned_19_during_renewal_with_pediatric_only_qdp?(member)
 
@@ -294,7 +294,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
         }
       end
       return true if dependent_coverage_eligible.success?
-    elsif child_relations.include?(member.family_member.relationship)
+    elsif valid_relations_for_pediatric_dental.include?(member.family_member.relationship)
       return true if member.person.age_on(renewal_coverage_start.prev_day) < 26
     end
 

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -279,7 +279,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   def eligible_to_get_covered?(member)
     valid_relations_for_pediatric_dental = ["self", "child", "ward", "foster_child", "adopted_child"]
     return true unless valid_relations_for_pediatric_dental.include?(member.family_member.relationship)
-    return true if member.family_member.relationship == "self" &&  member.person.age_on(member.coverage_start_on) > 19
+    return true if member.family_member.relationship == "self" && member.person.age_on(member.coverage_start_on) > 19
 
     return false if turned_19_during_renewal_with_pediatric_only_qdp?(member)
 

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -267,7 +267,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
     return false if enrollment.is_health_enrollment?
     return false unless dental_renewal_product.allows_child_only_offering?
 
-    member.person.age_on(member.coverage_start_on) < 19 && member.person.age_on(renewal_coverage_start) >= 19
+    member.person.age_on(renewal_coverage_start) >= 19
   end
 
   # Find the dental product using renewal_product_id
@@ -279,6 +279,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   def eligible_to_get_covered?(member)
     valid_relations_for_pediatric_dental = ["self", "child", "ward", "foster_child", "adopted_child"]
     return true unless valid_relations_for_pediatric_dental.include?(member.family_member.relationship)
+    return true if member.family_member.relationship == "self" &&  member.person.age_on(member.coverage_start_on) > 19
 
     return false if turned_19_during_renewal_with_pediatric_only_qdp?(member)
 

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -589,7 +589,7 @@ registry:
           - key: :cut_off_age
             item: 26
           - key: :relationship_kinds
-            item: ['child', 'ward', 'foster_child', 'adopted_child']
+            item: ['self', 'child', 'ward', 'foster_child', 'adopted_child']
       - key: :age_off_relaxed_eligibility
         item: Operations::AgeOffRelaxedEligibility.new
         is_enabled: true

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -608,7 +608,7 @@ registry:
           - key: :cut_off_age
             item: 26
           - key: :relationship_kinds
-            item: ['child', 'ward', 'foster_child', 'adopted_child']
+            item: ['self', 'child', 'ward', 'foster_child', 'adopted_child']
       - key: :age_off_relaxed_eligibility
         item: Operations::AgeOffRelaxedEligibility.new
         is_enabled: true

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec_1.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec_1.rb
@@ -299,21 +299,21 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
         enrollment_renewal
       end
 
-      context 'where member age is less than 19 years old' do
+      context 'when member age is less than 19 years old' do
         let(:value) { 18 }
-        it 'member is not eligible to get covered' do
+        it 'member is eligible to get covered' do
           expect(subject.eligible_to_get_covered?(member)).to be_truthy
         end
       end
 
-      context 'where member age is 19 years old' do
+      context 'when member age is 19 years old' do
         let(:value) { 19 }
         it 'member is not eligible to get covered' do
           expect(subject.eligible_to_get_covered?(member)).to be_falsey
         end
       end
 
-      context 'where member age is greater than 19 years old' do
+      context 'when member age is greater than 19 years old' do
         let(:value) { 20 }
         it 'member is eligible to get covered' do
           expect(subject.eligible_to_get_covered?(member)).to be_truthy

--- a/spec/shared_contexts/family_enrollment_renewal.rb
+++ b/spec/shared_contexts/family_enrollment_renewal.rb
@@ -129,6 +129,19 @@ RSpec.shared_context "setup family initial and renewal enrollments data", :share
     prod
   end
 
+  let!(:current_dental_product) do
+    prod =
+    FactoryBot.create(:benefit_markets_products_dental_products_dental_product,
+      :with_renewal_product,
+      application_period: application_period,
+      product_package_kinds: [:single_product],
+      service_area: service_area,
+      renewal_service_area: renewal_service_area,
+      metal_level_kind: :dental
+    )
+    prod
+  end
+
   let(:premium_table)        { build(:benefit_markets_products_premium_table, effective_period: application_period, rating_area: rating_area) }
 
   let!(:renewal_product) do

--- a/spec/shared_contexts/family_enrollment_renewal.rb
+++ b/spec/shared_contexts/family_enrollment_renewal.rb
@@ -131,14 +131,13 @@ RSpec.shared_context "setup family initial and renewal enrollments data", :share
 
   let!(:current_dental_product) do
     prod =
-    FactoryBot.create(:benefit_markets_products_dental_products_dental_product,
-      :with_renewal_product,
-      application_period: application_period,
-      product_package_kinds: [:single_product],
-      service_area: service_area,
-      renewal_service_area: renewal_service_area,
-      metal_level_kind: :dental
-    )
+      FactoryBot.create(:benefit_markets_products_dental_products_dental_product,
+                        :with_renewal_product,
+                        application_period: application_period,
+                        product_package_kinds: [:single_product],
+                        service_area: service_area,
+                        renewal_service_area: renewal_service_area,
+                        metal_level_kind: :dental)
     prod
   end
 

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -589,7 +589,7 @@ registry:
           - key: :cut_off_age
             item: 26
           - key: :relationship_kinds
-            item: ['child', 'ward', 'foster_child', 'adopted_child']
+            item: ['self', 'child', 'ward', 'foster_child', 'adopted_child']
       - key: :age_off_relaxed_eligibility
         item: Operations::AgeOffRelaxedEligibility.new
         is_enabled: true


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [pivotal-187003687](https://www.pivotaltracker.com/story/show/187003687)

# A brief description of the changes

Current behavior: Currently logic checks if the member has one of the relationships ["child", "ward", "foster_child", "adopted_child"]. Since the member is primary and relationship is self, the logic skips to validate the member age and renews the renewal product that is defined on the product.

New behavior: Verify if primary member is eligible for pediatric dental

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.