### PR TITLE
modify help_paying_coverage authorization

### DIFF
--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -308,8 +308,8 @@ class Insured::ConsumerRolesController < ApplicationController
 
   def help_paying_coverage
     if EnrollRegistry.feature_enabled?(:financial_assistance)
-      authorize @consumer_role, :ridp_verified? unless Rails.env.test? && defined?(Cucumber)
       set_current_person
+      authorize @consumer_role, :ridp_verified? unless Rails.env.test? && defined?(Cucumber)
       save_faa_bookmark(request.original_url)
       set_admin_bookmark_url
       @transaction_id = params[:id]

--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -310,6 +310,7 @@ class Insured::ConsumerRolesController < ApplicationController
     if EnrollRegistry.feature_enabled?(:financial_assistance)
       set_current_person
       # Rails.env.test? && defined?(Cucumber) is used to bypass the authorization check in cucumber tests
+      # This is a temporary fix and should be removed once the cucumber tests are modified and the ridp verification is stubbed in lower environments.
       authorize @person.consumer_role, :ridp_verified? unless Rails.env.test? && defined?(Cucumber)
       save_faa_bookmark(request.original_url)
       set_admin_bookmark_url

--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -309,9 +309,9 @@ class Insured::ConsumerRolesController < ApplicationController
   def help_paying_coverage
     if EnrollRegistry.feature_enabled?(:financial_assistance)
       set_current_person
-      # Rails.env.test? && defined?(Cucumber) is used to bypass the authorization check in cucumber tests
+      # defined?(Cucumber) is used to bypass the authorization check in cucumber tests
       # This is a temporary fix and should be removed once the cucumber tests are modified and the ridp verification is stubbed in lower environments.
-      authorize @person.consumer_role, :ridp_verified? unless Rails.env.test? && defined?(Cucumber)
+      authorize @person.consumer_role, :ridp_verified? unless defined?(Cucumber)
       save_faa_bookmark(request.original_url)
       set_admin_bookmark_url
       @transaction_id = params[:id]

--- a/app/controllers/insured/consumer_roles_controller.rb
+++ b/app/controllers/insured/consumer_roles_controller.rb
@@ -309,7 +309,8 @@ class Insured::ConsumerRolesController < ApplicationController
   def help_paying_coverage
     if EnrollRegistry.feature_enabled?(:financial_assistance)
       set_current_person
-      authorize @consumer_role, :ridp_verified? unless Rails.env.test? && defined?(Cucumber)
+      # Rails.env.test? && defined?(Cucumber) is used to bypass the authorization check in cucumber tests
+      authorize @person.consumer_role, :ridp_verified? unless Rails.env.test? && defined?(Cucumber)
       save_faa_bookmark(request.original_url)
       set_admin_bookmark_url
       @transaction_id = params[:id]

--- a/app/policies/consumer_role_policy.rb
+++ b/app/policies/consumer_role_policy.rb
@@ -55,7 +55,7 @@ class ConsumerRolePolicy < ApplicationPolicy
   def ridp_verified?
     # NOTE: brokers and consumers both require consumer identity to be verified beyond ridp page
     # the second condition covers both cases
-    current_user.person.hbx_staff_role&.permission&.modify_family || record.identity_verified?
+    @user&.person&.hbx_staff_role&.permission&.modify_family || record.identity_verified?
   end
 
   def update?

--- a/app/policies/consumer_role_policy.rb
+++ b/app/policies/consumer_role_policy.rb
@@ -53,11 +53,9 @@ class ConsumerRolePolicy < ApplicationPolicy
   # Checking if consumer identity has been verified or if user has hbx_staff_role.
   # If either are true, then the user has access beyond the RIDP page.
   def ridp_verified?
-    user_person = @user&.person
-
     # NOTE: brokers and consumers both require consumer identity to be verified beyond ridp page
     # the second condition covers both cases
-    user_person&.hbx_staff_role&.permission&.modify_family || @record&.person&.consumer_role&.identity_verified?
+    current_user.person.hbx_staff_role&.permission&.modify_family || record.identity_verified?
   end
 
   def update?

