### PR TITLE
allow user to toggle tobacco use question

### DIFF
--- a/app/views/insured/group_selection/_coverage_household.html.erb
+++ b/app/views/insured/group_selection/_coverage_household.html.erb
@@ -77,7 +77,7 @@
                   <% member = @latest_enrollment.hbx_enrollment_members.where(applicant_id: family_member.id).first if @latest_enrollment %>
                   <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_tobacco_user_Y_<%= index %>')" class="col-xs-2 top-buffer pb-1">
                     <input id="is_tobacco_user_Y_<%= index %>" type="radio" value="Y" name="is_tobacco_user_<%= family_member.id %>" <%='checked' if member&.tobacco_use == 'Y' %>>
-                    <label class="radio-label" for="is_tobacco_user_Y_<%= index %>"><span>Yes</span></label>
+                    <label data-cuke="is_tobacco_user_Y_<%= index %>" class="radio-label" for="is_tobacco_user_Y_<%= index %>"><span>Yes</span></label>
                   </div>
                   <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_tobacco_user_N_<%= index %>')" class="col-md-2 col-xs-1 top-buffer pb-1">
                     <input id="is_tobacco_user_N_<%= index %>" type="radio" value="N" name="is_tobacco_user_<%= family_member.id %>" <%='checked' if member&.tobacco_use != 'Y' %>>
@@ -99,9 +99,9 @@
   $(document).on('turbolinks:load', function() {
     $(document).on("change", "input[type=checkbox]", function () {
       if (this.checked) {
-        $(this).closest('tr').find("input[type='radio']").attr('disabled','false');
+        $(this).closest('tr').find("input[type='radio']").prop('disabled',false);
       } else {
-        $(this).closest('tr').find("input[type='radio']").attr('disabled','true');
+        $(this).closest('tr').find("input[type='radio']").prop('disabled',true);
       }
     });
   });

--- a/app/views/insured/group_selection/_coverage_household.html.erb
+++ b/app/views/insured/group_selection/_coverage_household.html.erb
@@ -98,11 +98,8 @@
 <script>
   $(document).on('turbolinks:load', function() {
     $(document).on("change", "input[type=checkbox]", function () {
-      if (this.checked) {
-        $(this).closest('tr').find("input[type='radio']").prop('disabled',false);
-      } else {
-        $(this).closest('tr').find("input[type='radio']").prop('disabled',true);
-      }
+      var isCheckboxChecked = this.checked;
+      $(this).closest('tr').find("input[type='radio']").prop('disabled',!isCheckboxChecked);
     });
   });
 </script>

--- a/features/group_selection/coverage_household.feature
+++ b/features/group_selection/coverage_household.feature
@@ -10,6 +10,6 @@ Feature: Coverage Household Page
     And I select a past qle date
     Then I should see confirmation and continue
     And ivl clicked continue on household info page
+    And consumer should see all the family members names
     And consumer reselects family member
     Then consumer should be able to toggle tobacco use question
-    

--- a/features/group_selection/coverage_household.feature
+++ b/features/group_selection/coverage_household.feature
@@ -1,0 +1,15 @@
+Feature: Coverage Household Page
+
+  Scenario: when tobacco cost feature is enabled
+    Given EnrollRegistry tobacco_cost feature is enabled
+    And a consumer exists
+    And the consumer is logged in
+    And consumer has successful ridp
+    When consumer visits home page
+    And consumer clicked on "Married" qle
+    And I select a past qle date
+    Then I should see confirmation and continue
+    And ivl clicked continue on household info page
+    And consumer reselects family member
+    Then consumer should be able to toggle tobacco use question
+    

--- a/features/step_definitions/group_selection_steps.rb
+++ b/features/step_definitions/group_selection_steps.rb
@@ -415,7 +415,7 @@ Then(/(.*) should see all the family members names/) do |role|
   people = Person.all
   people.each do |person|
     expect(page).to have_content "#{person.last_name}"
-
+    expect(page).to have_content "#{person.first_name}"
   end
 end
 

--- a/features/step_definitions/group_selection_steps.rb
+++ b/features/step_definitions/group_selection_steps.rb
@@ -415,9 +415,19 @@ Then(/(.*) should see all the family members names/) do |role|
   people = Person.all
   people.each do |person|
     expect(page).to have_content "#{person.last_name}"
-    expect(page).to have_content "#{person.first_name}"
 
   end
+end
+
+And(/consumer reselects family member/) do
+  # mimic user behavior
+  find('#family_member_ids_0').click
+  find('#family_member_ids_0').click
+end
+
+Then(/consumer should be able to toggle tobacco use question/) do
+  find(IvlChooseCoverage.is_tobacco_user_yes).click
+  expect(find("#is_tobacco_user_Y_0", visible: false).checked?).to be_truthy
 end
 
 When(/(.*) (.*) the primary person/) do |role, checked|

--- a/features/support/object_model_pages/ivl/registration/ivl_choose_coverage.rb
+++ b/features/support/object_model_pages/ivl/registration/ivl_choose_coverage.rb
@@ -23,6 +23,10 @@ class IvlChooseCoverage
     'label[for="coverage_kind_dental"] span'
   end
 
+  def self.is_tobacco_user_yes
+    '[data-cuke="is_tobacco_user_Y_0"]'
+  end
+
   def self.shop_for_new_plan_btn
     'input[class="btn btn-primary  btn-lg no-op  interaction-click-control-shop-for-new-plan"]'
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [ME-187013857](https://www.pivotaltracker.com/n/projects/2640060/stories/187013857)

# A brief description of the changes

Current behavior: When a user deselects their name from the coverage household page, then reselects their name, the tobacco use question is disabled.

New behavior: The tobacco use question will be enabled if a consumer is selected.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.