### PR TITLE
export only filtered visible detail rows into csv

### DIFF
--- a/app/models/event_logs/monitored_event.rb
+++ b/app/models/event_logs/monitored_event.rb
@@ -48,6 +48,7 @@ module EventLogs
       details[:title] = parsed[:title]&.gsub(/osse/i, "Hc4cc")&.gsub("Aca ", "")&.gsub("Eligibility ", "")&.upcase || ""
       details[:effective_on] = effective_on || ""
       details[:detail] = detail || ""
+      details[:event_time] = format_time_display(details[:event_time])
       details
     end
 
@@ -113,6 +114,10 @@ module EventLogs
           ]
         end
       end
+    end
+
+    def format_time_display(timestamp)
+      timestamp.present? ? timestamp.in_time_zone('Eastern Time (US & Canada)') : ""
     end
   end
 end

--- a/app/views/event_logs/_event_log_tab.html.erb
+++ b/app/views/event_logs/_event_log_tab.html.erb
@@ -167,7 +167,7 @@
               <td colspan="2"></td>
               <td><%= detail[:detail] %></td>
               <td id="<%= detail[:account_hbx_id] %>" class="user_id"><%= detail[:account_username] %></td>
-              <td class="event-time"><%= format_time_display(detail[:event_time]) %></td>
+              <td class="event-time"><%= detail[:event_time] %></td>
             </tr>
             <% end %>
           <% end %>
@@ -241,7 +241,7 @@
       var primaryRowId = $(this).attr('id');
 
       if ($(this).is(':visible')) {
-        var detailRows = $('.detail-row[id="' + primaryRowId + '"]');
+        var detailRows = $('.detail-row:visible[id="' + primaryRowId + '"]');
 
         detailRows.each(function() {
           var eventId = $(this).data('event-id');


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187038539

# A brief description of the changes

Current behavior: currently csv exporting all detail rows, even the hidden rows

New behavior: csv should export only the detail rows that are visible

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.