### PR TITLE
storing actual jwt token in localstorage

### DIFF
--- a/app/views/ui-components/v1/navs/_primary_nav.html.slim
+++ b/app/views/ui-components/v1/navs/_primary_nav.html.slim
@@ -56,7 +56,7 @@
               - if external_application_configured?("admin") && EnrollRegistry.feature_enabled?(:agency_staff)
                 li
                   - url = ExternalApplications::ApplicationProfile.find_by_application_name("admin").url + "/agencies/agency-staff"
-                  = link_to(url, "aria-expanded" => "true", data: { turbolinks: false }, id: "agencyStaffLinkToExternal") do
+                  = link_to(url, "aria-expanded" => "true", data: { turbolinks: false, jwt_token: jwt_for_external_application }, id: "agencyStaffLinkToExternal") do
                     span.hidden-xs
                       | Agency Staff
                     span.glyphicon.glyphicon-th-list.hidden-md.hidden-sm.hidden-lg title="Agency Staff"
@@ -101,9 +101,8 @@ javascript:
     const agencyStaffLink = document.getElementById('agencyStaffLinkToExternal');
     agencyStaffLink.addEventListener('click', function(event) {
       event.preventDefault();
-      const jwtToken = "<%= jwt_for_external_application %>";
+      const jwtToken = agencyStaffLink.dataset.jwtToken;
       window.localStorage.setItem("jwt", jwtToken);
       window.location.href = agencyStaffLink.href;
     });
   });
-


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/n/projects/2640063/stories/186571692
# A brief description of the changes

Current behavior:
storing a string in local storage 

New behavior:
storing actual jwt token in local storage

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.