### PR TITLE
add pundit permission to verify acccess for identify verifications

### DIFF
--- a/app/controllers/insured/fdsh_ridp_verifications_controller.rb
+++ b/app/controllers/insured/fdsh_ridp_verifications_controller.rb
@@ -110,8 +110,6 @@ module Insured
       render "failed_validation"
     end
 
-    private
-
     def received_response(event_kind)
       find_params = {primary_member_hbx_id: @person.primary_family.primary_applicant.hbx_id, event_kind: event_kind}
       Operations::Fdsh::Ridp::FindEligibilityResponse.new.call(find_params)

--- a/app/controllers/insured/fdsh_ridp_verifications_controller.rb
+++ b/app/controllers/insured/fdsh_ridp_verifications_controller.rb
@@ -5,6 +5,7 @@ module Insured
   class FdshRidpVerificationsController < ApplicationController
     before_action :set_current_person
     before_action :set_cache_headers, only: [:failed_validation]
+    before_action :set_consumer_bookmark_url, only: [:service_unavailable, :failed_validation]
 
     def new
       result = Operations::Fdsh::Ridp::RequestPrimaryDetermination.new.call(@person.primary_family)
@@ -95,6 +96,22 @@ module Insured
       render :plain => result.success?
     end
 
+    def service_unavailable
+      @person.consumer_role.move_identity_documents_to_outstanding
+      render "service_unavailable"
+    end
+
+    def failed_validation
+      @person = Person.find(params[:person_id]) if params[:person_id].present?
+      authorize @person, :can_access_identity_verifications?
+      @step = params[:step]
+      @verification_transaction_id = params[:verification_transaction_id]
+      @person.consumer_role.move_identity_documents_to_outstanding
+      render "failed_validation"
+    end
+
+    private
+
     def received_response(event_kind)
       find_params = {primary_member_hbx_id: @person.primary_family.primary_applicant.hbx_id, event_kind: event_kind}
       Operations::Fdsh::Ridp::FindEligibilityResponse.new.call(find_params)
@@ -103,21 +120,6 @@ module Insured
     def find_response(event_kind)
       primary_member_hbx_id = @person.primary_family.primary_applicant.hbx_id
       ::Fdsh::Ridp::EligibilityResponseModel.where(event_kind: event_kind, primary_member_hbx_id: primary_member_hbx_id, :deleted_at.ne => nil).to_a.max_by(&:deleted_at)
-    end
-
-    def service_unavailable
-      set_consumer_bookmark_url
-      @person.consumer_role.move_identity_documents_to_outstanding
-      render "service_unavailable"
-    end
-
-    def failed_validation
-      set_consumer_bookmark_url
-      @step = params[:step]
-      @verification_transaction_id = params[:verification_transaction_id]
-      @person = Person.find(params[:person_id]) if params[:person_id].present?
-      @person.consumer_role.move_identity_documents_to_outstanding
-      render "failed_validation"
     end
 
     def session_identification_id(response)

--- a/app/controllers/insured/interactive_identity_verifications_controller.rb
+++ b/app/controllers/insured/interactive_identity_verifications_controller.rb
@@ -1,6 +1,7 @@
 module Insured
   class InteractiveIdentityVerificationsController < ApplicationController
     before_action :set_current_person
+    before_action :set_consumer_bookmark_url, only: [:service_unavailable, :failed_validation]
 
     def new
       service = ::IdentityVerification::InteractiveVerificationService.new
@@ -24,16 +25,15 @@ module Insured
     end
 
     def service_unavailable
-      set_consumer_bookmark_url
       @person.consumer_role.move_identity_documents_to_outstanding
       render "service_unavailable"
     end
 
     def failed_validation
-      set_consumer_bookmark_url
+      @person = Person.find(params[:person_id]) if params[:person_id].present?
+      authorize @person, :can_access_identity_verifications?
       @step = params[:step]
       @verification_transaction_id = params[:verification_transaction_id]
-      @person = Person.find(params[:person_id]) if params[:person_id].present?
       @person.consumer_role.move_identity_documents_to_outstanding
       render "failed_validation"
     end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -8,4 +8,10 @@ class PersonPolicy < ApplicationPolicy
     return true if user.person.hbx_staff_role
     true if user.person.broker_role || record.broker_role
   end
+
+  def can_access_identity_verifications?
+    return true if user.person.hbx_staff_role
+    return true if user.person.id == record.id
+    false
+  end
 end

--- a/spec/controllers/insured/interactive_identity_verifications_controller_spec.rb
+++ b/spec/controllers/insured/interactive_identity_verifications_controller_spec.rb
@@ -308,5 +308,37 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
         expect(response).to render_template(:failed_validation)
       end
     end
+
+    describe '.failed_validation' do
+      let(:user){ FactoryBot.create(:user, :consumer, person: person) }
+      let(:person){ FactoryBot.create(:person, :with_consumer_role) }
+
+      context "GET failed_validation", dbclean: :after_each do
+        before(:each) do
+          sign_in user
+          allow(user).to receive(:person).and_return(person)
+        end
+
+        it "should render template" do
+          allow_any_instance_of(ConsumerRole).to receive(:move_identity_documents_to_outstanding).and_return(true)
+          get :failed_validation, params: {}
+
+          expect(response).to have_http_status(:success)
+          expect(response).to render_template("failed_validation")
+        end
+
+        context "when tried to access unauthorized person" do
+          let(:person_B){ FactoryBot.create(:person, :with_consumer_role) }
+          let!(:user_B){ FactoryBot.create(:user, person: person_B) }
+
+          it "should redirect with authorization error" do
+            get :failed_validation, params: {person_id: person_B.id.to_s}
+
+            expect(response).to have_http_status(:redirect)
+            expect(flash[:error]).to eq("Access not allowed for person_policy.can_access_identity_verifications?, (Pundit policy)")
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -8,7 +8,6 @@ describe PersonPolicy do
   let(:hbx_profile) {FactoryBot.create(:hbx_profile)}
   Permission.all.delete
 
-
   context 'hbx_staff_role subroles' do
     it 'hbx_staff' do
       allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_staff))
@@ -39,6 +38,40 @@ describe PersonPolicy do
       allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :developer))
       expect(policy.updateable?).to be false
     end
+  end
 
+  context 'permissions' do
+    subject { described_class }
+
+    permissions :can_access_identity_verifications? do
+
+      let(:person_A){FactoryBot.create(:person)}
+      let!(:user_A){FactoryBot.create(:user, person: person_A)}
+
+      let(:person_B){ FactoryBot.create(:person) }
+      let!(:user_B){ FactoryBot.create(:user, person: person_B) }
+
+      context 'logged in current user not matched with passed record' do
+        context 'when user is not an admin' do
+          it "denies access if current person not matched with passed record" do
+            expect(subject).not_to permit(user_A, person_B)
+          end
+        end
+
+        context 'when user is an admin' do
+          let!(:hbx_staff_role) { FactoryBot.create(:hbx_staff_role, person: person_A)}
+
+          it "grants access if the current user is an admin" do
+            expect(subject).to permit(user_A, person_B)
+          end
+        end
+      end
+
+      context 'logged in person matched with passed record' do
+        it "grants access" do
+          expect(subject).to permit(user_A, person_A)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187039692

# A brief description of the changes

Current behavior: The `failed_validation` action in the `FdshRidpVerificationsController` lacks authorization for the `person_id` parameter passed to it.

New behavior: I've implemented a Pundit policy authorization check to verify that the current logged-in user has access to the `person_id` being passed in.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.