### PR TITLE
export csv with filtered/displayed event log rows

### DIFF
--- a/app/controllers/event_logs_controller.rb
+++ b/app/controllers/event_logs_controller.rb
@@ -18,7 +18,7 @@ class EventLogsController < ApplicationController
   private
 
   def event_params
-    params.require(:events)
+    params[:events] || []
   end
 
   def check_hbx_staff_role

--- a/app/controllers/event_logs_controller.rb
+++ b/app/controllers/event_logs_controller.rb
@@ -3,9 +3,9 @@
 # Handles Audit Log requests
 class EventLogsController < ApplicationController
   before_action :check_hbx_staff_role
+
   def index
-    events = params[:events]
-    @event_logs = events ? EventLogs::MonitoredEvent.where(:_id.in => params[:events]) : EventLogs::MonitoredEvent.all
+    @event_logs = EventLogs::MonitoredEvent.where(:_id.in => event_params)
     respond_to do |format|
       format.js
       format.csv do
@@ -17,12 +17,11 @@ class EventLogsController < ApplicationController
 
   private
 
-  def event_log_params
-    params.permit(:family, :events)
+  def event_params
+    params.require(:events)
   end
 
   def check_hbx_staff_role
     redirect_to root_path, :flash => { :error => "You must be an HBX staff member" } unless current_user.has_hbx_staff_role?
   end
-
 end

--- a/app/views/event_logs/_event_log_tab.html.erb
+++ b/app/views/event_logs/_event_log_tab.html.erb
@@ -219,27 +219,17 @@
       arrow.toggleClass('glyphicon-chevron-right glyphicon-chevron-down');
     });
 
-    disableExportButton();
-    hideFilters();
-
-    enableExportButton();
-    showFilters();
+    if ($('tr.primary-row:visible').length === 0) {
+      disableExportButton();
+    }
   });
 
-  function disableButtons() {
-    $('#run-query, #export-table').prop('disabled', true);
-  }
-
-  function enableButtons() {
-    $('#run-query, #export-table').prop('disabled', false);
-  }
-
   function enableExportButton() {
-    $('#export-table').prop('disabled', false);
+    $('#export-table').show();
   }
 
   function disableExportButton() {
-    $('#export-table').prop('disabled', true);
+    $('#export-table').hide();
   }
 
   // Handle click event for csv export
