### PR TITLE
display osse application effective date for shop event logs

### DIFF
--- a/app/models/event_logs/monitored_event.rb
+++ b/app/models/event_logs/monitored_event.rb
@@ -68,12 +68,15 @@ module EventLogs
       return unless event_category == :shop_osse_eligibility && subject.is_a?(BenefitSponsors::Organizations::GeneralOrganization)
       return if details[:effective_on].blank?
 
-      benefit_sponsorship = subject.active_benefit_sponsorship
-      applications = benefit_sponsorship.benefit_applications.by_year(details[:effective_on].year).approved_and_terminated
-      application = applications.select(&:osse_eligible?).last
-
+      application = osse_eligibile_application_for(details[:effective_on].year)
       return unless application
       details[:effective_on] = application.effective_period.min
+    end
+
+    def osse_eligibile_application_for(year)
+      benefit_sponsorship = subject.active_benefit_sponsorship
+      applications = benefit_sponsorship.benefit_applications.by_year(year).approved_and_terminated
+      applications.select(&:osse_eligible?).last
     end
 
     def get_subject_name(subject)

--- a/app/views/event_logs/_event_log_tab.html.erb
+++ b/app/views/event_logs/_event_log_tab.html.erb
@@ -154,7 +154,7 @@
               <% end %>
               <td class="eligibility"><%= event_log[1]&.upcase %></td>
               <td class="status"><%= details[0][:current_state]&.titleize %></td>
-              <td class="effective-on"><%= details[0][:effective_on] %></td>
+              <td class="effective-on"><%= details[0][:effective_on]&.strftime("%m/%d/%Y") %></td>
             </tr>
             <tr class="secondary-header" id="<%= index %>">
               <td colspan="2"></td>

--- a/spec/models/event_logs/monitored_event_spec.rb
+++ b/spec/models/event_logs/monitored_event_spec.rb
@@ -1,16 +1,29 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-RSpec.describe EventLogs::MonitoredEvent, :type => :model, dbclean: :around_each do
+require "rails_helper"
+require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_market.rb"
+require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_application.rb"
 
-  before(:each) do
-    @user = FactoryBot.create(:user)
-    @person_event_log = FactoryBot.create(:people_eligibilities_event_log, account: @user)
-    @monitored_event = FactoryBot.create(:monitored_event, account_username: @user.email, monitorable: @person_event_log)
-    @monitored_event_2 = FactoryBot.create(:monitored_event, event_category: :osse, subject_hbx_id: "10005", monitorable: @person_event_log)
-  end
-
-  describe "monitored event" do
+RSpec.describe EventLogs::MonitoredEvent, type: :model, dbclean: :around_each do
+  describe "person monitored event" do
+    before(:each) do
+      @user = FactoryBot.create(:user)
+      @person_event_log =
+        FactoryBot.create(:people_eligibilities_event_log, account: @user)
+      @monitored_event =
+        FactoryBot.create(
+          :monitored_event,
+          account_username: @user.email,
+          monitorable: @person_event_log
+        )
+      @monitored_event_2 =
+        FactoryBot.create(
+          :monitored_event,
+          event_category: :osse,
+          subject_hbx_id: "10005",
+          monitorable: @person_event_log
+        )
+    end
 
     context ".save" do
       it "should persist event log" do
@@ -29,65 +42,263 @@ RSpec.describe EventLogs::MonitoredEvent, :type => :model, dbclean: :around_each
 
     context ".get_category_options" do
       it "should return event category options" do
-        expect(EventLogs::MonitoredEvent.get_category_options).to eq [:login, :osse]
+        expect(EventLogs::MonitoredEvent.get_category_options).to eq %i[
+             login
+             osse
+           ]
       end
 
       it "should return event category options for given subject" do
-        expect(EventLogs::MonitoredEvent.get_category_options(@monitored_event.subject_hbx_id)).to eq [:login]
+        expect(
+          EventLogs::MonitoredEvent.get_category_options(
+            @monitored_event.subject_hbx_id
+          )
+        ).to eq [:login]
       end
     end
 
     context ".fetch_event_logs" do
       let(:params) { { account: @user.email, event_category: :login } }
       it "should return event logs" do
-        expect(EventLogs::MonitoredEvent.fetch_event_logs(params).first).to eq @monitored_event
+        expect(
+          EventLogs::MonitoredEvent.fetch_event_logs(params).first
+        ).to eq @monitored_event
       end
 
       it "should return event logs for given subject" do
         params[:subject_hbx_id] = @monitored_event.subject_hbx_id
-        expect(EventLogs::MonitoredEvent.fetch_event_logs(params).first).to eq @monitored_event
+        expect(
+          EventLogs::MonitoredEvent.fetch_event_logs(params).first
+        ).to eq @monitored_event
       end
 
       it "should return event logs for given account" do
         params[:account] = @monitored_event.account_hbx_id
