### PR TITLE
remove RIDP check for all roles

### DIFF
--- a/app/policies/eligibilities/evidence_policy.rb
+++ b/app/policies/eligibilities/evidence_policy.rb
@@ -35,16 +35,15 @@ module Eligibilities
     #
     # @note The user is the one who is trying to perform the action. The record_user is the user who owns the record. The record is an instance of Eligibilities::Evidence.
     def allowed_to_modify?
-      return false unless individual_market_role_identity_verified?
-      return true if (current_user == associated_user)
+      return true if current_user == associated_user && individual_market_role_identity_verified?
       return false unless role.present?
       return can_hbx_staff_modify? if role.is_a?(HbxStaffRole)
-      return can_broker_modify? if (has_active_broker_role? || has_active_broker_agency_staff_role?)
+      return can_broker_modify? if has_active_broker_role? || has_active_broker_agency_staff_role?
       false
     end
 
     def individual_market_role_identity_verified?
-      return true if (associated_person.resident_role || associated_person.consumer_role&.identity_verified?)
+      return true if associated_person.resident_role || associated_person.consumer_role&.identity_verified?
       false
     end
 
@@ -71,6 +70,7 @@ module Eligibilities
     end
 
     def matches_individual_market_broker_account?
+      return false unless individual_market_role_identity_verified?
       return false unless associated_family.active_broker_agency_account.present?
       matches_broker_agency_profile?(associated_family.active_broker_agency_account.benefit_sponsors_broker_agency_profile_id)
     end

--- a/app/policies/eligibilities/evidence_policy.rb
+++ b/app/policies/eligibilities/evidence_policy.rb
@@ -35,15 +35,10 @@ module Eligibilities
     #
     # @note The user is the one who is trying to perform the action. The record_user is the user who owns the record. The record is an instance of Eligibilities::Evidence.
     def allowed_to_modify?
-      return true if current_user == associated_user && individual_market_role_identity_verified?
+      return true if current_user == associated_user
       return false unless role.present?
       return can_hbx_staff_modify? if role.is_a?(HbxStaffRole)
       return can_broker_modify? if has_active_broker_role? || has_active_broker_agency_staff_role?
-      false
-    end
-
-    def individual_market_role_identity_verified?
-      return true if associated_person.resident_role || associated_person.consumer_role&.identity_verified?
       false
     end
 
@@ -70,7 +65,6 @@ module Eligibilities
     end
 
     def matches_individual_market_broker_account?
-      return false unless individual_market_role_identity_verified?
       return false unless associated_family.active_broker_agency_account.present?
       matches_broker_agency_profile?(associated_family.active_broker_agency_account.benefit_sponsors_broker_agency_profile_id)
     end

--- a/components/financial_assistance/spec/controllers/financial_assistance/verification_documents_controller_spec.rb
+++ b/components/financial_assistance/spec/controllers/financial_assistance/verification_documents_controller_spec.rb
@@ -76,8 +76,24 @@ RSpec.describe FinancialAssistance::VerificationDocumentsController, type: :cont
 
         it 'should not download' do
           get :download, params: params
-          expect(response).to have_http_status(:found)
-          expect(flash[:error]).to eq("Access not allowed for eligibilities/evidence_policy.can_download?, (Pundit policy)")
+          expect(response).to be_successful
+        end
+      end
+    end
+
+    context 'POST #upload' do
+      let!(:bucket_name) { 'id-verification' }
+      let!(:doc_id) { "urn:openhbx:terms:v1:file_storage:s3:bucket:#{bucket_name}sample-key" }
+      let!(:params) { { "applicant_id" => applicant.id, "evidence" => esi_evidence.id, "evidence_kind" => "esi_evidence", "application_id" => application.id, file: file} }
+
+      context 'with valid params' do
+        before do
+          allow(Aws::S3Storage).to receive(:save).and_return(doc_id)
+        end
+
+        it 'uploads a new VerificationDocument' do
+          post :upload, params: params
+          expect(flash[:notice]).to eq("File Saved")
         end
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640059/stories/187226912

# A brief description of the changes

Current behavior: Does not allow hbx staff , broker, broker staff and consumer to upload, download and delete documents when consumer is not RIDP verified.

New behavior: Allow hbx staff , broker, broker staff and consumer to upload, download and delete documents when even when consumer is not RIDP verified.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.