### PR TITLE
fixes pundit authorization for broker role messages destroy action

### DIFF
--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/inboxes/messages_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/inboxes/messages_controller.rb
@@ -36,9 +36,17 @@ module BenefitSponsors
         raise 'User not authorized to perform this operation'
       end
 
-      # id passed in is not the message id but the person id or profile id.
+      # Destroys an inbox message.
+      # The id passed in is not the message id but the person id or profile id.
       # The message id is passed in as message_id.
-      # The implementation is so weird that the messages of a BrokerAgencyProfile are attached to the person who is the primary broker of the agency and not the agency itself.
+      # The implementation is so that the messages of a BrokerAgencyProfile are attached to the person
+      # who is the primary broker of the agency and not the agency itself.
+      # This method checks if the user has the necessary permissions to destroy the message and then destroys it.
+      # A success message is displayed to the user after the message is destroyed.
+      # If a url is passed in the parameters, it is stored in the @inbox_url instance variable.
+      #
+      # @note This method is used in the destroy action of the messages controller.
+      # @note The authorization checks are performed using the BenefitSponsors::PersonPolicy policy.
       def destroy
         if is_broker?
           authorize @inbox_provider, :destroy_inbox_message?, policy_class: BenefitSponsors::PersonPolicy

--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/inboxes/messages_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/inboxes/messages_controller.rb
@@ -36,8 +36,13 @@ module BenefitSponsors
         raise 'User not authorized to perform this operation'
       end
 
+      # id passed in is not the message id but the person id or profile id.
+      # The message id is passed in as message_id.
+      # The implementation is so weird that the messages of a BrokerAgencyProfile are attached to the person who is the primary broker of the agency and not the agency itself.
       def destroy
-        if @inbox_provider.instance_of?(Person)
+        if is_broker?
+          authorize @inbox_provider, :destroy_inbox_message?, policy_class: BenefitSponsors::PersonPolicy
+        elsif @inbox_provider.instance_of?(Person)
           authorize @inbox_provider, :can_read_inbox?, policy_class: BenefitSponsors::PersonPolicy
         else
           authorize @inbox_provider, :can_read_inbox?

--- a/components/benefit_sponsors/app/policies/benefit_sponsors/person_policy.rb
+++ b/components/benefit_sponsors/app/policies/benefit_sponsors/person_policy.rb
@@ -2,10 +2,30 @@
 
 module BenefitSponsors
   # Policy for person
-  class PersonPolicy < ApplicationPolicy
+  class PersonPolicy < ::ApplicationPolicy
     def can_read_inbox?
       return true if user.person.hbx_staff_role
       return true if (user.person&.broker_role || record.broker_role) && (user.person.id == record.id)
+      false
+    end
+
+    # This is implemented for the destroy action in the messages controller.
+    # This method currently only supports people with broker roles.
+    def destroy_inbox_message?
+      broker = record.broker_role
+      broker_staff_roles = account_holder_person&.broker_agency_staff_roles&.active
+
+      return false if broker.blank?
+
+      # Current User Person same as the record(person).
+      return true if account_holder_person == record
+
+      # Current User is HbxStaffAdmin.
+      return true if shop_market_admin?
+
+      # Current User is Broker Agency Staff.
+      return true if broker_staff_roles&.any? { |role| role&.broker_agency_profile_id == broker.broker_agency_profile_id }
+
       false
     end
   end

--- a/components/benefit_sponsors/app/policies/benefit_sponsors/person_policy.rb
+++ b/components/benefit_sponsors/app/policies/benefit_sponsors/person_policy.rb
@@ -9,8 +9,13 @@ module BenefitSponsors
       false
     end
 
-    # This is implemented for the destroy action in the messages controller.
+    # Determines if the current user has permission to destroy an inbox message.
+    # The user can destroy an inbox message if they are the person associated with the record,
+    # an admin in the shop market, or a broker agency staff member associated with the broker agency of the record.
     # This method currently only supports people with broker roles.
+    #
+    # @return [Boolean] Returns true if the user has permission to destroy an inbox message, false otherwise.
+    # @note This method is implemented for the destroy action in the messages controller.
     def destroy_inbox_message?
       broker = record.broker_role
       broker_staff_roles = account_holder_person&.broker_agency_staff_roles&.active

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/inboxes/destroy_messages_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/inboxes/destroy_messages_controller_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BenefitSponsors::Inboxes::MessagesController, type: :controller, dbclean: :after_each do
+  routes {BenefitSponsors::Engine.routes}
+
+  let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+  let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+  let(:user_of_family) { FactoryBot.create(:user, person: person) }
+  let(:hbx_profile) do
+    FactoryBot.create(
+      :hbx_profile,
+      :normal_ivl_open_enrollment,
+      us_state_abbreviation: EnrollRegistry[:enroll_app].setting(:state_abbreviation).item,
+      cms_id: "#{EnrollRegistry[:enroll_app].setting(:state_abbreviation).item.upcase}0"
+    )
+  end
+  let(:hbx_staff_person) { FactoryBot.create(:person) }
+  let(:hbx_staff_role) do
+    hbx_staff_person.create_hbx_staff_role(
+      permission_id: permission.id,
+      subrole: permission.name,
+      hbx_profile: hbx_profile
+    )
+  end
+  let(:hbx_admin_user) do
+    FactoryBot.create(:user, person: hbx_staff_person)
+    hbx_staff_role.person.user
+  end
+
+  let(:market_kind) { :both }
+  let(:broker_person) { FactoryBot.create(:person) }
+  let(:broker_role) { FactoryBot.create(:broker_role, person: broker_person) }
+  let(:broker_user) { FactoryBot.create(:user, person: broker_person) }
+  let(:message) { FactoryBot.create(:message, :inbox_folder, inbox: broker_person.inbox) }
+
+  let(:site) do
+    FactoryBot.create(
+      :benefit_sponsors_site,
+      :with_benefit_market,
+      :as_hbx_profile,
+      site_key: ::EnrollRegistry[:enroll_app].settings(:site_key).item
+    )
+  end
+
+  let(:broker_agency_organization) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+  let(:broker_agency_profile) { broker_agency_organization.broker_agency_profile }
+  let(:broker_agency_id) { broker_agency_profile.id }
+
+  let(:logged_in_user) { broker_user }
+
+  let(:broker_agency_account) do
+    family.broker_agency_accounts.create!(
+      benefit_sponsors_broker_agency_profile_id: broker_agency_id,
+      writing_agent_id: broker_role.id,
+      is_active: baa_active,
+      start_on: TimeKeeper.date_of_record
+    )
+  end
+
+  let(:broker_staff_person) { FactoryBot.create(:person) }
+
+  let(:broker_staff_state) { 'active' }
+
+  let(:broker_staff) do
+    FactoryBot.create(
+      :broker_agency_staff_role,
+      person: broker_staff_person,
+      aasm_state: broker_staff_state,
+      benefit_sponsors_broker_agency_profile_id: broker_agency_id
+    )
+  end
+  let(:broker_staff_user) { FactoryBot.create(:user, person: broker_staff_person) }
+
+  let(:permission) { FactoryBot.create(:permission, :super_admin) }
+
+  before do
+    broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+    broker_person.create_broker_agency_staff_role(
+      benefit_sponsors_broker_agency_profile_id: broker_role.benefit_sponsors_broker_agency_profile_id
+    )
+    broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id, market_kind: market_kind)
+    broker_role.approve!
+    broker_staff
+  end
+
+  describe "DELETE #destroy" do
+    before do
+      sign_in logged_in_user
+      delete :destroy, params: { id: broker_role.person.id, message_id: message.id }, format: :js
+    end
+
+    context 'broker logged in' do
+      let(:logged_in_user) { broker_user }
+
+      it 'succesfully deletes the message' do
+        expect(message.reload.folder).to eq(Message::FOLDER_TYPES[:deleted])
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:destroy)
+        expect(flash[:notice]).to eq('Successfully deleted inbox message.')
+      end
+    end
+
+    context 'active broker staff logged in' do
+      let(:logged_in_user) { broker_staff_user }
+
+      it 'succesfully deletes the message' do
+        expect(message.reload.folder).to eq(Message::FOLDER_TYPES[:deleted])
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:destroy)
+        expect(flash[:notice]).to eq('Successfully deleted inbox message.')
+      end
+    end
+
+    context 'inactive broker staff logged in' do
+      let(:broker_staff_state) { 'broker_agency_terminated' }
+      let(:logged_in_user) { broker_staff_user }
+
+      it 'denies access to inactive broker staff' do
+        expect(response.status).to eq(403)
+        expect(flash[:error]).to eq('Access not allowed for destroy_inbox_message?, (Pundit policy)')
+      end
+    end
+
+    context 'hbx staff admin with super_admin role logged in' do
+      let(:logged_in_user) { hbx_admin_user }
+
+      it 'succesfully deletes the message' do
+        expect(message.reload.folder).to eq(Message::FOLDER_TYPES[:deleted])
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:destroy)
+        expect(flash[:notice]).to eq('Successfully deleted inbox message.')
+      end
+    end
+
+    context 'hbx staff admin with developer role logged in' do
+      let(:permission) { FactoryBot.create(:permission, :developer) }
+      let(:logged_in_user) { hbx_admin_user }
+
+      it 'denies access to inactive broker staff' do
+        expect(response.status).to eq(403)
+        expect(flash[:error]).to eq('Access not allowed for destroy_inbox_message?, (Pundit policy)')
+      end
+    end
+  end
+end

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/inboxes/messages_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/inboxes/messages_controller_spec.rb
@@ -138,16 +138,6 @@ module BenefitSponsors
             expect(response).to have_http_status(:success)
           end
         end
-
-        context "delete message" do
-          before do
-            delete :destroy, params:{id: broker_person.id, message_id: @broker_inbox.messages.first.id}, format: :js
-          end
-
-          it "should get a notice" do
-            expect(flash[:notice]).to match /Successfully deleted inbox message./
-          end
-        end
       end
     end
   end

