### PR TITLE
allow broker staff to delete broker messages

### DIFF
--- a/components/benefit_sponsors/app/policies/benefit_sponsors/person_policy.rb
+++ b/components/benefit_sponsors/app/policies/benefit_sponsors/person_policy.rb
@@ -22,7 +22,7 @@ module BenefitSponsors
     end
 
     def can_hbx_staff_modify?
-      role.is_a?(HbxStaffRole)
+      role.is_a?(HbxStaffRole) && role.permission.modify_family
     end
 
     def has_broker_role?

--- a/components/benefit_sponsors/app/policies/benefit_sponsors/person_policy.rb
+++ b/components/benefit_sponsors/app/policies/benefit_sponsors/person_policy.rb
@@ -11,16 +11,8 @@ module BenefitSponsors
       false
     end
 
-    def can_active_broker_staff_role_modify?
-      person = user&.person
-      return false unless person.active_broker_staff_roles.present?
-      person.active_broker_staff_roles.any? do |broker_staff_role|
-        record&.broker_role&.benefit_sponsors_broker_agency_profile_id == broker_staff_role.benefit_sponsors_broker_agency_profile_id
-      end
-    end
-
     def can_broker_modify?
-      (has_active_broker_role? || has_active_broker_agency_staff_role?) && matches_broker_agency_profile?(record&.broker_role&.benefit_sponsors_broker_agency_profile_id)
+      (has_broker_role? || has_active_broker_agency_staff_role?) && matches_broker_agency_profile?(record&.broker_role&.benefit_sponsors_broker_agency_profile_id)
     end
 
     def matches_broker_agency_profile?(broker_agency_profile_id)
@@ -33,7 +25,7 @@ module BenefitSponsors
       role.is_a?(HbxStaffRole)
     end
 
-    def has_active_broker_role?
+    def has_broker_role?
       role.is_a?(::BrokerRole)
     end
 

--- a/components/benefit_sponsors/app/policies/benefit_sponsors/person_policy.rb
+++ b/components/benefit_sponsors/app/policies/benefit_sponsors/person_policy.rb
@@ -3,10 +3,56 @@
 module BenefitSponsors
   # Policy for person
   class PersonPolicy < ApplicationPolicy
+    ACCESSABLE_ROLES = %w[hbx_staff_role broker_role active_broker_staff_roles].freeze
+
     def can_read_inbox?
-      return true if user.person.hbx_staff_role
-      return true if (user.person&.broker_role || record.broker_role) && (user.person.id == record.id)
+      return true if can_hbx_staff_modify?
+      return true if can_broker_modify?
       false
+    end
+
+    def can_active_broker_staff_role_modify?
+      person = user&.person
+      return false unless person.active_broker_staff_roles.present?
+      person.active_broker_staff_roles.any? do |broker_staff_role|
+        record&.broker_role&.benefit_sponsors_broker_agency_profile_id == broker_staff_role.benefit_sponsors_broker_agency_profile_id
+      end
+    end
+
+    def can_broker_modify?
+      (has_active_broker_role? || has_active_broker_agency_staff_role?) && matches_broker_agency_profile?(record&.broker_role&.benefit_sponsors_broker_agency_profile_id)
+    end
+
+    def matches_broker_agency_profile?(broker_agency_profile_id)
+      Array(role).any? do |role|
+        role.benefit_sponsors_broker_agency_profile_id == broker_agency_profile_id
+      end
+    end
+
+    def can_hbx_staff_modify?
+      role.is_a?(HbxStaffRole)
+    end
+
+    def has_active_broker_role?
+      role.is_a?(::BrokerRole)
+    end
+
+    def has_active_broker_agency_staff_role?
+      role.any? { |role| role.is_a?(::BrokerAgencyStaffRole) }
+    end
+
+    def role
+      @role ||= find_role
+    end
+
+    def find_role
+      person = user&.person
+      return nil unless person
+      ACCESSABLE_ROLES.detect do |role|
+        return person.send(role) if person.respond_to?(role) && person.send(role)
+      end
+
+      nil
     end
   end
 end

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/inboxes/messages_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/inboxes/messages_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 module BenefitSponsors
@@ -16,7 +18,7 @@ module BenefitSponsors
 
     let(:broker_organization) {FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site)}
     let(:broker_person) { FactoryBot.create(:person, :with_broker_role) }
-    let(:broker_user) { FactoryBot.create(:user, person: broker_person ) }
+    let(:broker_user) { FactoryBot.create(:user, person: broker_person) }
 
     describe "GET show / DELETE destroy" do
       context "redirect show message if user not signed in" do
@@ -67,7 +69,7 @@ module BenefitSponsors
           end
 
           it "should get a notice" do
-            expect(flash[:notice]).to match /Successfully deleted inbox message./
+            expect(flash[:notice]).to match(/Successfully deleted inbox message./)
           end
         end
 
@@ -105,10 +107,52 @@ module BenefitSponsors
 
           it "should get a notice" do
 
