### PR TITLE
allows access to broker agency staff roles if eligible

### DIFF
--- a/app/models/broker_agency_staff_role.rb
+++ b/app/models/broker_agency_staff_role.rb
@@ -68,6 +68,16 @@ class BrokerAgencyStaffRole
   # Scopes
 
   # @!scope class
+  # @scope active
+  # Retrieves all Broker Agency Staff Roles that are in the 'active' state.
+  #
+  # @return [Mongoid::Criteria<BrokerAgencyStaffRole>] Returns a Mongoid::Criteria of BrokerAgencyStaffRole objects that are in the 'active' state.
+  #
+  # @example Retrieve all active Broker Agency Staff Roles
+  #   BrokerAgencyStaffRole.active #=> Mongoid::Criteria<BrokerAgencyStaffRole>
+  scope :active, -> { where(aasm_state: 'active') }
+
+  # @!scope class
   # @scope broker_agency_pending
   # Retrieves all Broker Agency Staff Roles that are in the 'broker_agency_pending' state.
   #

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -86,16 +86,6 @@ class ApplicationPolicy
     individual_market_role&.identity_verified?
   end
 
-  # Determines if the current user is an active associated broker in the individual market.
-  # The user is considered an active associated broker if they are an active associated broker for the family in the individual market.
-  # The primary family member must be verified for their identity.
-  # The broker is allowed to access only if the broker is active and associated to the family if the primary person of the family is RIDP verified.
-  #
-  # @return [Boolean] Returns true if the user is an active associated broker in the individual market who has verified their identity, false otherwise.
-  def active_associated_individual_market_ridp_verified_family_broker?
-    primary_family_member_ridp_verified? && active_associated_individual_market_family_broker?
-  end
-
   # Determines if the primary person of the family has verified their identity (RIDP).
   #
   # @return [Boolean] Returns true if the primary person of the family has verified their identity, false otherwise.
@@ -107,6 +97,44 @@ class ApplicationPolicy
     return false if consumer_role.blank?
 
     consumer_role.identity_verified?
+  end
+
+  # Checks if the current user is a primary family member who has verified their identity and is an active associated individual market family broker staff.
+  #
+  # @return [Boolean] Returns true if the primary family member has verified their
+  # identity and the user is an active associated individual market family broker staff, false otherwise.
+  def active_associated_individual_market_ridp_verified_family_broker_staff?
+    primary_family_member_ridp_verified? && active_associated_individual_market_family_broker_staff?
+  end
+
+  # Checks if the current user is an active associated individual market family broker staff.
+  # It checks if the user has any active broker agency staff roles and if the user's family has an active broker agency account.
+  # If both conditions are met, it checks if any of the user's broker agency staff roles
+  # are associated with the broker agency profile of the family's active broker agency account.
+  #
+  # @return [Boolean] Returns true if the user is an active associated individual market family broker staff, false otherwise.
+  def active_associated_individual_market_family_broker_staff?
+    broker_staffs = account_holder_person&.broker_agency_staff_roles&.active
+    return false if broker_staffs.blank?
+
+    broker_agency_account = family.active_broker_agency_account
+    return false if broker_agency_account.blank?
+
+    broker_agency = broker_agency_account.broker_agency_profile
+
+    broker_staffs.any? do |staff|
+      staff.benefit_sponsors_broker_agency_profile_id == broker_agency.id
+    end
+  end
+
+  # Determines if the current user is an active associated broker in the individual market.
+  # The user is considered an active associated broker if they are an active associated broker for the family in the individual market.
+  # The primary family member must be verified for their identity.
+  # The broker is allowed to access only if the broker is active and associated to the family if the primary person of the family is RIDP verified.
+  #
+  # @return [Boolean] Returns true if the user is an active associated broker in the individual market who has verified their identity, false otherwise.
+  def active_associated_individual_market_ridp_verified_family_broker?
+    primary_family_member_ridp_verified? && active_associated_individual_market_family_broker?
   end
 
   # Determines if the current user is an active associated broker in the individual market.
