### PR TITLE
read metadata headers for job id and status

### DIFF
--- a/app/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor.rb
+++ b/app/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor.rb
@@ -26,7 +26,7 @@ module Operations
             return Success({}) unless EnrollRegistry[:ssa_h3].setting(:use_transmittable).item
             person = find_person(params[:person_hbx_id], nil)
             subject = person.value!&.to_global_id&.uri if person.success?
-            result = Operations::Transmittable::GenerateResponseObjects.new.call({job_id: params[:metadata][:header]&.job_id,
+            result = Operations::Transmittable::GenerateResponseObjects.new.call({job_id: params[:metadata][:headers]&.job_id,
                                                                                   key: :ssa_verification_response,
                                                                                   payload: params[:response],
                                                                                   correlation_id: params[:person_hbx_id],

--- a/app/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor.rb
+++ b/app/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor.rb
@@ -26,7 +26,7 @@ module Operations
             return Success({}) unless EnrollRegistry[:ssa_h3].setting(:use_transmittable).item
             person = find_person(params[:person_hbx_id], nil)
             subject = person.value!&.to_global_id&.uri if person.success?
-            result = Operations::Transmittable::GenerateResponseObjects.new.call({job_id: params[:metadata]&.job_id,
+            result = Operations::Transmittable::GenerateResponseObjects.new.call({job_id: params[:metadata][:header]&.job_id,
                                                                                   key: :ssa_verification_response,
                                                                                   payload: params[:response],
                                                                                   correlation_id: params[:person_hbx_id],

--- a/spec/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor_spec.rb
+++ b/spec/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor_spec.rb
@@ -117,7 +117,7 @@ module Operations
       end
 
       subject do
-        described_class.new.call({person_hbx_id: person.hbx_id, response: response.to_h})
+        described_class.new.call({person_hbx_id: person.hbx_id, metadata: {}, response: response.to_h})
       end
 
       it "should pass" do
@@ -155,7 +155,7 @@ module Operations
         allow(EnrollRegistry[:ssa_h3].setting(:use_transmittable)).to receive(:item).and_return(true)
         person.consumer_role.update!(aasm_state: "ssa_pending")
         person.consumer_role.vlp_documents << FactoryBot.build(:vlp_document, :identifier => 'identifier', :verification_type => 'Immigration type')
-        @result = described_class.new.call({person_hbx_id: person.hbx_id, response: response.to_h})
+        @result = described_class.new.call({person_hbx_id: person.hbx_id, metadata: {}, response: response.to_h})
       end
 
       it "should pass" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186938499

# A brief description of the changes

Current behavior: currently trying to read job id incorrectly

New behavior: checking headers to pick job id.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.