-            expect(flash[:notice]).to match /Successfully deleted inbox message./
+            expect(flash[:notice]).to match(/Successfully deleted inbox message./)
           end
         end
       end
+
+      context "for user with broker agency staff role" do
+        let(:broker_staff_person) { FactoryBot.create(:person) }
+        let(:broker_staff_user) { FactoryBot.create(:user, person: broker_staff_person) }
+
+        before do
+          broker_staff_person.broker_agency_staff_roles.create(aasm_state: :active, benefit_sponsors_broker_agency_profile_id: broker_organization.broker_agency_profile.id)
+          broker_person.broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_organization.broker_agency_profile.id)
+          @broker_inbox = broker_person.build_inbox
+          @broker_inbox.save!
+          welcome_subject = "Welcome to #{EnrollRegistry[:enroll_app].setting(:short_name).item}"
+          welcome_body = "#{EnrollRegistry[:enroll_app].setting(:short_name).item} is the #{Settings.aca.state_name}'s on-line marketplace to shop, compare, and select health insurance that meets your health needs and budgets."
+          @broker_inbox.messages.create(subject: welcome_subject, body: welcome_body)
+          sign_in broker_staff_user
+        end
+
+        context "show message" do
+          before do
+            get :show, params: {id: broker_person.id, message_id: @broker_inbox.messages.first.id}
+          end
+
+          it "should render show template" do
+            expect(response).to render_template("show")
+          end
+
+          it "should return http success" do
+            expect(response).to have_http_status(:success)
+          end
+        end
+
+        context "delete message" do
+          before do
+            delete :destroy, params: {id: broker_person.id, message_id: @broker_inbox.messages.first.id}, format: :js
+          end
+
+          it "should get a notice" do
+
+            expect(flash[:notice]).to match(/Successfully deleted inbox message./)
+          end
+        end
+      end
+
 
       context "for broker agency profile - from Admin login" do
         before do
@@ -127,7 +171,7 @@ module BenefitSponsors
 
         context "show message" do
           before do
-            get :show, params:{id: broker_person.id, message_id: @broker_inbox.messages.first.id}
+            get :show, params: {id: broker_person.id, message_id: @broker_inbox.messages.first.id}
           end
 
           it "should render show template" do
@@ -141,11 +185,11 @@ module BenefitSponsors
 
         context "delete message" do
           before do
-            delete :destroy, params:{id: broker_person.id, message_id: @broker_inbox.messages.first.id}, format: :js
+            delete :destroy, params: {id: broker_person.id, message_id: @broker_inbox.messages.first.id}, format: :js
           end
 
           it "should get a notice" do
-            expect(flash[:notice]).to match /Successfully deleted inbox message./
+            expect(flash[:notice]).to match(/Successfully deleted inbox message./)
           end
         end
       end

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/inboxes/messages_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/inboxes/messages_controller_spec.rb
@@ -155,10 +155,13 @@ module BenefitSponsors
 
 
       context "for broker agency profile - from Admin login" do
+
+        let!(:super_admin_permission) { FactoryBot.create(:permission, :super_admin) }
         before do
           user_with_hbx_staff_role = FactoryBot.create(:user, :with_hbx_staff_role)
           FactoryBot.create(:person, user: user_with_hbx_staff_role)
           user_with_hbx_staff_role.person.build_hbx_staff_role(hbx_profile_id: broker_organization.broker_agency_profile.id)
+          user_with_hbx_staff_role.person.hbx_staff_role.permission_id = super_admin_permission.id
           user_with_hbx_staff_role.person.hbx_staff_role.save!
           broker_person.broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_organization.broker_agency_profile.id)
           @broker_inbox = broker_person.build_inbox

--- a/components/benefit_sponsors/spec/policies/benefit_sponsors/person_policy_spec.rb
+++ b/components/benefit_sponsors/spec/policies/benefit_sponsors/person_policy_spec.rb
@@ -7,11 +7,13 @@ module BenefitSponsors
     context "checks authorization of person role" do
       let!(:site) { create(:benefit_sponsors_site, :with_benefit_market, :as_hbx_profile, :cca) }
       let(:organization_with_hbx_profile)  { site.owner_organization }
+      let!(:super_admin_permission) { FactoryBot.create(:permission, :super_admin) }
 
       it "returns true if user is a HBX admin" do
         user_with_hbx_staff_role = FactoryBot.create(:user, :with_hbx_staff_role)
         FactoryBot.create(:person, user: user_with_hbx_staff_role)
         user_with_hbx_staff_role.person.build_hbx_staff_role(hbx_profile_id: organization_with_hbx_profile.hbx_profile.id)
+        user_with_hbx_staff_role.person.hbx_staff_role.permission_id = super_admin_permission.id
         user_with_hbx_staff_role.person.hbx_staff_role.save!
         policy = BenefitSponsors::PersonPolicy.new(user_with_hbx_staff_role, nil)
         expect(policy.can_read_inbox?).to be true


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640059/stories/187226920#

# A brief description of the changes

Current behavior: Broker staff are unable to delete broker messages

New behavior: Broker staff will be able to delete broker messages

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.