--- a/components/benefit_sponsors/spec/dummy/app/models/benefit_coverage_period.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/benefit_coverage_period.rb
@@ -1,0 +1,349 @@
+# frozen_string_literal: true
+
+# A time period during which Organizations, including {HbxProfile}, who are eligible for a {BenefitSponsorship}, may offer
+# {BenefitPackage}(s) to participants within a market place. Each {BenefitCoveragePeriod} includes an open enrollment
+# period, during which eligible partipants may enroll.
+
+class BenefitCoveragePeriod
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include GlobalID::Identification
+
+  embedded_in :benefit_sponsorship
+
+  # This Benefit Coverage Period's name
+  field :title, type: String
+
+  # Market where benefits are available
+  field :service_market, type: String
+
+  field :start_on, type: Date
+  field :end_on, type: Date
+  field :open_enrollment_start_on, type: Date
+  field :open_enrollment_end_on, type: Date
+
+  # Second Lowest Cost Silver Plan, by rating area (only one rating area in DC)
+  field :slcsp, type: BSON::ObjectId
+  field :slcsp_id, type: BSON::ObjectId
+
+  # embeds_many :open_enrollment_periods, class_name: "EnrollmentPeriod"
+  embeds_many :benefit_packages
+  embeds_many :eligibilities, class_name: '::Eligible::Eligibility', as: :eligible, cascade_callbacks: true
+
+  accepts_nested_attributes_for :benefit_packages
+
+  validates_presence_of :start_on, :end_on, :open_enrollment_start_on, :open_enrollment_end_on, message: "is invalid"
+
+  validates :service_market,
+            inclusion: { in: BenefitSponsorship::SERVICE_MARKET_KINDS, message: "%{value} is not a valid service market" }
+
+  validate :end_date_follows_start_date
+
+  before_save :set_title
+
+  scope :by_date, ->(date) { where({:start_on.lte => date, :end_on.gte => date}) }
+
+  scope :by_year, ->(year) { where(start_on: (Date.new(year)..Date.new(year).end_of_year)) }
+
+  # Gets the successor coverage period.
+  # @return [BenefitCoveragePeriod, nil] the successor
+  def successor
+    benefit_sponsorship.benefit_coverage_periods.detect do |bcp|
+      (self.end_on + 1.day) == bcp.start_on
+    end
+  end
+
+  # Sets the ACA Second Lowest Cost Silver Plan (SLCSP) reference plan
+  #
+  # @raise [ArgumentError] if the referenced plan is not silver metal level
+  #
+  # @param new_plan [ Plan ] The reference plan.
+  def second_lowest_cost_silver_plan=(new_plan)
+    raise ArgumentError, 'expected Plan' unless new_plan.is_a?(BenefitMarkets::Products::Product)
+    raise ArgumentError, "slcsp metal level must be silver" unless new_plan.metal_level == "silver"
+    self.slcsp_id = new_plan._id
+    self.slcsp = new_plan._id
+    @second_lowest_cost_silver_plan = new_plan
+  end
+
+  # Gets the ACA Second Lowest Cost Silver Plan (SLCSP) reference plan
+  #
+  # @return [ Plan ] reference plan
+  def second_lowest_cost_silver_plan
+    return @second_lowest_cost_silver_plan if defined? @second_lowest_cost_silver_plan
+    @second_lowest_cost_silver_plan = product_factory.new({product_id: slcsp_id}).product if slcsp_id.present?
+  end
+
+  # @todo Available products from which this sponsor may offer benefits during this benefit coverage period
+  def benefit_products; end
+
+  # Sets the earliest coverage effective date
+  #
+  # @overload start_on=(new_date)
+  #
+  # @param new_date [ Date ] The earliest coverage effective date
+  def start_on=(new_date)
+    new_date = Date.parse(new_date) if new_date.is_a? String
+    write_attribute(:start_on, new_date.beginning_of_day)
+  end
+
+  # Sets the latest date a participant may enroll for coverage
+  #
+  # @overload end_on=(new_date)
+  #
+  # @param new_date [ Date ] The latest date a participant may enroll for coverage
+  def end_on=(new_date)
+    new_date = Date.parse(new_date) if new_date.is_a? String
+    write_attribute(:end_on, new_date.end_of_day)
+  end
+
+  # Determine if this date is within the benefit coverage period start/end dates
+  #
+  # @example Is the date within the benefit coverage period?
+  #   model.contains?(date)
+  #
+  # @return [ true, false ] true if the date falls within the period, false if the date is outside the period
+  def contains?(date)
+    (start_on <= date.to_date) && (date.to_date <= end_on)
+  end
+
+  # Determine if this date is within the open enrollment period start/end dates
+  #
+  # @param date [ Date ] The comparision date
+  #
+  # @example Is the date within the open enrollment period?
+  #   model.open_enrollment_contains?(date)
+  #
+  # @return [ true, false ] true if the date falls within the period, false if the date is outside the period
+  def open_enrollment_contains?(date)
+    (open_enrollment_start_on <= date) && (date <= open_enrollment_end_on)
+  end
+
+  # The earliest enrollment termination effective date, based on this date and site settings
+  #
+  # @param date [ Date ] The comparision date.
+  #
+  # @example When is the earliest termination effective date?
+  #   model.termination_effective_on_for(date)
+  #
+  # @return [ Date ] the earliest termination effective date.
+  def termination_effective_on_for(date)
+    # Add guard to prevent the temination date exceeding end date in the Individual Market
+    [date, end_on].min # see 20996
+  end
+
+  # The earliest coverage start effective date, based on today's date and site settings
+  #
+  # @example When is the earliest coverage start effective date?
+  #   model.earliest_effective_date
+  #
+  # @return [ Date ] the earliest coverage start effective date
+  def earliest_effective_date
+    effective_date = if TimeKeeper.date_of_record.day <= HbxProfile::IndividualEnrollmentDueDayOfMonth
+                       TimeKeeper.date_of_record.end_of_month + 1.day
+                     else
+                       TimeKeeper.date_of_record.next_month.end_of_month + 1.day
+                     end
+
+    [[effective_date, start_on].max, end_on].min
+  end
+
+  # Determine list of available products (plans), based on member enrollment eligibility for each {BenefitPackage} under this
+  # {BenefitCoveragePeriod}. In the Individual market, BenefitPackage types may include Catastrophic, Cost Sharing
+  # Reduction (CSR), etc., and eligibility criteria such as member age, ethnicity, residency and lawful presence.
+  #
+  # @param hbx_enrollment_members [ Array ] the list of enrolling members
+  # @param coverage_kind [ String ] the benefit type.  Only 'health' is currently supported
+  # @param tax_household [ TaxHousehold ] if eligible for financial assistance
+  #
+  # @return [ Array<Plan> ] the list of eligible products
+
+  # TODO: This can be removed once we get rid of temporary config.
+  # rubocop:disable Metrics/CyclomaticComplexity, Style/ConditionalAssignment
+  def elected_plans_by_enrollment_members(hbx_enrollment_members, coverage_kind, tax_household = nil, market = nil)
+    hbx_enrollment = hbx_enrollment_members.first.hbx_enrollment
+    shopping_family_member_ids = hbx_enrollment_members.map(&:applicant_id)
+    subcriber = hbx_enrollment_members.detect(&:is_subscriber)
+    family_members = hbx_enrollment_members.map(&:family_member)
+    american_indian_members = extract_american_indian_status(hbx_enrollment, shopping_family_member_ids)
+
+    if EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
+      csr_kind = ::Operations::PremiumCredits::FindCsrValue.new.call({ family: hbx_enrollment.family,
+                                                                       year: hbx_enrollment.effective_on.year,
+                                                                       family_member_ids: shopping_family_member_ids }).value!
+    else
+      csr_kind = if tax_household
+                   extract_csr_kind(tax_household, shopping_family_member_ids)
+                 elsif american_indian_members && FinancialAssistanceRegistry.feature_enabled?(:native_american_csr)
+                   'csr_limited'
+                 end
+    end
+
+    ivl_bgs = get_benefit_packages({family_members: family_members, coverage_kind: coverage_kind, family: hbx_enrollment.family, american_indian_members: american_indian_members,
+                                    hbx_enrollment: hbx_enrollment,
+                                    effective_on: hbx_enrollment.effective_on, market: market, shopping_family_members_ids: shopping_family_member_ids, csr_kind: csr_kind }).uniq
+    elected_product_ids = ivl_bgs.map(&:benefit_ids).flatten.uniq
+    market = market.nil? || market == 'coverall' ? 'individual' : market
+    product_entries({market: market, coverage_kind: coverage_kind, csr_kind: csr_kind, elected_product_ids: elected_product_ids, subcriber: subcriber, effective_on: hbx_enrollment.effective_on})
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity, Style/ConditionalAssignment
+
+  def get_benefit_packages(**attrs)
+    any_member_greater_than_30 = attrs[:hbx_enrollment].any_member_greater_than_30?
+    fetch_benefit_packages(any_member_greater_than_30, attrs[:csr_kind], attrs[:coverage_kind]).inject([]) do |result, bg|
+      satisfied = true
+      attrs[:family_members].each do |family_member|
+        consumer_role = family_member.person.consumer_role if family_member.person.is_consumer_role_active?
+        resident_role = family_member.person.resident_role if family_member.person.is_resident_role_active?
+        rule = if resident_role.nil?
+                 InsuredEligibleForBenefitRule.new(consumer_role, bg, { coverage_kind: attrs[:coverage_kind], family: attrs[:family],
+                                                                        new_effective_on: attrs[:effective_on],  market_kind: attrs[:market], shopping_family_members_ids: attrs[:shopping_family_members_ids], csr_kind: attrs[:csr_kind]})
+               else
+                 InsuredEligibleForBenefitRule.new(resident_role, bg, coverage_kind: attrs[:coverage_kind], family: attrs[:family], market_kind: attrs[:market], shopping_family_members_ids: attrs[:shopping_family_members_ids],
+                                                                      csr_kind: attrs[:csr_kind])
+               end
+        satisfied = false and break unless rule.satisfied?[0]
+      end
+      result << bg if satisfied
+      result
+    end
+  end
+
+  def product_entries(**attrs)
+    factory = product_factory.new({market_kind: attrs[:market]})
+    elected_products = factory.by_coverage_kind_year_and_csr(attrs[:coverage_kind], start_on.year, csr_kind: attrs[:csr_kind]).by_product_ids(attrs[:elected_product_ids])
+
+    if EnrollRegistry[:service_area].settings(:service_area_model).item == 'single'
+      elected_products.entries
+    else
+      person = attrs[:subcriber].family_member.person
+      address = person.home_address || person.mailing_address
+      service_area_ids = ::BenefitMarkets::Locations::ServiceArea.service_areas_for(address, during: attrs[:effective_on]).map(&:id)
+      elected_products.where(:service_area_id.in => service_area_ids).entries
+    end
+  end
+
+  def dental_benefit_package
+    benefit_packages.detect { |bp| bp.benefit_categories.include?('dental') }
+  end
+
+  def fetch_benefit_packages(any_member_greater_than_30, csr_kind, coverage_kind = "health")
+    return [dental_benefit_package] if coverage_kind == 'dental'
+
+    return benefit_packages.select { |bp| bp.cost_sharing == '' && bp.benefit_categories.include?('health') } if csr_kind.blank?
+
+    eligible_packages = benefit_packages.select { |bp| [csr_kind, 'csr_0'].include?(bp.cost_sharing) }
+    return eligible_packages if any_member_greater_than_30
+
+    cat_benefit_package = benefit_packages.select { |bp| bp.title.match?(/catastrophic_health_benefits/i) }.last
+    return eligible_packages if cat_benefit_package.blank?
+
+    eligible_packages.push(cat_benefit_package)
+  end
+
+  def eligibilities_on(date)
+    eligibility_key = "aca_ivl_osse_eligibility_#{date.year}".to_sym
+
+    eligibilities.by_key(eligibility_key)
+  end
+
+  def eligibility_on(effective_date)
+    eligibilities_on(effective_date).last
+  end
+
+  def active_eligibilities_on(date)
+    eligibilities_on(date).select { |e| e.is_eligible_on?(date) }
+  end
+
+  def active_eligibility_on(effective_date)
+    active_eligibilities_on(effective_date).last
+  end
+
+  ## Class methods
+  class << self
+
+    # The HBX benefit coverage period instance for this identifier
+    #
+    # @param id [ String ] the BSON object identifier
+    #
+    # @example Which HBX benefit coverage period matches this id?
+    #   BenefitCoveragePeriod.find(id)
+    #
+    # @return [ BenefitCoveragePeriod ] the matching HBX benefit coverage period instance
+    def find(id)
+      organizations = Organization.where("hbx_profile.benefit_sponsorship.benefit_coverage_periods._id" => BSON::ObjectId.from_string(id))
+      return unless organizations.present?
+      hbx_profile = organizations.first.hbx_profile
+      benefit_sponsorship = hbx_profile&.benefit_sponsorship
+      benefit_sponsorship&.benefit_coverage_periods&.find(BSON::ObjectId.from_string(id))
+    end
+
+    # The HBX benefit coverage period instance that includes this date within its start and end dates
+    #
+    # @param date [ Date ] the comparison date
+    #
+    # @example Which HBX benefit coverage period covers this date?
+    #   BenefitCoveragePeriod.find_by_date(date)
+    #
+    # @return [ BenefitCoveragePeriod ] the matching HBX benefit coverage period instance
+    def find_by_date(date)
+      organizations = Organization.where(
+        :"hbx_profile.benefit_sponsorship.benefit_coverage_periods.start_on".lte => date,
+        :"hbx_profile.benefit_sponsorship.benefit_coverage_periods.end_on".gte => date
+      )
+      unless organizations.empty?
+        bcps = organizations.first.hbx_profile.benefit_sponsorship.benefit_coverage_periods
+        bcps.select{ |bcp| bcp.start_on <= date && bcp.end_on >= date }.first
+      end
+    end
+
+    # All HBX benefit coverage periods
+    #
+    # @example Which HBX benefit coverage periods are defined?
+    #   BenefitCoveragePeriod.all
+    #
+    # @return [ Array ] the list of HBX benefit coverage periods
+    def all
+      organizations = Organization.exists(:"hbx_profile.benefit_sponsorship.benefit_coverage_periods" => true)
+      organizations.empty? ? nil : organizations.first.hbx_profile.benefit_sponsorship.benefit_coverage_periods
+    end
+
+    #TODO: update the logic once settings moved to benefit coverage period
+    def osse_eligibility_years_for_display
+      return [] if all.blank?
+      all.collect do |bcp|
+        year = bcp.start_on.year
+        eligibility = bcp.eligibilities.by_key("aca_ivl_osse_eligibility_#{year}".to_sym).first
+        next unless eligibility&.eligible?
+        year
+      end.compact
+    end
+  end
+
+  private
+
+  def extract_csr_kind(tax_household, shopping_family_member_ids)
+    tax_household.eligibile_csr_kind(shopping_family_member_ids)
+  end
+
+  def end_date_follows_start_date
+    return unless self.end_on.present?
+    # Passes validation if end_on == start_date
+    errors.add(:end_on, "end_on cannot preceed start_on date") if self.end_on < self.start_on
+  end
+
+  def set_title
+    return if title.present?
+    market_name = service_market == "shop" ? "SHOP" : "Individual"
+    self.title = "#{market_name} Market Benefits #{start_on.year}"
+  end
+
+  def product_factory
+    ::BenefitMarkets::Products::ProductFactory
+  end
+
+  def extract_american_indian_status(hbx_enrollment, shopping_family_members_ids)
+    shopping_family_members = hbx_enrollment.family.family_members.where(:id.in => shopping_family_members_ids)
+    shopping_family_members.all?{|fm| fm.person.indian_tribe_member }
+  end
+end

