### PR TITLE
fix race condition for announcement banners not closing

### DIFF
--- a/app/assets/javascripts/announcement.js
+++ b/app/assets/javascripts/announcement.js
@@ -3,7 +3,6 @@ $(document).on('click', 'div.alert-warning a.close', function() {
   
   // The previous^ way to get the modal content returns null for some of the flash notices
   // If it exists, do nothing, but if it is null or an empty string, try getting text from the direct parent
-  // content ? null : content = $(this).parent().text();
   content ? null : content = $(this).parent().text();
   
   if (content != undefined && content != "") {

--- a/app/assets/javascripts/announcement.js
+++ b/app/assets/javascripts/announcement.js
@@ -1,16 +1,21 @@
 $(document).on('click', 'div.alert-warning a.close', function() {
-  var content = $(this).parents('.alert-warning').text();
-
+  var warningContent = $(this).parents('.alert-warning').text();
+  
   // The previous^ way to get the modal content returns null for some of the flash notices
   // If it exists, do nothing, but if it is null or an empty string, try getting text from the direct parent
-  content ? null : content = $(this).parent().text();
-
+  // content ? null : content = $(this).parent().text();
+  content = (warningContent ? warningContent : $(this).parent().text());
+  
   if (content != undefined && content != "") {
     content = content.trim().replace(/^×/, '').trim();
+
+    // if the call is asynchronous, sometimes a race condition emerges and the page reload occurs prior to ajax hitting the /dismiss endpoint
+    // which causes a page reload without actually dismissing the announcement
     $.ajax({
       type: "GET",
-      data:{content: content},
-      url: "/exchanges/announcements/dismiss"
+      data: {content: content},
+      url: `/exchanges/announcements/dismiss`,
+      async: false
     });
   }
 })

--- a/app/assets/javascripts/announcement.js
+++ b/app/assets/javascripts/announcement.js
@@ -1,10 +1,10 @@
 $(document).on('click', 'div.alert-warning a.close', function() {
-  var warningContent = $(this).parents('.alert-warning').text();
+  content = $(this).parents('.alert-warning').text();
   
   // The previous^ way to get the modal content returns null for some of the flash notices
   // If it exists, do nothing, but if it is null or an empty string, try getting text from the direct parent
   // content ? null : content = $(this).parent().text();
-  content = (warningContent ? warningContent : $(this).parent().text());
+  content ? null : content = $(this).parent().text();
   
   if (content != undefined && content != "") {
     content = content.trim().replace(/^×/, '').trim();

--- a/app/assets/javascripts/announcement.js
+++ b/app/assets/javascripts/announcement.js
@@ -1,5 +1,5 @@
 $(document).on('click', 'div.alert-warning a.close', function() {
-  content = $(this).parents('.alert-warning').text();
+  var content = $(this).parents('.alert-warning').text();
   
   // The previous^ way to get the modal content returns null for some of the flash notices
   // If it exists, do nothing, but if it is null or an empty string, try getting text from the direct parent


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: [187106433](https://www.pivotaltracker.com/n/projects/2640059/stories/187106433)

# A brief description of the changes

Current behavior: After closing an announcement modal, refreshing the page will cause the modal to appear again

New behavior: After closing an announcement modal, the modal will not appear again in the same session

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.