### PR TITLE
Fix Plan Shopping Bug

### DIFF
--- a/app/domain/operations/premium_credits/find_aptc.rb
+++ b/app/domain/operations/premium_credits/find_aptc.rb
@@ -161,7 +161,7 @@ module Operations
         coinciding_enrollments.reduce(0.0) do |sum, previous_enrollment|
           th_enrollment = TaxHouseholdEnrollment.where(enrollment_id: previous_enrollment.id, tax_household_id: aptc_grant.tax_household_id).first
           next sum if th_enrollment.blank?
-          value = round_down_float_two_decimals(th_enrollment.available_max_aptc)
+          value = round_down_float_two_decimals(th_enrollment.available_max_aptc || 0.0)
 
           sum += (value > 0.0 ? value : 0.0)
           sum

--- a/app/domain/operations/premium_credits/find_aptc.rb
+++ b/app/domain/operations/premium_credits/find_aptc.rb
@@ -161,7 +161,7 @@ module Operations
         coinciding_enrollments.reduce(0.0) do |sum, previous_enrollment|
           th_enrollment = TaxHouseholdEnrollment.where(enrollment_id: previous_enrollment.id, tax_household_id: aptc_grant.tax_household_id).first
           next sum if th_enrollment.blank?
-          value = round_down_float_two_decimals(th_enrollment.available_max_aptc || 0.0)
+          value = round_down_float_two_decimals(th_enrollment.available_max_aptc || 0)
 
           sum += (value > 0.0 ? value : 0.0)
           sum

--- a/spec/domain/operations/premium_credits/find_aptc_spec.rb
+++ b/spec/domain/operations/premium_credits/find_aptc_spec.rb
@@ -639,7 +639,7 @@ RSpec.describe Operations::PremiumCredits::FindAptc, dbclean: :after_each do
 
             it 'returns difference of benchmark_premium and remaining monthly_expected_contribution that was met from prev enrollment' do
               expect(result.success?).to eq true
-              expect(result.value!).to eq 0.0
+              expect(result.value!).to eq 1045.00
             end
           end
         end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/187001973

# A brief description of the changes

Current behavior:
When a user is plan shopping with available_max_aptc: nil, we are having an error on plan shopping page.

`ArgumentError (invalid value for BigDecimal(): "")`

If a person is uqhp ineligible then aptc is being set to nil, which is correct behavior.

New behavior:
Fixing that issue by setting 0.0 value for nil values fixes this issue

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.