### PR TITLE
fix broker staff role authorization

### DIFF
--- a/app/policies/eligibilities/evidence_policy.rb
+++ b/app/policies/eligibilities/evidence_policy.rb
@@ -37,8 +37,8 @@ module Eligibilities
     def allowed_to_modify?
       return true if current_user == associated_user
       return false unless role.present?
-      return true if can_hbx_staff_modify?
-      return true if can_broker_modify?
+      return can_hbx_staff_modify? if role.is_a?(HbxStaffRole)
+      return can_broker_modify? if (has_active_broker_role? || has_active_broker_agency_staff_role?)
       false
     end
 

--- a/app/policies/eligibilities/evidence_policy.rb
+++ b/app/policies/eligibilities/evidence_policy.rb
@@ -46,7 +46,7 @@ module Eligibilities
       role.is_a?(HbxStaffRole) && role&.permission&.modify_family
     end
 
-    def can_individual_market_broker_modify?
+    def can_broker_modify?
       (has_active_broker_role? || has_active_broker_agency_staff_role?) && matches_individual_market_broker_account?
     end
 

--- a/app/policies/eligibilities/evidence_policy.rb
+++ b/app/policies/eligibilities/evidence_policy.rb
@@ -35,23 +35,50 @@ module Eligibilities
     #
     # @note The user is the one who is trying to perform the action. The record_user is the user who owns the record. The record is an instance of Eligibilities::Evidence.
     def allowed_to_modify?
-      role_has_permission_to_modify? || (current_user == associated_user)
-    end
-
-    def role_has_permission_to_modify?
-      role.present? && (can_hbx_staff_modify? || can_broker_modify?)
+      return true if current_user == associated_user
+      return false unless role.present?
+      return true if can_hbx_staff_modify?
+      return true if can_broker_modify?
+      false
     end
 
     def can_hbx_staff_modify?
       role.is_a?(HbxStaffRole) && role&.permission&.modify_family
     end
 
-    def can_broker_modify?
-      (role.is_a?(::BrokerRole) || role.is_a?(::BrokerAgencyStaffRole)) && broker_agency_profile_matches?
+    def can_individual_market_broker_modify?
+      (has_active_broker_role? || has_active_broker_agency_staff_role?) && matches_individual_market_broker_account?
     end
 
     def broker_agency_profile_matches?
       associated_family.active_broker_agency_account.present? && associated_family.active_broker_agency_account.benefit_sponsors_broker_agency_profile_id == role.benefit_sponsors_broker_agency_profile_id
+    end
+
+    # Checks if the broker agency profile ID of any of the roles
+    # matches the provided broker agency profile ID.
+    #
+    # @note The `role` can be a single broker role or multiple active broker agency staff roles.
+    #
+    # @param active_broker_agency_profile_id [String] The broker agency profile ID to match against.
+    #
+    # @return [Boolean] returns true if there is a match, false otherwise.
+    def matches_broker_agency_profile?(active_broker_agency_profile_id)
+      Array(role).any? do |role|
+        role.benefit_sponsors_broker_agency_profile_id == active_broker_agency_profile_id
+      end
+    end
+
+    def matches_individual_market_broker_account?
+      return false unless associated_family.active_broker_agency_account.present?
+      matches_broker_agency_profile?(associated_family.active_broker_agency_account.benefit_sponsors_broker_agency_profile_id)
+    end
+
+    def has_active_broker_role?
+      role.is_a?(::BrokerRole) && role.active?
+    end
+
+    def has_active_broker_agency_staff_role?
+      role.any? { |r| r.is_a?(::BrokerAgencyStaffRole) }
     end
 
     def role

--- a/app/policies/eligibilities/evidence_policy.rb
+++ b/app/policies/eligibilities/evidence_policy.rb
@@ -35,10 +35,16 @@ module Eligibilities
     #
     # @note The user is the one who is trying to perform the action. The record_user is the user who owns the record. The record is an instance of Eligibilities::Evidence.
     def allowed_to_modify?
-      return true if current_user == associated_user
+      return false unless individual_market_role_identity_verified?
+      return true if (current_user == associated_user)
       return false unless role.present?
       return can_hbx_staff_modify? if role.is_a?(HbxStaffRole)
       return can_broker_modify? if (has_active_broker_role? || has_active_broker_agency_staff_role?)
+      false
+    end
+
+    def individual_market_role_identity_verified?
+      return true if (associated_person.resident_role || associated_person.consumer_role&.identity_verified?)
       false
     end
 
@@ -100,16 +106,16 @@ module Eligibilities
       user
     end
 
