### PR TITLE
Block Consumer match if a broker role exists

### DIFF
--- a/app/models/forms/consumer_candidate.rb
+++ b/app/models/forms/consumer_candidate.rb
@@ -59,6 +59,8 @@ module Forms
       # rubocop:enable Lint/EmptyRescueClause
     end
 
+    # TODO: Refactor this
+    # rubocop:disable Metrics/CyclomaticComplexity
     def match_person
       match_criteria, records = Operations::People::Match.new.call({:dob => dob,
                                                                     :last_name => last_name,
@@ -70,12 +72,13 @@ module Forms
       dob_ssn_condition = (match_criteria == :dob_present && ssn.present?)
 
       if (dob_ssn_condition && records.first.employer_staff_roles?) ||
-        (dob_ssn_condition && (records.first.broker_role.present? || records.first.broker_agency_staff_roles.present?)) ||
+         (dob_ssn_condition && (records.first.broker_role.present? || records.first.broker_agency_staff_roles.present?)) ||
          (match_criteria == :dob_present && ssn.blank?) ||
          match_criteria == :ssn_present
         records.first
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def state_based_policy_satisfied?
       @configuration = EnrollRegistry[:person_match_policy].settings.map(&:to_h).each_with_object({}) do |s,c|

--- a/app/models/forms/consumer_candidate.rb
+++ b/app/models/forms/consumer_candidate.rb
@@ -67,8 +67,10 @@ module Forms
 
       return nil if records.blank?
 
-      if (match_criteria == :dob_present && ssn.present? && records.first.employer_staff_roles?) ||
-        (match_criteria == :dob_present && ssn.present? && (records.first.broker_role.present? || records.first.broker_agency_staff_roles.present?)) ||
+      dob_ssn_condition = (match_criteria == :dob_present && ssn.present?)
+
+      if (dob_ssn_condition && records.first.employer_staff_roles?) ||
+        (dob_ssn_condition && (records.first.broker_role.present? || records.first.broker_agency_staff_roles.present?)) ||
          (match_criteria == :dob_present && ssn.blank?) ||
          match_criteria == :ssn_present
         records.first

--- a/app/models/forms/consumer_candidate.rb
+++ b/app/models/forms/consumer_candidate.rb
@@ -68,6 +68,7 @@ module Forms
       return nil if records.blank?
 
       if (match_criteria == :dob_present && ssn.present? && records.first.employer_staff_roles?) ||
+        (match_criteria == :dob_present && ssn.present? && (records.first.broker_role.present? || records.first.broker_agency_staff_roles.present?)) ||
          (match_criteria == :dob_present && ssn.blank?) ||
          match_criteria == :ssn_present
         records.first

--- a/spec/models/forms/consumer_candidate_spec.rb
+++ b/spec/models/forms/consumer_candidate_spec.rb
@@ -155,7 +155,7 @@ describe "match a person in db" do
         allow(search_params).to receive(:ssn).and_return('517991234')
         subject.does_not_match_a_different_users_person
         expect(subject.errors.messages.present?).to eq true
-        expect(subject.errors[:base]).to match(['#{db_person.first_name} #{db_person.last_name} is already affiliated with another account.'])
+        expect(subject.errors[:base]).to match(["#{db_person.first_name} #{db_person.last_name} is already affiliated with another account."])
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes / features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/187180506

# A brief description of the changes

Current behavior:

Currently if a broker person exists with a n account.
If that person tries to create a person with different email with person PII, its matching the person & showing a green panel in the UI 

New behavior:

Currently if a broker person exists with a n account.
If that person tries to create a person with different email with person PII, 
it should not match the person & throw the errorthat this person is already affiliated with other account.


# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable that is used to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.