--- a/components/benefit_sponsors/spec/dummy/app/models/benefit_eligibility_element_group.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/benefit_eligibility_element_group.rb
@@ -3,8 +3,6 @@
 class BenefitEligibilityElementGroup
   include Mongoid::Document
 
-  # whitelist approach
-
   embedded_in :benefit_package
 
   INDIVIDUAL_MARKET_RELATIONSHIP_CATEGORY_KINDS = %w[
@@ -48,26 +46,17 @@ class BenefitEligibilityElementGroup
     ].freeze
 
 
-  field :market_places,          type: Array, default: ["any"]   # %w[any shop individual],
-  field :enrollment_periods,     type: Array, default: ["any"]   # %w[any open_enrollment special_enrollment],
-  field :family_relationships,   type: Array, default: ["any"]   # %w[any self spouse domestic_partner child_under_26 child_26_and_over disabled_children_26_and_over],
-  field :benefit_categories,     type: Array, default: ["any"]   # %w[health dental retirement disability],
+  field :market_places,          type: Array, default: ["any"]
+  field :enrollment_periods,     type: Array, default: ["any"]
+  field :family_relationships,   type: Array, default: ["any"]
+  field :benefit_categories,     type: Array, default: ["any"]
 
-  field :incarceration_status,   type: Array, default: ["any"]   # %w[any unincarcerated],
+  field :incarceration_status,   type: Array, default: ["any"]
   field :age_range,              type: Range, default: 0..0
-  field :citizenship_status,     type: Array, default: ["any"]   # %w[any us_citizen naturalized_citizen alien_lawfully_present lawful_permanent_resident],
-  field :residency_status,       type: Array, default: ["any"]   # %w[any state_resident],
-  field :ethnicity,              type: Array, default: ["any"]   # %w[any indian_tribe_member],
+  field :citizenship_status,     type: Array, default: ["any"]
+  field :residency_status,       type: Array, default: ["any"]
+  field :ethnicity,              type: Array, default: ["any"]
   field :cost_sharing,           type: String, default: ""
   field :lawful_presence_status, type: String, default: ""
   field :active_individual_role, type: Boolean, default: false
-
-
-  # validates :eligible_relationship_categories,
-  #   allow_blank: false,
-  #   inclusion: {
-  #     in: ELIGIBLE_RELATIONSHIP_CATEGORY_KINDS,
-  #     message: "%{value} is not a valid eligible relationship category kind"
-  #   }
-
 end

--- a/components/benefit_sponsors/spec/dummy/app/models/benefit_eligibility_element_group.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/benefit_eligibility_element_group.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class BenefitEligibilityElementGroup
+  include Mongoid::Document
+
+  # whitelist approach
+
+  embedded_in :benefit_package
+
+  INDIVIDUAL_MARKET_RELATIONSHIP_CATEGORY_KINDS = %w[
+      self
+      spouse
+      domestic_partner
+      child
+      parent
+      sibling
+      ward
+      guardian
+      unrelated
+      other_tax_dependent
+      aunt_or_uncle
+      nephew_or_niece
+      grandchild
+      grandparent
+    ].freeze
+
+  Relationships_UI = %w[
+      self
+      spouse
+      domestic_partner
+      child
+      parent
+      sibling
+      unrelated
+      aunt_or_uncle
+      nephew_or_niece
+      grandchild
+      grandparent
+    ] + (EnrollRegistry.feature_enabled?(:mitc_relationships) ? %w[father_or_mother_in_law daughter_or_son_in_law brother_or_sister_in_law cousin domestic_partners_child parents_domestic_partner] : [])
+
+  SHOP_MARKET_RELATIONSHIP_CATEGORY_KINDS = %w[
+      self
+      spouse
+      domestic_partner
+      children_under_26
+      disabled_children_26_and_over
+      children_26_and_over
+    ].freeze
+
+
+  field :market_places,          type: Array, default: ["any"]   # %w[any shop individual],
+  field :enrollment_periods,     type: Array, default: ["any"]   # %w[any open_enrollment special_enrollment],
+  field :family_relationships,   type: Array, default: ["any"]   # %w[any self spouse domestic_partner child_under_26 child_26_and_over disabled_children_26_and_over],
+  field :benefit_categories,     type: Array, default: ["any"]   # %w[health dental retirement disability],
+
+  field :incarceration_status,   type: Array, default: ["any"]   # %w[any unincarcerated],
+  field :age_range,              type: Range, default: 0..0
+  field :citizenship_status,     type: Array, default: ["any"]   # %w[any us_citizen naturalized_citizen alien_lawfully_present lawful_permanent_resident],
+  field :residency_status,       type: Array, default: ["any"]   # %w[any state_resident],
+  field :ethnicity,              type: Array, default: ["any"]   # %w[any indian_tribe_member],
+  field :cost_sharing,           type: String, default: ""
+  field :lawful_presence_status, type: String, default: ""
+  field :active_individual_role, type: Boolean, default: false
+
+
+  # validates :eligible_relationship_categories,
+  #   allow_blank: false,
+  #   inclusion: {
+  #     in: ELIGIBLE_RELATIONSHIP_CATEGORY_KINDS,
+  #     message: "%{value} is not a valid eligible relationship category kind"
+  #   }
+
+end

