### PR TITLE
add font weight class to fix bold on buttons

### DIFF
--- a/app/assets/stylesheets/ui-components/mahc-theme.scss
+++ b/app/assets/stylesheets/ui-components/mahc-theme.scss
@@ -114,6 +114,10 @@ h1,h2,h3,h4,h5,h6 {
   }
 }
 
+button, .button, .normal-font-weight {
+  font-weight: 400;
+}
+
 #uic-primary-nav {
   background:$dark-blue;
 

--- a/app/views/ui-components/v1/cards/_benefit_groups.html.slim
+++ b/app/views/ui-components/v1/cards/_benefit_groups.html.slim
@@ -20,7 +20,7 @@
     - bg.sponsored_benefits.each do |sb|
       div class="#{sb.product_kind.downcase}"
         div style="float:right"
-          button#showhidebutton type="button" data-toggle="collapse" data-target="#collapse#{sb.id.to_s}" aria-expanded="false" aria-controls="collapse#{sb.id.to_s}"
+          button#showhidebutton type="button" class="normal-font-weight" data-toggle="collapse" data-target="#collapse#{sb.id.to_s}" aria-expanded="false" aria-controls="collapse#{sb.id.to_s}"
             | View Details
             a
               i.fa.fa-chevron-down.fa-lg

--- a/app/views/ui-components/v1/cards/_custom_dental_offered_plans.html.slim
+++ b/app/views/ui-components/v1/cards/_custom_dental_offered_plans.html.slim
@@ -19,7 +19,7 @@
             = "#{bg.effective_on_kind.humanize} following #{bg.effective_on_offset} days"
     .health
       div style="float:right"
-        button#showhidebutton type="button" data-toggle="collapse" data-target="#collapseHealth" aria-expanded="false" aria-controls="collapseHealth"
+        button#showhidebutton type="button" class="normal-font-weight" data-toggle="collapse" data-target="#collapseHealth" aria-expanded="false" aria-controls="collapseHealth"
           | View Details
           a
             i.fa.fa-chevron-down.fa-lg
@@ -64,7 +64,7 @@
   - if bg.dental_reference_plan_id.present?
     .dental
       div style="float:right"
-        button#showhidebuttonDental type="button" data-toggle="collapse" data-target="#collapseDental" aria-expanded="false" aria-controls="collapseDental"
+        button#showhidebuttonDental type="button" class="normal-font-weight" data-toggle="collapse" data-target="#collapseDental" aria-expanded="false" aria-controls="collapseDental"
           | View Details
           a
             i.fa.fa-chevron-down.fa-lg


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187106069

# A brief description of the changes

Current behavior: Different level of boldness found in DC lower environments. This change was caused by a button class pushing the text to semi-bold.

New behavior: New class applied to the buttons that didn't need the bolding to enforce they stay at the normal bold level (400).

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

No tests added due to this being a pure front-end styling change and not involving accessibility.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.