### PR TITLE
changing the feature flag value to boolean

### DIFF
--- a/app/domain/operations/fdsh/ssa/h3/request_ssa_verification.rb
+++ b/app/domain/operations/fdsh/ssa/h3/request_ssa_verification.rb
@@ -16,7 +16,7 @@ module Operations
           # @param [ Hash ] params Applicant Attributes
           # @return [ BenefitMarkets::Entities::Applicant ] applicant Applicant
           def call(person)
-            if EnrollRegistry[:ssa_h3].setting(:use_transmittable).item == "true"
+            if EnrollRegistry[:ssa_h3].setting(:use_transmittable).item
               values = yield build_transmittable_values(person)
               @job = yield create_job(values)
               transmission_params = yield construct_response_transmission_params(values)
@@ -63,7 +63,7 @@ module Operations
 
           def build_and_validate_payload_entity(person)
             result = Operations::Fdsh::BuildAndValidatePersonPayload.new.call(person, :ssa)
-            return result unless EnrollRegistry[:ssa_h3].setting(:use_transmittable).item == "true"
+            return result unless EnrollRegistry[:ssa_h3].setting(:use_transmittable).item
             if result.success?
               @transaction.json_payload = result.value!.to_h
               @transaction.save
@@ -94,7 +94,7 @@ module Operations
 
           def publish(event)
             event.publish
-            if EnrollRegistry[:ssa_h3].setting(:use_transmittable).item == "true"
+            if EnrollRegistry[:ssa_h3].setting(:use_transmittable).item
               update_status("successfully sent request to fdsh_gateway", :transmitted, { job: @job })
               update_status("successfully sent request to fdsh_gateway", :succeeded, { transmission: @transmission, transaction: @transaction })
             end

--- a/app/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor.rb
+++ b/app/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor.rb
@@ -23,7 +23,7 @@ module Operations
           private
 
           def find_transmittable(params)
-            return Success({}) unless EnrollRegistry[:ssa_h3].setting(:use_transmittable).item == "true"
+            return Success({}) unless EnrollRegistry[:ssa_h3].setting(:use_transmittable).item
             person = find_person(params[:person_hbx_id], nil)
             subject = person.value!&.to_global_id&.uri if person.success?
             result = Operations::Transmittable::GenerateResponseObjects.new.call({job_id: params[:metadata]&.job_id,
@@ -94,7 +94,7 @@ module Operations
           end
 
           def record_results(transmittable_objects)
-            return Success() unless EnrollRegistry[:ssa_h3].setting(:use_transmittable).item == "true"
+            return Success() unless EnrollRegistry[:ssa_h3].setting(:use_transmittable).item
             update_status("Processed SSA response", :succeeded, transmittable_objects.except(:subject))
           end
         end

--- a/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -26,7 +26,7 @@ registry:
         - key: :payload_type
           item:  <%= ENV['SSA_H3_PAYLOAD_TYPE'] || "xml" %>
         - key: :use_transmittable
-          item: <%= ENV['SSA_H3_USE_TRANSMITTABLE'] || "false" %>
+          item: <%= ENV['SSA_H3_USE_TRANSMITTABLE'] || false %>
       - key: :non_esi_h31
         is_enabled: true
         settings:

--- a/config/client_config/me/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -26,7 +26,7 @@ registry:
         - key: :payload_type
           item:  <%= ENV['SSA_H3_PAYLOAD_TYPE'] || "xml" %>
         - key: :use_transmittable
-          item: <%= ENV['SSA_H3_USE_TRANSMITTABLE'] || "false" %>
+          item: <%= ENV['SSA_H3_USE_TRANSMITTABLE'] || false %>
       - key: :non_esi_h31
         is_enabled: true
         settings:

--- a/spec/domain/operations/fdsh/ssa/h3/request_ssa_verification_spec.rb
+++ b/spec/domain/operations/fdsh/ssa/h3/request_ssa_verification_spec.rb
@@ -27,7 +27,7 @@ module Operations
 
     context "when use_transmittable is true" do
       before do
-        allow(EnrollRegistry[:ssa_h3].setting(:use_transmittable)).to receive(:item).and_return("true")
+        allow(EnrollRegistry[:ssa_h3].setting(:use_transmittable)).to receive(:item).and_return(true)
         @result = described_class.new.call(person)
       end
 

--- a/spec/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor_spec.rb
+++ b/spec/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor_spec.rb
@@ -152,7 +152,7 @@ module Operations
       end
 
       before do
-        allow(EnrollRegistry[:ssa_h3].setting(:use_transmittable)).to receive(:item).and_return("true")
+        allow(EnrollRegistry[:ssa_h3].setting(:use_transmittable)).to receive(:item).and_return(true)
         person.consumer_role.update!(aasm_state: "ssa_pending")
         person.consumer_role.vlp_documents << FactoryBot.build(:vlp_document, :identifier => 'identifier', :verification_type => 'Immigration type')
         @result = described_class.new.call({person_hbx_id: person.hbx_id, response: response.to_h})

--- a/system/config/templates/features/enroll_app/fdsh_services.yml
+++ b/system/config/templates/features/enroll_app/fdsh_services.yml
@@ -26,7 +26,7 @@ registry:
         - key: :payload_type
           item:  <%= ENV['SSA_H3_PAYLOAD_TYPE'] || "xml" %>
         - key: :use_transmittable
-          item: <%= ENV['SSA_H3_USE_TRANSMITTABLE'] || "false" %>
+          item: <%= ENV['SSA_H3_USE_TRANSMITTABLE'] || false %>
       - key: :non_esi_h31
         is_enabled: true
         settings:


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186938487

# A brief description of the changes

Current behavior: current the flag value is string.

New behavior: Changing the flag value to boolean

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.