--- a/components/benefit_sponsors/spec/dummy/app/models/benefit_package.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/benefit_package.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class BenefitPackage
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  embedded_in :benefit_coverage_period
+
+  BENEFIT_BEGIN_AFTER_EVENT_OFFSET_KINDS = [0, 30, 60, 90].freeze
+  BENEFIT_EFFECTIVE_DATE_KINDS      = %w[date_of_event first_of_month].freeze
+  BENEFIT_TERMINATION_DATE_KINDS    = %w[date_of_event end_of_month].freeze
+
+  # Premium Credit Strategies
+  # 1. Unassisted: subscriber is responsible for total premium cost
+  # 2. Employer fixed cost: employer fixed dollar amount applied toward employee's total premium cost
+  # 3. Employee fixed cost: employee costs defined, regardless of age, and employer pays the difference
+  # 4. Allocated lump sum credit (e.g. APTC): fixed dollar amount apportioned among eligible relationship categories
+  # 5. Percentage contribution: contribution ratio applied to each eligible relationship category
+  # 6. Indexed percentage contribution (e.g. DCHL SHOP method): using selected reference benefit, contribution ratio applied to each eligible relationship category
+  # 7. Federal Employee Health Benefits (FEHB - congress): percentage contribution, with employer cost cap
+
+  PREMIUM_CREDIT_STRATEGY_KINDS = %w[unassisted employer_fixed_cost employee_fixed_cost allocated_lump_sum_credit
+                                     percentage_contribution indexed_percentage_contribution federal_employee_health_benefit].freeze
+
+
+  field :title, type: String, default: ""
+
+  field :benefit_begin_after_event_offsets, type: Array, default: []
+  field :benefit_effective_dates,           type: Array, default: []
+  field :benefit_termination_dates,         type: Array, default: []
+
+  field :elected_premium_credit_strategy,   type: String
+  field :index_benefit_id,                  type: BSON::ObjectId
+  field :benefit_ids,                       type: Array, default: []
+
+  delegate :start_on, :end_on, to: :benefit_coverage_period
+
+  delegate :market_places, :enrollment_periods, :family_relationships, :benefit_categories,
+           :incarceration_status, :age_range, :citizenship_status, :residency_status, :ethnicity, :cost_sharing,
+           to: :benefit_eligibility_element_group
+
+  delegate :market_places=, :enrollment_periods=, :family_relationships=, :benefit_categories=,
+           :incarceration_status=, :age_range=, :citizenship_status=, :residency_status=, :ethnicity=,
+           to: :benefit_eligibility_element_group
+
+
+  embeds_one :benefit_eligibility_element_group
+  accepts_nested_attributes_for :benefit_eligibility_element_group
+
+  after_initialize :initialize_dependent_models
+
+  def initialize_dependent_models
+    build_benefit_eligibility_element_group if benefit_eligibility_element_group.nil?
+  end
+
+  def effective_year
+    start_on.year
+  end
+
+  def cost_sharing
+    benefit_eligibility_element_group&.cost_sharing
+  end
+
+  # def initialize(*args)
+  #   self.build_benefit_eligibility_element_group
+  #   super(*args)
+  # end
+
+  # embeds_one :premium_credit_strategy
+
+  # validates :benefit_begin_after_event_offsets,
+  #   allow_blank: false,
+  #   inclusion: {
+  #     in: BENEFIT_BEGIN_AFTER_EVENT_OFFSET_KINDS,
+  #     message: "%{value} is not a valid benefit begin offset period kind"
+  #   }
+
+  # validates :benefit_effective_dates,
+  #   allow_blank: false,
+  #   inclusion: {
+  #     in: BENEFIT_EFFECTIVE_DATE_KINDS,
+  #     message: "%{value} is not a valid benefit effective date kind"
+  #   }
+
+  # validates :benefit_termination_dates,
+  #   allow_blank: false,
+  #   inclusion: {
+  #     in: BENEFIT_TERMINATION_DATE_KINDS,
+  #     message: "%{value} is not a valid benefit termination date kind"
+  #   }
+
+  validates :elected_premium_credit_strategy,
+            allow_blank: false,
+            inclusion: {
+              in: PREMIUM_CREDIT_STRATEGY_KINDS,
+              message: "%{value} is not a valid premium credit strategy kind"
+            }
+end

--- a/components/benefit_sponsors/spec/dummy/app/models/benefit_package.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/benefit_package.rb
@@ -10,15 +10,6 @@ class BenefitPackage
   BENEFIT_EFFECTIVE_DATE_KINDS      = %w[date_of_event first_of_month].freeze
   BENEFIT_TERMINATION_DATE_KINDS    = %w[date_of_event end_of_month].freeze
 
-  # Premium Credit Strategies
-  # 1. Unassisted: subscriber is responsible for total premium cost
-  # 2. Employer fixed cost: employer fixed dollar amount applied toward employee's total premium cost
-  # 3. Employee fixed cost: employee costs defined, regardless of age, and employer pays the difference
-  # 4. Allocated lump sum credit (e.g. APTC): fixed dollar amount apportioned among eligible relationship categories
-  # 5. Percentage contribution: contribution ratio applied to each eligible relationship category
-  # 6. Indexed percentage contribution (e.g. DCHL SHOP method): using selected reference benefit, contribution ratio applied to each eligible relationship category
-  # 7. Federal Employee Health Benefits (FEHB - congress): percentage contribution, with employer cost cap
-
   PREMIUM_CREDIT_STRATEGY_KINDS = %w[unassisted employer_fixed_cost employee_fixed_cost allocated_lump_sum_credit
                                      percentage_contribution indexed_percentage_contribution federal_employee_health_benefit].freeze
 
@@ -60,34 +51,6 @@ class BenefitPackage
   def cost_sharing
     benefit_eligibility_element_group&.cost_sharing
   end
-
-  # def initialize(*args)
-  #   self.build_benefit_eligibility_element_group
-  #   super(*args)
-  # end
-
-  # embeds_one :premium_credit_strategy
-
-  # validates :benefit_begin_after_event_offsets,
-  #   allow_blank: false,
-  #   inclusion: {
-  #     in: BENEFIT_BEGIN_AFTER_EVENT_OFFSET_KINDS,
-  #     message: "%{value} is not a valid benefit begin offset period kind"
-  #   }
-
-  # validates :benefit_effective_dates,
-  #   allow_blank: false,
-  #   inclusion: {
-  #     in: BENEFIT_EFFECTIVE_DATE_KINDS,
-  #     message: "%{value} is not a valid benefit effective date kind"
-  #   }
-
-  # validates :benefit_termination_dates,
-  #   allow_blank: false,
-  #   inclusion: {
-  #     in: BENEFIT_TERMINATION_DATE_KINDS,
-  #     message: "%{value} is not a valid benefit termination date kind"
-  #   }
 
   validates :elected_premium_credit_strategy,
             allow_blank: false,

--- a/components/benefit_sponsors/spec/dummy/app/models/benefit_sponsorship.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/benefit_sponsorship.rb
@@ -5,10 +5,6 @@ class BenefitSponsorship
   include Mongoid::Timestamps
 
   embedded_in :hbx_profile
-  # embedded_in :employer_profile
-
-  # person/roles can determine which sponsor in a class has a relationship (offer products)
-  # which benefit packages should be offered to person/roles
 
   SERVICE_MARKET_KINDS = %w[shop individual coverall].freeze
 
@@ -52,11 +48,6 @@ class BenefitSponsorship
     benefit_coverage_periods.detect { |bcp| bcp.contains?(effective_date) }
   end
 
-
-  # def is_under_special_enrollment_period?
-  #   benefit_coverage_periods.detect { |bcp| bcp.contains?(TimeKeeper.date_of_record) }
-  # end
-
   def is_coverage_period_under_open_enrollment?
     benefit_coverage_periods.any? do |benefit_coverage_period|
       benefit_coverage_period.open_enrollment_contains?(TimeKeeper.date_of_record)
@@ -75,30 +66,6 @@ class BenefitSponsorship
       current_benefit_coverage_period
     end
   end
-
-# effective_coverage_period
-# HBX: Jan-Dec
-# Employers: year-over-year, e.g. Jun-May
-
-# Shopping time range
-# Benefit effective time range: can exceed one year
-# Issuer begin date
-# Issuer end date --
-
-# Employer
-# Effective start on date: Dec 1, 2015
-# Effective end on date: Nov 30, 2016
-# (policy) contract start on date
-# (policy) contract end on date
-
-# SHOP plan effective start on date Jan 1, 2015
-# SHOP plan effective end on date: Dec 31, 2015
-
-# product effective_start_on
-# product effective_end_on
-
-# 2015 SHOP plan that becomes effective Jan 1 2015
-#   benefit_service_period between Jan 1 2015 and Nov 30, 2016
 
   class << self
     def advance_day(new_date)

