### PR TITLE
authorize broker agency staff to access application

### DIFF
--- a/app/policies/eligibilities/evidence_policy.rb
+++ b/app/policies/eligibilities/evidence_policy.rb
@@ -56,10 +56,6 @@ module Eligibilities
       (has_active_broker_role? || has_active_broker_agency_staff_role?) && matches_individual_market_broker_account?
     end
 
-    def broker_agency_profile_matches?
-      associated_family.active_broker_agency_account.present? && associated_family.active_broker_agency_account.benefit_sponsors_broker_agency_profile_id == role.benefit_sponsors_broker_agency_profile_id
-    end
-
     # Checks if the broker agency profile ID of any of the roles
     # matches the provided broker agency profile ID.
     #
@@ -84,7 +80,7 @@ module Eligibilities
     end
 
     def has_active_broker_agency_staff_role?
-      role.any? { |r| r.is_a?(::BrokerAgencyStaffRole) }
+      Array(role).any? { |r| r.is_a?(::BrokerAgencyStaffRole) }
     end
 
     def role

--- a/components/financial_assistance/app/policies/financial_assistance/application_policy.rb
+++ b/components/financial_assistance/app/policies/financial_assistance/application_policy.rb
@@ -33,7 +33,6 @@ module FinancialAssistance
     end
 
     def allowed_to_modify?
-      return false unless individual_market_role_identity_verified?
       return true if (current_user == associated_user)
       return false unless role.present?
       return can_hbx_staff_modify? if role.is_a?(HbxStaffRole)
@@ -41,16 +40,11 @@ module FinancialAssistance
       false
     end
 
-    def individual_market_role_identity_verified?
-      return true if (associated_person.resident_role || associated_person.consumer_role&.identity_verified?)
-      false
-    end
-
     def role_has_permission_to_access_applications?
       role.present? && (can_hbx_staff_modify? || can_broker_access?)
     end
 
-        # Checks if the broker agency profile ID of any of the roles
+    # Checks if the broker agency profile ID of any of the roles
     # matches the provided broker agency profile ID.
     #
     # @note The `role` can be a single broker role or multiple active broker agency staff roles.

--- a/components/financial_assistance/app/policies/financial_assistance/application_policy.rb
+++ b/components/financial_assistance/app/policies/financial_assistance/application_policy.rb
@@ -32,24 +32,58 @@ module FinancialAssistance
       false
     end
 
+    def allowed_to_modify?
+      return false unless individual_market_role_identity_verified?
+      return true if (current_user == associated_user)
+      return false unless role.present?
+      return can_hbx_staff_modify? if role.is_a?(HbxStaffRole)
+      return can_broker_modify? if (has_active_broker_role? || has_active_broker_agency_staff_role?)
+      false
+    end
+
+    def individual_market_role_identity_verified?
+      return true if (associated_person.resident_role || associated_person.consumer_role&.identity_verified?)
+      false
+    end
+
     def role_has_permission_to_access_applications?
       role.present? && (can_hbx_staff_modify? || can_broker_access?)
     end
+
+        # Checks if the broker agency profile ID of any of the roles
+    # matches the provided broker agency profile ID.
+    #
+    # @note The `role` can be a single broker role or multiple active broker agency staff roles.
+    #
+    # @param active_broker_agency_profile_id [String] The broker agency profile ID to match against.
+    #
+    # @return [Boolean] returns true if there is a match, false otherwise.
+    def matches_broker_agency_profile?(active_broker_agency_profile_id)
+      Array(role).any? do |role|
+        role.benefit_sponsors_broker_agency_profile_id == active_broker_agency_profile_id
+      end
+    end
+
+    def matches_individual_market_broker_account?
+      return false unless associated_family.active_broker_agency_account.present?
+      matches_broker_agency_profile?(associated_family.active_broker_agency_account.benefit_sponsors_broker_agency_profile_id)
+    end
+
+    def has_active_broker_role?
+      role.is_a?(::BrokerRole) && role.active?
+    end
+
+    def has_active_broker_agency_staff_role?
+      role.any? { |r| r.is_a?(::BrokerAgencyStaffRole) }
+    end
+
 
     def can_hbx_staff_modify?
       role.is_a?(HbxStaffRole) && role&.permission&.modify_family
     end
 