--- a/spec/controllers/insured/consumer_roles_controller_spec.rb
+++ b/spec/controllers/insured/consumer_roles_controller_spec.rb
@@ -849,11 +849,10 @@ RSpec.describe Insured::ConsumerRolesController, dbclean: :after_each, :type => 
         allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
         allow(EnrollRegistry).to receive(:feature_enabled?).with(:draft_application_after_ridp).and_return(true)
         allow(user).to receive(:person).and_return(person)
-        allow(controller).to receive(:authorize).and_return(true)
         sign_in user
       end
 
-      context 'user has most recent existing application in draft state' do
+      context 'unverified user has most recent existing application in draft state' do
         let!(:person){ FactoryBot.create(:person) }
         let!(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person)}
         let!(:primary) { family.primary_family_member }
@@ -861,11 +860,28 @@ RSpec.describe Insured::ConsumerRolesController, dbclean: :after_each, :type => 
         let!(:assistance_year) { FinancialAssistance::Operations::EnrollmentDates::ApplicationYear.new.call.value! }
         let!(:application) { FactoryBot.create(:financial_assistance_application, aasm_state: 'draft', assistance_year: assistance_year, family_id: family.id, applicants: [applicant])}
 
-        it 'should redirect to draft application edit page' do
+        it 'should error out for attempting to navigate without identity verification' do
           edit_application_path = FinancialAssistance::Engine.routes.url_helpers.edit_application_path(application).split('/.').last
+          expect { get :help_paying_coverage }.to raise_error(Pundit::NotDefinedError)
+        end
+      end
+
+      context 'verified user has most recent existing application in draft state' do
+        before do
+          allow(person.consumer_role).to receive(:identity_verified?).and_return(true)
+        end
+
+        let(:person) { FactoryBot.create(:person, :with_consumer_role) }
+        let!(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person)}
+        let!(:primary) { family.primary_family_member }
+        let!(:applicant) { FactoryBot.create(:financial_assistance_applicant, family_member_id: primary.id, person_hbx_id: primary.hbx_id) }
+        let!(:assistance_year) { FinancialAssistance::Operations::EnrollmentDates::ApplicationYear.new.call.value! }
+        let!(:application) { FactoryBot.create(:financial_assistance_application, aasm_state: 'draft', assistance_year: assistance_year, family_id: family.id, applicants: [applicant])}
+
+        it 'should redirect to draft application edit page' do
           get :help_paying_coverage
           expect(response).to have_http_status(:redirect)
-          expect(response).to redirect_to(edit_application_path)
+          expect(response).to redirect_to(FinancialAssistance::Engine.routes.url_helpers.edit_application_path(application).split('/.').last)
         end
       end
     end

--- a/spec/controllers/insured/consumer_roles_controller_spec.rb
+++ b/spec/controllers/insured/consumer_roles_controller_spec.rb
@@ -861,7 +861,6 @@ RSpec.describe Insured::ConsumerRolesController, dbclean: :after_each, :type => 
         let!(:application) { FactoryBot.create(:financial_assistance_application, aasm_state: 'draft', assistance_year: assistance_year, family_id: family.id, applicants: [applicant])}
 
         it 'should error out for attempting to navigate without identity verification' do
-          edit_application_path = FinancialAssistance::Engine.routes.url_helpers.edit_application_path(application).split('/.').last
           expect { get :help_paying_coverage }.to raise_error(Pundit::NotDefinedError)
         end
       end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features) **specs added in previous PR**

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187041088 

# A brief description of the changes

Current behavior: _Added a new method to the Pundit policy ConsumerRoles that checks on indentity_validation being valid or user being hbx_staff_role. Use pundit_class and pundit_allow to add more restrictions to continue buttons, including blocking class and reload page path if user does not pass the checks added. Added specs for method._

This was tested and failed for broker users, as they are still able to bypass the authorization

New behavior: Modified the code to call `set_current_user` prior to the authorization to prevent any data missing along with using `@person.consumer_role` for the authorization.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.