--- a/components/benefit_sponsors/spec/dummy/app/models/benefit_sponsorship.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/benefit_sponsorship.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+class BenefitSponsorship
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  embedded_in :hbx_profile
+  # embedded_in :employer_profile
+
+  # person/roles can determine which sponsor in a class has a relationship (offer products)
+  # which benefit packages should be offered to person/roles
+
+  SERVICE_MARKET_KINDS = %w[shop individual coverall].freeze
+
+  field :service_markets, type: Array, default: []
+  validates_presence_of :service_markets
+
+  # 2015, 2016, etc. (aka plan_year)
+  embeds_many :benefit_coverage_periods
+  embeds_many :geographic_rating_areas
+
+  accepts_nested_attributes_for :benefit_coverage_periods, :geographic_rating_areas
+  # Query Census member collection
+  def census_employees
+    @census_employees = CensusMembers::PlanDesignCensusEmployee.by_benefit_sponsorship(self)
+  end
+
+  def create_benefit_coverage_period(year)
+    bcp = benefit_coverage_periods.by_year(year).first
+    return bcp if bcp.present?
+
+    benefit_coverage_periods.create!(bcp_create_params(year))
+  end
+
+  def current_benefit_coverage_period
+    benefit_coverage_periods.detect { |bcp| bcp.contains?(TimeKeeper.date_of_record) }
+  end
+
+  def renewal_benefit_coverage_period
+    benefit_coverage_periods.detect { |bcp| bcp.contains?(TimeKeeper.date_of_record + 1.year) }
+  end
+
+  def previous_benefit_coverage_period
+    benefit_coverage_periods.detect { |bcp| bcp.contains?(TimeKeeper.date_of_record - 1.year) }
+  end
+
+  def earliest_effective_date
+    current_benefit_period&.earliest_effective_date
+  end
+
+  def benefit_coverage_period_by_effective_date(effective_date)
+    benefit_coverage_periods.detect { |bcp| bcp.contains?(effective_date) }
+  end
+
+
+  # def is_under_special_enrollment_period?
+  #   benefit_coverage_periods.detect { |bcp| bcp.contains?(TimeKeeper.date_of_record) }
+  # end
+
+  def is_coverage_period_under_open_enrollment?
+    benefit_coverage_periods.any? do |benefit_coverage_period|
+      benefit_coverage_period.open_enrollment_contains?(TimeKeeper.date_of_record)
+    end
+  end
+
+  def self.find(id)
+    orgs = Organization.where("hbx_profile.benefit_sponsorship._id" => BSON::ObjectId.from_string(id))
+    orgs.empty? ? nil : orgs.first.hbx_profile.benefit_sponsorship
+  end
+
+  def current_benefit_period
+    if renewal_benefit_coverage_period&.open_enrollment_contains?(TimeKeeper.date_of_record)
+      renewal_benefit_coverage_period
+    else
+      current_benefit_coverage_period
+    end
+  end
+
+# effective_coverage_period
+# HBX: Jan-Dec
+# Employers: year-over-year, e.g. Jun-May
+
+# Shopping time range
+# Benefit effective time range: can exceed one year
+# Issuer begin date
+# Issuer end date --
+
+# Employer
+# Effective start on date: Dec 1, 2015
+# Effective end on date: Nov 30, 2016
+# (policy) contract start on date
+# (policy) contract end on date
+
+# SHOP plan effective start on date Jan 1, 2015
+# SHOP plan effective end on date: Dec 31, 2015
+
+# product effective_start_on
+# product effective_end_on
+
+# 2015 SHOP plan that becomes effective Jan 1 2015
+#   benefit_service_period between Jan 1 2015 and Nov 30, 2016
+
+  class << self
+    def advance_day(new_date)
+      create_prospective_year_benefit_coverage_period(new_date)
+
+      hbx_sponsors = Organization.exists("hbx_profile.benefit_sponsorship": true).reduce([]) { |memo, org| memo << org.hbx_profile }
+
+      hbx_sponsors.each do |hbx_sponsor|
+        hbx_sponsor.advance_day
+        hbx_sponsor.advance_month   if new_date.day == 1
+        hbx_sponsor.advance_quarter if new_date.day == 1 && [1, 4, 7, 10].include?(new_date.month)
+        hbx_sponsor.advance_year    if new_date.day == 1 && new_date.month == 1
+      end
+
+      renewal_benefit_coverage_period = HbxProfile.current_hbx.benefit_sponsorship.renewal_benefit_coverage_period
+      return unless EnrollRegistry.feature_enabled?(:ivl_enrollment_renewal_begin_date)
+      oe_month = EnrollRegistry[:ivl_enrollment_renewal_begin_date].setting(:ivl_enrollment_renewal_begin_effective_month).item
+      oe_day_of_month = EnrollRegistry[:ivl_enrollment_renewal_begin_date].setting(:ivl_enrollment_renewal_begin_effective_day).item
+      renewal_oe_date = Date.new(TimeKeeper.date_of_record.year, oe_month, oe_day_of_month)
+      return unless renewal_benefit_coverage_period.present? && renewal_oe_date == new_date && !Rails.env.test?
+      oe_begin = Enrollments::IndividualMarket::OpenEnrollmentBegin.new
+      oe_begin.process_renewals
+    end
+
+    # Creates BCP for the prospective year
+    def create_prospective_year_benefit_coverage_period(new_date)
+      return unless eligible_for_new_benefit_coverage_period?(new_date)
+
+      HbxProfile.current_hbx.benefit_sponsorship.create_benefit_coverage_period(new_date.year.next)
+    rescue StandardError => e
+      Rails.logger.error { "Couldn't create prospective year benefit coverage period due to #{e.inspect}" }
+    end
+
+    def eligible_for_new_benefit_coverage_period?(new_date)
+      FinancialAssistanceRegistry.feature_enabled?(:create_bcp_on_date_change) &&
+        new_date.month == FinancialAssistanceRegistry[:create_bcp_on_date_change].settings(:bcp_creation_month).item &&
+        new_date.day == FinancialAssistanceRegistry[:create_bcp_on_date_change].settings(:bcp_creation_day).item
+    end
+  end
+
+  private
+
+  def bcp_create_params(year)
+    previous_bcp = benefit_coverage_periods.by_year(year.pred).first
+
+    if previous_bcp.present?
+      {
+        title: "Individual Market Benefits #{year}",
+        service_market: previous_bcp.service_market,
+        start_on: previous_bcp.start_on.next_year,
+        end_on: previous_bcp.end_on.next_year,
+        open_enrollment_start_on: previous_bcp.open_enrollment_start_on.next_year,
+        open_enrollment_end_on: previous_bcp.open_enrollment_end_on.next_year
+      }
+    else
+      {
+        title: "Individual Market Benefits #{year}",
+        service_market: 'individual',
+        start_on: Date.new(year, 1, 1),
+        end_on: Date.new(year, 12, 31),
+        open_enrollment_start_on: Date.new(year.pred, 11, 1),
+        open_enrollment_end_on: Date.new(year, 1, 31)
+      }
+    end
+  end
+end

--- a/components/benefit_sponsors/spec/dummy/app/models/enrollment_period.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/enrollment_period.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class EnrollmentPeriod
+  include Mongoid::Document
+
+  embedded_in :benefit_sponsor
+
+  field :title, type: String
+  field :start_on, type: Date
+  field :end_on, type: Date
+
+  validates_presence_of :start_on, :end_on, :message => "is invalid"
+  validate :end_date_follows_start_date
+
+  def start_on=(new_date)
+    new_date = Date.parse(new_date) if new_date.is_a? String
+    write_attribute(:start_on, new_date.beginning_of_day)
+  end
+
+  def end_on=(new_date)
+    new_date = Date.parse(new_date) if new_date.is_a? String
+    write_attribute(:end_on, new_date.end_of_day)
+  end
+
+  alias effective_date= start_on=
+  alias effective_date start_on
+
+  private
+
+  def end_date_follows_start_date
+    return unless self.end_on.present?
+    # Passes validation if end_on == start_date
+    errors.add(:end_on, "end_on cannot preceed start_on date") if self.end_on < self.start_on
+  end
+
+
+end

--- a/components/benefit_sponsors/spec/dummy/app/models/geographic_rating_area.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/geographic_rating_area.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class GeographicRatingArea
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  # An area that all issuers in the state must uniformly use as part of their rate setting
+  # Rating areas are made up of counties, metroplitan statistical areas or 3 digit zip codes
+  # Default areas are Metropolitan Statistical Areas (MSAs) plus the remainder of the state
+  # not included in a MSA
+  # Example: http://insuremekevin.com/california-navigator/covered-california-regions-plans/
+
+  embedded_in :benefit_sponsorship
+
+  field :rating_area_code, type: String
+
+  has_many :us_counties
+  # embeds_many :zip_codes
+
+end

--- a/components/benefit_sponsors/spec/dummy/app/models/hbx_staff_role.rb
+++ b/components/benefit_sponsors/spec/dummy/app/models/hbx_staff_role.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 class HbxStaffRole
   include Mongoid::Document
+  include SetCurrentUser
   include Mongoid::Timestamps
 
   embedded_in :person
@@ -10,19 +13,51 @@ class HbxStaffRole
   field :department, type: String, default: ""
   field :is_active, type: Boolean, default: true
 
-  validates_presence_of :hbx_profile_id
-
   delegate :hbx_id, to: :person, allow_nil: true
   delegate :dob, :dob=, to: :person, allow_nil: true
 
   accepts_nested_attributes_for :person
 
-  alias_method :is_active?, :is_active
+  validates_presence_of :hbx_profile_id, :if => proc { |m| m.benefit_sponsor_hbx_profile_id.blank? }
+  validates_presence_of :benefit_sponsor_hbx_profile_id, :if => proc { |m| m.hbx_profile_id.blank? }
+
+  alias is_active? is_active
   #subrole is for documentation. should be redundant with permission_id
   field :subrole, type: String, default: ""
   field :permission_id, type: BSON::ObjectId
-
   def permission
-    Permission.find(permission_id)
+    return nil if permission_id.blank?
+    @permission ||= Permission.find(permission_id)
   end
+
+  def self.find(id)
+    return nil if id.blank?
+    people = Person.where("hbx_staff_role._id" => BSON::ObjectId.from_string(id))
+    people.any? ? people[0].hbx_staff_role : nil
+  end
+
+  # belongs_to Hbx
+  def hbx_profile=(new_hbx_profile)
+    raise ArgumentError, "expected HbxProfile" unless (new_hbx_profile.is_a? BenefitSponsors::Organizations::HbxProfile) || (new_hbx_profile.is_a? HbxProfile)
+    if new_hbx_profile.is_a? BenefitSponsors::Organizations::HbxProfile
+      self.benefit_sponsor_hbx_profile_id = new_hbx_profile._id
+    else
+      self.hbx_profile_id = new_hbx_profile._id
+    end
+    @hbx_profile = new_hbx_profile
+  end
+
+  def hbx_profile
+    return @hbx_profile if defined? @hbx_profile
+    @hbx_profile = if self.benefit_sponsor_hbx_profile_id.present?
+                     BenefitSponsors::Organizations::HbxProfile.find(self.benefit_sponsor_hbx_profile_id)
+                   else
+                     HbxProfile.find(self.hbx_profile_id)
+                   end
+  end
+
+  def parent
+    person
+  end
+
 end