+    def associated_person
+      associated_family.primary_person
+    end
+
     def associated_user
-      associated_family.primary_person.user
+      associated_person.user
     end
 
     def associated_family
       record.applicant.family
-    end
-
-    def record_user
-      record.applicant.family.primary_person.user
     end
   end
 end

--- a/components/financial_assistance/app/controllers/financial_assistance/verification_documents_controller.rb
+++ b/components/financial_assistance/app/controllers/financial_assistance/verification_documents_controller.rb
@@ -57,7 +57,7 @@ module FinancialAssistance
     def destroy
       authorize record, :can_destroy?
 
-      @document.delete if @evidence.present? && @evidence.send(:type_unverified?)
+      @document.delete if !@evidence.type_verified?
 
       if @document.destroyed?
         add_verification_history(@document)

--- a/components/financial_assistance/app/controllers/financial_assistance/verification_documents_controller.rb
+++ b/components/financial_assistance/app/controllers/financial_assistance/verification_documents_controller.rb
@@ -57,7 +57,7 @@ module FinancialAssistance
     def destroy
       authorize record, :can_destroy?
 
-      @document.delete if @evidence.present? && @evidence.type_unverified?
+      @document.delete if @evidence.present? && @evidence.send(:type_unverified?)
 
       if @document.destroyed?
         add_verification_history(@document)

--- a/components/financial_assistance/app/controllers/financial_assistance/verification_documents_controller.rb
+++ b/components/financial_assistance/app/controllers/financial_assistance/verification_documents_controller.rb
@@ -57,7 +57,8 @@ module FinancialAssistance
     def destroy
       authorize record, :can_destroy?
 
-      @document.delete if @evidence.type_unverified?
+      @document.delete if @evidence.present? && @evidence.type_unverified?
+
       if @document.destroyed?
         add_verification_history(@document)
         @docs_owner.save!

--- a/components/financial_assistance/spec/controllers/financial_assistance/verification_documents_controller_spec.rb
+++ b/components/financial_assistance/spec/controllers/financial_assistance/verification_documents_controller_spec.rb
@@ -2,18 +2,18 @@
 
 RSpec.describe FinancialAssistance::VerificationDocumentsController, type: :controller do
   routes { FinancialAssistance::Engine.routes }
-  let!(:fake_person) { FactoryBot.create(:person, :with_consumer_role) }
-  let!(:fake_user) {FactoryBot.create(:user, :person => fake_person)}
+  let(:fake_person) { FactoryBot.create(:person, :with_consumer_role) }
+  let(:fake_user) {FactoryBot.create(:user, :person => fake_person)}
   let!(:fake_family) { FactoryBot.create(:family, :with_primary_family_member, person: fake_person) }
   let!(:fake_family_member) { fake_family.family_members.first }
 
-  let!(:admin_person) { FactoryBot.create(:person, :with_hbx_staff_role) }
-  let!(:admin_user) {FactoryBot.create(:user, :with_hbx_staff_role, :person => admin_person)}
+  let(:admin_person) { FactoryBot.create(:person, :with_hbx_staff_role) }
+  let(:admin_user) {FactoryBot.create(:user, :with_hbx_staff_role, :person => admin_person)}
   let!(:permission) { FactoryBot.create(:permission, :super_admin) }
   let!(:update_admin) { admin_person.hbx_staff_role.update_attributes(permission_id: permission.id) }
 
