### PR TITLE
ssa subscriber properly handle failure responses

### DIFF
--- a/app/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor.rb
+++ b/app/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor.rb
@@ -26,7 +26,7 @@ module Operations
             return Success({}) unless EnrollRegistry[:ssa_h3].setting(:use_transmittable).item
             person = find_person(params[:person_hbx_id], nil)
             subject = person.value!&.to_global_id&.uri if person.success?
-            result = Operations::Transmittable::GenerateResponseObjects.new.call({job_id: params[:metadata][:headers]&.job_id,
+            result = Operations::Transmittable::GenerateResponseObjects.new.call({job_id: params[:metadata][:headers]["job_id"],
                                                                                   key: :ssa_verification_response,
                                                                                   payload: params[:response],
                                                                                   correlation_id: params[:person_hbx_id],

--- a/app/event_source/subscribers/fdsh_gateway/ssa_verifications_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/ssa_verifications_subscriber.rb
@@ -10,19 +10,21 @@ module Subscribers
       subscribe(:on_ssa_verification_complete) do |delivery_info, metadata, response|
         logger.info "Ssa::SsaverificationsSubscriber: invoked on_ssa_verification_complete with delivery_info: #{delivery_info.inspect}, response: #{response.inspect}"
         payload = JSON.parse(response, :symbolize_names => true)
-        status = metadata[:headers].status
-        verification_payload = { person_hbx_id: metadata.correlation_id, metadata: metadata, response: payload }
-        if status == "failure"
-          handle_failure_response(metadata[:headers]&.job_id)
-        else
-          result = Operations::Fdsh::Ssa::H3::SsaVerificationResponseProcessor.new.call(verification_payload)
-        end
+        job_id = metadata[:headers]["job_id"]
+        status = metadata[:headers]["status"]
 
-        if result.success?
-          logger.info "Ssa::SsaverificationsSubscriber: on_ssa_verification_complete acked with success: #{result.success}"
+        if status == "failure"
+          handle_failure_response(job_id)
+          logger.info "Ssa::SsaverificationsSubscriber: on_ssa_verification_complete acked and processed failure from fdsh_gateway"
         else
-          errors = result.failure&.errors&.to_h
-          logger.info "Ssa::SsaverificationsSubscriber: on_ssa_verification_complete acked with failure, errors: #{errors}"
+          verification_payload = { person_hbx_id: metadata.correlation_id, metadata: metadata, response: payload }
+          result = Operations::Fdsh::Ssa::H3::SsaVerificationResponseProcessor.new.call(verification_payload)
+          if result.success?
+            logger.info "Ssa::SsaverificationsSubscriber: on_ssa_verification_complete acked with success: #{result.success}"
+          elsif result.failure
+            errors = result.failure
+            logger.info "Ssa::SsaverificationsSubscriber: on_ssa_verification_complete acked with failure, errors: #{errors}"
+          end
         end
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
@@ -35,8 +37,8 @@ module Subscribers
         job = Transmittable::Job.where(job_id: job_id)&.last
         return unless job
         message = "Job failed in FDSH Gateway"
-        Operations::Transmittable::UpdateProcessStatus.new.call({ transmittable_objects: { job: @job }, state: :failed, message: message })
-        Operations::Transmittable::AddError.new.call({ transmittable_objects: { job: @job }, key: :fdsh_gateway, message: message })
+        Operations::Transmittable::UpdateProcessStatus.new.call({ transmittable_objects: { job: job }, state: :failed, message: message })
+        Operations::Transmittable::AddError.new.call({ transmittable_objects: { job: job }, key: :fdsh_gateway, message: message })
       end
     end
   end

--- a/spec/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor_spec.rb
+++ b/spec/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor_spec.rb
@@ -117,7 +117,7 @@ module Operations
       end
 
       subject do
-        described_class.new.call({person_hbx_id: person.hbx_id, metadata: {}, response: response.to_h})
+        described_class.new.call({person_hbx_id: person.hbx_id, metadata: {headers: {}}, response: response.to_h})
       end
 
       it "should pass" do
@@ -155,7 +155,7 @@ module Operations
         allow(EnrollRegistry[:ssa_h3].setting(:use_transmittable)).to receive(:item).and_return(true)
         person.consumer_role.update!(aasm_state: "ssa_pending")
         person.consumer_role.vlp_documents << FactoryBot.build(:vlp_document, :identifier => 'identifier', :verification_type => 'Immigration type')
-        @result = described_class.new.call({person_hbx_id: person.hbx_id, metadata: {}, response: response.to_h})
+        @result = described_class.new.call({person_hbx_id: person.hbx_id, metadata: {headers: {}}, response: response.to_h})
       end
 
       it "should pass" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186938491

# A brief description of the changes

Current behavior: previously the job id was not being properly accessed and some of the logic in the subscriber lead to errors

New behavior: both failures and successes from FDSH are properly saved to transmittableobjects

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.