### PR TITLE
fix effective date display and formatting

### DIFF
--- a/app/models/event_logs/monitored_event.rb
+++ b/app/models/event_logs/monitored_event.rb
@@ -35,8 +35,8 @@ module EventLogs
       return {} unless json?(log&.payload)
       parsed = JSON.parse(log.payload, symbolize_names: true)
       details = JSON.parse(self.attributes.to_json, symbolize_names: true)
-      datetime = parsed.dig(:state_histories, 0, :effective_on)
-      effective_on = DateTime.parse(datetime.to_s)&.strftime("%d/%m/%Y") if datetime
+      datetime = parsed.dig(:state_histories, -1, :effective_on)
+      effective_on = DateTime.parse(datetime.to_s)&.strftime("%m/%d/%Y") if datetime
       subject = get_subject_name(log.subject_gid)
       detail = log.event_name&.match(/[^.]+\z/)&.to_s&.titleize
       build_details(parsed, details, effective_on, detail, subject)

--- a/app/views/event_logs/_event_log_tab.html.erb
+++ b/app/views/event_logs/_event_log_tab.html.erb
@@ -167,7 +167,7 @@
               <td colspan="2"></td>
               <td><%= detail[:detail] %></td>
               <td id="<%= detail[:account_hbx_id] %>" class="user_id"><%= detail[:account_username] %></td>
-              <td class="event-time"><%= detail[:event_time] %></td>
+              <td class="event-time"><%= format_time_display(detail[:event_time]) %></td>
             </tr>
             <% end %>
           <% end %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187046170

# A brief description of the changes

Current behavior: event log rows display incorrect effective date and also date displayed in format "%d/%m/%Y"

New behavior: event log row will display state and date correctly and fixed date format as "%m/%d/%Y"

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.