### PR TITLE
add permissions for audit logging

### DIFF
--- a/app/data_migrations/permissions/dc_define_permissions.rb
+++ b/app/data_migrations/permissions/dc_define_permissions.rb
@@ -129,6 +129,7 @@ class DcDefinePermissions < MigrationTask
     hbx_admin_can_edit_osse_eligibility
     hbx_admin_can_view_notice_templates
     hbx_admin_can_edit_notice_templates
+    hbx_admin_can_view_audit_log
   end
 
   def build_test_roles
@@ -179,6 +180,11 @@ class DcDefinePermissions < MigrationTask
     Permission.hbx_staff.update_attributes!(can_edit_osse_eligibility: true)
     Permission.super_admin.update_attributes!(can_edit_osse_eligibility: true)
     Permission.hbx_tier3.update_attributes!(can_edit_osse_eligibility: true)
+  end
+
+  def hbx_admin_can_view_audit_log
+    Permission.super_admin.update_attributes!(can_view_audit_log: true)
+    Permission.hbx_tier3.update_attributes!(can_view_audit_log: true)
   end
 
   def hbx_admin_can_update_ssn

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -61,6 +61,7 @@ class Permission
   field :can_edit_broker_agency_profile, type: Boolean, default: false
   field :can_view_notice_templates, type: Boolean, default: false
   field :can_edit_notice_templates, type: Boolean, default: false
+  field :can_view_audit_log, type: Boolean, default: false
 
   class << self
     def hbx_staff

--- a/app/policies/family_policy.rb
+++ b/app/policies/family_policy.rb
@@ -129,6 +129,6 @@ class FamilyPolicy < ApplicationPolicy
   def can_view_audit_log?
     return false if user.blank? || user.person.blank?
 
-    user.has_hbx_staff_role?
+    user.has_hbx_staff_role? && user.person.hbx_staff_role.permission.can_view_audit_log
   end
 end

--- a/app/policies/hbx_profile_policy.rb
+++ b/app/policies/hbx_profile_policy.rb
@@ -209,6 +209,12 @@ class HbxProfilePolicy < ApplicationPolicy
     true if role
   end
 
+  def can_view_audit_log?
+    role = user_hbx_staff_role
+    return false unless role
+    role.permission.can_view_audit_log
+  end
+
   private
 
   def user_hbx_staff_role

--- a/app/views/ui-components/v1/navs/_families_navigation.html.slim
+++ b/app/views/ui-components/v1/navs/_families_navigation.html.slim
@@ -33,7 +33,7 @@ nav
         span.badge.message-unread.ml-half
           = @person.inbox.unread_messages.size
 
-    - if current_user.try(:has_hbx_staff_role?) && event_logging_enabled?
+    - if event_logging_enabled? && pundit_allow(HbxProfile, :can_view_audit_log?)
       li
         = link_to(main_app.event_logs_insured_families_path(tab: 'event_log_ivl')) do
           = l10n("audit_log")

--- a/features/support/worlds/permissions_world.rb
+++ b/features/support/worlds/permissions_world.rb
@@ -24,11 +24,11 @@ module PermissionsWorld
                        modify_admin_tabs: false, view_admin_tabs: true,  view_the_configuration_tab: true, can_submit_time_travel_request: false)
     Permission.create!(name: 'hbx_tier3', modify_family: true, modify_employer: false, revert_application: false, list_enrollments: true,
                        send_broker_agency_message: false, approve_broker: false, approve_ga: false,
-                       modify_admin_tabs: false, view_admin_tabs: true,  view_the_configuration_tab: true, can_submit_time_travel_request: false)
+                       modify_admin_tabs: false, view_admin_tabs: true,  view_the_configuration_tab: true, can_submit_time_travel_request: false, can_view_audit_log: true)
     Permission.create!(name: 'super_admin', modify_family: true, modify_employer: true, revert_application: true, list_enrollments: true,
                        send_broker_agency_message: true, approve_broker: true, approve_ga: true, can_update_ssn: false, can_complete_resident_application: false,
                        can_add_sep: false, can_lock_unlock: true, can_view_username_and_email: false, can_reset_password: false, modify_admin_tabs: true,
-                       view_admin_tabs: true, can_extend_open_enrollment: true, can_change_fein: true, view_the_configuration_tab: true, can_submit_time_travel_request: false, can_send_secure_message: true)
+                       view_admin_tabs: true, can_extend_open_enrollment: true, can_change_fein: true, view_the_configuration_tab: true, can_submit_time_travel_request: false, can_send_secure_message: true, can_view_audit_log: true)
   end
 
   def hbx_admin_can_update_ssn


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186781770

# A brief description of the changes

Current behavior: allowing audit log to be visible for all users with hbx_staff_role

New behavior: added permission attribute to set true/false for viewing audit log. Updated dc permissions rake task to set view_audit_log permission true only for super_admin and hbx_tier3 roles.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.