### PR TITLE
disable audit logging for default osse eligibilities

### DIFF
--- a/app/domain/operations/ivl_osse_eligibilities/create_ivl_osse_eligibility.rb
+++ b/app/domain/operations/ivl_osse_eligibilities/create_ivl_osse_eligibility.rb
@@ -164,6 +164,7 @@ module Operations
 
       def publish_event(eligibility)
         event_name = eligibility_event_for(eligibility.current_state)
+        return Succcess(eligibility) unless event_name
 
         Operations::EventLogs::TrackableEvent.new.call({
                                                          event_name: event_name,
@@ -173,7 +174,11 @@ module Operations
                                                        })
       end
 
+      # This method is used to determine the event name for the current eligibility state.
+      # If default_eligibility is true, returns false indicating no eligibility event.
+      # If prospective_eligibility is true, returns the string representing the event for renewed eligibility.
       def eligibility_event_for(current_state)
+        return false if default_eligibility
         return 'events.people.eligibilities.ivl_osse_eligibility.eligibility_renewed' if prospective_eligibility
 
         case current_state
@@ -181,6 +186,8 @@ module Operations
           'events.people.eligibilities.ivl_osse_eligibility.eligibility_created'
         when :ineligible
           'events.people.eligibilities.ivl_osse_eligibility.eligibility_terminated'
+        else
+          false
         end
       end
     end

--- a/app/models/concerns/childcare_subsidy_concern.rb
+++ b/app/models/concerns/childcare_subsidy_concern.rb
@@ -97,7 +97,9 @@ module ChildcareSubsidyConcern
           effective_date = Date.new(year, 1, 1)
           next if eligibility_on(effective_date)
 
-          ::Operations::IvlOsseEligibilities::CreateIvlOsseEligibility.new.call(
+          operation = ::Operations::IvlOsseEligibilities::CreateIvlOsseEligibility.new
+          operation.default_eligibility = true
+          operation.call(
             osse_eligibility_params(false, effective_date)
           )
         rescue StandardError => e

--- a/components/benefit_sponsors/app/domain/benefit_sponsors/operations/benefit_sponsorships/shop_osse_eligibilities/create_shop_osse_eligibility.rb
+++ b/components/benefit_sponsors/app/domain/benefit_sponsors/operations/benefit_sponsorships/shop_osse_eligibilities/create_shop_osse_eligibility.rb
@@ -150,6 +150,7 @@ module BenefitSponsors
 
           def publish_event(eligibility)
             event_name = eligibility_event_for(eligibility.current_state)
+            return Succcess(eligibility) unless event_name
 
             ::Operations::EventLogs::TrackableEvent.new.call({
                                                                event_name: event_name,
@@ -160,6 +161,7 @@ module BenefitSponsors
           end
 
           def eligibility_event_for(current_state)
+            return false if default_eligibility
             return 'events.benefit_sponsors.benefit_sponsorships.eligibilities.shop_osse_eligibility.eligibility_renewed' if prospective_eligibility
 
             case current_state

--- a/components/benefit_sponsors/app/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship.rb
@@ -944,7 +944,9 @@ module BenefitSponsors
           effective_date = Date.new(year, 1, 1)
           next if eligibility_on(effective_date)
 
-          ::BenefitSponsors::Operations::BenefitSponsorships::ShopOsseEligibilities::CreateShopOsseEligibility.new.call(
+          operation = ::BenefitSponsors::Operations::BenefitSponsorships::ShopOsseEligibilities::CreateShopOsseEligibility.new
+          operation.default_eligibility = true
+          operation.call(
             initial_osse_eligibility_params(effective_date)
           )
         rescue StandardError => e

--- a/components/benefit_sponsors/spec/domain/benefit_sponsors/operations/benefit_sponsorships/shop_osse_eligibilities/create_shop_osse_eligibility_spec.rb
+++ b/components/benefit_sponsors/spec/domain/benefit_sponsors/operations/benefit_sponsorships/shop_osse_eligibilities/create_shop_osse_eligibility_spec.rb
@@ -177,8 +177,17 @@ RSpec.describe BenefitSponsors::Operations::BenefitSponsorships::ShopOsseEligibi
 
   describe "#eligibility_event_for" do
     subject(:instance) { described_class.new }
+    let(:prospective_eligibility) { false }
 
     before { instance.prospective_eligibility = prospective_eligibility }
+
+    context "when default_eligibility is true" do
+
+      it "should return false" do
+        instance.default_eligibility = true
+        expect(instance.send(:eligibility_event_for, :eligible)).to be_falsey
+      end
+    end
 
     context "when current_state is eligible" do
       let(:current_state) { :eligible }

--- a/spec/domain/operations/ivl_osse_eligibilities/create_ivl_osse_eligibility_spec.rb
+++ b/spec/domain/operations/ivl_osse_eligibilities/create_ivl_osse_eligibility_spec.rb
@@ -143,8 +143,17 @@ RSpec.describe ::Operations::IvlOsseEligibilities::CreateIvlOsseEligibility,
 
   describe "#eligibility_event_for" do
     subject(:instance) { described_class.new }
+    let(:prospective_eligibility) { false }
 
     before { instance.prospective_eligibility = prospective_eligibility }
+
+    context "when default_eligibility is true" do
+
+      it "should return false" do
+        instance.default_eligibility = true
+        expect(instance.send(:eligibility_event_for, :eligible)).to be_falsey
+      end
+    end
 
     context "when current_state is eligible" do
       let(:current_state) { :eligible }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187055397

# A brief description of the changes

Current behavior: currently when default osse eligibility record created, audit log event getting stored

New behavior: we don't need to create audit log events, for default osse eligibilities

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.