-    def can_broker_access?
-      (role.is_a?(::BrokerRole) || role.is_a?(::BrokerAgencyStaffRole)) && broker_agency_profile_matches?
-    end
-
-    def can_consumer_access?
-      role.is_a?(::ConsumerRole)
-    end
-
-    def broker_agency_profile_matches?
-      associated_family.active_broker_agency_account.present? && associated_family.active_broker_agency_account.benefit_sponsors_broker_agency_profile_id == role.benefit_sponsors_broker_agency_profile_id
+    def can_broker_modify?
+      (has_active_broker_role? || has_active_broker_agency_staff_role?) && matches_individual_market_broker_account?
     end
 
     def role
@@ -72,10 +106,10 @@ module FinancialAssistance
     end
 
     def associated_user
-      associated_family_primary_member&.user
+      associated_primary_person.user
     end
 
-    def associated_family_primary_member
+    def associated_primary_person
       associated_family&.primary_person
     end
 

--- a/components/financial_assistance/app/policies/financial_assistance/application_policy.rb
+++ b/components/financial_assistance/app/policies/financial_assistance/application_policy.rb
@@ -74,7 +74,7 @@ module FinancialAssistance
     end
 
     def has_active_broker_agency_staff_role?
-      role.any? { |r| r.is_a?(::BrokerAgencyStaffRole) }
+      Array(role).any? { |r| r.is_a?(::BrokerAgencyStaffRole) }
     end
 
 
@@ -106,10 +106,10 @@ module FinancialAssistance
     end
 
     def associated_user
-      associated_primary_person.user
+      associated_person.user
     end
 
-    def associated_primary_person
+    def associated_person
       associated_family&.primary_person
     end
 

--- a/components/financial_assistance/app/policies/financial_assistance/application_policy.rb
+++ b/components/financial_assistance/app/policies/financial_assistance/application_policy.rb
@@ -71,7 +71,6 @@ module FinancialAssistance
       Array(role).any? { |r| r.is_a?(::BrokerAgencyStaffRole) }
     end
 
-
     def can_hbx_staff_modify?
       role.is_a?(HbxStaffRole) && role&.permission&.modify_family
     end

--- a/components/financial_assistance/spec/controllers/financial_assistance/applications_controller_spec.rb
+++ b/components/financial_assistance/spec/controllers/financial_assistance/applications_controller_spec.rb
@@ -259,9 +259,9 @@ RSpec.describe FinancialAssistance::ApplicationsController, dbclean: :after_each
 
 
     context 'broker logged in' do
-      let!(:broker_user) { FactoryBot.create(:user, :person => writing_agent.person, roles: ['broker_role', 'broker_agency_staff_role']) }
+      let!(:broker_user) { FactoryBot.create(:user, :person => writing_agent.person, roles: ['broker_role']) }
       let(:broker_agency_profile) { FactoryBot.build(:benefit_sponsors_organizations_broker_agency_profile)}
-      let(:writing_agent)         { FactoryBot.create(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id) }
+      let(:writing_agent)         { FactoryBot.create(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, aasm_state: :active) }
       let(:assister)  do
         assister = FactoryBot.build(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, npn: "SMECDOA00")
         assister.save(validate: false)
@@ -532,7 +532,7 @@ RSpec.describe FinancialAssistance::ApplicationsController, dbclean: :after_each
     context 'broker logged in' do
       let!(:broker_user) { FactoryBot.create(:user, :person => writing_agent.person, roles: ['broker_role', 'broker_agency_staff_role']) }
       let(:broker_agency_profile) { FactoryBot.build(:benefit_sponsors_organizations_broker_agency_profile)}
-      let(:writing_agent)         { FactoryBot.create(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id) }
+      let(:writing_agent)         { FactoryBot.create(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, aasm_state: :active) }
       let(:assister)  do
         assister = FactoryBot.build(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, npn: "SMECDOA00")
         assister.save(validate: false)

--- a/components/financial_assistance/spec/controllers/financial_assistance/applications_controller_spec_1.rb
+++ b/components/financial_assistance/spec/controllers/financial_assistance/applications_controller_spec_1.rb
@@ -38,6 +38,10 @@ RSpec.describe FinancialAssistance::ApplicationsController, dbclean: :after_each
       applicant
     end
 
+    before do
+      person.consumer_role.move_identity_documents_to_verified
+    end
+
     context 'admin with permissions' do
       before do
         sign_in(admin_user)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187226902

# A brief description of the changes

Current behavior: Broker agency staff role cannot access FAA application

New behavior: Broker agency staff role will be able to access/update FAA application

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.