--- a/components/benefit_sponsors/spec/dummy/spec/factories/benefit_coverage_periods.rb
+++ b/components/benefit_sponsors/spec/dummy/spec/factories/benefit_coverage_periods.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :benefit_coverage_period do
+    transient do
+      coverage_year { TimeKeeper.date_of_record.year }
+    end
+
+    service_market           { "individual" }
+    start_on                 { Date.new(coverage_year, 1, 1) }
+    end_on                   { Date.new(coverage_year, 12, 31) }
+    open_enrollment_start_on { Date.new(coverage_year - 1, 11, 1) }
+    open_enrollment_end_on   { Date.new(coverage_year, 1, 31) }
+    benefit_packages { [FactoryBot.build(:benefit_package, coverage_year: coverage_year)] }
+
+    trait :open_enrollment_coverage_period do
+      start_on                 { Date.new(coverage_year, 1, 1) }
+      end_on                   { Date.new(coverage_year, 12, 31) }
+      open_enrollment_start_on { Date.new(coverage_year, 1, 1) }
+      open_enrollment_end_on   { Date.new(coverage_year, 12, 31) }
+      benefit_packages { [FactoryBot.build(:benefit_package, coverage_year: coverage_year)] }
+    end
+
+    trait :no_open_enrollment_coverage_period do
+      start_on                 { Date.new(coverage_year, 1, 1) }
+      end_on                   { Date.new(coverage_year, 12, 31) }
+      open_enrollment_start_on { Date.new(coverage_year - 1, 11, 1) }
+      open_enrollment_end_on   { Date.new(coverage_year - 1, 12, 31) }
+      benefit_packages { [FactoryBot.build(:benefit_package, coverage_year: coverage_year)] }
+    end
+
+    trait :next_years_open_enrollment_coverage_period do
+      start_on                 { Date.new(coverage_year + 1, 1, 1) }
+      end_on                   { Date.new(coverage_year + 1, 12, 31) }
+      open_enrollment_start_on { Date.new(coverage_year, 11, 1) }
+      open_enrollment_end_on   { Date.new(coverage_year + 1, 2, 3) }
+      benefit_packages { [FactoryBot.build(:benefit_package, :next_coverage_year_title, coverage_year: coverage_year)] }
+    end
+
+    trait :next_years_no_open_enrollment_coverage_period do
+      start_on                 { Date.new(coverage_year + 1, 1, 1) }
+      end_on                   { Date.new(coverage_year + 1, 12, 31) }
+      open_enrollment_start_on { Date.new(coverage_year + 1, 1, 1) }
+      open_enrollment_end_on   { Date.new(coverage_year + 1, 1, 1) }
+      benefit_packages { [FactoryBot.build(:benefit_package, :next_coverage_year_title, coverage_year: coverage_year)] }
+    end
+
+    trait :last_years_coverage_period do
+      start_on                 { Date.new(coverage_year - 1, 1, 1) }
+      end_on                   { Date.new(coverage_year - 1, 12, 31) }
+      open_enrollment_start_on { Date.new(coverage_year - 2, 11, 1) }
+      open_enrollment_end_on   { Date.new(coverage_year - 1, 2, 3) }
+      benefit_packages { [FactoryBot.build(:benefit_package, :last_coverage_year_title, coverage_year: coverage_year)] }
+    end
+
+    trait :last_years_no_open_enrollment_coverage_period do
+      start_on                 { Date.new(coverage_year - 1, 1, 1) }
+      end_on                   { Date.new(coverage_year - 1, 12, 31) }
+      open_enrollment_start_on { Date.new(coverage_year - 1, 1, 1) }
+      open_enrollment_end_on   { Date.new(coverage_year - 1, 1, 1) }
+      benefit_packages { [FactoryBot.build(:benefit_package, :last_coverage_year_title, coverage_year: coverage_year)] }
+    end
+  end
+end

--- a/components/benefit_sponsors/spec/dummy/spec/factories/benefit_packages.rb
+++ b/components/benefit_sponsors/spec/dummy/spec/factories/benefit_packages.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :benefit_package do
+    transient do
+      coverage_year { TimeKeeper.date_of_record.year }
+    end
+
+    title {"individual_health_benefits_#{coverage_year}"}
+    elected_premium_credit_strategy { "unassisted" }
+    benefit_begin_after_event_offsets { [30, 60, 90] }
+    benefit_effective_dates { ["first_of_month"] }
+    benefit_categories { ["health"]}
+
+    after :build do |bp, evaluator|
+      issuer_profile = FactoryBot.create(:benefit_sponsors_organizations_issuer_profile, :kaiser_profile)
+      ivl_bronze = FactoryBot.create(:benefit_markets_products_health_products_health_product,
+                                     title: 'IVL Test Plan Bronze',
+                                     benefit_market_kind: :aca_individual,
+                                     kind: 'health', deductible: 3000,
+                                     metal_level_kind: "bronze",
+                                     application_period: (Date.new(evaluator.coverage_year, 1, 1)..Date.new(evaluator.coverage_year, 12, 31)),
+                                     csr_variant_id: "01",
+                                     issuer_profile: issuer_profile,
+                                     service_area: FactoryBot.create(:benefit_markets_locations_service_area, active_year: evaluator.coverage_year))
+      ivl_silver = FactoryBot.create(:benefit_markets_products_health_products_health_product,
+                                     title: 'IVL Test Plan Silver',
+                                     benefit_market_kind: :aca_individual,
+                                     kind: 'health',
+                                     deductible: 2000,
+                                     metal_level_kind: "silver",
+                                     application_period: (Date.new(evaluator.coverage_year, 1, 1)..Date.new(evaluator.coverage_year, 12, 31)),
+                                     csr_variant_id: "01",
+                                     issuer_profile: issuer_profile,
+                                     service_area: FactoryBot.create(:benefit_markets_locations_service_area, active_year: evaluator.coverage_year))
+      ivl_gold = FactoryBot.create(:benefit_markets_products_health_products_health_product,
+                                   title: 'IVL Test Plan Gold',
+                                   benefit_market_kind: :aca_individual,
+                                   kind: 'health', deductible: 1000,
+                                   metal_level_kind: "gold",
+                                   application_period: (Date.new(evaluator.coverage_year, 1, 1)..Date.new(evaluator.coverage_year, 12, 31)),
+                                   csr_variant_id: "01",
+                                   issuer_profile: issuer_profile,
+                                   service_area: FactoryBot.create(:benefit_markets_locations_service_area, active_year: evaluator.coverage_year))
+      ivl_plat = FactoryBot.create(:benefit_markets_products_health_products_health_product,
+                                   title: 'IVL Test Plan Plat',
+                                   benefit_market_kind: :aca_individual,
+                                   kind: 'health',
+                                   deductible: 500,
+                                   metal_level_kind: "platinum",
+                                   application_period: (Date.new(evaluator.coverage_year, 1, 1)..Date.new(evaluator.coverage_year, 12, 31)),
+                                   csr_variant_id: "01",
+                                   issuer_profile: issuer_profile,
+                                   service_area: FactoryBot.create(:benefit_markets_locations_service_area, active_year: evaluator.coverage_year))
+      future_ivl_bronze = FactoryBot.create(:benefit_markets_products_health_products_health_product,
+                                            title: 'IVL Test Plan Bronze',
+                                            benefit_market_kind: :aca_individual,
+                                            kind: 'health',
+                                            deductible: 3000,
+                                            metal_level_kind: "bronze",
+                                            csr_variant_id: "01",
+                                            application_period: (Date.new(evaluator.coverage_year + 1, 1, 1)..Date.new(evaluator.coverage_year + 1, 12, 31)),
+                                            issuer_profile: issuer_profile,
+                                            service_area: FactoryBot.create(:benefit_markets_locations_service_area, active_year: (evaluator.coverage_year + 1)))
+      future_ivl_silver = FactoryBot.create(:benefit_markets_products_health_products_health_product,
+                                            title: 'IVL Test Plan Silver',
+                                            benefit_market_kind: :aca_individual,
+                                            kind: 'health', deductible: 2000,
+                                            metal_level_kind: "silver",
+                                            csr_variant_id: "01",
+                                            application_period: (Date.new(evaluator.coverage_year + 1, 1, 1)..Date.new(evaluator.coverage_year + 1, 12, 31)),
+                                            issuer_profile: issuer_profile,
+                                            service_area: FactoryBot.create(:benefit_markets_locations_service_area, active_year: (evaluator.coverage_year + 1)))
+      future_ivl_gold = FactoryBot.create(:benefit_markets_products_health_products_health_product,
+                                          title: 'IVL Test Plan Gold',
+                                          benefit_market_kind: :aca_individual,
+                                          kind: 'health',
+                                          deductible: 1000,
+                                          metal_level_kind: "gold",
+                                          csr_variant_id: "01",
+                                          application_period: (Date.new(evaluator.coverage_year + 1, 1, 1)..Date.new(evaluator.coverage_year + 1, 12, 31)),
+                                          issuer_profile: issuer_profile,
+                                          service_area: FactoryBot.create(:benefit_markets_locations_service_area, active_year: (evaluator.coverage_year + 1)))
+      future_ivl_plat = FactoryBot.create(:benefit_markets_products_health_products_health_product,
+                                          title: 'IVL Test Plan Plat',
+                                          benefit_market_kind: :aca_individual,
+                                          kind: 'health',
+                                          deductible: 500,
+                                          metal_level_kind: "platinum",
+                                          csr_variant_id: "01",
+                                          application_period: (Date.new(evaluator.coverage_year + 1, 1, 1)..Date.new(evaluator.coverage_year + 1, 12, 31)),
+                                          issuer_profile: issuer_profile,
+                                          service_area: FactoryBot.create(:benefit_markets_locations_service_area, active_year: (evaluator.coverage_year + 1)))
+      bp.benefit_ids = [ivl_bronze.id, ivl_silver.id, ivl_gold.id, ivl_plat.id, future_ivl_bronze.id, future_ivl_silver.id, future_ivl_gold.id, future_ivl_plat.id]
+    end
+
+    trait :next_coverage_year_title do
+      title {"individual_health_benefits_#{coverage_year + 1}"}
+    end
+
+    trait :last_coverage_year_title do
+      title {"individual_health_benefits_#{coverage_year - 1}"}
+    end
+
+    trait :with_csr_0_benefit_eligibility_element_group do
+      after :build do |bp, _evaluator|
+        FactoryBot.build(:benefit_eligibility_element_group, cost_sharing: 'csr_0', benefit_package: bp)
+      end
+    end
+
+    trait :with_csr_73_benefit_eligibility_element_group do
+      after :build do |bp, _evaluator|
+        FactoryBot.build(:benefit_eligibility_element_group, cost_sharing: 'csr_73', benefit_package: bp)
+      end
+    end
+  end
+end

