### PR TITLE
add eligible_child_care_subsidy to hbx_enrollment entity and contract

### DIFF
--- a/app/domain/entities/hbx_enrollments/hbx_enrollment.rb
+++ b/app/domain/entities/hbx_enrollments/hbx_enrollment.rb
@@ -46,6 +46,7 @@ module Entities
       attribute :applied_aptc_amount,                  Types::Strict::Float.optional.meta(omittable: true)
       attribute :consumer_role_id,                     Types::Bson.optional.meta(omittable: true)
       attribute :resident_role_id,                     Types::Bson.optional.meta(omittable: true)
+      attribute :eligible_child_care_subsidy,          Types::Strict::Float.optional.meta(omittable: true)
       # SHOP fields
       attribute :employee_role_id,                     Types::Bson.optional.meta(omittable: true)
       attribute :benefit_group_id,                     Types::Bson.optional.meta(omittable: true)

--- a/app/domain/validators/hbx_enrollments/hbx_enrollment_contract.rb
+++ b/app/domain/validators/hbx_enrollments/hbx_enrollment_contract.rb
@@ -64,6 +64,8 @@ module Validators
         optional(:elected_premium_credit).maybe(:float)
         optional(:applied_premium_credit).maybe(:float)
 
+        optional(:eligible_child_care_subsidy).maybe(:float)
+
         optional(:hbx_enrollment_members).array(:hash)
 
         optional(:family_id).maybe(Types::Bson)

--- a/spec/domain/operations/hbx_enrollments/reinstate_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/reinstate_spec.rb
@@ -83,7 +83,11 @@ RSpec.describe Operations::HbxEnrollments::Reinstate, :type => :model, dbclean: 
 
       context 'for a terminated enrollment' do
         before do
+          # binding.pry
+          # TODO: REMOVE
+          # enrollment.eligible_child_care_subsidy = Money.new(100)
           @reinstated_enrollment = subject.call({hbx_enrollment: enrollment, options: {benefit_package: new_bga.benefit_package}}).success
+          # binding.pry
         end
 
         it 'should build reinstated enrollment' do
@@ -117,6 +121,17 @@ RSpec.describe Operations::HbxEnrollments::Reinstate, :type => :model, dbclean: 
           expect(enrollment_member.coverage_start_on).to eq enrollment.effective_on
           expect(enrollment_member.eligibility_date).to eq @reinstated_enrollment.effective_on
           expect(@reinstated_enrollment.hbx_enrollment_members.size).to eq enrollment.hbx_enrollment_members.size
+        end
+      end
+
+      context 'for a terminated HC4CC enrollment' do
+        before do
+          enrollment.eligible_child_care_subsidy = Money.new(15000)
+          @reinstated_enrollment = subject.call({hbx_enrollment: enrollment, options: {benefit_package: new_bga.benefit_package}}).success
+        end
+
+        it 'should reapply childcare subsidy for reinstated HC4CC enrollment' do
+          expect(@reinstated_enrollment.eligible_child_care_subsidy.to_s).to eq "150.00"
         end
       end
 

--- a/spec/domain/operations/hbx_enrollments/reinstate_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/reinstate_spec.rb
@@ -83,11 +83,7 @@ RSpec.describe Operations::HbxEnrollments::Reinstate, :type => :model, dbclean: 
 
       context 'for a terminated enrollment' do
         before do
-          # binding.pry
-          # TODO: REMOVE
-          # enrollment.eligible_child_care_subsidy = Money.new(100)
           @reinstated_enrollment = subject.call({hbx_enrollment: enrollment, options: {benefit_package: new_bga.benefit_package}}).success
-          # binding.pry
         end
 
         it 'should build reinstated enrollment' do

--- a/spec/domain/operations/hbx_enrollments/reinstate_spec.rb
+++ b/spec/domain/operations/hbx_enrollments/reinstate_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Operations::HbxEnrollments::Reinstate, :type => :model, dbclean: 
 
       context 'for a terminated HC4CC enrollment' do
         before do
-          enrollment.eligible_child_care_subsidy = Money.new(15000)
+          enrollment.eligible_child_care_subsidy = Money.new(15_000)
           @reinstated_enrollment = subject.call({hbx_enrollment: enrollment, options: {benefit_package: new_bga.benefit_package}}).success
         end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[104802](https://redmine.priv.dchbx.org/issues/104802)

# A brief description of the changes

Current behavior:
When reinstating a terminated HC4CC enrollment the eligible_child_care_subsidy amount is not reapplied.

New behavior:
The eligible_child_care_subsidy amount is reapplied to the reinstated HC4CC enrollment.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.