### PR TITLE
adding policies for admin permissions

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -115,7 +115,7 @@ class ApplicationPolicy
   #
   # @return [Boolean] Returns true if the user is an active associated broker in the individual market, false otherwise.
   def active_associated_individual_market_family_broker?
-    broker = account_holder_person.broker_role
+    broker = account_holder_person&.broker_role
     return false if broker.blank? || !broker.active? || !broker.individual_market?
 
     broker_agency_account = family.active_broker_agency_account
@@ -130,7 +130,7 @@ class ApplicationPolicy
   #
   # @return [Boolean] Returns true if the user is an admin in the individual market, false otherwise.
   def individual_market_admin?
-    hbx_role = account_holder_person.hbx_staff_role
+    hbx_role = account_holder_person&.hbx_staff_role
     return false if hbx_role.blank?
 
     permission = hbx_role.permission
@@ -162,7 +162,7 @@ class ApplicationPolicy
   def active_associated_coverall_market_family_broker?
     return false unless coverall_market_role
 
-    broker = account_holder_person.broker_role
+    broker = account_holder_person&.broker_role
     return false if broker.blank? || !broker.active? || !broker.individual_market?
 
     broker_agency_account = family.active_broker_agency_account
@@ -178,7 +178,7 @@ class ApplicationPolicy
   #
   # @return [Boolean] Returns true if the account holder is an admin in the coverall market, false otherwise.
   def coverall_market_admin?
-    hbx_role = account_holder_person.hbx_staff_role
+    hbx_role = account_holder_person&.hbx_staff_role
     return false if hbx_role.blank?
 
     permission = hbx_role.permission
@@ -197,7 +197,7 @@ class ApplicationPolicy
   # @param family [Family] The family to check.
   # @return [Boolean] Returns true if the account holder is a primary family member in the ACA Shop market for the given family, false otherwise.
   def shop_market_primary_family_member?
-    primary_person = family.primary_person
+    primary_person = family&.primary_person
     return false unless primary_person
 
     primary_person.employee_roles.present? && account_holder_person == primary_person
@@ -273,6 +273,158 @@ class ApplicationPolicy
   end
   #
   # END - Non-ACA Fehb Market related methods
