### PR TITLE
disable general agency and employer data table

### DIFF
--- a/app/controllers/exchanges/hbx_profiles_controller.rb
+++ b/app/controllers/exchanges/hbx_profiles_controller.rb
@@ -875,11 +875,11 @@ def employer_poc
   private
 
   def redirect_if_employer_datatable_is_disabled
-    redirect_to(exchanges_hbx_profiles_root_path, notice: l10n('insured.employer_datatable_disabled_warning')) unless EnrollRegistry.feature_enabled?(:aca_shop_market)
+    redirect_to(exchanges_hbx_profiles_root_path, alert: l10n('insured.employer_datatable_disabled_warning')) unless EnrollRegistry.feature_enabled?(:aca_shop_market)
   end
 
   def redirect_if_general_agency_is_disabled
-    redirect_to(exchanges_hbx_profiles_root_path, notice: l10n('insured.general_agency_index_disabled_warning')) unless EnrollRegistry.feature_enabled?(:general_agency)
+    redirect_to(exchanges_hbx_profiles_root_path, alert: l10n('insured.general_agency_index_disabled_warning')) unless EnrollRegistry.feature_enabled?(:general_agency)
   end
 
   def redirect_if_staff_tab_is_disabled

--- a/app/controllers/exchanges/hbx_profiles_controller.rb
+++ b/app/controllers/exchanges/hbx_profiles_controller.rb
@@ -19,6 +19,8 @@ class Exchanges::HbxProfilesController < ApplicationController
   before_action :find_benefit_sponsorship, only: [:oe_extendable_applications, :oe_extended_applications, :edit_open_enrollment, :extend_open_enrollment, :close_extended_open_enrollment, :edit_fein, :update_fein, :force_publish, :edit_force_publish]
   before_action :redirect_if_staff_tab_is_disabled, only: [:staff_index]
   before_action :set_cache_headers, only: [:show, :family_index_dt, :user_account_index, :identity_verification, :broker_agency_index, :outstanding_verification_dt, :configuration, :inbox]
+  before_action :redirect_if_general_agency_is_disabled, only: [:general_agency_index]
+  before_action :redirect_if_employer_index_is_disabled, only: [:employer_datatable]
   # GET /exchanges/hbx_profiles
   # GET /exchanges/hbx_profiles.json
   layout 'single_column'
@@ -871,6 +873,14 @@ def employer_poc
   end
 
   private
+
+  def redirect_if_employer_index_is_disabled
+    redirect_to(exchanges_hbx_profiles_root_path, notice: l10n('insured.employer_index_disabled_warning')) unless EnrollRegistry.feature_enabled?(:aca_shop_market)
+  end
+
+  def redirect_if_general_agency_is_disabled
+    redirect_to(exchanges_hbx_profiles_root_path, notice: l10n('insured.general_agency_index_disabled_warning')) unless EnrollRegistry.feature_enabled?(:general_agency)
+  end
 
   def redirect_if_staff_tab_is_disabled
     redirect_to(main_app.root_path, notice: l10n("staff_index_not_enabled")) unless EnrollRegistry.feature_enabled?(:staff_tab)

--- a/app/controllers/exchanges/hbx_profiles_controller.rb
+++ b/app/controllers/exchanges/hbx_profiles_controller.rb
@@ -20,7 +20,7 @@ class Exchanges::HbxProfilesController < ApplicationController
   before_action :redirect_if_staff_tab_is_disabled, only: [:staff_index]
   before_action :set_cache_headers, only: [:show, :family_index_dt, :user_account_index, :identity_verification, :broker_agency_index, :outstanding_verification_dt, :configuration, :inbox]
   before_action :redirect_if_general_agency_is_disabled, only: [:general_agency_index]
-  before_action :redirect_if_employer_index_is_disabled, only: [:employer_datatable]
+  before_action :redirect_if_employer_datatable_is_disabled, only: [:employer_datatable]
   # GET /exchanges/hbx_profiles
   # GET /exchanges/hbx_profiles.json
   layout 'single_column'
