### PR TITLE
allow additional bootstrap attributes in HTML sanitization

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -401,6 +401,27 @@
     {
       "warning_type": "Usage of html_safe",
       "warning_code": 2,
+      "fingerprint": "2b928dacb5985ae7f3a03e7575a6a916b2025a8ef059d886eb411a463c6d7a30",
+      "check_name": "HtmlSafeUsage",
+      "message": "Html_safe used",
+      "file": "lib/html_scrubber_util.rb",
+      "line": 10,
+      "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
+      "code": "ActionController::Base.helpers.sanitize(value, :tags => Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.delete(\"select\").add(\"style\"), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\").add(\"data-toggle\").add(\"data-slide-to\").add(\"data-target\")).html_safe",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "HtmlScrubberUtil",
+        "method": "sanitize_html"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": null,
+      "note": ""
+    },
+    {
+      "warning_type": "Usage of html_safe",
+      "warning_code": 2,
       "fingerprint": "2babd752f4f07d86c0cf403f946b348ec2a25b95dfab59561bdcc62be79187f1",
       "check_name": "HtmlSafeUsage",
       "message": "Html_safe used",
@@ -1049,27 +1070,6 @@
         77
       ],
       "note": ""
-    },
-    {
-      "warning_type": "Usage of html_safe",
-      "warning_code": 2,
-      "fingerprint": "62626698d10a3174d1a1c3fea559d4ad648531bfaf57418b725196517f2feb10",
-      "check_name": "HtmlSafeUsage",
-      "message": "Html_safe used",
-      "file": "lib/html_scrubber_util.rb",
-      "line": 10,
-      "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
-      "code": "ActionController::Base.helpers.sanitize(value, :tags => (Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\")).html_safe",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "HtmlScrubberUtil",
-        "method": "sanitize_html"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": null,
-      "note": "Safe used after explicit scrubbing."
     },
     {
       "warning_type": "Remote Code Execution",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -703,7 +703,7 @@
       "file": "lib/pdf_scrubber_util.rb",
       "line": 10,
       "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
-      "code": "ActionController::Base.helpers.sanitize(value, :tags => Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.delete(\"select\").add(\"style\"), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\")).html_safe",
+      "code": "ActionController::Base.helpers.sanitize(value, :tags => Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.delete(\"select\").add(\"style\"), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\").add(\"data-toggle\").add(\"data-slide-to\").add(\"data-target\")).html_safe",
       "render_path": null,
       "location": {
         "type": "method",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -703,7 +703,7 @@
       "file": "lib/pdf_scrubber_util.rb",
       "line": 10,
       "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
-      "code": "ActionController::Base.helpers.sanitize(value, :tags => Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.delete(\"select\").add(\"style\"), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\").add(\"data-toggle\").add(\"data-slide-to\").add(\"data-target\")).html_safe",
+      "code": "ActionController::Base.helpers.sanitize(value, :tags => Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.delete(\"select\").add(\"style\"), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\")).html_safe",
       "render_path": null,
       "location": {
         "type": "method",
@@ -1059,7 +1059,7 @@
       "file": "lib/html_scrubber_util.rb",
       "line": 10,
       "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
-      "code": "ActionController::Base.helpers.sanitize(value, :tags => (Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\")).html_safe",
+      "code": "ActionController::Base.helpers.sanitize(value, :tags => (Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\").add(\"data-toggle\").add(\"data-slide-to\").add(\"data-target\")).html_safe",
       "render_path": null,
       "location": {
         "type": "method",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -401,27 +401,6 @@
     {
       "warning_type": "Usage of html_safe",
       "warning_code": 2,
-      "fingerprint": "2b928dacb5985ae7f3a03e7575a6a916b2025a8ef059d886eb411a463c6d7a30",
-      "check_name": "HtmlSafeUsage",
-      "message": "Html_safe used",
-      "file": "lib/html_scrubber_util.rb",
-      "line": 10,
-      "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
-      "code": "ActionController::Base.helpers.sanitize(value, :tags => Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.delete(\"select\").add(\"style\"), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\").add(\"data-toggle\").add(\"data-slide-to\").add(\"data-target\")).html_safe",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "HtmlScrubberUtil",
-        "method": "sanitize_html"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": null,
-      "note": ""
-    },
-    {
-      "warning_type": "Usage of html_safe",
-      "warning_code": 2,
       "fingerprint": "2babd752f4f07d86c0cf403f946b348ec2a25b95dfab59561bdcc62be79187f1",
       "check_name": "HtmlSafeUsage",
       "message": "Html_safe used",
@@ -714,27 +693,6 @@
         22
       ],
       "note": ""
-    },
-    {
-      "warning_type": "Usage of html_safe",
-      "warning_code": 2,
-      "fingerprint": "50fc2f6fb0ff3689f1044372d33bc887584cf7545eb47c5d4e631102356929c0",
-      "check_name": "HtmlSafeUsage",
-      "message": "Html_safe used",
-      "file": "lib/pdf_scrubber_util.rb",
-      "line": 10,
-      "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
-      "code": "ActionController::Base.helpers.sanitize(value, :tags => Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.delete(\"select\").add(\"style\"), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\")).html_safe",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PdfScrubberUtil",
-        "method": "sanitize_pdf"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": null,
-      "note": "Safe called after explicit scrubbing."
     },
     {
       "warning_type": "Usage of html_safe",
@@ -1660,6 +1618,27 @@
     {
       "warning_type": "Usage of html_safe",
       "warning_code": 2,
+      "fingerprint": "a85ebc5a995561d2080a705be23075fa1a1c84cbf187cb5f7ac7fa52308ff678",
+      "check_name": "HtmlSafeUsage",
+      "message": "Html_safe used",
+      "file": "lib/html_scrubber_util.rb",
+      "line": 10,
+      "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
+      "code": "ActionController::Base.helpers.sanitize(value, :tags => Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.delete(\"select\").add(\"style\"), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\").add(\"data-toggle\").add(\"data-slide-to\").add(\"data-target\")).html_safe",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "HtmlScrubberUtil",
+        "method": "sanitize_html"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": null,
+      "note": ""
+    },
+    {
+      "warning_type": "Usage of html_safe",
+      "warning_code": 2,
       "fingerprint": "aaa0288e835c23b720c7ef74ac172440d89b7fd7af4c3af2514d5a8ba9272ea6",
       "check_name": "HtmlSafeUsage",
       "message": "Html_safe used",
@@ -1862,7 +1841,7 @@
       "check_name": "Send",
       "message": "User controlled method execution",
       "file": "components/financial_assistance/app/controllers/financial_assistance/verification_documents_controller.rb",
-      "line": 115,
+      "line": 122,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
       "code": "@docs_owner.send(params[:evidence_kind])",
       "render_path": null,
@@ -2296,6 +2275,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-02-20 17:29:18 +0000",
+  "updated": "2024-02-27 15:09:50 -0700",
   "brakeman_version": "5.4.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -401,27 +401,6 @@
     {
       "warning_type": "Usage of html_safe",
       "warning_code": 2,
-      "fingerprint": "62626698d10a3174d1a1c3fea559d4ad648531bfaf57418b725196517f2feb10",
-      "check_name": "HtmlSafeUsage",
-      "message": "Html_safe used",
-      "file": "lib/html_scrubber_util.rb",
-      "line": 10,
-      "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
-      "code": "ActionController::Base.helpers.sanitize(value, :tags => (Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\").add(\"data-toggle\").add(\"data-slide-to\").add(\"data-target\")).html_safe",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "HtmlScrubberUtil",
-        "method": "sanitize_html"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": null,
-      "note": "Safe used after explicit scrubbing."
-    },
-    {
-      "warning_type": "Usage of html_safe",
-      "warning_code": 2,
       "fingerprint": "2babd752f4f07d86c0cf403f946b348ec2a25b95dfab59561bdcc62be79187f1",
       "check_name": "HtmlSafeUsage",
       "message": "Html_safe used",
@@ -1070,6 +1049,27 @@
         77
       ],
       "note": ""
+    },
+    {
+      "warning_type": "Usage of html_safe",
+      "warning_code": 2,
+      "fingerprint": "62626698d10a3174d1a1c3fea559d4ad648531bfaf57418b725196517f2feb10",
+      "check_name": "HtmlSafeUsage",
+      "message": "Html_safe used",
+      "file": "lib/html_scrubber_util.rb",
+      "line": 10,
+      "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
+      "code": "ActionController::Base.helpers.sanitize(value, :tags => (Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\")).html_safe",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "HtmlScrubberUtil",
+        "method": "sanitize_html"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": null,
+      "note": "Safe used after explicit scrubbing."
     },
     {
       "warning_type": "Remote Code Execution",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -401,6 +401,27 @@
     {
       "warning_type": "Usage of html_safe",
       "warning_code": 2,
+      "fingerprint": "62626698d10a3174d1a1c3fea559d4ad648531bfaf57418b725196517f2feb10",
+      "check_name": "HtmlSafeUsage",
+      "message": "Html_safe used",
+      "file": "lib/html_scrubber_util.rb",
+      "line": 10,
+      "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
+      "code": "ActionController::Base.helpers.sanitize(value, :tags => (Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\").add(\"data-toggle\").add(\"data-slide-to\").add(\"data-target\")).html_safe",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "HtmlScrubberUtil",
+        "method": "sanitize_html"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": null,
+      "note": "Safe used after explicit scrubbing."
+    },
+    {
+      "warning_type": "Usage of html_safe",
+      "warning_code": 2,
       "fingerprint": "2babd752f4f07d86c0cf403f946b348ec2a25b95dfab59561bdcc62be79187f1",
       "check_name": "HtmlSafeUsage",
       "message": "Html_safe used",
@@ -1049,27 +1070,6 @@
         77
       ],
       "note": ""
-    },
-    {
-      "warning_type": "Usage of html_safe",
-      "warning_code": 2,
-      "fingerprint": "62626698d10a3174d1a1c3fea559d4ad648531bfaf57418b725196517f2feb10",
-      "check_name": "HtmlSafeUsage",
-      "message": "Html_safe used",
-      "file": "lib/html_scrubber_util.rb",
-      "line": 10,
-      "link": "https://brakemanscanner.org/docs/warning_types/usage_of_html_safe/",
-      "code": "ActionController::Base.helpers.sanitize(value, :tags => (Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS), :attributes => Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.add(\"style\").add(\"data-toggle\").add(\"data-slide-to\").add(\"data-target\")).html_safe",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "HtmlScrubberUtil",
-        "method": "sanitize_html"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": null,
-      "note": "Safe used after explicit scrubbing."
     },
     {
       "warning_type": "Remote Code Execution",

--- a/lib/html_scrubber_util.rb
+++ b/lib/html_scrubber_util.rb
@@ -10,7 +10,11 @@ module HtmlScrubberUtil
     ActionController::Base.helpers.sanitize(
       value,
       tags: Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS,
-      attributes: Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.dup.add("style")
+      attributes: Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.dup
+        .add("style")
+        .add("data-toggle")
+        .add("data-slide-to")
+        .add("data-target")
     ).html_safe
   end
 end

--- a/lib/html_scrubber_util.rb
+++ b/lib/html_scrubber_util.rb
@@ -9,7 +9,7 @@ module HtmlScrubberUtil
   def sanitize_html(value)
     ActionController::Base.helpers.sanitize(
       value,
-      tags: Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS,
+      tags: Loofah::HTML5::SafeList::ACCEPTABLE_ELEMENTS.dup.delete("select").add("style"),
       attributes: Loofah::HTML5::SafeList::ACCEPTABLE_ATTRIBUTES.dup
         .add("style")
         .add("data-toggle")


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [187106404](https://www.pivotaltracker.com/story/show/187106404)

# A brief description of the changes

Current behavior: Tooltip on `/benefit_sponsors/profiles/employers/employer_profiles/:id?tab=home` not static nor styled correctly due to `data-toggle` attribute being removed during sanitization

New behavior: Tooltip now displays statically (not on hover) with correct styling

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.