### PR TITLE
adds check for thankyou page agreement terms

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -787,8 +787,15 @@ $(document).on('click', '#terms_check_thank_you', function() {
   subscriber_first_name = $("#subscriber_first_name").val();
   subscriber_last_name = $("#subscriber_last_name").val();
 
+  // Appends a query parameter to the 'btn-continue' button's href attribute to indicate that the user has disagreed to the terms on the thank you page.
+  document.getElementById('btn-continue').href += "&thankyou_page_agreement_terms=disagreed";
+
   if($(this).prop("checked") == true){
     if( first_name_thank_you == subscriber_first_name && last_name_thank_you == subscriber_last_name){
+
+      // Appends a query parameter to the 'btn-continue' button's href attribute to indicate that the user has agreed to the terms on the thank you page.
+      document.getElementById('btn-continue').href += "&thankyou_page_agreement_terms=agreed";
+
       $('#btn-continue').removeClass('disabled');
     } else {
       $('#btn-continue').addClass('disabled');
@@ -815,16 +822,21 @@ $(document).on('blur keyup', 'input.thank_you_field', function() {
   subscriber_first_name = $("#subscriber_first_name").val();
   subscriber_last_name = $("#subscriber_last_name").val();
 
+  // Appends a query parameter to the 'btn-continue' button's href attribute to indicate that the user has disagreed to the terms on the thank you page.
+  document.getElementById('btn-continue').href += "&thankyou_page_agreement_terms=disagreed";
+
   if(last_name_thank_you == ""){
     $('#btn-continue').addClass('disabled');
   }else{
     if($("#terms_check_thank_you").prop("checked") == true){
       if( first_name_thank_you == subscriber_first_name && last_name_thank_you == subscriber_last_name){
-        $('#btn-continue').removeClass('disabled');
 
+        // Appends a query parameter to the 'btn-continue' button's href attribute to indicate that the user has agreed to the terms on the thank you page.
+        document.getElementById('btn-continue').href += "&thankyou_page_agreement_terms=agreed";
+
+        $('#btn-continue').removeClass('disabled');
       } else {
         $('#btn-continue').addClass('disabled');
-
       }
     }
   }

--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -16,7 +16,7 @@ class Insured::PlanShoppingsController < ApplicationController
   before_action :validate_rating_address, only: [:show]
 
   def checkout
-    (redirect_back(fallback_location: :back) and return) unless agreed_to_thankyou_ivl_page_terms
+    (redirect_back(fallback_location: root_path) and return) unless agreed_to_thankyou_ivl_page_terms
 
     authorize @hbx_enrollment, :checkout?
     @enrollment = @hbx_enrollment

--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -8,6 +8,7 @@ class Insured::PlanShoppingsController < ApplicationController
   extend Acapi::Notifiers
   include Aptc
   include Config::AcaHelper
+  include L10nHelper
 
   before_action :find_hbx_enrollment
   before_action :set_current_person, :only => [:receipt, :thankyou, :waive, :show, :plans, :checkout, :terminate, :plan_selection_callback]
@@ -15,6 +16,8 @@ class Insured::PlanShoppingsController < ApplicationController
   before_action :validate_rating_address, only: [:show]
 
   def checkout
+    (redirect_back(fallback_location: :back) and return) unless agreed_to_thankyou_page_terms
+
     authorize @hbx_enrollment, :checkout?
     @enrollment = @hbx_enrollment
 
@@ -272,6 +275,18 @@ class Insured::PlanShoppingsController < ApplicationController
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
   private
+
+  # Determines if the user has agreed to the terms on the thank you page.
+  # The user has agreed if the 'thankyou_page_agreement_terms' parameter is set to 'agreed'.
+  #
+  # @return [Boolean] Returns true if the user has agreed to the terms, false otherwise.
+  # @note This method sets a flash error message if the user has not agreed to the terms.
+  def agreed_to_thankyou_page_terms
+    return true if params['thankyou_page_agreement_terms'] == 'agreed'
+
+    flash[:error] = l10n('insured.plan_shopping.thankyou.agreement_terms_conditions')
+    false
+  end
 
   def show_ivl(hbx_enrollment_id)
     set_consumer_bookmark_url(family_account_path) if params[:market_kind] == 'individual'

--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -16,7 +16,7 @@ class Insured::PlanShoppingsController < ApplicationController
   before_action :validate_rating_address, only: [:show]
 
   def checkout
-    (redirect_back(fallback_location: :back) and return) unless agreed_to_thankyou_page_terms
+    (redirect_back(fallback_location: :back) and return) unless agreed_to_thankyou_ivl_page_terms
 
     authorize @hbx_enrollment, :checkout?
     @enrollment = @hbx_enrollment
@@ -276,12 +276,14 @@ class Insured::PlanShoppingsController < ApplicationController
 
   private
 
-  # Determines if the user has agreed to the terms on the thank you page.
+  # Determines if the user has agreed to the terms on the individual market thank you page.
   # The user has agreed if the 'thankyou_page_agreement_terms' parameter is set to 'agreed'.
+  # This check is only performed for enrollments of individual market kinds.
   #
-  # @return [Boolean] Returns true if the user has agreed to the terms, false otherwise.
+  # @return [Boolean] Returns true if the user has agreed to the terms or the enrollment is not of individual market kind, false otherwise.
   # @note This method sets a flash error message if the user has not agreed to the terms.
-  def agreed_to_thankyou_page_terms
+  def agreed_to_thankyou_ivl_page_terms
+    return true unless HbxEnrollment::IVL_KINDS.include?(@hbx_enrollment.kind)
     return true if params['thankyou_page_agreement_terms'] == 'agreed'
 
     flash[:error] = l10n('insured.plan_shopping.thankyou.agreement_terms_conditions')

--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -450,5 +450,6 @@ How to find the SEVIS ID: On the DS-2019, the number is on the top right hand si
   :'en.insured.verification_acceptable_file_types' => "PDF, JPEG, PNG, and GIF",
   :'en.insured.verification_max_file_size' => "File should not exceed 100 MB",
   :'en.waiting_for_eligibility' => "Waiting for your eligibility results...",
-  :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.'
+  :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.',
+  :'en.insured.plan_shopping.thankyou.agreement_terms_conditions' => 'You must complete Agreement and Terms and Conditions sections to continue.'
 }.freeze

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -603,5 +603,6 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.waiting_for_eligibility' => "Waiting for your eligibility results...",
   :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.',
   :'en.insured.general_agency_index_disabled_warning' => 'The General Agency Index is Disabled',
-  :'en.insured.employer_datatable_disabled_warning' => 'The Employer Data Table is Disabled'
+  :'en.insured.employer_datatable_disabled_warning' => 'The Employer Data Table is Disabled',
+  :'en.insured.plan_shopping.thankyou.agreement_terms_conditions' => 'You must complete Agreement and Terms and Conditions sections to continue.'
 }.freeze

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -601,5 +601,6 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.waiting_for_eligibility' => "Waiting for your eligibility results...",
   :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.',
   :'en.insured.general_agency_index_disabled_warning' => 'The General Agency Index is Disabled',
-  :'en.insured.employer_datatable_disabled_warning' => 'The Employer Data Table is Disabled'
+  :'en.insured.employer_datatable_disabled_warning' => 'The Employer Data Table is Disabled',
+  :'en.insured.plan_shopping.thankyou.agreement_terms_conditions' => 'You must complete Agreement and Terms and Conditions sections to continue.'
 }.freeze

--- a/features/group_selection/mixed_consumer_resident_plan_shopping.feature
+++ b/features/group_selection/mixed_consumer_resident_plan_shopping.feature
@@ -22,5 +22,5 @@ Feature: Mixed household with consumer and resident role plan purchase
     Then consumer selects a plan on the plan shopping page
     And consumer completes agreement terms and conditions sections on thankyou page
     When consumer clicks on Confirm button on the coverage summary page
-    Then the consumer clicks continue to my account button
+    Then consumer clicks back to my account button
     Then consumer should see primary and dependent person on enrollment

--- a/features/group_selection/mixed_consumer_resident_plan_shopping.feature
+++ b/features/group_selection/mixed_consumer_resident_plan_shopping.feature
@@ -20,6 +20,7 @@ Feature: Mixed household with consumer and resident role plan purchase
     Then consumer should see both dependent and primary
     And consumer should see the list of plans
     Then consumer selects a plan on the plan shopping page
+    And consumer completes agreement terms and conditions sections on thankyou page
     When consumer clicks on Confirm button on the coverage summary page
-    Then consumer clicks back to my account button
+    Then the consumer clicks continue to my account button
     Then consumer should see primary and dependent person on enrollment

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -946,6 +946,20 @@ Then(/^.+ should see the coverage summary page$/) do
   # screenshot("summary_page")
 end
 
+# This step completes the agreement terms and conditions sections on the thank you page for the consumer.
+# It selects the checkbox for the terms and conditions and fills in the first and last name of the primary person.
+And(/consumer completes agreement terms and conditions sections on thankyou page$/) do
+  find('#terms_check_thank_you').click
+  primary = Person.all.select { |person| person.primary_family.present? }.first
+  fill_in('First Name *', with: primary.first_name)
+  fill_in('Last Name *', with: primary.last_name)
+end
+
+# This step simulates the consumer clicking the 'Continue to My Account' button.
+Then(/the consumer clicks continue to my account button/) do
+  find('.interaction-click-control-continue-to-my-account').click
+end
+
 When(/^.+ clicks? on Confirm button on the coverage summary page$/) do
   find(EmployeeConfirmYourPlanSelection.confirm_btn, wait: 10).click
 end

--- a/spec/controllers/insured/checkout_plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/checkout_plan_shoppings_controller_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_market.rb"
+require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_application.rb"
+
+RSpec.describe Insured::PlanShoppingsController, type: :controller, dbclean: :after_each do
+  describe 'POST #checkout' do
+    let(:rating_area) { FactoryBot.create_default(:benefit_markets_locations_rating_area) }
+    let(:user) { FactoryBot.create(:user, person: person) }
+    let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+    let(:consumer_role) { person.consumer_role }
+    let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+    let(:session_params) { { person_id: family.primary_person.id } }
+
+    let(:input_params) do
+      {
+        id: checkout_enrollment.id,
+        plan_id: checkout_enrollment.product.id,
+        market_kind: checkout_enrollment.kind,
+        coverage_kind: checkout_enrollment.coverage_kind,
+        enrollment_kind: checkout_enrollment.kind,
+        thankyou_page_agreement_terms: thankyou_page_agreement_terms
+      }
+    end
+
+    before do
+      sign_in user
+      post :checkout, params: input_params, session: session_params
+    end
+
+    context 'for individual market enrollment' do
+      let(:checkout_enrollment) do
+        FactoryBot.create(
+          :hbx_enrollment,
+          :individual_unassisted,
+          :with_health_product,
+          family: family,
+          household: family.active_household,
+          coverage_kind: 'health',
+          effective_on: TimeKeeper.date_of_record.beginning_of_month,
+          consumer_role: consumer_role,
+          rating_area_id: rating_area.id
+        )
+      end
+
+      context 'with agreed thankyou_page_agreement_terms' do
+        let(:thankyou_page_agreement_terms) { 'agreed' }
+
+        it 'redirects to root as pundit authorization failed' do
+          expect(response).to redirect_to(root_path)
+          expect(flash[:error]).to eq('Access not allowed for hbx_enrollment_policy.checkout?, (Pundit policy)')
+        end
+      end
+
+      context 'with disagreed thankyou_page_agreement_terms' do
+        let(:thankyou_page_agreement_terms) { 'disagreed' }
+
+        it 'redirects to fallback location root_path' do
+          expect(response).to redirect_to(root_path)
+          expect(flash[:error]).to eq(l10n('insured.plan_shopping.thankyou.agreement_terms_conditions'))
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/insured/checkout_plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/checkout_plan_shoppings_controller_spec.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_market.rb"
-require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_application.rb"
 
 RSpec.describe Insured::PlanShoppingsController, type: :controller, dbclean: :after_each do
+  before :all do
+    DatabaseCleaner.clean
+  end
+
+  after :all do
+    DatabaseCleaner.clean
+  end
+
   describe 'POST #checkout' do
     let(:rating_area) { FactoryBot.create_default(:benefit_markets_locations_rating_area) }
     let(:user) { FactoryBot.create(:user, person: person) }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 187212404](https://www.pivotaltracker.com/story/show/187212404)

# A brief description of the changes

Current behavior: Users can bypass the Agreement, Terms, and Conditions on the thank-you page using developer tools and proceed to the checkout page without restrictions.

New behavior: Users are blocked if they attempt to bypass the Agreement, Terms, and Conditions on the thank-you page using developer tools and proceed to the checkout page with a flash message.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.