### PR TITLE
sanitizes text display in family data tables and inbox messages

### DIFF
--- a/app/models/concerns/sanitize_concern.rb
+++ b/app/models/concerns/sanitize_concern.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# The SanitizeConcern module provides a method for sanitizing input values.
+# It is intended to be used as a mixin to add sanitization functionality to any class.
+module SanitizeConcern
+  extend ActiveSupport::Concern
+
+  included do
+    # Sanitizes a given value if it is a string.
+    # It uses the full sanitizer provided by ActionView::Base to strip all HTML tags from the string, leaving only the text content.
+    # This is used to prevent cross-site scripting (XSS) attacks by ensuring that any user-supplied input is safe to display in a view.
+    #
+    # @param value [Object] The value to sanitize.
+    # @return [Object] The sanitized value if it was a string, or the original value if it was not a string.
+    def sanitize(value)
+      return value unless value.is_a?(String)
+
+      ::ActionView::Base.full_sanitizer.sanitize(value)
+    end
+  end
+end

--- a/app/models/effective/datatables/family_data_table.rb
+++ b/app/models/effective/datatables/family_data_table.rb
@@ -7,11 +7,15 @@ module Effective
       include Config::AcaModelConcern
       include Config::SiteModelConcern
       include ApplicationHelper
+      include SanitizeConcern
 
       datatable do
         #table_column :family_hbx_id, :proc => Proc.new { |row| row.hbx_assigned_id }, :filter => false, :sql_column => "hbx_id"
         table_column :name, :label => 'Name', :proc => proc { |row|
-          link_to_with_noopener_noreferrer(row.primary_applicant.person.full_name, resume_enrollment_exchanges_agents_path(person_id: row.primary_applicant.person.id))
+          link_to_with_noopener_noreferrer(
+            sanitize(row.primary_person.full_name),
+            resume_enrollment_exchanges_agents_path(person_id: row.primary_applicant.person.id)
+          )
         }, :filter => false, :sortable => false
         table_column :ssn, :label => 'SSN', :proc => proc { |row| truncate(number_to_obscured_ssn(row.primary_applicant.person.ssn)) }, :filter => false, :sortable => false
         table_column :dob, :label => 'DOB', :proc => proc { |row| format_date(row.primary_applicant.person.dob)}, :filter => false, :sortable => false

--- a/app/views/shared/inboxes/_message.html.erb
+++ b/app/views/shared/inboxes/_message.html.erb
@@ -7,10 +7,10 @@
       <br></li>
     <li class="list-group-item">
       Subject:
-      <%= message.try(:subject).html_safe %>
+      <%= sanitize(message&.subject) %>
       <br></li>
     <li class="list-group-item">
-      <%= message.try(:body).html_safe %>
+      <%= sanitize(message&.body) %>
       <br></li>
   </ul>
   <br class="clear"/>

--- a/spec/models/concerns/sanitize_concern_spec.rb
+++ b/spec/models/concerns/sanitize_concern_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class SanitizeConcernTestClass
+  include SanitizeConcern
+end
+
+describe SanitizeConcernTestClass, type: :model do
+  describe '#sanitize' do
+    context 'when the value is a string' do
+      context 'when the value contains img tag' do
+        let(:input_value) { "<img src=x onerror=alert('NHBR');> Lastname" }
+
+        it 'returns the sanitized value' do
+          expect(subject.sanitize(input_value)).to eq(' Lastname')
+        end
+      end
+
+      context 'when the value contains script tag' do
+        let(:input_value) { "<script>alert('NHBR');</script> Lastname" }
+
+        it 'returns the sanitized value' do
+          expect(subject.sanitize(input_value)).to eq(' Lastname')
+        end
+      end
+
+      context 'when the value contains other HTML tags' do
+        let(:input_value) { "<div>Firstname</div> Lastname" }
+
+        it 'returns the sanitized value' do
+          expect(subject.sanitize(input_value)).to eq('Firstname Lastname')
+        end
+      end
+
+      context 'when the value contains iframe tag' do
+        let(:input_value) { "<iframe src='https://www.google.com' title='A search Engine'></iframe> Lastname" }
+
+        it 'returns the sanitized value' do
+          expect(subject.sanitize(input_value)).to eq(' Lastname')
+        end
+      end
+    end
+
+    context 'when the value is not a string' do
+      it 'returns the original value' do
+        expect(subject.sanitize(123)).to eq(123)
+      end
+    end
+  end
+end

--- a/spec/views/shared/inboxes/_message.html.erb_spec.rb
+++ b/spec/views/shared/inboxes/_message.html.erb_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'shared/inboxes/_message.html.erb', db_clean: :after_each do
+  let(:person) { FactoryBot.create(:person) }
+  let(:message) do
+    FactoryBot.create(
+      :message,
+      body: input_body,
+      subject: input_subject,
+      inbox: person.inbox
+    )
+  end
+
+  before :each do
+    render 'shared/inboxes/message.html.erb', message: message
+  end
+
+  let(:input_body) { "<img src=x onerror=alert('NHBR');> The message body" }
+  let(:input_subject) do
+    "<script>alert('NHBR');</script> The message subject <iframe src='https://www.google.com' title='A search Engine'></iframe>"
+  end
+
+  # Test for the sanitized value.
+  # The sanitized content should not have script tags, iframe tags and JavaScript event attributes.
+  it 'renders sanitized content' do
+    expect(rendered).not_to include('onerror=')
+    expect(rendered).not_to include('<script>')
+    expect(rendered).not_to include('<iframe>')
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or updated version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 187054475](https://www.pivotaltracker.com/story/show/187054475)

# A brief description of the changes

Current behavior: Currently, the name-related fields for a person and subject, body for messages in data tables, and in the person's inbox are rendering unsanitized text respectively that could allow Cross-Site Scripting (XSS).

New behavior: Sanitzed text is rendered in the UI for the name-related fields for the person and subject, & the body for inbox messages.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.