+
+  # START - Hbx Staff Role permissions
+
+  def staff_view_admin_tabs?
+    permission&.view_admin_tabs
+  end
+
+  def staff_modify_employer?
+    permission&.modify_employer
+  end
+
+  def staff_modify_admin_tabs?
+    permission&.modify_admin_tabs
+  end
+
+  def staff_view_the_configuration_tab?
+    permission&.view_the_configuration_tab
+  end
+
+  def staff_can_submit_time_travel_request?
+    permission&.can_submit_time_travel_request
+  end
+
+  def staff_can_edit_aptc?
+    permission&.can_edit_aptc
+  end
+
+  def staff_send_broker_agency_message?
+    permission&.send_broker_agency_message
+  end
+
+  def staff_approve_broker?
+    permission&.approve_broker
+  end
+
+  def staff_approve_ga?
+    permission&.approve_ga
+  end
+
+  def staff_can_extend_open_enrollment?
+    permission&.can_extend_open_enrollment
+  end
+
+  def staff_can_modify_plan_year?
+    permission&.can_modify_plan_year
+  end
+
+  def staff_can_create_benefit_application?
+    permission&.can_create_benefit_application
+  end
+
+  def staff_can_change_fein?
+    permission&.can_change_fein
+  end
+
+  def staff_can_force_publish?
+    permission&.can_force_publish
+  end
+
+  def staff_can_access_age_off_excluded?
+    permission&.can_access_age_off_excluded
+  end
+
+  def staff_can_send_secure_message?
+    permission&.can_send_secure_message
+  end
+
+  def staff_can_add_sep?
+    permission&.can_add_sep
+  end
+
+  def staff_can_view_sep_history?
+    permission&.can_view_sep_history
+  end
+
+  def staff_can_cancel_enrollment?
+    permission&.can_cancel_enrollment
+  end
+
+  def staff_can_terminate_enrollment?
+    permission&.can_terminate_enrollment
+  end
+
+  def staff_can_reinstate_enrollment?
+    permission&.can_reinstate_enrollment
+  end
+
+  def staff_can_drop_enrollment_members?
+    permission&.can_drop_enrollment_members
+  end
+
+  def staff_change_enrollment_end_date?
+    permission&.change_enrollment_end_date
+  end
+
+  def staff_can_access_identity_verification_sub_tab?
+    permission&.can_access_identity_verification_sub_tab
+  end
+
+  def staff_can_access_outstanding_verification_sub_tab?
+    permission&.can_access_outstanding_verification_sub_tab
+  end
+
+  def staff_can_access_accept_reject_identity_documents?
+    permission&.can_access_accept_reject_identity_documents
+  end
+
+  def staff_can_access_accept_reject_paper_application_documents?
+    permission&.can_access_accept_reject_paper_application_documents
+  end
+
+  def staff_can_delete_identity_application_documents?
+    permission&.can_delete_identity_application_documents
+  end
+
+  def staff_can_access_user_account_tab?
+    permission&.can_access_user_account_tab
+  end
+
+  def staff_can_add_pdc?
+    permission&.can_add_pdc
+  end
+
+  def staff_can_call_hub?
+    permission&.can_call_hub
+  end
+
+  def staff_can_edit_osse_eligibility?
+    permission&.can_edit_osse_eligibility
+  end
+
+  def staff_can_view_audit_log?
+    permission&.can_view_audit_log
+  end
+
+  def staff_can_update_ssn?
+    permission&.can_update_ssn
+  end
+
+  def permission
+    return @permission if defined? @permission
+
+    @permission = hbx_role&.permission
+  end
+
+  def hbx_role
+    return @hbx_role if defined? @hbx_role
+
+    @hbx_role = account_holder_person&.hbx_staff_role
+  end
+
+  # END - Hbx Staff Role permissions
 
   def index?
     read_all?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -130,7 +130,6 @@ class ApplicationPolicy
   #
   # @return [Boolean] Returns true if the user is an admin in the individual market, false otherwise.
   def individual_market_admin?
-    hbx_role = account_holder_person&.hbx_staff_role
     return false if hbx_role.blank?
 
     permission = hbx_role.permission
@@ -178,13 +177,7 @@ class ApplicationPolicy
   #
   # @return [Boolean] Returns true if the account holder is an admin in the coverall market, false otherwise.
   def coverall_market_admin?
-    hbx_role = account_holder_person&.hbx_staff_role
-    return false if hbx_role.blank?
-
-    permission = hbx_role.permission
-    return false if permission.blank?
-
-    permission.modify_family
+    individual_market_admin?
   end
   #
   # END - Non-ACA Coverall Market related methods

--- a/app/policies/hbx_profile_policy.rb
+++ b/app/policies/hbx_profile_policy.rb
@@ -1,5 +1,267 @@
 class HbxProfilePolicy < ApplicationPolicy
 