--- a/components/benefit_sponsors/spec/dummy/spec/factories/benefit_sponsorships.rb
+++ b/components/benefit_sponsors/spec/dummy/spec/factories/benefit_sponsorships.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :benefit_sponsorship do
+    transient do
+      coverage_year { TimeKeeper.date_of_record.year }
+    end
+
+    service_markets { %w[individual shop] }
+    benefit_coverage_periods { [FactoryBot.build(:benefit_coverage_period, coverage_year: coverage_year)] }
+
+    trait :single_open_enrollment_coverage_period do
+      benefit_coverage_periods { [FactoryBot.build(:benefit_coverage_period, :open_enrollment_coverage_period, coverage_year: coverage_year)] }
+    end
+
+    trait :open_enrollment_coverage_period do
+      benefit_coverage_periods do
+        [FactoryBot.build(:benefit_coverage_period, :open_enrollment_coverage_period, coverage_year: coverage_year), FactoryBot.build(:benefit_coverage_period, :next_years_open_enrollment_coverage_period, coverage_year: coverage_year)]
+      end
+    end
+
+    trait :normal_ivl_open_enrollment_coverage_period do
+      benefit_coverage_periods do
+        [FactoryBot.build(:benefit_coverage_period, coverage_year: coverage_year), FactoryBot.build(:benefit_coverage_period, :next_years_open_enrollment_coverage_period, coverage_year: coverage_year)]
+      end
+    end
+
+    trait :no_open_enrollment_coverage_period do
+      benefit_coverage_periods do
+        [FactoryBot.build(:benefit_coverage_period, :no_open_enrollment_coverage_period, coverage_year: coverage_year), FactoryBot.build(:benefit_coverage_period, :next_years_no_open_enrollment_coverage_period, coverage_year: coverage_year)]
+      end
+    end
+
+    trait :last_years_coverage_period do
+      benefit_coverage_periods do
+        [FactoryBot.build(:benefit_coverage_period, :no_open_enrollment_coverage_period, coverage_year: coverage_year), FactoryBot.build(:benefit_coverage_period, :last_years_coverage_period, coverage_year: coverage_year)]
+      end
+    end
+
+    trait :normal_oe_period_with_past_coverage_periods do
+      benefit_coverage_periods do
+        [FactoryBot.build(:benefit_coverage_period, :last_years_no_open_enrollment_coverage_period, coverage_year: coverage_year), FactoryBot.build(:benefit_coverage_period, :no_open_enrollment_coverage_period, coverage_year: coverage_year),
+         FactoryBot.build(:benefit_coverage_period, :next_years_open_enrollment_coverage_period, coverage_year: coverage_year)]
+      end
+    end
+  end
+end

--- a/components/benefit_sponsors/spec/dummy/spec/factories/hbx_profiles.rb
+++ b/components/benefit_sponsors/spec/dummy/spec/factories/hbx_profiles.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :hbx_profile do
+    transient do
+      coverage_year { TimeKeeper.date_of_record.year }
+    end
+
+    organization            { FactoryBot.build(:organization) }
+    us_state_abbreviation   { Settings.aca.state_abbreviation }
+    cms_id   { "DC0" }
+    benefit_sponsorship { FactoryBot.build(:benefit_sponsorship, coverage_year: coverage_year) }
+
+    trait :open_enrollment_coverage_period do
+      benefit_sponsorship { FactoryBot.build(:benefit_sponsorship, :open_enrollment_coverage_period, coverage_year: coverage_year) }
+    end
+
+    trait :normal_ivl_open_enrollment do
+      benefit_sponsorship { FactoryBot.build(:benefit_sponsorship, :normal_ivl_open_enrollment_coverage_period, coverage_year: coverage_year) }
+    end
+
+    trait :single_open_enrollment_coverage_period do
+      benefit_sponsorship { FactoryBot.build(:benefit_sponsorship, :single_open_enrollment_coverage_period, coverage_year: coverage_year) }
+    end
+
+    trait :no_open_enrollment_coverage_period do
+      benefit_sponsorship { FactoryBot.build(:benefit_sponsorship, :no_open_enrollment_coverage_period, coverage_year: coverage_year) }
+    end
+
+    trait :last_years_coverage_period do
+      benefit_sponsorship { FactoryBot.build(:benefit_sponsorship, :last_years_coverage_period, coverage_year: coverage_year) }
+    end
+
+    trait :current_oe_period_with_past_coverage_periods do
+      benefit_sponsorship { FactoryBot.build(:benefit_sponsorship, :normal_oe_period_with_past_coverage_periods, coverage_year: coverage_year) }
+    end
+  end
+end

--- a/components/benefit_sponsors/spec/dummy/spec/factories/messages.rb
+++ b/components/benefit_sponsors/spec/dummy/spec/factories/messages.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :message do
+    subject { 'phoenix project' }
+    body    { 'welcome to the hbx' }
+
+    trait :inbox_folder do
+      folder { 'inbox' }
+    end
+
+    trait :sent_folder do
+      folder { 'sent' }
+    end
+
+    trait :deleted_folder do
+      folder { 'deleted' }
+    end
+  end
+
+  factory :message1, :class => :Message do
+    subject { 'test message 1' }
+    body    { 'welcome' }
+    created_at { DateTime.new(1998,10,1) }
+  end
+
+  factory :message2, :class => :Message do
+    subject { 'test message 2' }
+    body    { 'welcome again' }
+    created_at { DateTime.new(1999,10,1) }
+  end
+end

--- a/components/benefit_sponsors/spec/dummy/spec/factories/office_locations.rb
+++ b/components/benefit_sponsors/spec/dummy/spec/factories/office_locations.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :office_location do
+
+    is_primary  { false }
+    address { FactoryBot.build(:address, kind: "branch") }
+    phone   { FactoryBot.build(:phone, kind: "work") }
+
+    trait :with_mailing_address do
+      address { FactoryBot.build(:address, kind: "mailing") }
+    end
+
+    trait :primary do
+      is_primary { true }
+      address { FactoryBot.build(:address, kind: "primary") }
+    end
+
+  end
+end