@@ -202,7 +230,6 @@ class ApplicationPolicy
   #
   # @return [Boolean] Returns true if the account holder is an admin in the shop market, false otherwise.
   def shop_market_admin?
-    individual_market_admin?
     # hbx_role = account_holder_person.hbx_staff_role
     # return false if hbx_role.blank?
 
@@ -210,6 +237,7 @@ class ApplicationPolicy
     # return false if permission.blank?
 
     # permission.modify_employer
+    individual_market_admin?
   end
 
   def active_associated_shop_market_family_broker?

--- a/app/policies/family_policy.rb
+++ b/app/policies/family_policy.rb
@@ -45,6 +45,7 @@ class FamilyPolicy < ApplicationPolicy
   # @return [Boolean] Returns true if the user has permission to view the record, false otherwise.
   def show?
     return true if individual_market_primary_family_member?
+    return true if active_associated_individual_market_ridp_verified_family_broker_staff?
     return true if active_associated_individual_market_ridp_verified_family_broker?
     return true if individual_market_admin?
 

--- a/app/policies/hbx_enrollment_policy.rb
+++ b/app/policies/hbx_enrollment_policy.rb
@@ -42,6 +42,7 @@ class HbxEnrollmentPolicy < ApplicationPolicy
   def set_elected_aptc?
     return true if individual_market_primary_family_member?
     return true if individual_market_admin?
+    return true if active_associated_individual_market_ridp_verified_family_broker_staff?
     return true if active_associated_individual_market_ridp_verified_family_broker?
 
     false
@@ -57,6 +58,7 @@ class HbxEnrollmentPolicy < ApplicationPolicy
   def create?
     return true if individual_market_primary_family_member?
     return true if individual_market_admin?
+    return true if active_associated_individual_market_ridp_verified_family_broker_staff?
     return true if active_associated_individual_market_ridp_verified_family_broker?
 
     return true if shop_market_primary_family_member?

--- a/components/financial_assistance/app/policies/financial_assistance/applicant_policy.rb
+++ b/components/financial_assistance/app/policies/financial_assistance/applicant_policy.rb
@@ -37,6 +37,7 @@ module FinancialAssistance
     # @return [Boolean] Returns true if the user has permission to edit an applicant, false otherwise.
     def edit?
       return true if individual_market_primary_family_member?
+      return true if active_associated_individual_market_ridp_verified_family_broker_staff?
       return true if active_associated_individual_market_ridp_verified_family_broker?
       return true if individual_market_admin?
 

--- a/components/financial_assistance/app/policies/financial_assistance/application_policy.rb
+++ b/components/financial_assistance/app/policies/financial_assistance/application_policy.rb
@@ -37,6 +37,7 @@ module FinancialAssistance
     # @return [Boolean] Returns true if the user has permission to edit the application, false otherwise.
     def edit?
       return true if individual_market_primary_family_member?
+      return true if active_associated_individual_market_ridp_verified_family_broker_staff?
       return true if active_associated_individual_market_ridp_verified_family_broker?
       return true if individual_market_admin?
 

--- a/components/financial_assistance/app/policies/financial_assistance/deduction_policy.rb
+++ b/components/financial_assistance/app/policies/financial_assistance/deduction_policy.rb
@@ -25,6 +25,7 @@ module FinancialAssistance
     # @return [Boolean] Returns true if the user has permission to perform a step, false otherwise.
     def step?
       return true if individual_market_primary_family_member?
+      return true if active_associated_individual_market_ridp_verified_family_broker_staff?
       return true if active_associated_individual_market_ridp_verified_family_broker?
       return true if individual_market_admin?
 

--- a/components/financial_assistance/app/policies/financial_assistance/income_policy.rb
+++ b/components/financial_assistance/app/policies/financial_assistance/income_policy.rb
@@ -33,6 +33,7 @@ module FinancialAssistance
     # @return [Boolean] Returns true if the user has permission to perform a step, false otherwise.
     def step?
       return true if individual_market_primary_family_member?