+  def oe_extendable_applications?
+    staff_can_extend_open_enrollment?
+  end
+
+  def oe_extended_applications?
+    staff_can_extend_open_enrollment?
+  end
+
+  def edit_open_enrollment?
+    staff_can_extend_open_enrollment?
+  end
+
+  def extend_open_enrollment?
+    staff_can_extend_open_enrollment?
+  end
+
+  def close_extended_open_enrollment?
+    staff_can_extend_open_enrollment?
+  end
+
+  def new_benefit_application?
+    staff_can_create_benefit_application?
+  end
+
+  def create_benefit_application?
+    staff_can_create_benefit_application?
+  end
+
+  def edit_fein?
+    staff_can_change_fein?
+  end
+
+  def update_fein?
+    staff_can_change_fein?
+  end
+
+  def binder_paid?
+    staff_modify_admin_tabs?
+  end
+
+  def new_secure_message?
+    staff_can_send_secure_message?
+  end
+
+  def create_send_secure_message?
+    staff_can_send_secure_message?
+  end
+
+  def disable_ssn_requirement?
+    staff_can_update_ssn?
+  end
+
+  def generate_invoice?
+    staff_modify_employer?
+  end
+
+  def edit_force_publish?
+    staff_can_force_publish?
+  end
+
+  def force_publish?
+    staff_can_force_publish?
+  end
+
+  def employer_invoice?
+    index?
+  end
+
+  def employer_datatable?
+    index?
+  end
+
+  def index?
+    return true if individual_market_admin?
+    return true if shop_market_admin?
+
+    false
+  end
+
+  def staff_index?
+    index?
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def assister_index?
+    return true if individual_market_primary_family_member?
+    return true if individual_market_admin?
+    return true if active_associated_individual_market_family_broker?
+
+    return true if shop_market_primary_family_member?
+    return true if shop_market_admin?
+    return true if active_associated_shop_market_family_broker?
+    return true if active_associated_shop_market_general_agency?
+
+    return true if fehb_market_primary_family_member?
+    return true if fehb_market_admin?
+    return true if active_associated_fehb_market_family_broker?
+    return true if active_associated_fehb_market_general_agency?
+
+    return true if coverall_market_primary_family_member?
+    return true if coverall_market_admin?
+    return true if active_associated_coverall_market_family_broker?
+
+    false
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+
+  def request_help?
+    assister_index?
+  end
+
+  def family_index?
+    return true if index?
+    return true if user.person&.csr_role&.cac
+
+    false
+  end
+
+  def family_index_dt?
+    index?
+  end
+
+  def identity_verification?
+    index?
+  end
+
+  def user_account_index?
+    staff_can_access_user_account_tab?
+  end
+
+  def outstanding_verification_dt?
+    index?
+  end
+
+  def hide_form?
+    staff_can_add_sep?
+  end
+
+  def add_sep_form?
+    staff_can_add_sep?
+  end
+
+  def show_sep_history?
+    staff_can_view_sep_history?
+  end
+
+  # rubocop:disable Naming/AccessorMethodName
+  def get_user_info?
+    index?
+  end
+  # rubocop:enable Naming/AccessorMethodName
+
+  def update_effective_date?
+    staff_can_add_sep?
+  end
+
+  def calculate_sep_dates?
+    staff_can_add_sep?
+  end
+
+  def add_new_sep?
+    staff_can_add_sep?
+  end
+
+  def cancel_enrollment?
+    staff_can_cancel_enrollment?
+  end
+
+  def update_cancel_enrollment?
+    staff_can_cancel_enrollment?
+  end
+
+  def terminate_enrollment?
+    staff_can_terminate_enrollment?
+  end
+
+  def update_terminate_enrollment?
+    staff_can_terminate_enrollment?
+  end
+
+  def drop_enrollment_member?
+    staff_can_drop_enrollment_members?
+  end
+
+  def update_enrollment_member_drop?
+    staff_can_drop_enrollment_members?
+  end
+
+  def view_enrollment_to_update_end_date?
+    staff_change_enrollment_end_date?
+  end
+
+  def update_enrollment_terminated_on_date?
+    staff_change_enrollment_end_date?
+  end
+
+  def broker_agency_index?
+    index?
+  end
+
+  def general_agency_index?
+    index?
+  end
+
+  def configuration?
+    staff_view_the_configuration_tab?
+  end
+
+  def view_terminated_hbx_enrollments?
+    index?
+  end
+
+  def reinstate_enrollment?
+    staff_can_reinstate_enrollment?
+  end
+
+  def edit_dob_ssn?
+    staff_can_update_ssn?
+  end
+
+  def verify_dob_change?
+    staff_can_update_ssn?
+  end
+
+  def update_dob_ssn?
+    staff_can_update_ssn?
+  end
+
+  def new_eligibility?
+    staff_can_add_pdc?
+  end
+
+  def process_eligibility?
+    staff_can_add_pdc?
+  end
+
+  def create_eligibility?
+    staff_can_add_pdc?
+  end
+
+  def show?
+    index?
+  end
+
+  def inbox?
+    index?
+  end
+
+  def set_date?
+    staff_can_submit_time_travel_request?
+  end
+
+  def aptc_csr_family_index?
+    index?
+  end
+
+  def update_setting?
+    staff_modify_admin_tabs?
+  end
+
+
+
   # Acts as the entire Pundit Policy for app/controllers/translations_controller.rb
   def can_view_or_change_translations?
     user_hbx_staff_role&.permission&.name == "super_admin"
