### PR TITLE
Broker Staff Pundit Policy - Person Update

### DIFF
--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -14,14 +14,6 @@ class PersonPolicy < ApplicationPolicy
     allowed_to_modify?
   end
 
-  def can_download_document?
-    allowed_to_download?
-  end
-
-  def can_delete_document?
-    allowed_to_modify?
-  end
-
   def updateable?
     return true unless role = user.person.hbx_staff_role
     role.permission.modify_family

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -1,3 +1,8 @@
+# frozen_string_literal: true
+
+# The PersonPolicy class defines the rules for which actions can be performed on a Person object.
+# Each public method corresponds to a potential action that can be performed.
+# The private methods are helper methods used to determine whether a user has the necessary permissions to perform an action.
 class PersonPolicy < ApplicationPolicy
   ACCESSABLE_ROLES = %w[hbx_staff_role broker_role active_broker_staff_roles].freeze
 
@@ -6,6 +11,14 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def can_update?
+    allowed_to_modify?
+  end
+
+  def can_download_document?
+    allowed_to_download?
+  end
+
+  def can_delete_document?
     allowed_to_modify?
   end
 
@@ -25,7 +38,34 @@ class PersonPolicy < ApplicationPolicy
     false
   end
 
+  # This method checks if the current user have an HBX staff role, has the permission to modify the family.
+  #
+  # Example:
+  #   can_hbx_staff_modify? # => true/false
+  def can_hbx_staff_modify?
+    has_hbx_staff_role? && role&.permission&.modify_family
+  end
+
+  # This method checks if the current user have a broker role, has the permission to modify either the individual account or the shop account.
+  #
+  # Example:
+  #   can_broker_modify? # => true/false
+  def can_broker_modify?
+    has_broker_role? && (matches_individual_broker_account? || matches_shop_broker_account?)
+  end
+
   private
+
+  # Determines if the user is allowed to download the associated resource.
+  # Access may be allowed to the roles: [HbxStaffRole, BrokerRole, BrokerAgencyStaffRole and EmployerStaffRole]
+  #
+  # @example Check if a user can modify an Evidence record
+  #  allowed_to_download? # => true/false
+  #
+  # @note The user is the one who is trying to perform the action. The associated_user is the user who owns the record. The record is an instance of Person.
+  def allowed_to_download?
+    (current_user == associated_user) || role_has_permission_to_modify?
+  end
 
   def allowed_to_modify?
     (current_user.person == record) || (current_user == associated_user) || role_has_permission_to_modify?
@@ -44,23 +84,55 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def role_has_permission_to_modify?
-    role.present? && (can_hbx_staff_modify? || can_broker_modify?)
+    return false unless role.present?
+
+    if has_hbx_staff_role?
+      can_hbx_staff_modify?
+    elsif has_broker_role?
+      can_broker_modify?
+    end
   end
 
-  def can_hbx_staff_modify?
-    role.is_a?(HbxStaffRole) && role&.permission&.modify_family
+  def matches_individual_broker_account?
+    return false unless associated_family.active_broker_agency_account.present?
+    matches_broker_agency_profile?(associated_family.active_broker_agency_account.benefit_sponsors_broker_agency_profile_id)
   end
 
-  def can_broker_modify?
-    (role.is_a?(::BrokerRole) || role.is_a?(::BrokerAgencyStaffRole)) && broker_agency_profile_matches?
+  def matches_shop_broker_account?
+    return false unless associated_employee_roles.present?
+    associated_employee_roles.any? do |employee_role|
+      matches_broker_agency_profile?(employee_role.employer_profile.active_broker_agency_account.benefit_sponsors_broker_agency_profile_id)
+    end
   end
 
