### PR TITLE
white list session attributes required for event logging

### DIFF
--- a/app/domain/operations/event_logs/trackable_event.rb
+++ b/app/domain/operations/event_logs/trackable_event.rb
@@ -33,7 +33,7 @@ module Operations
       def validate(params)
         errors = []
         errors << "subject is required" unless params[:subject]
-        errors << "resource is required" unless params[:subject]
+        errors << "resource is required" unless params[:resource]
         errors << "event name is required" unless params[:event_name]
 
         errors.empty? ? Success(params) : Failure(errors)

--- a/app/models/concerns/session_concern.rb
+++ b/app/models/concerns/session_concern.rb
@@ -18,7 +18,7 @@ module SessionConcern
 
     def system_account
       system_email = EnrollRegistry[:aca_event_logging].setting(:system_account_email)&.item
-      @system_account ||= User.find_by(email: system_email) if system_email
+      @system_account ||= User.find_by(email: system_email) if system_email.present?
     end
   end
 end

--- a/app/models/concerns/session_concern.rb
+++ b/app/models/concerns/session_concern.rb
@@ -10,13 +10,15 @@ module SessionConcern
     end
 
     def session
-      session_values = Thread.current[:current_session_values] || {}
+      keys_to_extract = ["portal", "warden.user.user.session", "login_token", "session_id"]
+      session_values = Thread.current[:current_session_values]&.slice(*keys_to_extract) || {}
       session_values[:login_session_id] = Thread.current[:login_session_id] if Thread.current[:login_session_id].present?
       session_values
     end
 
     def system_account
-      @system_account ||= User.find_by(email: "admin@dc.gov")
+      system_email = EnrollRegistry[:aca_event_logging].setting(:system_account_email)&.item
+      @system_account ||= User.find_by(email: system_email) if system_email
     end
   end
 end

--- a/config/client_config/dc/system/config/templates/features/enroll_app/event_log.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/event_log.yml
@@ -5,3 +5,6 @@ registry:
     features:
       - key: :aca_event_logging
         is_enabled: <%= ENV['ACA_EVENT_LOGGING_IS_ENABLED'] || false %>
+        settings:
+          - key: :system_account_email
+            item: "admin@dc.gov"

--- a/config/client_config/me/system/config/templates/features/enroll_app/event_log.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/event_log.yml
@@ -7,4 +7,4 @@ registry:
         is_enabled: <%= ENV['ACA_EVENT_LOGGING_IS_ENABLED'] || false %>
         settings:
           - key: :system_account_email
-            item: "admin@dc.gov"
+            item: ""

--- a/config/client_config/me/system/config/templates/features/enroll_app/event_log.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/event_log.yml
@@ -5,3 +5,6 @@ registry:
     features:
       - key: :aca_event_logging
         is_enabled: <%= ENV['ACA_EVENT_LOGGING_IS_ENABLED'] || false %>
+        settings:
+          - key: :system_account_email
+            item: "admin@dc.gov"

--- a/spec/models/concerns/session_concern_spec.rb
+++ b/spec/models/concerns/session_concern_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SessionConcern, type: :model do
+
+  let(:dummy_class)  { Class.new { include SessionConcern } }
+  let(:subject) { dummy_class.new }
+
+  describe '#current_user' do
+
+    it 'returns nil if no user is set in the thread' do
+      Thread.current[:current_user] = nil
+
+      expect(subject.current_user).to be_nil
+    end
+
+    it 'returns the current user from the thread' do
+      user = build(:user)
+      Thread.current[:current_user] = user
+
+      expect(subject.current_user).to eq(user)
+    end
+  end
+
+  describe '#session' do
+
+    let(:session) do
+      {
+        "portal" => "exchanges/hbx_profiles",
+        "warden.user.user.session" => {
+          "last_request_at" => "1709818105"
+        },
+        "login_token" => "kTZM8ysv853JSva_x7zk",
+        "original_application_type" => "phone",
+        "last_market_visited" => "individual",
+        "person_id" => BSON::ObjectId('65e9c0bca54d75774749ab81'),
+        "session_id" => "ea7d5c32df2e0afc099128abab941400"
+      }
+    end
+
+    let(:expected_keys) { ["portal", "warden.user.user.session", "login_token", "session_id"] }
+
+    it 'returns empty hash if no session is set in the thread' do
+      Thread.current[:current_session_values] = nil
+
+      expect(subject.session).to eq({})
+    end
+
+    it 'returns the current user from the thread' do
+      Thread.current[:current_session_values] = session
+
+      expect(subject.session).to eq(session.slice(*expected_keys))
+    end
+  end
+
+  describe '#system_account' do
+
+    context 'when system email is not present' do
+      before do
+        allow(EnrollRegistry[:aca_event_logging]).to receive_message_chain(:setting, :item).and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(subject.system_account).to be_nil
+      end
+    end
+
+    context 'when system email is present' do
+      let(:system_email) { 'admin@dc.gov' }
+      let!(:system_user) { create(:user, email: system_email) }
+
+      before do
+        allow(EnrollRegistry[:aca_event_logging]).to receive_message_chain(:setting, :item).and_return(system_email)
+      end
+
+      it 'returns the system account user' do
+        expect(subject.system_account).to eq(system_user)
+      end
+    end
+  end
+end

--- a/system/config/templates/features/enroll_app/event_log.yml
+++ b/system/config/templates/features/enroll_app/event_log.yml
@@ -5,3 +5,6 @@ registry:
     features:
       - key: :aca_event_logging
         is_enabled: <%= ENV['ACA_EVENT_LOGGING_IS_ENABLED'] || false %>
+        settings:
+          - key: :system_account_email
+            item: "admin@dc.gov"


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187192047

# A brief description of the changes

Current behavior: When enabling OSSE eligibility during the creation of a new user in the admin interface, an error related to event logging may occur. However, this error will not occur if you reload or revisit the consumer account.

New behavior: Ensure that session attributes are whitelisted for event logging to prevent issues with new IDs being added to the session, such as the person_id in the current context.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: N/A

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.