+      return true if active_associated_individual_market_ridp_verified_family_broker_staff?
       return true if active_associated_individual_market_ridp_verified_family_broker?
       return true if individual_market_admin?
 

--- a/components/financial_assistance/spec/policies/financial_assistance/applicant_policy_spec.rb
+++ b/components/financial_assistance/spec/policies/financial_assistance/applicant_policy_spec.rb
@@ -102,7 +102,6 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
 
         context 'when the user is an assigned broker' do
           let(:market_kind) { :both }
-          let(:broker_person) { FactoryBot.create(:person, :with_broker_role) }
           let(:broker_person) { FactoryBot.create(:person) }
           let(:broker_role) { FactoryBot.create(:broker_role, person: broker_person) }
           let(:broker_user) { FactoryBot.create(:user, person: broker_person) }
@@ -171,6 +170,123 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
 
           context 'with unassociated broker' do
             let(:baa_active) { false }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, dependent_applicant)
+            end
+          end
+        end
+
+        context 'when the user is a broker staff' do
+          let(:market_kind) { :both }
+          let(:broker_person) { FactoryBot.create(:person) }
+          let(:broker_role) { FactoryBot.create(:broker_role, person: broker_person) }
+          let(:broker_staff_person) { FactoryBot.create(:person) }
+
+          let(:broker_staff_state) { 'active' }
+
+          let(:broker_staff) do
+            FactoryBot.create(
+              :broker_agency_staff_role,
+              person: broker_staff_person,
+              aasm_state: broker_staff_state,
+              benefit_sponsors_broker_agency_profile_id: broker_agency_id
+            )
+          end
+          let(:broker_staff_user) { FactoryBot.create(:user, person: broker_staff_person) }
+
+          let(:site) do
+            FactoryBot.create(
+              :benefit_sponsors_site,
+              :with_benefit_market,
+              :as_hbx_profile,
+              site_key: ::EnrollRegistry[:enroll_app].settings(:site_key).item
+            )
+          end
+
+          let(:broker_agency_organization) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+          let(:broker_agency_profile) { broker_agency_organization.broker_agency_profile }
+          let(:broker_agency_id) { broker_agency_profile.id }
+
+          let(:logged_in_user) { broker_staff_user }
+
+          let(:broker_agency_account) do
+            family.broker_agency_accounts.create!(
+              benefit_sponsors_broker_agency_profile_id: broker_agency_id,
+              writing_agent_id: broker_role.id,
+              is_active: baa_active,
+              start_on: TimeKeeper.date_of_record
+            )
+          end
+
+          before do
+            broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+            broker_person.create_broker_agency_staff_role(
+              benefit_sponsors_broker_agency_profile_id: broker_role.benefit_sponsors_broker_agency_profile_id
+            )
+            broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id, market_kind: market_kind)
+            broker_role.approve!
+            broker_agency_account
+            broker_staff
+          end
+
+          context 'with active associated individual market broker staff' do
+            context 'consumer RIDP is verified' do
+              let(:baa_active) { true }
+
+              it 'grants access' do
+                expect(subject).to permit(logged_in_user, dependent_applicant)
+              end
+            end
+
+            context 'consumer RIDP is unverified' do
+              let(:baa_active) { true }
+
+              it 'denies access' do
+                consumer_role.update_attributes(identity_validation: 'na', application_validation: 'na')
+                expect(subject).not_to permit(logged_in_user, dependent_applicant)
+              end
+            end
+          end
+
+          context 'with active associated shop market broker staff' do
+            let(:baa_active) { false }
+            let(:market_kind) { :shop }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, dependent_applicant)
+            end
+          end
+
+          context 'with unassociated broker staff' do
+            let(:baa_active) { false }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, dependent_applicant)
+            end
+          end
+
+          context 'with unapproved broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_pending' }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, dependent_applicant)
+            end
+          end
+
+          context 'with broker_agency_declined broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_declined' }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, dependent_applicant)
+            end
+          end
+
+          context 'with broker_agency_terminated broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_terminated' }
 
             it 'denies access' do
               expect(subject).not_to permit(logged_in_user, dependent_applicant)