@@ -504,9 +494,11 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
     if (visible_rows.length === 0) {
       $('#event-table-data').hide()
       $('#no-results').show()
+      disableExportButton();
     } else {
       $('#event-table-data').show()
       $('#no-results').hide()
+      enableExportButton();
       $('#event-log-table tbody tr').each(function( index ) {
         var row = $(this).prop('id');
         var row_index = visible_rows.indexOf(row)

--- a/app/views/event_logs/_event_log_tab.html.erb
+++ b/app/views/event_logs/_event_log_tab.html.erb
@@ -37,10 +37,10 @@
               <dd>
                 <div class="mutliSelect">
                   <ul>
-                    <li><label><input type="checkbox" name="<%= l10n("subject").downcase %>" value="all" checked/>All</label></li>
+                    <li><label><input type="checkbox" name="subject" value="all" checked/>All</label></li>
                     <% if members&.any? %>
                     <% members.uniq.each do |member| %>
-                      <li><label><input type="checkbox" name="<%= l10n("subject").downcase %>" value="<%= member %>" checked/><%= member %></label></li>
+                      <li><label><input type="checkbox" name="subject" value="<%= member %>" checked/><%= member %></label></li>
                     <% end %>
                     <% end %>
                   </ul>
@@ -61,10 +61,10 @@
               <dd>
                 <div class="mutliSelect">
                   <ul>
-                    <li><label><input type="checkbox" name="<%= l10n("event_log.eligibility").downcase %>" value="all" checked/>All</label></li>
+                    <li><label><input type="checkbox" name="eligibility" value="all" checked/>All</label></li>
                     <% if @event_logs %>
                       <% @event_logs.map{|event_log| event_log[:title]&.upcase }.uniq.each do |category| %>
-                        <li><label><input type="checkbox" name="<%= l10n("event_log.eligibility").downcase %>" value="<%= category %>" checked/><%= category %></label></li>
+                        <li><label><input type="checkbox" name="eligibility" value="<%= category %>" checked/><%= category %></label></li>
                       <% end %>
                     <% end %>
                   </ul>
@@ -84,9 +84,9 @@
               <dd>
                 <div class="mutliSelect">
                   <ul>
-                    <li><label><input type="checkbox" name="<%= l10n('status').downcase %>" value="all" checked/>All</label></li>
-                    <li><label><input type="checkbox" name="<%= l10n('status').downcase %>" value="eligible" checked/><%= l10n("eligible") %></label></li>
-                    <li><label><input type="checkbox" name="<%= l10n('status').downcase %>" value="ineligible" checked/><%= l10n("ineligible") %></label></li>
+                    <li><label><input type="checkbox" name="status" value="all" checked/>All</label></li>
+                    <li><label><input type="checkbox" name="status" value="eligible" checked/><%= l10n("eligible") %></label></li>
+                    <li><label><input type="checkbox" name="status" value="ineligible" checked/><%= l10n("ineligible") %></label></li>
                   </ul>
                 </div>
               </dd>
@@ -195,6 +195,7 @@
     const startDateFilter = $('#start-date');
     const endDateFilter = $('#end-date');
     const hbx_id = <%= sanitize hbx_id.to_json %>;
+
     // Event handler for start date change
     startDateFilter.on('change', function() {
       const startDate = new Date(startDateFilter.val());
@@ -347,6 +348,7 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
     $('input[name="status"]:checked').each(function( index ) {
       statuses.push($(this).val().toUpperCase())
     });
+
     $('#event-log-table tbody tr').each(function( index ) {
       var row = $(this).prop('id');
       var row_index = visible_rows.indexOf(row)

--- a/app/views/event_logs/_event_log_tab.html.erb
+++ b/app/views/event_logs/_event_log_tab.html.erb
@@ -127,7 +127,7 @@
     <div class="event-log-header">
       <div class="event-log-export-text">
         <h3><b><%= type === "consumer" ? l10n("event_log.table_label_consumer") + hbx_id : l10n("event_log.table_label_employer")%></b></h3>
-        <a href="/event_logs.csv?<% @event_logs.each do |event| %>&events[]=<%= event[:_id] %><% end %>" id="export-table" class="button button-primary"><%= l10n("Export") %> <%= l10n("to") %> CSV</a>
+        <a href="#" id="export-table" class="button button-primary"><%= l10n("Export") %> <%= l10n("to") %> CSV</a>
       </div>
     </div>
     <div id="event-table-data">
@@ -163,7 +163,7 @@
               <th><%= l10n("Account (Date/Time)") %></th>
             </tr>
             <% details.each do |detail| %>
-            <tr class="detail-row" id="<%= index %>">
+            <tr class="detail-row" data-event-id="<%= detail[:_id] %>" id="<%= index %>">
               <td colspan="2"></td>
               <td><%= detail[:detail] %></td>
               <td id="<%= detail[:account_hbx_id] %>" class="user_id"><%= detail[:account_username] %></td>
@@ -219,10 +219,6 @@
       arrow.toggleClass('glyphicon-chevron-right glyphicon-chevron-down');
     });
 
-    exportTableButton.on('click', function() {
-      window.location.href = '/event_logs.csv';
-    });
-
     disableExportButton();
     hideFilters();
 
@@ -245,6 +241,28 @@
   function disableExportButton() {
     $('#export-table').prop('disabled', true);
   }
+
+  // Handle click event for csv export
+  $('#export-table').on('click', function(event) {
+    event.preventDefault();
+
+    var eventIds = [];
+    $('.primary-row').each(function() {
+      var primaryRowId = $(this).attr('id');
+
+      if ($(this).is(':visible')) {
+        var detailRows = $('.detail-row[id="' + primaryRowId + '"]');
+
+        detailRows.each(function() {
+          var eventId = $(this).data('event-id');
+          eventIds.push(eventId);
+        });
+      }
+    });
+
+    var url = '/event_logs.csv?' + $.param({ events: eventIds });
+    window.location.href = url;
+  });
 
   function showFilters() {
     $('.filters-container').css('visibility', 'visible');

--- a/spec/controllers/event_logs_controller_spec.rb
+++ b/spec/controllers/event_logs_controller_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe EventLogsController, :type => :controller do
       expect(assigns(:event_logs).first.subject_hbx_id).to eq person.hbx_id
     end
 
-    it "should assign event logs without a param" do
+    it "should fetch none without a param" do
       get :index, format: :js
-      expect(assigns(:event_logs).count).to eq 2
+      expect(assigns(:event_logs).count).to eq 0
     end
 
     it "should render index" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187038539

# A brief description of the changes

Current behavior:  csv export including both visible and hidden rows 

New behavior: csv export should only export visible/filtered rows under event logs page.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.