### PR TITLE
sanitize notice template inputs

### DIFF
--- a/components/notifier/app/models/notifier/notice_builder.rb
+++ b/components/notifier/app/models/notifier/notice_builder.rb
@@ -68,7 +68,12 @@ module Notifier
     end
 
     def to_pdf
-      WickedPdf.new.pdf_from_string(execute_html_pdf_render, pdf_options)
+      sanitized_html = sanitize_html(execute_html_pdf_render)
+      WickedPdf.new.pdf_from_string(sanitized_html, pdf_options)
+    end
+
+    def sanitize_html(html)
+      Loofah.scrub_fragment(html, :strip).to_s
     end
 
     def generate_pdf_notice

--- a/components/notifier/app/models/notifier/template.rb
+++ b/components/notifier/app/models/notifier/template.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 module Notifier
+  # Template model
   class Template
     include Mongoid::Document
     include Mongoid::Timestamps
 
-    BLOCKED_ELEMENTS = ['<script', '%script', 'iframe', 'file://', 'dict://', 'ftp://', 'gopher://'].freeze
+    BLOCKED_ELEMENTS = ['<script', '%script', 'iframe', 'file://', 'dict://', 'ftp://', 'gopher://', '%x', 'system', 'exec', 'Kernel.spawn', 'Open3', '`', 'IO'].freeze
 
     embedded_in :notice_kind
 

--- a/components/notifier/spec/models/notifier/notice_kind_spec.rb
+++ b/components/notifier/spec/models/notifier/notice_kind_spec.rb
@@ -86,6 +86,18 @@ module Notifier
           expect(subject.valid?).to eq false
           expect(subject.errors.full_messages).to eq ['Template is invalid']
         end
+
+        it 'makes record invalid' do
+          template.raw_body = 'raw body content with invalid elements #{%x|env|}' # rubocop:disable Lint/InterpolationCheck
+          expect(subject.valid?).to eq false
+          expect(subject.errors.full_messages).to eq ['Template is invalid']
+        end
+
+        it 'makes record invalid' do
+          template.raw_body = 'raw body content with invalid elements #{`env`}' # rubocop:disable Lint/InterpolationCheck
+          expect(subject.valid?).to eq false
+          expect(subject.errors.full_messages).to eq ['Template is invalid']
+        end
       end
 
       context 'when raw_body does not have any blocking elements' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [187031792](https://www.pivotaltracker.com/story/show/187031792)

# A brief description of the changes

Current behavior:
Notifier Template does not block these elements:
```
'%x', 'system', 'exec', 'Kernel.spawn', 'Open3', '`', 'IO'
```
Pdf is build from HTML string without sanitization in Notice Builder. 

New behavior:
Notifier Template blocks these elements as well:
```
'%x', 'system', 'exec', 'Kernel.spawn', 'Open3', '`', 'IO'
```
HTML strings are sanitized before being passed to PDF builder in Notice Builder. 


# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.