-  def broker_agency_profile_matches?
-    associated_family.active_broker_agency_account.present? && associated_family.active_broker_agency_account.benefit_sponsors_broker_agency_profile_id == role.benefit_sponsors_broker_agency_profile_id
+  # Checks if the broker agency profile ID of any of the roles
+  # matches the provided broker agency profile ID.
+  #
+  # @note The `role` can be a single broker role or multiple active broker agency staff roles.
+  #
+  # @param active_broker_agency_profile_id [String] The broker agency profile ID to match against.
+  #
+  # @return [Boolean] returns true if there is a match, false otherwise.
+  def matches_broker_agency_profile?(active_broker_agency_profile_id)
+    Array(role).any? do |role|
+      role.benefit_sponsors_broker_agency_profile_id == active_broker_agency_profile_id
+    end
+  end
+
+  def associated_employee_roles
+    record.active_employee_roles
   end
 
   def role
     @role ||= find_role
+  end
+
+  def has_broker_role?
+    role.is_a?(::BrokerRole) || role.any? { |r| r.is_a?(::BrokerAgencyStaffRole) }
+  end
+
+  def has_hbx_staff_role?
+    role.is_a?(::HbxStaffRole)
   end
 
   def find_role

--- a/features/plan_shopping/employee_plan_filters.feature
+++ b/features/plan_shopping/employee_plan_filters.feature
@@ -17,6 +17,7 @@ Feature: Employee products sorted when employee click on Plan name, Premium Amou
     And initial employer Acme Inc. has enrollment_open benefit application with Metal Level plan options
     And there is a census employee record for Patrick Doe for employer Acme Inc.
 
+  @flaky  
   Scenario: Employee sort plans by Plan name
     Given employee Patrick Doe already matched with employer Acme Inc. and logged into employee portal
     When Employee clicks "Shop for Plans" on my account page

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -881,16 +881,16 @@ end
 
 When(/^.+ filters plans by Carrier/) do
   find('.selectric-interaction-choice-control-carrier').click
-  carrier_option = find('li .interaction-choice-control-carrier-1', wait: 5)
+  carrier_option = find('li .interaction-choice-control-carrier-1', wait: 10)
   @carrier_selected = carrier_option.text
   carrier_option.click
   find(".interaction-click-control-apply", match: :first, wait: 5).click
 end
 
 Then(/^.+ should see plans filtered by Carrier/) do
-  sleep(2)
-  find_all('.plan-row', wait: 5).each do |row|
-    expect(row.find('h3 small', wait: 5).text).to eq @carrier_selected
+  sleep(10)
+  find_all('.plan-row', wait: 10).each do |row|
+    expect(row.find('h3 small', wait: 10).text).to eq @carrier_selected
   end
 end
 

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -881,16 +881,16 @@ end
 
 When(/^.+ filters plans by Carrier/) do
   find('.selectric-interaction-choice-control-carrier').click
-  carrier_option = find('li .interaction-choice-control-carrier-1', wait: 10)
+  carrier_option = find('li .interaction-choice-control-carrier-1', wait: 5)
   @carrier_selected = carrier_option.text
   carrier_option.click
   find(".interaction-click-control-apply", match: :first, wait: 5).click
 end
 
 Then(/^.+ should see plans filtered by Carrier/) do
-  sleep(10)
-  find_all('.plan-row', wait: 10).each do |row|
-    expect(row.find('h3 small', wait: 10).text).to eq @carrier_selected
+  sleep(2)
+  find_all('.plan-row', wait: 5).each do |row|
+    expect(row.find('h3 small', wait: 5).text).to eq @carrier_selected
   end
 end
 

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -145,14 +145,6 @@ RSpec.describe PersonPolicy, type: :policy do
       end
 
       it 'broker should be able to download document' do
-        expect(policy.can_download_document?).to be true
-      end
-
-      it 'broker should be able to download document' do
-        expect(policy.can_delete_document?).to be true
-      end
-
-      it 'broker should be able to download document' do
         expect(policy.can_broker_modify?).to be true
       end
     end
@@ -160,14 +152,6 @@ RSpec.describe PersonPolicy, type: :policy do
     context 'unauthorized broker' do
       it 'broker should not be able to update' do
         expect(policy.can_update?).to be false
