### PR TITLE
cleanup more RIDP checks for Brokers and Broker Staffs

### DIFF
--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -77,9 +77,9 @@ class PersonPolicy < ApplicationPolicy
     return true if shop_market_primary_family_member?
     return true if individual_market_admin?
     return true if shop_market_admin?
-    return true if active_associated_individual_market_ridp_verified_family_broker_staff?
+    return true if active_associated_individual_market_family_broker_staff?
     return true if active_associated_individual_market_ridp_verified_family_broker?
-    return true if active_associated_shop_market_family_broker?
+    return true if active_associated_individual_market_family_broker?
 
     false
   end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -379,6 +379,13 @@ RSpec.describe DocumentsController, dbclean: :after_each, :type => :controller d
           expect(response.status).to eq(200)
           expect(response.headers["Content-Disposition"]).to eq 'attachment'
         end
+
+        it 'downloads document even if Consumer is not RIDP verified' do
+          consumer_person.consumer_role.update_attributes!(identity_validation: 'na', application_validation: 'na')
+          get :cartafact_download, params: {model: "Person", model_id: consumer_person.id, relation: "documents", relation_id: document.id}
+          expect(response.status).to eq(200)
+          expect(response.headers["Content-Disposition"]).to eq 'attachment'
+        end
       end
 
       context 'is not authorized' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 187247591](https://www.pivotaltracker.com/story/show/187247591)

# A brief description of the changes

Current behavior: RIDP verification of consumers is required for Brokers and BrokerAgencyStaffRoles in PersonPolicy.

New behavior: RIDP verification of consumers is now not required for Brokers and BrokerAgencyStaffRoles. This PR is handling more cleanup in PersonPolicy.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.