### PR TITLE
update flash notice after default devise flash is set

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -9,9 +9,9 @@ class Users::PasswordsController < Devise::PasswordsController
     if verify_recaptcha_if_needed
       self.resource = resource_class.send_reset_password_instructions(resource_params)
       yield resource if block_given?
-      show_generic_forgot_password_text
       if successfully_sent?(resource)
         resource.security_question_responses.destroy_all
+        show_generic_forgot_password_text
 
         respond_to do |format|
           format.html { respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name)) }

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -880,7 +880,7 @@ Then(/^.+ should see plans sorted by Plan Name/) do
 end
 
 When(/^.+ filters plans by Carrier/) do
-  find('.selectric-interaction-choice-control-carrier').click
+  find('.interaction-choice-control-carrier').click
   carrier_option = find('li .interaction-choice-control-carrier-1', wait: 5)
   @carrier_selected = carrier_option.text
   carrier_option.click


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[187097782](https://www.pivotaltracker.com/n/projects/2640063/stories/187097782)

# A brief description of the changes

Current behavior:
Devise is updating the flash notice after the generic message has been set.

New behavior:
Generic flash notice will override the default devise flash.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.