--- a/components/financial_assistance/spec/policies/financial_assistance/application_policy_spec.rb
+++ b/components/financial_assistance/spec/policies/financial_assistance/application_policy_spec.rb
@@ -11,6 +11,10 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
     let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
     let(:application) { FactoryBot.create(:financial_assistance_application, family_id: family.id) }
 
+    before do
+      consumer_role.move_identity_documents_to_verified
+    end
+
     permissions :edit? do
       context 'when a valid user is logged in' do
         context 'when the user is a consumer' do
@@ -19,7 +23,6 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
             let(:logged_in_user) { user_of_family }
 
             it 'grants access' do
-              consumer_role.move_identity_documents_to_verified
               expect(subject).to permit(logged_in_user, application)
             end
           end
@@ -29,6 +32,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
             let(:logged_in_user) { user_of_family }
 
             it 'denies access' do
+              consumer_role.update_attributes(identity_validation: 'na', application_validation: 'na')
               expect(subject).not_to permit(logged_in_user, application)
             end
           end
@@ -120,7 +124,6 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
               let(:baa_active) { true }
 
               it 'grants access' do
-                application.family.primary_person.consumer_role.move_identity_documents_to_verified
                 expect(subject).to permit(logged_in_user, application)
               end
             end
@@ -129,6 +132,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
               let(:baa_active) { true }
 
               it 'denies access' do
+                consumer_role.update_attributes(identity_validation: 'na', application_validation: 'na')
                 expect(subject).not_to permit(logged_in_user, application)
               end
             end
@@ -145,6 +149,123 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
 
           context 'with unassociated broker' do
             let(:baa_active) { false }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, application)
+            end
+          end
+        end
+
+        context 'when the user is a broker staff' do
+          let(:market_kind) { :both }
+          let(:broker_person) { FactoryBot.create(:person) }
+          let(:broker_role) { FactoryBot.create(:broker_role, person: broker_person) }
+          let(:broker_staff_person) { FactoryBot.create(:person) }
+
+          let(:broker_staff_state) { 'active' }
+
+          let(:broker_staff) do
+            FactoryBot.create(
+              :broker_agency_staff_role,
+              person: broker_staff_person,
+              aasm_state: broker_staff_state,
+              benefit_sponsors_broker_agency_profile_id: broker_agency_id
+            )
+          end
+          let(:broker_staff_user) { FactoryBot.create(:user, person: broker_staff_person) }
+
+          let(:site) do
+            FactoryBot.create(
+              :benefit_sponsors_site,
+              :with_benefit_market,
+              :as_hbx_profile,
+              site_key: ::EnrollRegistry[:enroll_app].settings(:site_key).item
+            )
+          end
+
+          let(:broker_agency_organization) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+          let(:broker_agency_profile) { broker_agency_organization.broker_agency_profile }
+          let(:broker_agency_id) { broker_agency_profile.id }
+
+          let(:logged_in_user) { broker_staff_user }
+
+          let(:broker_agency_account) do
+            family.broker_agency_accounts.create!(
+              benefit_sponsors_broker_agency_profile_id: broker_agency_id,
+              writing_agent_id: broker_role.id,
+              is_active: baa_active,
+              start_on: TimeKeeper.date_of_record
+            )
+          end
+
+          before do
+            broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+            broker_person.create_broker_agency_staff_role(
+              benefit_sponsors_broker_agency_profile_id: broker_role.benefit_sponsors_broker_agency_profile_id
+            )
+            broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id, market_kind: market_kind)
+            broker_role.approve!
+            broker_agency_account
+            broker_staff
+          end
+
+          context 'with active associated individual market broker staff' do
+            context 'consumer RIDP is verified' do
+              let(:baa_active) { true }
+
+              it 'grants access' do
+                expect(subject).to permit(logged_in_user, application)
+              end
+            end
+
+            context 'consumer RIDP is unverified' do
+              let(:baa_active) { true }
+
+              it 'denies access' do
+                consumer_role.update_attributes(identity_validation: 'na', application_validation: 'na')
+                expect(subject).not_to permit(logged_in_user, application)
+              end
+            end
+          end
+
+          context 'with active associated shop market broker staff' do
+            let(:baa_active) { false }
+            let(:market_kind) { :shop }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, application)
+            end
+          end
+
+          context 'with unassociated broker staff' do
+            let(:baa_active) { false }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, application)
+            end
+          end
+
+          context 'with unapproved broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_pending' }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, application)
+            end
+          end
+
+          context 'with broker_agency_declined broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_declined' }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, application)
+            end
+          end
+
+          context 'with broker_agency_terminated broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_terminated' }
 
             it 'denies access' do
               expect(subject).not_to permit(logged_in_user, application)