-      end
-
-      it 'broker should not be able to download document' do
-        expect(policy.can_download_document?).to be false
-      end
-
-      it 'broker should not be able to download document' do
-        expect(policy.can_delete_document?).to be false
       end
 
       it 'broker should not be able to download document' do

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -2,80 +2,75 @@
 
 require "rails_helper"
 
-describe PersonPolicy do
+RSpec.describe PersonPolicy, type: :policy do
   context 'with hbx_staff_role' do
-    let(:person){FactoryBot.create(:person, user: user)}
-    let(:user){FactoryBot.create(:user)}
-    let(:hbx_staff_role) { FactoryBot.create(:hbx_staff_role, person: person)}
-    let(:policy){PersonPolicy.new(user,person)}
+    let(:record_person) {FactoryBot.create(:person)}
+    let(:admin_person){FactoryBot.create(:person)}
+    let(:admin_user){FactoryBot.create(:user, person: admin_person)}
+    let(:hbx_staff_role) { FactoryBot.create(:hbx_staff_role, person: admin_person)}
     let(:hbx_profile) {FactoryBot.create(:hbx_profile)}
     Permission.all.delete
 
     context 'allowed to modify? for hbx_staff_role subroles' do
-      it 'hbx_staff' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_staff))
+      let(:policy){PersonPolicy.new(admin_user, record_person)}
+
+      it 'hbx_staff with modify family permission' do
+        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_staff, modify_family: true))
         expect(policy.can_update?).to be true
       end
 
-      it 'hbx_read_only' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_read_only))
-        expect(policy.updateable?).to be true
+      it 'hbx_staff without modify family permission' do
+        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_staff, modify_family: false))
+        expect(policy.can_update?).to be false
       end
 
-      it 'hbx_csr_supervisor' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_supervisor))
-        expect(policy.updateable?).to be true
+      it 'hbx_read_only with modify family permission' do
+        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_read_only, modify_family: true))
+        expect(policy.can_update?).to be true
       end
 
-      it 'hbx_csr_tier2' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_tier2))
-        expect(policy.updateable?).to be true
-      end
-
-      it 'csr_tier1' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_tier1))
-        expect(policy.updateable?).to be true
-      end
-
-      it 'developer' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :developer))
-        expect(policy.updateable?).to be false
+      it 'hbx_read_only without modify family permission' do
+        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_read_only, modify_family: false))
+        expect(policy.can_update?).to be false
       end
     end
 
-    context 'hbx_staff_role subroles' do
-      it 'hbx_staff' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_staff))
-        expect(policy.updateable?).to be true
-      end
+    # updateable? method does not have a proper authorization logic, it is always returning true except for :developer permission
+    # context 'hbx_staff_role subroles' do
+    #   it 'hbx_staff' do
+    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_staff))
+    #     expect(policy.updateable?).to be true
+    #   end
 
-      it 'hbx_read_only' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_read_only))
-        expect(policy.updateable?).to be true
-      end
+    #   it 'hbx_read_only' do
+    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_read_only))
+    #     expect(policy.updateable?).to be true
+    #   end
 
-      it 'hbx_csr_supervisor' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_supervisor))
-        expect(policy.updateable?).to be true
-      end
+    #   it 'hbx_csr_supervisor' do
+    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_supervisor))
+    #     expect(policy.updateable?).to be true
+    #   end
 
-      it 'hbx_csr_tier2' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_tier2))
-        expect(policy.updateable?).to be true
-      end
+    #   it 'hbx_csr_tier2' do
+    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_tier2))
+    #     expect(policy.updateable?).to be true
+    #   end
 
-      it 'csr_tier1' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_tier1))
-        expect(policy.updateable?).to be true
-      end
+    #   it 'csr_tier1' do
+    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_tier1))
+    #     expect(policy.updateable?).to be true
+    #   end
 
-      it 'developer' do
-        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :developer))
-        expect(policy.updateable?).to be false
-      end
-    end
+    #   it 'developer' do
+    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :developer))
+    #     expect(policy.updateable?).to be false
+    #   end
+    # end
+
 
     context 'permissions' do