@@ -874,8 +874,8 @@ def employer_poc
 
   private
 
-  def redirect_if_employer_index_is_disabled
-    redirect_to(exchanges_hbx_profiles_root_path, notice: l10n('insured.employer_index_disabled_warning')) unless EnrollRegistry.feature_enabled?(:aca_shop_market)
+  def redirect_if_employer_datatable_is_disabled
+    redirect_to(exchanges_hbx_profiles_root_path, notice: l10n('insured.employer_datatable_disabled_warning')) unless EnrollRegistry.feature_enabled?(:aca_shop_market)
   end
 
   def redirect_if_general_agency_is_disabled

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -600,5 +600,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.verification_acceptable_file_types' => "PDF, JPEG, PNG, and GIF",
   :'en.insured.verification_max_file_size' => "File should not exceed 100 MB",
   :'en.waiting_for_eligibility' => "Waiting for your eligibility results...",
-  :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.'
+  :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.',
+  :'en.insured.general_agency_index_disabled_warning' => 'The General Agency Index is Disabled',
+  :'en.insured.employer_datatable_disabled_warning' => 'The Employer Data Table is Disabled'
 }.freeze

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -599,6 +599,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.verification_acceptable_file_types' => "PDF, JPEG, PNG, and GIF",
   :'en.insured.verification_max_file_size' => "File should not exceed 100 MB",
   :'en.waiting_for_eligibility' => "Waiting for your eligibility results...",
-  :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.',:'en.insured.general_agency_index_disabled_warning' => 'The General Agency Index is Disabled',
+  :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.',
+  :'en.insured.general_agency_index_disabled_warning' => 'The General Agency Index is Disabled',
   :'en.insured.employer_datatable_disabled_warning' => 'The Employer Data Table is Disabled'
 }.freeze

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -599,5 +599,6 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.verification_acceptable_file_types' => "PDF, JPEG, PNG, and GIF",
   :'en.insured.verification_max_file_size' => "File should not exceed 100 MB",
   :'en.waiting_for_eligibility' => "Waiting for your eligibility results...",
-  :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.'
+  :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.',:'en.insured.general_agency_index_disabled_warning' => 'The General Agency Index is Disabled',
+  :'en.insured.employer_datatable_disabled_warning' => 'The Employer Data Table is Disabled'
 }.freeze

--- a/spec/controllers/exchanges/hbx_profiles_controller_spec.rb
+++ b/spec/controllers/exchanges/hbx_profiles_controller_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Exchanges::HbxProfilesController, dbclean: :around_each do
 
       it "has flash message" do
         get :employer_datatable, format: :html
-        expect(flash[:notice]).to eql(l10n('insured.employer_index_disabled_warning'))
+        expect(flash[:notice]).to eql(l10n('insured.employer_datatable_disabled_warning'))
       end
     end
 

--- a/spec/controllers/exchanges/hbx_profiles_controller_spec.rb
+++ b/spec/controllers/exchanges/hbx_profiles_controller_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Exchanges::HbxProfilesController, dbclean: :around_each do
 
       it "has flash message" do
         get :employer_datatable, format: :html
-        expect(flash[:notice]).to eql(l10n('insured.employer_datatable_disabled_warning'))
+        expect(flash[:alert]).to eql(l10n('insured.employer_datatable_disabled_warning'))
       end
     end
 
@@ -1067,7 +1067,7 @@ RSpec.describe Exchanges::HbxProfilesController, dbclean: :around_each do
 
       it "has flash message" do
         get :general_agency_index, format: :html, xhr: true
-        expect(flash[:notice]).to eql(l10n('insured.general_agency_index_disabled_warning'))
+        expect(flash[:alert]).to eql(l10n('insured.general_agency_index_disabled_warning'))
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-187050744](https://www.pivotaltracker.com/n/projects/2640060/stories/187050744)

# A brief description of the changes

Current behavior: Admin are able to navigate to the employer data table and the general agency page via url.

New behavior: Admin are blocked from navigating to the employer data table and the general agency page, and are redirected with a message.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.