-        expect(EventLogs::MonitoredEvent.fetch_event_logs(params).first).to eq @monitored_event
+        expect(
+          EventLogs::MonitoredEvent.fetch_event_logs(params).first
+        ).to eq @monitored_event
       end
 
       it "should return event logs for given account username" do
         params[:account] = @monitored_event.account_username
         expect(EventLogs::MonitoredEvent.fetch_event_logs(params).size).to eq(1)
-        expect(EventLogs::MonitoredEvent.fetch_event_logs(params).first).to eq @monitored_event
+        expect(
+          EventLogs::MonitoredEvent.fetch_event_logs(params).first
+        ).to eq @monitored_event
       end
 
       it "should return event logs for given event start date" do
         params[:event_start_date] = @monitored_event.event_time.to_date
         expect(EventLogs::MonitoredEvent.fetch_event_logs(params).size).to eq(1)
-        expect(EventLogs::MonitoredEvent.fetch_event_logs(params).first).to eq @monitored_event
+        expect(
+          EventLogs::MonitoredEvent.fetch_event_logs(params).first
+        ).to eq @monitored_event
       end
 
       it "should return event logs for given event end date" do
         params[:event_end_date] = @monitored_event.event_time.to_date
-        expect(EventLogs::MonitoredEvent.fetch_event_logs(params).first).to eq @monitored_event
+        expect(
+          EventLogs::MonitoredEvent.fetch_event_logs(params).first
+        ).to eq @monitored_event
       end
 
       it "should return event logs for given event start and end date" do
         params[:event_start_date] = @monitored_event.event_time.to_date
         params[:event_end_date] = @monitored_event.event_time.to_date
-        expect(EventLogs::MonitoredEvent.fetch_event_logs(params).first).to eq @monitored_event
+        expect(
+          EventLogs::MonitoredEvent.fetch_event_logs(params).first
+        ).to eq @monitored_event
       end
 
       it "should return event logs for given account and event start date" do
         params[:account] = @monitored_event.account_hbx_id
         params[:event_start_date] = @monitored_event.event_time.to_date
         expect(EventLogs::MonitoredEvent.fetch_event_logs(params).size).to eq(1)
-        expect(EventLogs::MonitoredEvent.fetch_event_logs(params).first).to eq @monitored_event
+        expect(
+          EventLogs::MonitoredEvent.fetch_event_logs(params).first
+        ).to eq @monitored_event
       end
 
       it "should return all event logs if no params are passed" do
         expect(EventLogs::MonitoredEvent.fetch_event_logs({}).count).to eq(2)
       end
     end
-
   end
 
