### PR TITLE
Avoid html-escaping and string interpolation problems in the view.

### DIFF
--- a/app/views/shared/_shopping_nav_panel.html.haml
+++ b/app/views/shared/_shopping_nav_panel.html.haml
@@ -33,7 +33,7 @@
         %br
         %li
           %p
-            = "If you select #{l10n('save_and_exit')}, you can save your work and continue where you left off the next time you login."
+            = "If you select #{t('save_and_exit')}, you can save your work and continue where you left off the next time you login."
   - if show_help_button && !back_to_account_flag
     .btn.btn-default{"data-target" => "#help_with_plan_shopping", "id" => "help_with_plan_shopping_btn", "data-toggle" => "modal", "style" => "width: 100%;", "tabindex" => "0", "onkeydown"=> "handleButtonKeyDown(event, 'help_with_plan_shopping_btn')"}
       = l10n("help_sign_up")


### PR DESCRIPTION
When using an html-escaped function (such as our l10n helper), in addition to the output escaping provided in a template (such as doing string interpolation), the HTML will be escaped twice, which isn't what we want.

https://www.pivotaltracker.com/story/show/187100341