### PR TITLE
grant permission to view audit log for super_admin and hbx_tier3 roles

### DIFF
--- a/app/views/ui-components/v1/navs/_employers_navigation.html.slim
+++ b/app/views/ui-components/v1/navs/_employers_navigation.html.slim
@@ -20,7 +20,7 @@ nav
         | Messages
         span.badge.message-unread #{profile_unread_messages_count(profile)}
 
-    - if current_user.try(:has_hbx_staff_role?) && event_logging_enabled?
+    - if event_logging_enabled? && pundit_allow(HbxProfile, :can_view_audit_log?)
       li
         = link_to 'Audit Log', benefit_sponsors.profiles_employers_employer_profile_path(profile.id, :tab => 'event_log_shop'), "aria-expanded" => "true"
   .my-account-widget.panel.panel-default

--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/employers/employer_profiles_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/employers/employer_profiles_controller.rb
@@ -58,6 +58,7 @@ module BenefitSponsors
           when 'inbox'
               # do something
           when 'event_log_shop'
+            authorize @employer_profile, :can_view_audit_log?
             @event_logs = EventLogs::MonitoredEvent.where(subject_hbx_id: @employer_profile.hbx_id)&.order(:event_time.desc)&.map(&:eligibility_details)
           else
             else_block

--- a/components/benefit_sponsors/app/policies/benefit_sponsors/employer_profile_policy.rb
+++ b/components/benefit_sponsors/app/policies/benefit_sponsors/employer_profile_policy.rb
@@ -91,5 +91,11 @@ module BenefitSponsors
     def can_modify_employer?
       user.has_hbx_staff_role? && user.person.hbx_staff_role.permission.modify_employer
     end
+
+    def can_view_audit_log?
+      return false if user.blank? || user.person.blank?
+
+      user.has_hbx_staff_role? && user.person.hbx_staff_role.permission.can_view_audit_log
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186781770

# A brief description of the changes

Current behavior: all hbx staff roles can view audit log

New behavior: restrict audit log to only hbx_tier3 and super_admin

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.