### PR TITLE
added action filter to event logging

### DIFF
--- a/app/views/event_logs/_event_log_tab.html.erb
+++ b/app/views/event_logs/_event_log_tab.html.erb
@@ -100,6 +100,29 @@
         <h2><%= l10n("Event") %> <%= l10n("Details") %></h2>
         <div class="filter-row">
           <div class="filter">
+            <label for="<%= l10n("status").downcase %>"><%= l10n("event_log.action_taken") %></label>
+            <dl class="dropdown">
+            <dt>
+              <div class="fake-select" style="display: flex;align-items: center;">
+                <span class="fake-select-label"><%= l10n("All") %></span>
+                <p class="multiSel"></p>
+              </div>
+            </dt>
+            <dd>
+              <div class="mutliSelect">
+                <ul>
+                  <li><label><input type="checkbox" name="action_taken" value="all" checked/>All</label></li>
+                  <% if @event_logs %>
+                    <% @event_logs.map{|event_log| event_log[:detail] }.uniq.each do |category| %>
+                      <li><label><input type="checkbox" name="action_taken" value="<%= category %>" checked/><%= category %></label></li>
+                    <% end %>
+                  <% end %>
+                </ul>
+              </div>
+            </dd>
+            </dl>
+          </div>
+          <div class="filter">
             <label for="user-id"><%= l10n("event_log.hbx_id_email") %></label>
             <input type="text" id="user-id">
           </div>
@@ -165,7 +188,7 @@
             <% details.each do |detail| %>
             <tr class="detail-row" data-event-id="<%= detail[:_id] %>" id="<%= index %>">
               <td colspan="2"></td>
-              <td><%= detail[:detail] %></td>
+              <td class="action-taken"><%= detail[:detail] %></td>
               <td id="<%= detail[:account_hbx_id] %>" class="user_id"><%= detail[:account_username] %></td>
               <td class="event-time"><%= detail[:event_time] %></td>
             </tr>
@@ -347,6 +370,8 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
         eligibilities = [],
         statuses = [],
         visible_rows = [];
+        actions_taken = [];
+
     $('input[name="subject"]:checked').each(function( index ) {
       subjects.push($(this).val().toUpperCase())
     });
@@ -355,6 +380,9 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
     });
     $('input[name="status"]:checked').each(function( index ) {
       statuses.push($(this).val().toUpperCase())
+    });
+    $('input[name="action_taken"]:checked').each(function( index ) {
+      actions_taken.push($(this).val().toUpperCase())
     });
 
     $('#event-log-table tbody tr').each(function( index ) {
@@ -433,6 +461,24 @@ $('.mutliSelect input[type="checkbox"]').on('click', function() {
           action_dates.push(new Date($(this).text()).getTime());
         }
       });
+
+      // eligibility status filter
+      if (!actions_taken.includes("ALL")){
+        var row_index = visible_rows.indexOf(row);
+        var ok_rows = 0;
+
+        $.each( detail_rows, function(){
+          var action_taken = $(this).find('td.action-taken').text()
+          if (actions_taken.includes(action_taken.toUpperCase())) {
+            ok_rows += 1
+          } else {
+            $(this).hide().addClass("hidden-by-filters");
+          }
+        });
+        if (ok_rows === 0 && row_index !== -1) {
+          visible_rows.splice( row_index, 1 );
+        }
+      }
 
       if ($('#user-id').val()) {
         var row_index = visible_rows.indexOf(row);

--- a/db/seedfiles/translations/en/dc/shared.rb
+++ b/db/seedfiles/translations/en/dc/shared.rb
@@ -76,6 +76,7 @@ SHARED_TRANSLATIONS = {
     "en.event_log.outcome" => "Outcome",
     "en.event_log.performed_by" => "Performed By",
     "en.event_log.time" => "Time",
+    "en.event_log.action_taken" => "Action Taken",
     "en.event_log.hbx_id_email" => "Account (HBX ID / Email)",
     "en.event_log.start_date" => "Action Date Range",
     "en.event_log.end_date" => "End Date",

--- a/db/seedfiles/translations/en/me/shared.rb
+++ b/db/seedfiles/translations/en/me/shared.rb
@@ -77,6 +77,7 @@ SHARED_TRANSLATIONS = {
     "en.event_log.outcome" => "Outcome",
     "en.event_log.performed_by" => "Performed By",
     "en.event_log.time" => "Time",
+    "en.event_log.action_taken" => "Action Taken",
     "en.event_log.hbx_id_email" => "Account (HBX ID / Email)",
     "en.event_log.start_date" => "Action Date Range",
     "en.event_log.end_date" => "End Date",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187054766

# A brief description of the changes

Current behavior: we can't filter the event log events by the action taken

New behavior: added new filter to filter events logs by action taken

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.