### PR TITLE
[01-H] Fix html escaping on some pages I missed.

### DIFF
--- a/app/views/sep_history/_index.html.erb
+++ b/app/views/sep_history/_index.html.erb
@@ -1,5 +1,5 @@
 <div style="margin: 15px" class="sep-display">
-  <h3 class='title'><%= l10n("hbx_profiles.sep_history_for", name: @family.primary_person.full_name) %></h3>
+  <h3 class='title'><%= l10n("hbx_profiles.sep_history_for", name: h(@family.primary_person.full_name)) %></h3>
   <div class="panel-heading" role="tab">
     <div class="row">
       <div class="col-md-6">

--- a/app/views/users/_login_history.html.erb
+++ b/app/views/users/_login_history.html.erb
@@ -3,7 +3,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title"><%= l10n('devise.login_history.admin.history_for_user', email: @user.email || @user.oim_id) %></h4>
+        <h4 class="modal-title"><%= l10n('devise.login_history.admin.history_for_user', email: h(@user.email || @user.oim_id)) %></h4>
       </div>
       <div class="modal-body">
         <ul>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187119720

# A brief description of the changes

Current behavior: Certain remaining portions of the administrative tables don't always correctly escape names and other user inputs.

New behavior: Those inputs are now escaped.