--- a/components/financial_assistance/spec/policies/financial_assistance/deduction_policy_spec.rb
+++ b/components/financial_assistance/spec/policies/financial_assistance/deduction_policy_spec.rb
@@ -190,6 +190,123 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
             end
           end
         end
+
+        context 'when the user is a broker staff' do
+          let(:market_kind) { :both }
+          let(:broker_person) { FactoryBot.create(:person) }
+          let(:broker_role) { FactoryBot.create(:broker_role, person: broker_person) }
+          let(:broker_staff_person) { FactoryBot.create(:person) }
+
+          let(:broker_staff_state) { 'active' }
+
+          let(:broker_staff) do
+            FactoryBot.create(
+              :broker_agency_staff_role,
+              person: broker_staff_person,
+              aasm_state: broker_staff_state,
+              benefit_sponsors_broker_agency_profile_id: broker_agency_id
+            )
+          end
+          let(:broker_staff_user) { FactoryBot.create(:user, person: broker_staff_person) }
+
+          let(:site) do
+            FactoryBot.create(
+              :benefit_sponsors_site,
+              :with_benefit_market,
+              :as_hbx_profile,
+              site_key: ::EnrollRegistry[:enroll_app].settings(:site_key).item
+            )
+          end
+
+          let(:broker_agency_organization) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+          let(:broker_agency_profile) { broker_agency_organization.broker_agency_profile }
+          let(:broker_agency_id) { broker_agency_profile.id }
+
+          let(:logged_in_user) { broker_staff_user }
+
+          let(:broker_agency_account) do
+            family.broker_agency_accounts.create!(
+              benefit_sponsors_broker_agency_profile_id: broker_agency_id,
+              writing_agent_id: broker_role.id,
+              is_active: baa_active,
+              start_on: TimeKeeper.date_of_record
+            )
+          end
+
+          before do
+            broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+            broker_person.create_broker_agency_staff_role(
+              benefit_sponsors_broker_agency_profile_id: broker_role.benefit_sponsors_broker_agency_profile_id
+            )
+            broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id, market_kind: market_kind)
+            broker_role.approve!
+            broker_agency_account
+            broker_staff
+          end
+
+          context 'with active associated individual market broker staff' do
+            context 'consumer RIDP is verified' do
+              let(:baa_active) { true }
+
+              it 'grants access' do
+                expect(subject).to permit(logged_in_user, deduction)
+              end
+            end
+
+            context 'consumer RIDP is unverified' do
+              let(:baa_active) { true }
+
+              it 'denies access' do
+                consumer_role.update_attributes(identity_validation: 'na', application_validation: 'na')
+                expect(subject).not_to permit(logged_in_user, deduction)
+              end
+            end
+          end
+
+          context 'with active associated shop market broker staff' do
+            let(:baa_active) { false }
+            let(:market_kind) { :shop }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, deduction)
+            end
+          end
+
+          context 'with unassociated broker staff' do
+            let(:baa_active) { false }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, deduction)
+            end
+          end
+
+          context 'with unapproved broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_pending' }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, deduction)
+            end
+          end
+
+          context 'with broker_agency_declined broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_declined' }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, deduction)
+            end
+          end
+
+          context 'with broker_agency_terminated broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_terminated' }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, deduction)
+            end
+          end
+        end
       end
 
       context 'when a valid user is not logged in' do

