### PR TITLE
move wf_sso logic from employer home tab to accounts

### DIFF
--- a/app/models/wells_fargo/bill_pay/single_sign_on.rb
+++ b/app/models/wells_fargo/bill_pay/single_sign_on.rb
@@ -55,6 +55,8 @@ module WellsFargo
           )
 
           req_options = {
+            open_timeout: 30,
+            ssl_timeout: 30,
             use_ssl: uri.scheme == "https"
           }
 

--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/employers/employer_profiles_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/employers/employer_profiles_controller.rb
@@ -16,7 +16,6 @@ module BenefitSponsors
         ]
         before_action :load_group_enrollments, only: [:coverage_reports], if: :is_format_csv?
         before_action :check_and_download_invoice, only: [:download_invoice, :show_invoice]
-        before_action :wells_fargo_sso, only: [:show]
         before_action :set_flash_by_announcement, only: :show
         layout "two_column", except: [:new]
 
@@ -66,6 +65,7 @@ module BenefitSponsors
         end
 
         def accounts_block
+          wells_fargo_sso
           collect_and_sort_invoices(params[:sort_order])
           @benefit_sponsorship = @employer_profile.organization.active_benefit_sponsorship
           @benefit_sponsorship_account = @benefit_sponsorship.benefit_sponsorship_account

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/profiles/employers/employer_profiles_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/profiles/employers/employer_profiles_controller_spec.rb
@@ -207,6 +207,32 @@ module BenefitSponsors
         end
       end
 
+      context 'employee tab' do
+        before do
+          allow(::WellsFargo::BillPay::SingleSignOn).to receive(:new).and_return(double(url: "http://example.com", token: "token"))
+          get :show, params: {id: benefit_sponsor.profiles.first.id.to_s, tab: 'employees'}
+          allow(employer_profile).to receive(:active_benefit_sponsorship).and_return benefit_sponsorship
+        end
+
+        it "does not create a WellsFargoSSO instance" do
+          expect(assigns(:wells_fargo_sso)).to be_nil
+          expect(assigns(:wf_url)).to be_nil
+        end
+      end
+
+      context 'accounts tab' do
+        before do
+          allow(::WellsFargo::BillPay::SingleSignOn).to receive(:new).and_return(double(url: "http://example.com", token: "token"))
+          get :show, params: {id: benefit_sponsor.profiles.first.id.to_s, tab: 'accounts'}
+          allow(employer_profile).to receive(:active_benefit_sponsorship).and_return benefit_sponsorship
+        end
+
+        it "creates a WellsFargoSSO instance and sets @wf_url" do
+          expect(assigns(:wells_fargo_sso)).to be_present
+          expect(assigns(:wf_url)).to eq("http://example.com")
+        end
+      end
+
     end
 
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[97986](https://redmine.priv.dchbx.org/issues/97986)

# A brief description of the changes

Current behavior:
WF SSO token is requested on the employer home tab while only being needed on the accounts tab. If an error happens at this point it can stop the employer from accessing their entire account page.

New behavior:
WF SSO token is requested on the accounts tab where "Pay Online" buttons are displayed.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.