### PR TITLE
add HttpOnly flag to cookie in http response headers

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -24,7 +24,7 @@ class WelcomeController < ApplicationController
   private
 
   def set_cookie_attributes
-    response.headers['Set-Cookie'] = "_session_id=#{session.id}; SameSite=Strict; Secure=true"
+    response.headers['Set-Cookie'] = "_session_id=#{session.id}; SameSite=Strict; Secure=true; HttpOnly"
     response.headers['Strict-Transport-Security'] = "max-age=31536000; includeSubDomains; preload"
   end
 

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe WelcomeController, :type => :controller do
 
       it "has Cookie attributes" do
         expect(response.headers["Set-Cookie"]).to match(/SameSite=Strict/)
+        expect(response.headers["Set-Cookie"]).to match(/HttpOnly/)
         expect(response.headers["Strict-Transport-Security"]).to match(/max-age=31536000; includeSubDomains; preload/)
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: 
[187153418](https://www.pivotaltracker.com/n/projects/2640063/stories/187153418)

# A brief description of the changes

Current behavior:
HttpOnly is not included in cookie response headers.

New behavior:
HttpOnly is included in cookie response headers.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.