-  let!(:person) { FactoryBot.create(:person, :with_consumer_role) }
-  let!(:associated_user) {FactoryBot.create(:user, :person => person)}
+  let(:person) { FactoryBot.create(:person, :with_consumer_role) }
+  let(:associated_user) {FactoryBot.create(:user, :person => person)}
   let!(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
   let!(:family_member) { family.family_members.first }
 
@@ -242,137 +242,256 @@ RSpec.describe FinancialAssistance::VerificationDocumentsController, type: :cont
   end
 
   context 'broker logged in' do
-    let!(:person) { FactoryBot.create(:person, :with_consumer_role) }
-    let!(:associated_user) {FactoryBot.create(:user, :person => person)}
-    let!(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
-    let!(:family_member) { family.family_members.first }
-    let!(:broker_user) {FactoryBot.create(:user, :person => writing_agent.person, roles: ['broker_role', 'broker_agency_staff_role'])}
+    let(:writing_agent)         { FactoryBot.create(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, aasm_state: :active) }
+    let(:broker_role_user) {FactoryBot.create(:user, :person => writing_agent.person, roles: ['broker_role'])}
     let(:broker_agency_profile) { FactoryBot.build(:benefit_sponsors_organizations_broker_agency_profile)}
-    let(:writing_agent)         { FactoryBot.create(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id) }
-    let(:assister)  do
-      assister = FactoryBot.build(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, npn: "SMECDOA00")
-      assister.save(validate: false)
-      assister
-    end
+    let(:broker_agency_staff_role) { FactoryBot.create(:broker_agency_staff_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, aasm_state: 'active')}
+    let(:broker_agency_staff_role_user) {FactoryBot.create(:user, :person => broker_agency_staff_role.person, roles: ['broker_agency_staff_role'])}
 
-    context 'hired by family' do
-      before(:each) do
-        family.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id,
-                                                                                            writing_agent_id: writing_agent.id,
-                                                                                            start_on: Time.now,
-                                                                                            is_active: true)
-        family.reload
+    context 'broker_role_user logged in' do
+      context 'hired by family' do
+        before(:each) do
+          family.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id,
+                                                                                              writing_agent_id: writing_agent.id,
+                                                                                              start_on: Time.now,
+                                                                                              is_active: true)
+          family.reload
 