--- a/components/financial_assistance/spec/policies/financial_assistance/income_policy_spec.rb
+++ b/components/financial_assistance/spec/policies/financial_assistance/income_policy_spec.rb
@@ -167,6 +167,123 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
             end
           end
         end
+
+        context 'when the user is a broker staff' do
+          let(:market_kind) { :both }
+          let(:broker_person) { FactoryBot.create(:person) }
+          let(:broker_role) { FactoryBot.create(:broker_role, person: broker_person) }
+          let(:broker_staff_person) { FactoryBot.create(:person) }
+
+          let(:broker_staff_state) { 'active' }
+
+          let(:broker_staff) do
+            FactoryBot.create(
+              :broker_agency_staff_role,
+              person: broker_staff_person,
+              aasm_state: broker_staff_state,
+              benefit_sponsors_broker_agency_profile_id: broker_agency_id
+            )
+          end
+          let(:broker_staff_user) { FactoryBot.create(:user, person: broker_staff_person) }
+
+          let(:site) do
+            FactoryBot.create(
+              :benefit_sponsors_site,
+              :with_benefit_market,
+              :as_hbx_profile,
+              site_key: ::EnrollRegistry[:enroll_app].settings(:site_key).item
+            )
+          end
+
+          let(:broker_agency_organization) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+          let(:broker_agency_profile) { broker_agency_organization.broker_agency_profile }
+          let(:broker_agency_id) { broker_agency_profile.id }
+
+          let(:logged_in_user) { broker_staff_user }
+
+          let(:broker_agency_account) do
+            family.broker_agency_accounts.create!(
+              benefit_sponsors_broker_agency_profile_id: broker_agency_id,
+              writing_agent_id: broker_role.id,
+              is_active: baa_active,
+              start_on: TimeKeeper.date_of_record
+            )
+          end
+
+          before do
+            broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+            broker_person.create_broker_agency_staff_role(
+              benefit_sponsors_broker_agency_profile_id: broker_role.benefit_sponsors_broker_agency_profile_id
+            )
+            broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id, market_kind: market_kind)
+            broker_role.approve!
+            broker_agency_account
+            broker_staff
+          end
+
+          context 'with active associated individual market broker staff' do
+            context 'consumer RIDP is verified' do
+              let(:baa_active) { true }
+
+              it 'grants access' do
+                expect(subject).to permit(logged_in_user, applicant_income)
+              end
+            end
+
+            context 'consumer RIDP is unverified' do
+              let(:baa_active) { true }
+
+              it 'denies access' do
+                consumer_role.update_attributes(identity_validation: 'na', application_validation: 'na')
+                expect(subject).not_to permit(logged_in_user, applicant_income)
+              end
+            end
+          end
+
+          context 'with active associated shop market broker staff' do
+            let(:baa_active) { false }
+            let(:market_kind) { :shop }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, applicant_income)
+            end
+          end
+
+          context 'with unassociated broker staff' do
+            let(:baa_active) { false }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, applicant_income)
+            end
+          end
+
+          context 'with unapproved broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_pending' }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, applicant_income)
+            end
+          end
+
+          context 'with broker_agency_declined broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_declined' }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, applicant_income)
+            end
+          end
+
+          context 'with broker_agency_terminated broker staff' do
+            let(:baa_active) { true }
+            let(:broker_staff_state) { 'broker_agency_terminated' }
+
+            it 'denies access' do
+              expect(subject).not_to permit(logged_in_user, applicant_income)
+            end
+          end
+        end
       end
 
       context 'when a valid user is not logged in' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 187177664](https://www.pivotaltracker.com/story/show/187177664)

# A brief description of the changes

Current behavior: Broker Agency Staff Roles do not have access to consumer family endpoints even if they are active and associated with the Family.

New behavior: Broker Agency Staff Roles can access consumer family endpoints if they are active and associated with the Family.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.