### PR TITLE
Revert "Block Consumer match if a broker role exists (#3632)"

### DIFF
--- a/app/models/forms/consumer_candidate.rb
+++ b/app/models/forms/consumer_candidate.rb
@@ -59,8 +59,6 @@ module Forms
       # rubocop:enable Lint/EmptyRescueClause
     end
 
-    # TODO: Refactor this
-    # rubocop:disable Metrics/CyclomaticComplexity
     def match_person
       match_criteria, records = Operations::People::Match.new.call({:dob => dob,
                                                                     :last_name => last_name,
@@ -69,16 +67,12 @@ module Forms
 
       return nil if records.blank?
 
-      dob_ssn_condition = (match_criteria == :dob_present && ssn.present?)
-
-      if (dob_ssn_condition && records.first.employer_staff_roles?) ||
-         (dob_ssn_condition && (records.first.broker_role.present? || records.first.broker_agency_staff_roles.present?)) ||
+      if (match_criteria == :dob_present && ssn.present? && records.first.employer_staff_roles?) ||
          (match_criteria == :dob_present && ssn.blank?) ||
          match_criteria == :ssn_present
         records.first
       end
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
 
     def state_based_policy_satisfied?
       @configuration = EnrollRegistry[:person_match_policy].settings.map(&:to_h).each_with_object({}) do |s,c|

--- a/spec/models/forms/consumer_candidate_spec.rb
+++ b/spec/models/forms/consumer_candidate_spec.rb
@@ -133,31 +133,6 @@ describe "match a person in db" do
         expect(subject.match_person).to eq db_person
       end
     end
-
-    context 'with a person who has no ssn but an employer staff role', dbclean: :after_each do
-      let!(:site)                { create(:benefit_sponsors_site, :with_benefit_market, :as_hbx_profile, :cca) }
-      let!(:benefit_sponsor)     { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_aca_shop_cca_employer_profile, site: site) }
-      let!(:employer_profile)    { benefit_sponsor.employer_profile }
-      let!(:employer_staff_role) { EmployerStaffRole.create(person: db_person, benefit_sponsor_employer_profile_id: employer_profile.id) }
-      let(:broker_role) { FactoryBot.build(:broker_role, npn: '234567890', person: db_person) }
-      let(:user){ create(:user) }
-
-      before do
-        allow(Person).to receive(:where).and_return([db_person])
-        allow(db_person).to receive(:user).and_return(user)
-        allow(db_person).to receive(:broker_role).and_return(broker_role)
-        db_person.save!
-      end
-
-      it 'matches person by last name, first name and dob' do
-        db_person.employer_staff_roles << employer_staff_role
-        db_person.save!
-        allow(search_params).to receive(:ssn).and_return('517991234')
-        subject.does_not_match_a_different_users_person
-        expect(subject.errors.messages.present?).to eq true
-        expect(subject.errors[:base]).to match(["#{db_person.first_name} #{db_person.last_name} is already affiliated with another account."])
-      end
-    end
   end
 
   context "with a person with a first name, last name, dob and ssn" do


### PR DESCRIPTION
This reverts commit 3f2fb84b3058788da4b37ac51ebb0f5698240ce3.

# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187231353

# A brief description of the changes

Current behavior: Recent ticket causing issues with consumer matching once a broker application has been submitted.

New behavior: Matching functionality should be restored.