-        sign_in(broker_user)
-      end
-
-
-      context 'POST #upload' do
-        let!(:bucket_name) { 'id-verification' }
-        let!(:doc_id) { "urn:openhbx:terms:v1:file_storage:s3:bucket:#{bucket_name}sample-key" }
-        let!(:params) { { "applicant_id" => applicant.id, "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, file: file} }
-
-        context 'with valid params' do
-          before do
-            allow(Aws::S3Storage).to receive(:save).and_return(doc_id)
-          end
-
-          it 'uploads a new VerificationDocument' do
-            post :upload, params: params
-            expect(flash[:notice]).to eq("File Saved")
-          end
-        end
-      end
-
-      context 'GET #download' do
-        let!(:document) { esi_evidence.documents.create}
-        context 'with valid params' do
-          before do
-            allow(controller).to receive(:get_document).with('sample-key').and_return(document)
-          end
-
-          let!(:params) {{"key" => "sample-key", "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}}
-
-          it 'downloads the requested verification document' do
-            get :download, params: params
-            expect(response).to be_successful
-          end
-        end
-      end
-
-      context 'DELETE #destroy' do
-        let!(:document) { esi_evidence.documents.create}
-
-        before do
-          allow(controller).to receive(:get_document).with('sample-key').and_return(document)
+          sign_in(broker_role_user)
         end
 
-        let!(:params) do
-          { "doc_key" => "sample-key", "doc_title" => "sample-key.Png", "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}
-        end
 
-        it 'destroys the requested verification document' do
-          expect do
-            delete :destroy, params: params
-          end.to change(esi_evidence.documents, :count).by(-1)
-        end
-      end
-    end
+        context 'POST #upload' do
+          let!(:bucket_name) { 'id-verification' }
+          let!(:doc_id) { "urn:openhbx:terms:v1:file_storage:s3:bucket:#{bucket_name}sample-key" }
+          let!(:params) { { "applicant_id" => applicant.id, "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, file: file} }
 
-    context 'not hired by family' do
-      before(:each) do
-        sign_in(broker_user)
-      end
+          context 'with valid params' do
+            before do
+              allow(Aws::S3Storage).to receive(:save).and_return(doc_id)
+            end
 
-      context 'POST #upload' do
-        let!(:bucket_name) { 'id-verification' }
-        let!(:doc_id) { "urn:openhbx:terms:v1:file_storage:s3:bucket:#{bucket_name}sample-key" }
-        let!(:params) { { "applicant_id" => applicant.id, "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, file: file} }
-
-        context 'with valid params' do
-          before do
-            allow(Aws::S3Storage).to receive(:save).and_return(doc_id)
-          end
-
-          it 'returns failure' do
-            post :upload, params: params
-            expect(flash[:error]).to eq("Access not allowed for eligibilities/evidence_policy.can_upload?, (Pundit policy)")
+            it 'uploads a new VerificationDocument' do
+              post :upload, params: params
+              expect(flash[:notice]).to eq("File Saved")
+            end
           end
         end
-      end
 
-      context 'GET #download' do
-        let!(:document) { esi_evidence.documents.create}
-        context 'with valid params' do
+        context 'GET #download' do
+          let!(:document) { esi_evidence.documents.create}
+          context 'with valid params' do
+            before do
+              allow(controller).to receive(:get_document).with('sample-key').and_return(document)
+            end
+
+            let!(:params) {{"key" => "sample-key", "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}}
+
+            it 'downloads the requested verification document' do
+              get :download, params: params
+              expect(response).to be_successful
+            end
+          end
+        end
+
+        context 'DELETE #destroy' do
+          let!(:document) { esi_evidence.documents.create}
+
           before do
             allow(controller).to receive(:get_document).with('sample-key').and_return(document)
           end
 
-          let!(:params) {{"key" => "sample-key", "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}}
+          let!(:params) do
+            { "doc_key" => "sample-key", "doc_title" => "sample-key.Png", "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}
+          end
 
-          it 'downloads the requested verification document' do
-            get :download, params: params
-            expect(response).to have_http_status(:found)
-            expect(flash[:error]).to eq("Access not allowed for eligibilities/evidence_policy.can_download?, (Pundit policy)")
+          it 'destroys the requested verification document' do
+            expect do
+              delete :destroy, params: params
+            end.to change(esi_evidence.documents, :count).by(-1)
           end
         end
       end
 
-      context 'DELETE #destroy' do
-        let!(:document) { esi_evidence.documents.create}
-
-        before do
-          allow(controller).to receive(:get_document).with('sample-key').and_return(document)
+      context 'not hired by family' do
+        before(:each) do
+          sign_in(broker_role_user)
         end
 
-        let!(:params) do
-          { "doc_key" => "sample-key", "doc_title" => "sample-key.Png", "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}
+        context 'POST #upload' do
+          let!(:bucket_name) { 'id-verification' }
+          let!(:doc_id) { "urn:openhbx:terms:v1:file_storage:s3:bucket:#{bucket_name}sample-key" }
+          let!(:params) { { "applicant_id" => applicant.id, "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, file: file} }
+
+          context 'with valid params' do
+            before do
+              allow(Aws::S3Storage).to receive(:save).and_return(doc_id)
+            end
+
+            it 'returns failure' do
+              post :upload, params: params
+              expect(flash[:error]).to eq("Access not allowed for eligibilities/evidence_policy.can_upload?, (Pundit policy)")
+            end
+          end
         end
 
-        it 'destroys the requested verification document' do
-          expect do
-            delete :destroy, params: params
-          end.to change(esi_evidence.documents, :count).by(0)
+        context 'GET #download' do
+          let!(:document) { esi_evidence.documents.create}
+          context 'with valid params' do
+            before do
+              allow(controller).to receive(:get_document).with('sample-key').and_return(document)
+            end
+
+            let!(:params) {{"key" => "sample-key", "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}}
+
+            it 'downloads the requested verification document' do
+              get :download, params: params
+              expect(response).to have_http_status(:found)
+              expect(flash[:error]).to eq("Access not allowed for eligibilities/evidence_policy.can_download?, (Pundit policy)")
+            end
+          end
+        end
+
+        context 'DELETE #destroy' do
+          let!(:document) { esi_evidence.documents.create}
+
+          before do
+            allow(controller).to receive(:get_document).with('sample-key').and_return(document)
+          end
+
+          let!(:params) do
+            { "doc_key" => "sample-key", "doc_title" => "sample-key.Png", "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}
+          end
+
+          it 'destroys the requested verification document' do
+            expect do
+              delete :destroy, params: params
+            end.to change(esi_evidence.documents, :count).by(0)
+          end
+        end
+      end
+    end
+
+    context 'broker_agency_staff_role_user logged in' do
+      context 'hired by family' do
+        before(:each) do
+          family.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id,
+                                                                                              writing_agent_id: writing_agent.id,
+                                                                                              start_on: Time.now,
+                                                                                              is_active: true)
+          family.reload
+
+          sign_in(broker_agency_staff_role_user)
+        end
+
+
+        context 'POST #upload' do
+          let!(:bucket_name) { 'id-verification' }
+          let!(:doc_id) { "urn:openhbx:terms:v1:file_storage:s3:bucket:#{bucket_name}sample-key" }
+          let!(:params) { { "applicant_id" => applicant.id, "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, file: file} }
+
+          context 'with valid params' do
+            before do
+              allow(Aws::S3Storage).to receive(:save).and_return(doc_id)
+            end
+
+            it 'uploads a new VerificationDocument' do
+              post :upload, params: params
+              expect(flash[:notice]).to eq("File Saved")
+            end
+          end
+        end
+
+        context 'GET #download' do
+          let!(:document) { esi_evidence.documents.create}
+          context 'with valid params' do
+            before do
+              allow(controller).to receive(:get_document).with('sample-key').and_return(document)
+            end
+
+            let!(:params) {{"key" => "sample-key", "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}}
+
+            it 'downloads the requested verification document' do
+              get :download, params: params
+              expect(response).to be_successful
+            end
+          end
+        end
+
+        context 'DELETE #destroy' do
+          let!(:document) { esi_evidence.documents.create}
+
+          before do
+            allow(controller).to receive(:get_document).with('sample-key').and_return(document)
+          end
+
+          let!(:params) do
+            { "doc_key" => "sample-key", "doc_title" => "sample-key.Png", "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}
+          end
+
+          it 'destroys the requested verification document' do
+            expect do
+              delete :destroy, params: params
+            end.to change(esi_evidence.documents, :count).by(-1)
+          end
+        end
+      end
+
+      context 'not hired by family' do
+        before(:each) do
+          sign_in(broker_agency_staff_role_user)
+        end
+
+        context 'POST #upload' do
+          let!(:bucket_name) { 'id-verification' }
+          let!(:doc_id) { "urn:openhbx:terms:v1:file_storage:s3:bucket:#{bucket_name}sample-key" }
+          let!(:params) { { "applicant_id" => applicant.id, "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, file: file} }
+
+          context 'with valid params' do
+            before do
+              allow(Aws::S3Storage).to receive(:save).and_return(doc_id)
+            end
+
+            it 'returns failure' do
+              post :upload, params: params
+              expect(flash[:error]).to eq("Access not allowed for eligibilities/evidence_policy.can_upload?, (Pundit policy)")
+            end
+          end
+        end
+
+        context 'GET #download' do
+          let!(:document) { esi_evidence.documents.create}
+          context 'with valid params' do
+            before do
+              allow(controller).to receive(:get_document).with('sample-key').and_return(document)
+            end
+
+            let!(:params) {{"key" => "sample-key", "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}}
+
+            it 'downloads the requested verification document' do
+              get :download, params: params
+              expect(response).to have_http_status(:found)
+              expect(flash[:error]).to eq("Access not allowed for eligibilities/evidence_policy.can_download?, (Pundit policy)")
+            end
+          end
+        end
+
+        context 'DELETE #destroy' do
+          let!(:document) { esi_evidence.documents.create}
+
+          before do
+            allow(controller).to receive(:get_document).with('sample-key').and_return(document)
+          end
+
+          let!(:params) do
+            { "doc_key" => "sample-key", "doc_title" => "sample-key.Png", "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, "applicant_id" => applicant.id}
+          end
+
+          it 'destroys the requested verification document' do
+            expect do
+              delete :destroy, params: params
+            end.to change(esi_evidence.documents, :count).by(0)
+          end
         end
       end
     end

--- a/spec/policies/eligibilities/evidence_policy_spec.rb
+++ b/spec/policies/eligibilities/evidence_policy_spec.rb
@@ -180,15 +180,9 @@ RSpec.describe Eligibilities::EvidencePolicy, type: :policy do
   end
 
   context 'broker logged in' do
-    let!(:broker_user) {FactoryBot.create(:user, :person => writing_agent.person, roles: ['broker_role', 'broker_agency_staff_role'])}
+    let(:broker_user) {FactoryBot.create(:user, :person => writing_agent.person, roles: ['broker_role', 'broker_agency_staff_role'])}
     let(:broker_agency_profile) { FactoryBot.build(:benefit_sponsors_organizations_broker_agency_profile)}
-    let(:writing_agent)         { FactoryBot.create(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id) }
-    let(:assister)  do
-      assister = FactoryBot.build(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, npn: "SMECDOA00")
-      assister.save(validate: false)
-      assister
-    end
-
+    let(:writing_agent)         { FactoryBot.create(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, aasm_state: :active) }
     let(:user) { broker_user }
 
     context 'hired by family' do

--- a/spec/policies/eligibilities/evidence_policy_spec.rb
+++ b/spec/policies/eligibilities/evidence_policy_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe Eligibilities::EvidencePolicy, type: :policy do
     )
   end
 
+  before do
+    person.consumer_role.move_identity_documents_to_verified
+  end
+
   context 'admin user' do
     let!(:admin_person) { FactoryBot.create(:person, :with_hbx_staff_role) }
     let!(:admin_user) {FactoryBot.create(:user, :with_hbx_staff_role, :person => admin_person)}


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640059/stories/187226912#

# A brief description of the changes

Current behavior: Broker agency staff role users are unable to access documents

New behavior:  Broker agency staff role users should be able to access documents of resident role and ridp verified consumer role. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.