--- a/components/benefit_sponsors/spec/dummy/spec/factories/organizations.rb
+++ b/components/benefit_sponsors/spec/dummy/spec/factories/organizations.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :organization do
+    legal_name  { "Turner Agency, Inc" }
+    dba         { "Turner Brokers" }
+    home_page   { "http://www.example.com" }
+    office_locations  do
+      [FactoryBot.build(:office_location, :primary),
+       FactoryBot.build(:office_location)]
+    end
+
+    fein do
+      Forgery('basic').text(:allow_lower => false,
+                            :allow_upper => false,
+                            :allow_numeric => true,
+                            :allow_special => false, :exactly => 9)
+    end
+
+    trait :with_active_plan_year do
+      before :create do |organization, _evaluator|
+        organization.employer_profile = FactoryBot.create :employer_profile, organization: organization, registered_on: Date.new(2015,12,1)
+      end
+      after :create do |organization, _evaluator|
+        start_on = TimeKeeper.date_of_record.beginning_of_month
+        active_plan_year = FactoryBot.create :plan_year, employer_profile: organization.employer_profile, aasm_state: "active",
+                                                         :start_on => start_on, :end_on => start_on + 1.year - 1.day, :open_enrollment_start_on => (start_on - 30).beginning_of_month, :open_enrollment_end_on => (start_on - 30).beginning_of_month + 1.weeks, fte_count: 5
+        active_benefit_group = FactoryBot.create :benefit_group, :with_valid_dental, plan_year: active_plan_year
+      end
+    end
+
+    trait :with_active_plan_year_and_without_dental do
+      before :create do |organization, _evaluator|
+        organization.employer_profile = FactoryBot.create :employer_profile, organization: organization, registered_on: Date.new(2015,12,1)
+      end
+      after :create do |organization, _evaluator|
+        start_on = TimeKeeper.date_of_record.beginning_of_month
+        active_plan_year = FactoryBot.create :plan_year, employer_profile: organization.employer_profile, aasm_state: "active",
+                                                         :start_on => start_on, :end_on => start_on + 1.year - 1.day, :open_enrollment_start_on => (start_on - 30).beginning_of_month, :open_enrollment_end_on => (start_on - 30).beginning_of_month + 1.weeks, fte_count: 5
+        active_benefit_group = FactoryBot.create :benefit_group, plan_year: active_plan_year
+      end
+    end
+
+    trait :with_expired_and_active_plan_years do
+      before :create do |organization, _evaluator|
+        organization.employer_profile = FactoryBot.create :employer_profile, organization: organization, registered_on: Date.new(2015,12,1)
+      end
+      after :create do |organization, _evaluator|
+        start_on = TimeKeeper.date_of_record.beginning_of_month - 1.year
+        expired_plan_year = FactoryBot.create :plan_year, employer_profile: organization.employer_profile, aasm_state: "expired",
+                                                          :start_on => start_on, :end_on => start_on + 1.year - 1.day, :open_enrollment_start_on => (start_on - 30).beginning_of_month, :open_enrollment_end_on => (start_on - 30).beginning_of_month + 1.weeks, fte_count: 5
+        start_on = TimeKeeper.date_of_record.beginning_of_month
+        active_plan_year = FactoryBot.create :plan_year, employer_profile: organization.employer_profile, aasm_state: "active",
+                                                         :start_on => start_on, :end_on => start_on + 1.year - 1.day, :open_enrollment_start_on => (start_on - 30).beginning_of_month, :open_enrollment_end_on => (start_on - 30).beginning_of_month + 1.weeks, fte_count: 5
+        expired_benefit_group = FactoryBot.create :benefit_group, :with_valid_dental, plan_year: expired_plan_year
+        active_benefit_group = FactoryBot.create :benefit_group, :with_valid_dental, plan_year: active_plan_year
+      end
+    end
+
+    trait :with_active_and_renewal_plan_years do
+      before :create do |organization, _evaluator|
+        organization.employer_profile = FactoryBot.create :employer_profile, organization: organization
+      end
+      after :create do |organization, _evaluator|
+        start_on = (TimeKeeper.date_of_record + 2.months).beginning_of_month - 1.year
+        active_plan_year = FactoryBot.create :plan_year, employer_profile: organization.employer_profile, aasm_state: "active", :start_on => start_on, :end_on => start_on + 1.year - 1.day, fte_count: 5
+        start_on = (TimeKeeper.date_of_record + 2.months).beginning_of_month
+        renewing_plan_year = FactoryBot.create(:future_plan_year, employer_profile: organization.employer_profile, aasm_state: "renewing_enrolling")
+        benefit_group = FactoryBot.create :benefit_group, :with_valid_dental, plan_year: active_plan_year
+        renewing_benefit_group = FactoryBot.create :benefit_group, :with_valid_dental, plan_year: renewing_plan_year
+      end
+    end
+
+    trait :with_draft_and_canceled_plan_years do
+      before :create do |organization, _evaluator|
+        organization.employer_profile = FactoryBot.create :employer_profile, organization: organization, registered_on: Date.new(2015,12,1)
+      end
+      after :create do |organization, _evaluator|
+        start_on = (TimeKeeper.date_of_record + 1.month).beginning_of_month - 1.year
+        FactoryBot.create :plan_year, employer_profile: organization.employer_profile, aasm_state: "canceled",
+                                      :start_on => start_on, :end_on => start_on + 1.year - 1.day, :open_enrollment_start_on => (start_on - 30).beginning_of_month, :open_enrollment_end_on => (start_on - 30).beginning_of_month + 1.weeks, fte_count: 5
+        FactoryBot.create :plan_year, employer_profile: organization.employer_profile, aasm_state: "draft",
+                                      :start_on => start_on, :end_on => start_on + 1.year - 1.day, :open_enrollment_start_on => (start_on - 30).beginning_of_month, :open_enrollment_end_on => (start_on - 30).beginning_of_month + 1.weeks, fte_count: 5
+      end
+    end
+
+    trait :with_conversion_expired_and_renewing_canceled_plan_years do
+      before :create do |organization, _evaluator|
+        organization.employer_profile = FactoryBot.create :employer_profile, organization: organization, registered_on: Date.new(2015,12,1), profile_source: "conversion"
+      end
+      after :create do |organization, _evaluator|
+        start_on = TimeKeeper.date_of_record.beginning_of_month - 1.year
+        con_expired_plan_year = FactoryBot.create :plan_year, employer_profile: organization.employer_profile, aasm_state: "conversion_expired",
+                                                              :start_on => start_on, :end_on => start_on + 1.year - 1.day, :open_enrollment_start_on => (start_on - 30).beginning_of_month,
+                                                              :open_enrollment_end_on => (start_on - 30).beginning_of_month + 1.weeks, fte_count: 5, is_conversion: true
+        start_on = TimeKeeper.date_of_record.beginning_of_month
+        renewing_canceled_plan_year = FactoryBot.create :plan_year, employer_profile: organization.employer_profile, aasm_state: "renewing_canceled",
+                                                                    :start_on => start_on, :end_on => start_on + 1.year - 1.day, :open_enrollment_start_on => (start_on - 30).beginning_of_month, :open_enrollment_end_on => (start_on - 30).beginning_of_month + 1.weeks, fte_count: 5
+        con_expired_benefit_group = FactoryBot.create :benefit_group, :with_valid_dental, plan_year: con_expired_plan_year
+        renewing_canceled_benefit_group = FactoryBot.create :benefit_group, :with_valid_dental, plan_year: renewing_canceled_plan_year
+      end
+    end
+  end
+
+  trait :conversion_employer_with_expired_and_active_plan_years do
+    before :create do |organization, _evaluator|
+      organization.employer_profile = FactoryBot.create :employer_profile, organization: organization, registered_on: Date.new(2017,12,1), profile_source: "conversion"
+    end
+    after :create do |organization, _evaluator|
+      start_on = TimeKeeper.date_of_record.beginning_of_month - 1.year
+      expired_plan_year = FactoryBot.create :plan_year, employer_profile: organization.employer_profile, aasm_state: "expired",
+                                                        :start_on => start_on, :end_on => start_on + 1.year - 1.day, :open_enrollment_start_on => (start_on - 30).beginning_of_month, :open_enrollment_end_on => (start_on - 30).beginning_of_month + 1.weeks, fte_count: 5, :is_conversion => true
+      start_on = TimeKeeper.date_of_record.beginning_of_month
+      active_plan_year = FactoryBot.create :plan_year, employer_profile: organization.employer_profile, aasm_state: "active",
+                                                       :start_on => start_on, :end_on => start_on + 1.year - 1.day, :open_enrollment_start_on => (start_on - 30).beginning_of_month, :open_enrollment_end_on => (start_on - 30).beginning_of_month + 1.weeks, fte_count: 5, :is_conversion => true
+      expired_benefit_group = FactoryBot.create :benefit_group, :with_valid_dental, plan_year: expired_plan_year
+      active_benefit_group = FactoryBot.create :benefit_group, :with_valid_dental, plan_year: active_plan_year
+    end
+  end
+
+  factory :broker_agency, class: Organization do
+    sequence(:legal_name) {|n| "Broker Agency#{n}" }
+    sequence(:dba) {|n| "Broker Agency#{n}" }
+    fein do
+      Forgery('basic').text(:allow_lower => false,
+                            :allow_upper => false,
+                            :allow_numeric => true,
+                            :allow_special => false, :exactly => 9)
+    end
+    home_page   { "http://www.example.com" }
+    office_locations  do
+      [FactoryBot.build(:office_location, :primary),
+       FactoryBot.build(:office_location)]
+    end
+
+    after(:create) do |organization|
+      FactoryBot.create(:broker_agency_profile, organization: organization)
+    end
+
+    trait :shop_only do
+      after(:create) do |organization|
+        FactoryBot.create(:broker_agency_profile, market_kind: "shop", organization: organization)
+      end
+    end
+
+    trait :ivl_only do
+      after(:create) do |organization|
+        FactoryBot.create(:broker_agency_profile, market_kind: "individual", organization: organization)
+      end
+    end
+
+    trait :both_ivl_and_shop do
+      after(:create) do |organization|
+        FactoryBot.create(:broker_agency_profile, market_kind: "both", organization: organization)
+      end
+    end
+  end
+
+  factory :employer, class: Organization do
+    legal_name { Forgery(:name).company_name }
+    dba { legal_name }
+
+    fein do
+      Forgery('basic').text(:allow_lower => false,
+                            :allow_upper => false,
+                            :allow_numeric => true,
+                            :allow_special => false, :exactly => 9)
+    end
+
+    office_locations  do
+      [FactoryBot.build(:office_location, :primary),
+       FactoryBot.build(:office_location)]
+    end
+
+    before :create do |organization, _evaluator|
+      organization.employer_profile = FactoryBot.create :employer_profile, organization: organization
+    end
+
+    trait :with_insured_employees do
+      after :create do |organization, _evaluator|
+
+        plan_year = FactoryBot.create :next_month_plan_year, employer_profile: organization.employer_profile
+        plan_year.benefit_groups.push(benefit_group = FactoryBot.create(:benefit_group, plan_year: plan_year, relationship_benefits: [relationship_benefit = FactoryBot.build(:relationship_benefit)]))
+
+        # data to create an enrollment
+        family = FactoryBot.create(:family, :with_primary_family_member)
+        household = FactoryBot.create(:household, family: family)
+        hbx_enrollment_member = FactoryBot.build(:hbx_enrollment_member, applicant_id: family.family_members.first.id, eligibility_date: TimeKeeper.date_of_record.beginning_of_month)
+        hbx_enrollment = FactoryBot.create(:hbx_enrollment, household: household, plan: FactoryBot.create(:plan), benefit_group: benefit_group, hbx_enrollment_members: [hbx_enrollment_member], coverage_kind: "health")
+        # end of data to create an enrollment
+
+        census_employees = FactoryBot.create_list(:census_employee, 1, :with_enrolled_census_employee, employer_profile_id: organization.employer_profile.id).tap do |census_employees|
+          census_employees.each do |census_employee|
+            census_employee.aasm_state = "employee_role_linked"
+            census_employee.benefit_group_assignments.create benefit_group: benefit_group, start_on: benefit_group.start_on, aasm_state: "coverage_selected", hbx_enrollment_id: hbx_enrollment.id
+
+            person = FactoryBot.create :person, first_name: census_employee.first_name, middle_name: census_employee.middle_name, last_name: census_employee.last_name, ssn: census_employee.ssn, gender: census_employee.gender
+            person.employee_roles.build person: person, hired_on: census_employee.hired_on, employer_profile_id: organization.employer_profile.id, census_employee_id: census_employee.id
+
+            hbx_enrollment.benefit_group_assignment_id = census_employee.benefit_group_assignments.first.id
+            hbx_enrollment.save!
+            census_employee.save!
+            person.save!
+          end
+        end
+      end
+    end
+  end
+
+  factory :broker, class: Organization do
+    sequence(:legal_name) {|n| "Broker Agency#{n}" }
+    sequence(:dba) {|n| "Broker Agency#{n}" }
+    sequence(:fein, 200_000_000)
+    home_page   { "http://www.example.com" }
+    office_locations  do
+      [FactoryBot.build(:office_location, :primary),
+       FactoryBot.build(:office_location)]
+    end
+
+    before :create do |organization, _evaluator|
+      organization.broker_agency_profile = FactoryBot.build :broker_agency_profile, organization: organization
+    end
+  end
+
+
+  factory :general_agency, class: Organization do
+    legal_name { Forgery(:name).company_name }
+    dba { legal_name }
+
+    fein do
+      Forgery('basic').text(:allow_lower => false,
+                            :allow_upper => false,
+                            :allow_numeric => true,
+                            :allow_special => false, :exactly => 9)
+    end
+
+    transient do
+      general_agency_traits { [] }
+      general_agency_attributes { {} }
+    end
+
+    before :create do |organization, _evaluator|
+      organization.office_locations.push FactoryBot.build :office_location, :primary
+    end
+
+    after :create do |organization, evaluator|
+      FactoryBot.create :general_agency_profile, *Array.wrap(evaluator.general_agency_traits) + [:with_staff], evaluator.general_agency_attributes.merge(organization: organization)
+    end
+  end
+
+  factory :general_agency_with_organization, class: Organization do
+    sequence(:legal_name) {|n| "General Agency#{n}" }
+    sequence(:dba) {|n| "General Agency#{n}" }
+    fein do
+      Forgery('basic').text(:allow_lower => false,
+                            :allow_upper => false,
+                            :allow_numeric => true,
+                            :allow_special => false, :exactly => 9)
+    end
+    home_page   { "http://www.example.com" }
+    office_locations  do
+      [FactoryBot.build(:office_location, :primary),
+       FactoryBot.build(:office_location)]
+    end
+
+    after(:create) do |organization|
+      FactoryBot.create(:general_agency_profile, organization: organization)
+    end
+  end
+end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -2,6 +2,18 @@ FactoryBot.define do
   factory :message do
     subject { "phoenix project" }
     body    { "welcome to the hbx" }
+
+    trait :inbox_folder do
+      folder { 'inbox' }
+    end
+
+    trait :sent_folder do
+      folder { 'sent' }
+    end
+
+    trait :deleted_folder do
+      folder { 'deleted' }
+    end
   end
 
   factory :message1, :class=>:Message do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 187269055](https://www.pivotaltracker.com/story/show/187269055)

# A brief description of the changes

Current behavior: Incorrect pundit authorization for Inbox Messages destroy action for Primary Person Broker Role

New behavior: Correct pundit authorization for Inbox Messages destroy action for Primary Broker Role Person.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.