@@ -90,29 +352,7 @@ class HbxProfilePolicy < ApplicationPolicy
     role.permission.can_send_secure_message
   end
 
-  def show?
-    @user.has_role?(:hbx_staff) ||
-      @user.has_role?(:csr) ||
-      @user.has_role?(:assister)
-  end
-
-  def index?
-    @user.has_role? :hbx_staff
-  end
-
   def employer_index?
-    index?
-  end
-
-  def family_index?
-    index?
-  end
-
-  def broker_agency_index?
-    index?
-  end
-
-  def configuration?
     index?
   end
 
@@ -142,10 +382,6 @@ class HbxProfilePolicy < ApplicationPolicy
 
   def destroy?
     edit?
-  end
-
-  def set_date?
-    index?
   end
 
   def can_add_sep?

--- a/spec/policies/hbx_profile_policy_spec.rb
+++ b/spec/policies/hbx_profile_policy_spec.rb
@@ -3,22 +3,20 @@ require "rails_helper"
 describe HbxProfilePolicy do
   subject { described_class }
   let(:hbx_profile){ hbx_staff_person.hbx_staff_role.hbx_profile }
+  let(:permission) { FactoryBot.create(:permission, modify_family: true)}
   let(:hbx_staff_person) { FactoryBot.create(:person, :with_hbx_staff_role) }
   let(:assister_person) { FactoryBot.create(:person, :with_assister_role) }
   let(:csr_person) { FactoryBot.create(:person, :with_csr_role) }
   let(:employee_person) { FactoryBot.create(:person, :with_employee_role)}
+  let(:hbx_staff_role) { hbx_staff_person.hbx_staff_role }
+
+  before do
+    allow(hbx_staff_role).to receive(:permission).and_return permission
+  end
 
   permissions :show? do
     it "grants access when hbx_staff" do
       expect(subject).to permit(FactoryBot.build(:user, :hbx_staff, person: hbx_staff_person), HbxProfile)
-    end
-
-    it "grants access when csr" do
-      expect(subject).to permit(FactoryBot.build(:user, :csr, person: csr_person), HbxProfile)
-    end
-
-    it "grants access when assister" do
-      expect(subject).to permit(FactoryBot.build(:user, :assister, person: assister_person), HbxProfile)
     end
 
     it "denies access when employee" do
@@ -95,9 +93,6 @@ describe HbxProfilePolicy do
       end
     end
   end
-end
-
-describe HbxProfilePolicy do
 
   describe "given an HbxStaffRole with permissions" do
     let(:person){FactoryBot.create(:person, user: user)}
@@ -265,9 +260,7 @@ describe HbxProfilePolicy do
       expect(policy.can_submit_time_travel_request?).to be false
     end
   end
-end
 
-describe HbxProfilePolicy do
   context '.can_create_benefit_application?' do
     let!(:user10)                  { FactoryBot.create(:user) }
     let!(:person)                  { FactoryBot.create(:person, :with_hbx_staff_role, user: user10) }
@@ -297,13 +290,12 @@ describe HbxProfilePolicy do
         end
       end
     end