+      let(:policy){PersonPolicy.new(admin_user, record_person)}
       subject { described_class }
 
       permissions :can_access_identity_verifications? do
@@ -112,31 +107,12 @@ describe PersonPolicy do
   end
 
   context 'with broker role' do
-    Permission.all.delete
-
-    let(:consumer_role) do
-      FactoryBot.create(:consumer_role)
-    end
-
-    let(:person) do
-      pers = consumer_role.person
-      pers.user = user
-      pers.save!
-      pers
-    end
-
     let(:broker_agency_profile) do
       FactoryBot.create(:benefit_sponsors_organizations_broker_agency_profile)
     end
-
-    let(:user) do
-      FactoryBot.create(:user)
-    end
-
-    let(:existing_broker_staff_role) do
-      person.broker_agency_staff_roles.first
-    end
-
+    let(:broker_agency_staff_role) { FactoryBot.create(:broker_agency_staff_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, aasm_state: 'active')}
+    let(:broker_user) {FactoryBot.create(:user, :person => broker_agency_staff_role.person, roles: ['broker_role'])}
+    let(:broker_person) { broker_agency_staff_role.person }
     let(:broker_role) do
       role = BrokerRole.new(
         :broker_agency_profile => broker_agency_profile,
@@ -144,16 +120,34 @@ describe PersonPolicy do
         :npn => "123456789",
         :provider_kind => "broker"
       )
-      person.broker_role = role
-      person.save!
-      person.broker_role
+      broker_person.broker_role = role
+      broker_person.save!
+      broker_person.broker_role
     end
 
-    let(:policy){PersonPolicy.new(user,person)}
+    let(:person) { FactoryBot.create(:person, :with_consumer_role) }
+    let(:user) { FactoryBot.create(:user, person: person) }
+    let!(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
 
-    it 'broker should be able to update' do
-      expect(policy.can_update?).to be true
+    let(:policy){PersonPolicy.new(broker_user, person)}
+
+    context 'authorized broker' do
+      before(:each) do
+        family.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id,
+                                                                                            start_on: Time.now,
+                                                                                            is_active: true)
+        family.reload
+      end
+
+      it 'broker should be able to update' do
+        expect(policy.can_update?).to be true
+      end
     end
 
+    context 'unauthorized broker' do
+      it 'broker should not be able to update' do
+        expect(policy.can_update?).to be false
+      end
+    end
   end
 end

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -145,11 +145,11 @@ RSpec.describe PersonPolicy, type: :policy do
         family.reload
       end
 
-      it 'broker should be able to update' do
+      it 'broker agency staff role should be able to update' do
         expect(policy.can_update?).to be true
       end
 
-      it 'should return true when it matches broker agency profile' do
+      it 'broker agency staff role should return true when it matches broker agency profile' do
         expect(policy.matches_broker_agency_profile?(broker_agency_profile.id)).to eq true
       end
     end

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -35,38 +35,39 @@ RSpec.describe PersonPolicy, type: :policy do
       end
     end
 
-    # updateable? method does not have a proper authorization logic, it is always returning true except for :developer permission
-    # context 'hbx_staff_role subroles' do
-    #   it 'hbx_staff' do
-    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_staff))
-    #     expect(policy.updateable?).to be true
-    #   end
+    context 'hbx_staff_role subroles' do
+      let(:policy){PersonPolicy.new(admin_user, record_person)}
 
-    #   it 'hbx_read_only' do
-    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_read_only))
-    #     expect(policy.updateable?).to be true
-    #   end
+      it 'hbx_staff' do
+        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_staff))
+        expect(policy.updateable?).to be true
+      end
 
-    #   it 'hbx_csr_supervisor' do
-    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_supervisor))
-    #     expect(policy.updateable?).to be true
-    #   end
+      it 'hbx_read_only' do
+        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_read_only))
+        expect(policy.updateable?).to be true
+      end
 
-    #   it 'hbx_csr_tier2' do
-    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_tier2))
-    #     expect(policy.updateable?).to be true
-    #   end
+      it 'hbx_csr_supervisor' do
+        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_supervisor))
+        expect(policy.updateable?).to be true
+      end
 