+  describe "organization monitored event" do
+    include_context "setup benefit market with market catalogs and product packages"
+
+    let(:site) do
+      ::BenefitSponsors::SiteSpecHelpers.create_site_with_hbx_profile_and_benefit_market
+    end
+    let(:benefit_market) { site.benefit_markets.first }
+
+    let(:employer_organization) do
+      FactoryBot.create(
+        :benefit_sponsors_organizations_general_organization,
+        :with_aca_shop_dc_employer_profile,
+        site: site
+      )
+    end
+
+    let(:benefit_sponsorship) do
+      employer_organization.active_benefit_sponsorship
+    end
+    let(:current_year) { TimeKeeper.date_of_record.year }
+    let(:current_effective_date) { Date.new(Date.today.year, 3, 1) }
+
+    let!(:catalog_eligibility) do
+      ::Operations::Eligible::CreateCatalogEligibility.new.call(
+        {
+          subject: current_benefit_market_catalog.to_global_id,
+          eligibility_feature: "aca_shop_osse_eligibility",
+          effective_date:
+            current_benefit_market_catalog.application_period.begin.to_date,
+          domain_model:
+            "AcaEntities::BenefitSponsors::BenefitSponsorships::BenefitSponsorship"
+        }
+      )
+    end
+
+    let!(:shop_osse_eligibility) do
+      osse_eligibility =
+        ::BenefitSponsors::Operations::BenefitSponsorships::ShopOsseEligibilities::CreateShopOsseEligibility.new.call(
+          {
+            subject: benefit_sponsorship.to_global_id,
+            evidence_key: :shop_osse_evidence,
+            evidence_value: "true",
+            effective_date: beginning_of_year
+          }
+        )
+      osse_eligibility
+    end
+
+    let!(:system_user) { FactoryBot.create(:user, email: "admin@dc.gov") }
+    let(:beginning_of_year) { TimeKeeper.date_of_record.beginning_of_year }
+
+    include_context "setup initial benefit application" do
+      let(:current_effective_date) do
+        Date.new(TimeKeeper.date_of_record.year, 2, 1)
+      end
+    end
+
+    before(:each) do
+      TimeKeeper.set_date_of_record_unprotected!(beginning_of_year + 4.months)
+    end
+
+    context ".eligibility_details" do
+      let(:person) { FactoryBot.create(:person, :with_hbx_staff_role) }
+      let!(:system_user) do
+        FactoryBot.create(:user, person: person, email: "admin@dc.gov")
+      end
+      let(:subject_gid) do
+        benefit_sponsorship.organization.to_global_id.uri.to_s
+      end
+
+      let(:payload) do
+        {
+          current_state: :eligible,
+          title: "Aca Shop Osse Eligibility 2024",
+          state_histories: [{ effective_on: Date.new(2024, 1, 1) }]
+        }
+      end
+
+      let(:session_details) do
+        {
+          session_id: SecureRandom.uuid,
+          login_session_id: SecureRandom.uuid,
+          portal: "http://dchealthlink.com"
+        }
+      end
+
+      let(:headers) do
+        {
+          correlation_id: SecureRandom.uuid,
+          message_id: SecureRandom.uuid,
+          host_id: "https://demo.dceligibility.assit.org",
+          subject_gid: subject_gid,
+          resource_gid: subject_gid,
+          event_time: DateTime.now,
+          event_name: event_name,
+          account: {
+            id: system_user.id.to_s,
+            session: session_details
+          }
+        }
+      end
+
+      let(:event_name) do
+        "events.benefit_sponsors.benefit_sponsorships.eligibilities.shop_osse_eligibility.eligibility_created"
+      end
+
+      let(:monitored_event) { event_log.monitored_event }
+
+      let!(:event_log) do
+        Operations::EventLogs::Store
+          .new
+          .call(payload: payload, headers: headers)
+          .success
+      end
+
+      context "when application osse eligible" do
+        before(:each) do
+          allow(monitored_event).to receive(
+            :osse_eligibile_application_for
+          ).with(TimeKeeper.date_of_record.year).and_return(initial_application)
+        end
+
+        subject { monitored_event.eligibility_details }
+
+        it "should return osse eligibile application effective date" do
+          expect(
+            subject[:effective_on]
+          ).to eq initial_application.effective_period.min
+        end
+
+        it "should return other attributes" do
+          expect(subject[:current_state]).to eq payload[:current_state].to_s
+          expect(
+            subject[:subject]
+          ).to eq benefit_sponsorship.organization.legal_name
+          expect(subject[:title]).to eq "SHOP HC4CC 2024"
+          expect(subject[:detail]).to eq "Eligibility Created"
+          expect(subject[:event_time].to_date).to eq event_log
+               .event_time
+               .in_time_zone("Eastern Time (US & Canada)")
+               .to_date
+        end
+      end
+
+      context "when application not osse eligible" do
+        before(:each) do
+          allow(monitored_event).to receive(
+            :osse_eligibile_application_for
+          ).with(TimeKeeper.date_of_record.year).and_return(nil)
+        end
+
+        let(:eligibility_effective_date) do
+          payload.dig(:state_histories, -1, :effective_on)
+        end
+
+        it "should return eligibility effective date" do
+          details = monitored_event.eligibility_details
+          expect(details[:effective_on]).to eq eligibility_effective_date
+        end
+
+        it "should return other attributes" do
+          details = monitored_event.eligibility_details
+          expect(details[:current_state]).to eq payload[:current_state].to_s
+          expect(
+            details[:subject]
+          ).to eq benefit_sponsorship.organization.legal_name
+          expect(details[:title]).to eq "SHOP HC4CC 2024"
+          expect(details[:detail]).to eq "Eligibility Created"
+          expect(details[:event_time].to_date).to eq event_log
+               .event_time
+               .in_time_zone("Eastern Time (US & Canada)")
+               .to_date
+        end
+      end
+    end
+  end
 end

--- a/spec/models/event_logs/monitored_event_spec.rb
+++ b/spec/models/event_logs/monitored_event_spec.rb
@@ -183,6 +183,8 @@ RSpec.describe EventLogs::MonitoredEvent, type: :model, dbclean: :around_each do
     end
 
     before do
+      allow(::EnrollRegistry).to receive(:feature?).and_return(true)
+      allow(::EnrollRegistry).to receive(:feature_enabled?).and_return(true)
       TimeKeeper.set_date_of_record_unprotected!(beginning_of_year + 4.months)
     end
 
@@ -236,6 +238,7 @@ RSpec.describe EventLogs::MonitoredEvent, type: :model, dbclean: :around_each do
       end
 
       let(:monitored_event) { event_log.monitored_event }
+
       let(:event_log) do
         Operations::EventLogs::Store
           .new
@@ -244,6 +247,12 @@ RSpec.describe EventLogs::MonitoredEvent, type: :model, dbclean: :around_each do
       end
 
       context "when application osse eligible" do
+        before do
+          allow_any_instance_of(
+            BenefitSponsors::BenefitApplications::BenefitApplication
+          ).to receive(:osse_eligible?).and_return(true)
+        end
+
         subject { monitored_event.eligibility_details }
 
         it "should return osse eligibile application effective date" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187046189

# A brief description of the changes

Current behavior: displaying effective date of the osse eligibility 

New behavior: should display effective date of the valid enrolling/enrolled osse eligibility application. If none exists then should display effective date of eligibility.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.