-  end
-    describe HbxProfilePolicy do
-      context 'super admin can view config tab?' do
-        let!(:user10)                  { FactoryBot.create(:user) }
-        let!(:person)                  { FactoryBot.create(:person, :with_hbx_staff_role, user: user10) }
 
-        subject                        { HbxProfilePolicy.new(user10, nil) }
+    context 'super admin can view config tab?' do
+      let!(:user10)                  { FactoryBot.create(:user) }
+      let!(:person)                  { FactoryBot.create(:person, :with_hbx_staff_role, user: user10) }
+
+      subject                        { HbxProfilePolicy.new(user10, nil) }
 
       ['super_admin'].each do |kind|
         context "for permissions which doesn't allow the user" do
@@ -320,4 +312,262 @@ describe HbxProfilePolicy do
     end
   end
 
+  describe 'instance methods' do
+    subject { described_class.new(user, HbxProfile) }
+
+    shared_examples_for 'access without role' do |def_name, result|
+      let(:user) { double(User, person: double(hbx_staff_role: nil, consumer_role: nil, csr_role: nil, broker_role: nil, active_general_agency_staff_roles: [], broker_agency_staff_roles: nil, resident_role: nil)) }
+
+      it "#{def_name} returns #{result}" do
+        expect(subject.send(def_name)).to eq result
+      end
+    end
+
+    it_behaves_like 'access without role', :oe_extendable_applications?
+    it_behaves_like 'access without role', :oe_extended_applications?
+    it_behaves_like 'access without role', :edit_open_enrollment?
+    it_behaves_like 'access without role', :extend_open_enrollment?
+    it_behaves_like 'access without role', :close_extended_open_enrollment?
+    it_behaves_like 'access without role', :new_benefit_application?
+    it_behaves_like 'access without role', :create_benefit_application?
+    it_behaves_like 'access without role', :edit_fein?
+    it_behaves_like 'access without role', :update_fein?
+    it_behaves_like 'access without role', :binder_paid?
+    it_behaves_like 'access without role', :new_secure_message?
+    it_behaves_like 'access without role', :create_send_secure_message?
+    it_behaves_like 'access without role', :disable_ssn_requirement?
+    it_behaves_like 'access without role', :generate_invoice?
+    it_behaves_like 'access without role', :edit_force_publish?
+    it_behaves_like 'access without role', :force_publish?
+    it_behaves_like 'access without role', :employer_invoice?, false
+    it_behaves_like 'access without role', :employer_datatable?, false
+    it_behaves_like 'access without role', :index?, false
+    it_behaves_like 'access without role', :staff_index?, false
+    it_behaves_like 'access without role', :assister_index?, false
+    it_behaves_like 'access without role', :request_help?, false
+    it_behaves_like 'access without role', :family_index?, false
+    it_behaves_like 'access without role', :family_index_dt?, false
+    it_behaves_like 'access without role', :identity_verification?, false
+    it_behaves_like 'access without role', :user_account_index?
+    it_behaves_like 'access without role', :outstanding_verification_dt?, false
+    it_behaves_like 'access without role', :hide_form?
+    it_behaves_like 'access without role', :add_sep_form?
+    it_behaves_like 'access without role', :show_sep_history?
+    it_behaves_like 'access without role', :get_user_info?, false
+    it_behaves_like 'access without role', :update_effective_date?
+    it_behaves_like 'access without role', :calculate_sep_dates?
+    it_behaves_like 'access without role', :add_new_sep?
+    it_behaves_like 'access without role', :cancel_enrollment?
+    it_behaves_like 'access without role', :update_cancel_enrollment?
+    it_behaves_like 'access without role', :terminate_enrollment?
+    it_behaves_like 'access without role', :update_terminate_enrollment?
+    it_behaves_like 'access without role', :drop_enrollment_member?
+    it_behaves_like 'access without role', :update_enrollment_member_drop?
+    it_behaves_like 'access without role', :view_enrollment_to_update_end_date?
+    it_behaves_like 'access without role', :update_enrollment_terminated_on_date?
+    it_behaves_like 'access without role', :broker_agency_index?, false
+    it_behaves_like 'access without role', :general_agency_index?, false
+    it_behaves_like 'access without role', :configuration?
+    it_behaves_like 'access without role', :view_terminated_hbx_enrollments?, false
+    it_behaves_like 'access without role', :reinstate_enrollment?
+    it_behaves_like 'access without role', :edit_dob_ssn?
+    it_behaves_like 'access without role', :verify_dob_change?
+    it_behaves_like 'access without role', :update_dob_ssn?
+    it_behaves_like 'access without role', :new_eligibility?
+    it_behaves_like 'access without role', :process_eligibility?
+    it_behaves_like 'access without role', :create_eligibility?
+    it_behaves_like 'access without role', :show?, false
+    it_behaves_like 'access without role', :inbox?, false
+    it_behaves_like 'access without role', :set_date?
+    it_behaves_like 'access without role', :aptc_csr_family_index?, false
+    it_behaves_like 'access without role', :update_setting?
+
+    shared_examples_for 'with role and permission' do |def_name, permission_name, permission_val, result|
+      let(:user) { double(User, person: double(hbx_staff_role: staff_role, consumer_role: nil, csr_role: nil, broker_role: nil, active_general_agency_staff_roles: [], broker_agency_staff_roles: nil, resident_role: nil)) }
+      let(:staff_role) { double(permission: permission) }
+      let(:permission) { double(:permission) }
+
+      before do
+        allow(permission).to receive(permission_name).and_return permission_val if permission_name
+      end
+
+      it "returns #{def_name} as #{result} when #{permission_name} is #{permission_val}" do
+        expect(subject.send(def_name)).to eq result
+      end
+    end
+
+    it_behaves_like 'with role and permission', :oe_extendable_applications?, :can_extend_open_enrollment, true, true
+    it_behaves_like 'with role and permission', :oe_extendable_applications?, :can_extend_open_enrollment, false, false
+
+    it_behaves_like 'with role and permission', :oe_extended_applications?, :can_extend_open_enrollment, true, true
+    it_behaves_like 'with role and permission', :oe_extended_applications?, :can_extend_open_enrollment, false, false
+
+    it_behaves_like 'with role and permission', :edit_open_enrollment?, :can_extend_open_enrollment, true, true
+    it_behaves_like 'with role and permission', :edit_open_enrollment?, :can_extend_open_enrollment, false, false
+
+    it_behaves_like 'with role and permission', :extend_open_enrollment?, :can_extend_open_enrollment, true, true
+    it_behaves_like 'with role and permission', :extend_open_enrollment?, :can_extend_open_enrollment, false, false
+
+    it_behaves_like 'with role and permission', :close_extended_open_enrollment?, :can_extend_open_enrollment, true, true
+    it_behaves_like 'with role and permission', :close_extended_open_enrollment?, :can_extend_open_enrollment, false, false
+
+    it_behaves_like 'with role and permission', :new_benefit_application?, :can_create_benefit_application, true, true
+    it_behaves_like 'with role and permission', :new_benefit_application?, :can_create_benefit_application, false, false
+
+    it_behaves_like 'with role and permission', :create_benefit_application?, :can_create_benefit_application, true, true
+    it_behaves_like 'with role and permission', :create_benefit_application?, :can_create_benefit_application, false, false
+
+    it_behaves_like 'with role and permission', :edit_fein?, :can_change_fein, true, true
+    it_behaves_like 'with role and permission', :edit_fein?, :can_change_fein, false, false
+
+    it_behaves_like 'with role and permission', :update_fein?, :can_change_fein, true, true
+    it_behaves_like 'with role and permission', :update_fein?, :can_change_fein, false, false
+
+    it_behaves_like 'with role and permission', :binder_paid?, :modify_admin_tabs, true, true
+    it_behaves_like 'with role and permission', :binder_paid?, :modify_admin_tabs, false, false
+
+    it_behaves_like 'with role and permission', :new_secure_message?, :can_send_secure_message, true, true
+    it_behaves_like 'with role and permission', :new_secure_message?, :can_send_secure_message, false, false
+
+    it_behaves_like 'with role and permission', :create_send_secure_message?, :can_send_secure_message, true, true
+    it_behaves_like 'with role and permission', :create_send_secure_message?, :can_send_secure_message, false, false
+
+    it_behaves_like 'with role and permission', :disable_ssn_requirement?, :can_update_ssn, true, true
+    it_behaves_like 'with role and permission', :disable_ssn_requirement?, :can_update_ssn, false, false
+
+    it_behaves_like 'with role and permission', :generate_invoice?, :modify_employer, true, true
+    it_behaves_like 'with role and permission', :generate_invoice?, :modify_employer, false, false
+
+    it_behaves_like 'with role and permission', :edit_force_publish?, :can_force_publish, true, true
+    it_behaves_like 'with role and permission', :edit_force_publish?, :can_force_publish, false, false
+
+    it_behaves_like 'with role and permission', :force_publish?, :can_force_publish, true, true
+    it_behaves_like 'with role and permission', :force_publish?, :can_force_publish, false, false
+
+    it_behaves_like 'with role and permission', :employer_invoice?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :employer_invoice?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :employer_datatable?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :employer_datatable?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :index?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :index?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :staff_index?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :staff_index?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :assister_index?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :assister_index?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :request_help?, :modify_family, true, true
+    it_behaves_like 'with role and permission', :request_help?, :modify_family, false, false
+
+    it_behaves_like 'with role and permission', :family_index?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :family_index?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :family_index_dt?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :family_index_dt?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :identity_verification?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :identity_verification?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :user_account_index?, :can_access_user_account_tab, true, true
+    it_behaves_like 'with role and permission', :user_account_index?, :can_access_user_account_tab, false, false
+
+    it_behaves_like 'with role and permission', :outstanding_verification_dt?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :outstanding_verification_dt?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :hide_form?, :can_add_sep, true, true
+    it_behaves_like 'with role and permission', :hide_form?, :can_add_sep, false, false
+
+    it_behaves_like 'with role and permission', :add_sep_form?, :can_add_sep, true, true
+    it_behaves_like 'with role and permission', :add_sep_form?, :can_add_sep, false, false
+
+    it_behaves_like 'with role and permission', :show_sep_history?, :can_view_sep_history, true, true
+    it_behaves_like 'with role and permission', :show_sep_history?, :can_view_sep_history, false, false
+
+    it_behaves_like 'with role and permission', :get_user_info?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :get_user_info?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :update_effective_date?, :can_add_sep, true, true
+    it_behaves_like 'with role and permission', :update_effective_date?, :can_add_sep, false, false
+
+    it_behaves_like 'with role and permission', :calculate_sep_dates?, :can_add_sep, true, true
+    it_behaves_like 'with role and permission', :calculate_sep_dates?, :can_add_sep, false, false
+
+    it_behaves_like 'with role and permission', :add_new_sep?, :can_add_sep, true, true
+    it_behaves_like 'with role and permission', :add_new_sep?, :can_add_sep, false, false
+
+    it_behaves_like 'with role and permission', :cancel_enrollment?, :can_cancel_enrollment, true, true
+    it_behaves_like 'with role and permission', :cancel_enrollment?, :can_cancel_enrollment, false, false
+
+    it_behaves_like 'with role and permission', :update_cancel_enrollment?, :can_cancel_enrollment, true, true
+    it_behaves_like 'with role and permission', :update_cancel_enrollment?, :can_cancel_enrollment, false, false
+
+    it_behaves_like 'with role and permission', :terminate_enrollment?, :can_terminate_enrollment, true, true
+    it_behaves_like 'with role and permission', :terminate_enrollment?, :can_terminate_enrollment, false, false
+
+    it_behaves_like 'with role and permission', :update_terminate_enrollment?, :can_terminate_enrollment, true, true
+    it_behaves_like 'with role and permission', :update_terminate_enrollment?, :can_terminate_enrollment, false, false
+
+    it_behaves_like 'with role and permission', :drop_enrollment_member?, :can_drop_enrollment_members, true, true
+    it_behaves_like 'with role and permission', :drop_enrollment_member?, :can_drop_enrollment_members, false, false
+
+    it_behaves_like 'with role and permission', :update_enrollment_member_drop?, :can_drop_enrollment_members, true, true
+    it_behaves_like 'with role and permission', :update_enrollment_member_drop?, :can_drop_enrollment_members, false, false
+
+    it_behaves_like 'with role and permission', :view_enrollment_to_update_end_date?, :change_enrollment_end_date, true, true
+    it_behaves_like 'with role and permission', :view_enrollment_to_update_end_date?, :change_enrollment_end_date, false, false
+
+    it_behaves_like 'with role and permission', :update_enrollment_terminated_on_date?, :change_enrollment_end_date, true, true
+    it_behaves_like 'with role and permission', :update_enrollment_terminated_on_date?, :change_enrollment_end_date, false, false
+
+    it_behaves_like 'with role and permission', :broker_agency_index?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :broker_agency_index?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :general_agency_index?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :general_agency_index?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :configuration?, :view_the_configuration_tab, true, true
+    it_behaves_like 'with role and permission', :configuration?, :view_the_configuration_tab, false, false
+
+    it_behaves_like 'with role and permission', :view_terminated_hbx_enrollments?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :view_terminated_hbx_enrollments?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :reinstate_enrollment?, :can_reinstate_enrollment, true, true
+    it_behaves_like 'with role and permission', :reinstate_enrollment?, :can_reinstate_enrollment, false, false
+
+    it_behaves_like 'with role and permission', :edit_dob_ssn?, :can_update_ssn, true, true
+    it_behaves_like 'with role and permission', :edit_dob_ssn?, :can_update_ssn, false, false
+
+    it_behaves_like 'with role and permission', :verify_dob_change?, :can_update_ssn, true, true
+    it_behaves_like 'with role and permission', :verify_dob_change?, :can_update_ssn, false, false
+
+    it_behaves_like 'with role and permission', :update_dob_ssn?, :can_update_ssn, true, true
+    it_behaves_like 'with role and permission', :update_dob_ssn?, :can_update_ssn, false, false
+
+    it_behaves_like 'with role and permission', :new_eligibility?, :can_add_pdc, true, true
+    it_behaves_like 'with role and permission', :new_eligibility?, :can_add_pdc, false, false
+
+    it_behaves_like 'with role and permission', :process_eligibility?, :can_add_pdc, true, true
+    it_behaves_like 'with role and permission', :process_eligibility?, :can_add_pdc, false, false
+
+    it_behaves_like 'with role and permission', :create_eligibility?, :can_add_pdc, true, true
+    it_behaves_like 'with role and permission', :create_eligibility?, :can_add_pdc, false, false
+
+    it_behaves_like 'with role and permission', :show?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :show?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :inbox?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :inbox?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :set_date?, :can_submit_time_travel_request, true, true
+    it_behaves_like 'with role and permission', :set_date?, :can_submit_time_travel_request, false, false
+
+    it_behaves_like 'with role and permission', :aptc_csr_family_index?, :modify_family, false, false
+    it_behaves_like 'with role and permission', :aptc_csr_family_index?, :modify_family, true, true
+
+    it_behaves_like 'with role and permission', :update_setting?, :modify_admin_tabs, true, true
+    it_behaves_like 'with role and permission', :update_setting?, :modify_admin_tabs, false, false
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187177630

# A brief description of the changes

Current behavior: policies are scattered

New behavior: adding admin permissions to application policy

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.