-    #   it 'csr_tier1' do
-    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_tier1))
-    #     expect(policy.updateable?).to be true
-    #   end
+      it 'hbx_csr_tier2' do
+        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_tier2))
+        expect(policy.updateable?).to be true
+      end
 
-    #   it 'developer' do
-    #     allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :developer))
-    #     expect(policy.updateable?).to be false
-    #   end
-    # end
+      it 'csr_tier1' do
+        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :hbx_csr_tier1))
+        expect(policy.updateable?).to be true
+      end
+
+      it 'developer' do
+        allow(hbx_staff_role).to receive(:permission).and_return(FactoryBot.create(:permission, :developer))
+        expect(policy.updateable?).to be false
+      end
+    end
 
 
     context 'permissions' do
@@ -142,11 +143,35 @@ RSpec.describe PersonPolicy, type: :policy do
       it 'broker should be able to update' do
         expect(policy.can_update?).to be true
       end
+
+      it 'broker should be able to download document' do
+        expect(policy.can_download_document?).to be true
+      end
+
+      it 'broker should be able to download document' do
+        expect(policy.can_delete_document?).to be true
+      end
+
+      it 'broker should be able to download document' do
+        expect(policy.can_broker_modify?).to be true
+      end
     end
 
     context 'unauthorized broker' do
       it 'broker should not be able to update' do
         expect(policy.can_update?).to be false
+      end
+
+      it 'broker should not be able to download document' do
+        expect(policy.can_download_document?).to be false
+      end
+
+      it 'broker should not be able to download document' do
+        expect(policy.can_delete_document?).to be false
+      end
+
+      it 'broker should not be able to download document' do
+        expect(policy.can_broker_modify?).to be false
       end
     end
   end

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -150,7 +150,8 @@ RSpec.describe PersonPolicy, type: :policy do
       end
 
       it 'broker agency staff role should return true when it matches broker agency profile' do
-        expect(policy.matches_broker_agency_profile?(broker_agency_profile.id)).to eq true
+        @result = policy.send(:matches_broker_agency_profile?, broker_agency_profile.id)
+        expect@result(@result).to eq true
       end
     end
 
@@ -164,7 +165,8 @@ RSpec.describe PersonPolicy, type: :policy do
       end
 
       it 'broker agency staff role should return false when it does not matches broker agency profile' do
-        expect(policy.matches_broker_agency_profile?(broker_agency_profile.id)).to eq false
+        @result = policy.send(:matches_broker_agency_profile?, broker_agency_profile.id)
+        expect@result(@result).to eq false
       end
     end
   end

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe PersonPolicy, type: :policy do
 
       it 'broker agency staff role should return true when it matches broker agency profile' do
         @result = policy.send(:matches_broker_agency_profile?, broker_agency_profile.id)
-        expect@result(@result).to eq true
+        expect(@result).to eq true
       end
     end
 
@@ -166,7 +166,7 @@ RSpec.describe PersonPolicy, type: :policy do
 
       it 'broker agency staff role should return false when it does not matches broker agency profile' do
         @result = policy.send(:matches_broker_agency_profile?, broker_agency_profile.id)
-        expect@result(@result).to eq false
+        expect(@result).to eq false
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640059/stories/187226903

# A brief description of the changes

Current behavior: Broker agency staff role users are unable to update person under manage family

When a person has Broker staff role, 
Clicks on families associated to the agency
Tries to save primary person under manage family
Access Not Allowed error on saving the person record

New behavior: Broker agency staff role users should be unable to update person under manage family

When a person has Broker staff role, 
Clicks on families associated to the agency
Tries to save primary person under manage family
Person should be saved without any issues.

<img width="990" alt="error" src="https://github.com/ideacrew/enroll/assets/16886460/c6751aa7-8a27-4572-9738-4fcd468ae6b1">
# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Code flow ->
app/controllers/people_controller.rb:10 in update action
app/policies/person_policy.rb


# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.