### PR TITLE
add new actions for documents download based on type and policy

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -54,7 +54,8 @@ class DocumentsController < ApplicationController
   end
 
   def product_sbc_download
-    authorize current_user, :can_download_sbc_documents?
+    set_current_person
+    authorize @person, :can_download_sbc_documents?
 
     begin
       sbc_document = fetch_product_sbc_document

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -66,7 +66,7 @@ class DocumentsController < ApplicationController
     end
   end
 
-  def employer_attestation_documents_download
+  def employer_attestation_document_download
     authorize current_user, :can_download_employer_attestation_doc?
 
     begin

--- a/app/models/effective/datatables/employer_document_datatable.rb
+++ b/app/models/effective/datatables/employer_document_datatable.rb
@@ -23,9 +23,7 @@ module Effective
         table_column :size, :proc => Proc.new { |row| number_to_human_size(row.size, precision: 2) }, :filter => false, :sortable => false
         table_column :date, :label => 'Submitted At', :proc => Proc.new { |row| TimeKeeper.local_time(row.created_at).strftime('%m/%d/%Y %I:%M%p') }, :filter => false, :sortable => false
         table_column :actions, :width => '50px', :proc => Proc.new { |row|
-           key, bucket = get_key_and_bucket(row.identifier)
           dropdown = [
-           ['Download',  document_download_path(bucket, key)+ "?id=#{@employer_profile.id}&content_type=#{row.format}&filename=#{row.title.gsub(/[^0-9a-z]/i,'')}",'static'],
            ['Delete', employers_employer_attestation_delete_attestation_documents_path(row.id), (@employer_profile.employer_attestation.editable? && row.submitted?) ? 'delete ajax with confirm' : 'disabled',  'Do you want to Delete this document?']
           ]
           render partial: 'datatables/shared/dropdown', locals: {dropdowns: dropdown, row_actions_id: "employer_actions_#{@employer_profile.id}"}, formats: :html

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -146,7 +146,7 @@ class ApplicationPolicy
     broker = account_holder_person&.broker_role
     return false if broker.blank? || !broker.active? || !broker.individual_market?
 
-    broker_agency_account = family.active_broker_agency_account
+    broker_agency_account = family&.active_broker_agency_account
     return false if broker_agency_account.blank?
 
     broker_agency_account.benefit_sponsors_broker_agency_profile_id == broker.benefit_sponsors_broker_agency_profile_id &&

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -69,6 +69,31 @@ class PersonPolicy < ApplicationPolicy
     has_broker_role? && (matches_individual_broker_account? || matches_shop_broker_account?)
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def can_download_sbc_documents?
+    return true if individual_market_primary_family_member?
+    return true if individual_market_admin?
+    return true if active_associated_individual_market_family_broker_staff?
+    return true if active_associated_individual_market_family_broker?
+
+    return true if shop_market_primary_family_member?
+    return true if shop_market_admin?
+    return true if active_associated_shop_market_family_broker?
+    return true if active_associated_shop_market_general_agency?
+
+    return true if fehb_market_primary_family_member?
+    return true if fehb_market_admin?
+    return true if active_associated_fehb_market_family_broker?
+    return true if active_associated_fehb_market_general_agency?
+
+    return true if coverall_market_primary_family_member?
+    return true if coverall_market_admin?
+    return true if active_associated_coverall_market_family_broker?
+
+    false
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
   private
 
   def allowed_to_modify?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -46,39 +46,15 @@ class UserPolicy < ApplicationPolicy
     view?
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-  def can_download_sbc_documents?
-    return true if individual_market_primary_family_member?
-    return true if individual_market_admin?
-    return true if active_associated_individual_market_family_broker_staff?
-    return true if active_associated_individual_market_family_broker?
-
-    return true if shop_market_primary_family_member?
-    return true if shop_market_admin?
-    return true if active_associated_shop_market_family_broker?
-    return true if active_associated_shop_market_general_agency?
-
-    return true if fehb_market_primary_family_member?
-    return true if fehb_market_admin?
-    return true if active_associated_fehb_market_family_broker?
-    return true if active_associated_fehb_market_general_agency?
-
-    return true if coverall_market_primary_family_member?
-    return true if coverall_market_admin?
-    return true if active_associated_coverall_market_family_broker?
-
-    false
-  end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-
-
   def can_download_employees_template?
     return false unless account_holder_person
     return true if account_holder_person.has_active_employer_staff_role?
     return true if shop_market_admin?
     return true if account_holder_person.broker_role&.active?
-    return true if account_holder_person.broker_agency_staff_roles&.active
+    return true if account_holder_person.broker_agency_staff_roles&.active.present?
     return true if account_holder_person.active_general_agency_staff_roles.present?
+
+    false
   end
 
   def can_download_employer_attestation_doc?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,5 +1,10 @@
 class UserPolicy < ApplicationPolicy
 
+  def initialize(user, record)
+    super
+    @family = user.person&.primary_family
+  end
+
   def lockable?
     return false unless role = user.person && user.person.hbx_staff_role
     return false unless role.permission
@@ -39,5 +44,44 @@ class UserPolicy < ApplicationPolicy
 
   def create?
     view?
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def can_download_sbc_documents?
+    return true if individual_market_primary_family_member?
+    return true if individual_market_admin?
+    return true if active_associated_individual_market_family_broker_staff?
+    return true if active_associated_individual_market_family_broker?
+
+    return true if shop_market_primary_family_member?
+    return true if shop_market_admin?
+    return true if active_associated_shop_market_family_broker?
+    return true if active_associated_shop_market_general_agency?
+
+    return true if fehb_market_primary_family_member?
+    return true if fehb_market_admin?
+    return true if active_associated_fehb_market_family_broker?
+    return true if active_associated_fehb_market_general_agency?
+
+    return true if coverall_market_primary_family_member?
+    return true if coverall_market_admin?
+    return true if active_associated_coverall_market_family_broker?
+
+    false
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+
+  def can_download_employees_template?
+    return false unless account_holder_person
+    return true if account_holder_person.has_active_employer_staff_role?
+    return true if shop_market_admin?
+    return true if account_holder_person.broker_role&.active?
+    return true if account_holder_person.broker_agency_staff_roles&.active
+    return true if account_holder_person.active_general_agency_staff_roles.present?
+  end
+
+  def can_download_employer_attestation_doc?
+    can_download_employees_template?
   end
 end

--- a/app/views/broker_agencies/quotes/_plan_comparison_export.html.erb
+++ b/app/views/broker_agencies/quotes/_plan_comparison_export.html.erb
@@ -59,9 +59,8 @@
            <% if qhp.plan.sbc_document.present? %>
             <th colspan="2">
               <div class="plan_comparison">
-                <% key, bucket = get_key_and_bucket(qhp.plan.sbc_document.identifier) %>
                 <% link_text = qhp.plan.coverage_kind == 'health' ? "Summary of Benefits and Coverage" : 'Plan Summary' %>
-                <%= link_to link_text, root_url + document_download_path(bucket, key) +
+                <%= link_to link_text, root_url + document_product_sbc_download_path(qhp.product.id) +
                                                   "?content_type=application/pdf&filename=#{qhp.plan.name.gsub(/[^0-9a-z]/i,'')}.
                                                   pdf&disposition=inline" %>
               </div>

--- a/app/views/broker_agencies/quotes/_plan_comparison_export.html.erb
+++ b/app/views/broker_agencies/quotes/_plan_comparison_export.html.erb
@@ -60,9 +60,9 @@
             <th colspan="2">
               <div class="plan_comparison">
                 <% link_text = qhp.plan.coverage_kind == 'health' ? "Summary of Benefits and Coverage" : 'Plan Summary' %>
-                <%= link_to link_text, root_url + document_product_sbc_download_path(qhp.product.id) +
+                <%= sanitize link_to(link_text, root_url + document_product_sbc_download_path(qhp.product.id) +
                                                   "?content_type=application/pdf&filename=#{qhp.plan.name.gsub(/[^0-9a-z]/i,'')}.
-                                                  pdf&disposition=inline" %>
+                                                  pdf&disposition=inline") %>
               </div>
             </th>
             <%end%>

--- a/app/views/broker_agencies/quotes/_plan_comparison_export.html.erb
+++ b/app/views/broker_agencies/quotes/_plan_comparison_export.html.erb
@@ -56,12 +56,12 @@
         <tr>
           <th></th>
           <% qhps.each do |qhp|%>
-           <% if qhp.plan.sbc_document.present? %>
+           <% if qhp.product.sbc_document.present? %>
             <th colspan="2">
               <div class="plan_comparison">
                 <% link_text = qhp.plan.coverage_kind == 'health' ? "Summary of Benefits and Coverage" : 'Plan Summary' %>
-                <%= sanitize link_to(link_text, root_url + document_product_sbc_download_path(qhp.product.id) +
-                                                  "?content_type=application/pdf&filename=#{qhp.plan.name.gsub(/[^0-9a-z]/i,'')}.
+                <%= sanitize link_to(link_text, root_url + document_product_sbc_download_path(qhp.product.sbc_document.id) +
+                                                  "?product_id=#{qhp.product.id}&content_type=application/pdf&filename=#{qhp.plan.name.gsub(/[^0-9a-z]/i,'')}.
                                                   pdf&disposition=inline") %>
               </div>
             </th>

--- a/app/views/broker_agencies/quotes/_upload_employee_modal.html.erb
+++ b/app/views/broker_agencies/quotes/_upload_employee_modal.html.erb
@@ -3,7 +3,7 @@
   <h2><%= l10n("upload_employee_roster")%></h2>
   <h4><%= l10n("broker_agencies.quotes.template_upload")%></h4>
   <% file_name = EnrollRegistry[:census_employee_roster].settings(:roster_upload_file_name).item %>
-  <%= link_to(document_download_path(env_bucket_name("templates"), s3_template_bucket_key) + "?contenttype=application/vnd.ms-excel&filename=#{file_name}", class: "download") do %>
+  <%= link_to(document_employees_template_download_path + "?contenttype=application/vnd.ms-excel&filename=#{file_name}", class: "download") do %>
     <h4>Need the template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
       Download it now.
     </h4>

--- a/app/views/broker_agencies/quotes/_upload_employee_modal.html.erb
+++ b/app/views/broker_agencies/quotes/_upload_employee_modal.html.erb
@@ -3,7 +3,7 @@
   <h2><%= l10n("upload_employee_roster")%></h2>
   <h4><%= l10n("broker_agencies.quotes.template_upload")%></h4>
   <% file_name = EnrollRegistry[:census_employee_roster].settings(:roster_upload_file_name).item %>
-  <%= link_to(document_employees_template_download_path + "?contenttype=application/vnd.ms-excel&filename=#{file_name}", class: "download") do %>
+  <%= sanitize link_to(document_employees_template_download_path + "?contenttype=application/vnd.ms-excel&filename=#{file_name}", class: "download") do %>
     <h4>Need the template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
       Download it now.
     </h4>

--- a/app/views/employers/employer_profiles/_download_new_template.html.erb
+++ b/app/views/employers/employer_profiles/_download_new_template.html.erb
@@ -1,7 +1,7 @@
 <div class="employee-upload">
   <i class="fa fa-times fa-3x pull-right modal-close"></i>
   <h4> <strong> Unrecognized Employee Census spreadsheet format.</strong> </h4>
-  <%= link_to(document_download_path(env_bucket_name("templates"), aca_shop_market_census_employees_template_file) + "?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
+  <%= link_to(document_employees_template_download_path + "?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
       <h4>Need the new template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
             Download it now.
       <% end %>

--- a/app/views/employers/employer_profiles/_download_new_template.html.erb
+++ b/app/views/employers/employer_profiles/_download_new_template.html.erb
@@ -1,7 +1,7 @@
 <div class="employee-upload">
   <i class="fa fa-times fa-3x pull-right modal-close"></i>
   <h4> <strong> Unrecognized Employee Census spreadsheet format.</strong> </h4>
-  <%= link_to(document_employees_template_download_path + "?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
+  <%= sanitize link_to(document_employees_template_download_path + "?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
       <h4>Need the new template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
             Download it now.
       <% end %>

--- a/app/views/employers/employer_profiles/_upload_employees.html.erb
+++ b/app/views/employers/employer_profiles/_upload_employees.html.erb
@@ -2,7 +2,7 @@
   <i class="fa fa-times fa-3x pull-right modal-close"></i>
   <h2>Upload Employee Roster</h2>
   <h4>If you completed your employee roster offline using our Microsoft Excel template, find the file on your computer and upload it here.</h4>
-  <%= link_to(document_employees_template_download_path + "?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
+  <%= sanitize link_to(document_employees_template_download_path + "?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
   <h4>Need the template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
         Download it now.
     <% end %>

--- a/app/views/employers/employer_profiles/_upload_employees.html.erb
+++ b/app/views/employers/employer_profiles/_upload_employees.html.erb
@@ -2,7 +2,7 @@
   <i class="fa fa-times fa-3x pull-right modal-close"></i>
   <h2>Upload Employee Roster</h2>
   <h4>If you completed your employee roster offline using our Microsoft Excel template, find the file on your computer and upload it here.</h4>
-  <%= link_to(document_download_path(env_bucket_name("templates"), aca_shop_market_census_employees_template_file) + "?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
+  <%= link_to(document_employees_template_download_path + "?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
   <h4>Need the template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
         Download it now.
     <% end %>

--- a/app/views/employers/employer_profiles/my_account/_documents.html.erb
+++ b/app/views/employers/employer_profiles/my_account/_documents.html.erb
@@ -26,11 +26,11 @@
             <div class="document-modal-body">
               <h4>MA DOR FORM-X</h4>
               <p class='document-modal-buttons'>
-                 <a href="<%= employer_attestation_documents_download(doc.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}" %>" ><button class="btn btn-default"><span class="glyphicons glyphicons-cloud-download"></span> Download</button></a>
+                 <a href="<%= document_employer_attestation_document_download_path(doc.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}" %>" ><button class="btn btn-default"><span class="glyphicons glyphicons-cloud-download"></span> Download</button></a>
                 <button class="btn btn-default" onclick='printDoc("<%=doc.id%>")'>Print</button>
               </p>
               <p id="print_<%=doc.id%>">
-                <iframe src="<%= employer_attestation_documents_download(doc.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}&disposition=inline" %>" width="100%" height="600" frameborder="0" scrolling="no" name="iframe_<%= doc.id%>"></iframe>
+                <iframe src="<%= document_employer_attestation_document_download_path(doc.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}&disposition=inline" %>" width="100%" height="600" frameborder="0" scrolling="no" name="iframe_<%= doc.id%>"></iframe>
               </p>
             </div>
           </div>

--- a/app/views/employers/employer_profiles/my_account/_documents.html.erb
+++ b/app/views/employers/employer_profiles/my_account/_documents.html.erb
@@ -26,12 +26,11 @@
             <div class="document-modal-body">
               <h4>MA DOR FORM-X</h4>
               <p class='document-modal-buttons'>
-                 <% key, bucket = get_key_and_bucket(doc.identifier) %>
-                 <a href="<%= document_download_path(bucket, key) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}" %>" ><button class="btn btn-default"><span class="glyphicons glyphicons-cloud-download"></span> Download</button></a>
+                 <a href="<%= employer_attestation_documents_download(doc.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}" %>" ><button class="btn btn-default"><span class="glyphicons glyphicons-cloud-download"></span> Download</button></a>
                 <button class="btn btn-default" onclick='printDoc("<%=doc.id%>")'>Print</button>
               </p>
               <p id="print_<%=doc.id%>">
-                <iframe src="<%= document_download_path(bucket, key) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}&disposition=inline" %>" width="100%" height="600" frameborder="0" scrolling="no" name="iframe_<%= doc.id%>"></iframe>
+                <iframe src="<%= employer_attestation_documents_download(doc.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}&disposition=inline" %>" width="100%" height="600" frameborder="0" scrolling="no" name="iframe_<%= doc.id%>"></iframe>
               </p>
             </div>
           </div>

--- a/app/views/shared/plan_shoppings/_sbc_link.html.erb
+++ b/app/views/shared/plan_shoppings/_sbc_link.html.erb
@@ -12,7 +12,7 @@
   <% key, bucket = get_key_and_bucket(plan.sbc_document.identifier) %>
   <% plan_name = plan.try(:title) || plan.try(:name) %>
   <% id = (defined? hbx_id) ? "plan_doc_#{hbx_id}" : "summary_benefits" %>
-  <a href="<%= main_app.document_product_sbc_download_path(plan.id) + "?content_type=application/pdf&filename=#{plan_name.gsub(/[^0-9a-z]/i,'')}.pdf&disposition=inline" %>" class="sbc_link <%= text_class %> vertically-aligned-row" target="_blank" id="<%= id %>">
+  <a href="<%= main_app.document_product_sbc_download_path(plan.sbc_document.id) + "?product_id=#{plan.id}&content_type=application/pdf&filename=#{plan_name.gsub(/[^0-9a-z]/i,'')}.pdf&disposition=inline" %>" class="sbc_link <%= text_class %> vertically-aligned-row" target="_blank" id="<%= id %>">
     <% if custom_css.present? %>
       <i class="fa fa-file-pdf-o fa-2x pull-left" ></i>
       <div class="fa-icon-label <%= text_class %> col-xs-11 enrollment-tile-summary" style="display: inline; font-size: 10px;"><%= link_text %></div>

--- a/app/views/shared/plan_shoppings/_sbc_link.html.erb
+++ b/app/views/shared/plan_shoppings/_sbc_link.html.erb
@@ -12,7 +12,7 @@
   <% key, bucket = get_key_and_bucket(plan.sbc_document.identifier) %>
   <% plan_name = plan.try(:title) || plan.try(:name) %>
   <% id = (defined? hbx_id) ? "plan_doc_#{hbx_id}" : "summary_benefits" %>
-  <a href="<%= main_app.document_download_path(bucket, key) + "?content_type=application/pdf&filename=#{plan_name.gsub(/[^0-9a-z]/i,'')}.pdf&disposition=inline" %>" class="sbc_link <%= text_class %> vertically-aligned-row" target="_blank" id="<%= id %>">
+  <a href="<%= main_app.document_product_sbc_download_path(plan.id) + "?content_type=application/pdf&filename=#{plan_name.gsub(/[^0-9a-z]/i,'')}.pdf&disposition=inline" %>" class="sbc_link <%= text_class %> vertically-aligned-row" target="_blank" id="<%= id %>">
     <% if custom_css.present? %>
       <i class="fa fa-file-pdf-o fa-2x pull-left" ></i>
       <div class="fa-icon-label <%= text_class %> col-xs-11 enrollment-tile-summary" style="display: inline; font-size: 10px;"><%= link_text %></div>

--- a/components/benefit_sponsors/app/models/effective/datatables/benefit_sponsors_employer_documents_data_table.rb
+++ b/components/benefit_sponsors/app/models/effective/datatables/benefit_sponsors_employer_documents_data_table.rb
@@ -24,7 +24,7 @@ module Effective
         table_column :date, :label => 'Submitted At', :proc => Proc.new { |row| TimeKeeper.local_time(row.created_at).strftime('%m/%d/%Y %I:%M%p') }, :filter => false, :sortable => false
         table_column :actions, :width => '50px', :proc => Proc.new { |row|
           dropdown = [
-           ['Download',  main_app.employer_attestation_documents_download(row.id) + "?id=#{@employer_profile.id}&content_type=#{row.format}&filename=#{row.title.gsub(/[^0-9a-z]/i,'')}",'static'],
+           ['Download',  main_app.document_employer_attestation_document_download_path(row.id) + "?id=#{@employer_profile.id}&content_type=#{row.format}&filename=#{row.title.gsub(/[^0-9a-z]/i,'')}",'static'],
            ['Delete', main_app.employers_employer_attestation_delete_attestation_documents_path(row.id), (@employer_profile.employer_attestation.editable? && row.submitted?) ? 'delete ajax with confirm' : 'disabled',  'Do you want to Delete this document?']
           ]
           render partial: 'datatables/shared/dropdown', locals: {dropdowns: dropdown, row_actions_id: "employer_actions_#{@employer_profile.id}"}, formats: :html

--- a/components/benefit_sponsors/app/models/effective/datatables/benefit_sponsors_employer_documents_data_table.rb
+++ b/components/benefit_sponsors/app/models/effective/datatables/benefit_sponsors_employer_documents_data_table.rb
@@ -23,9 +23,8 @@ module Effective
         table_column :size, :proc => Proc.new { |row| number_to_human_size(row.size, precision: 2) }, :filter => false, :sortable => false
         table_column :date, :label => 'Submitted At', :proc => Proc.new { |row| TimeKeeper.local_time(row.created_at).strftime('%m/%d/%Y %I:%M%p') }, :filter => false, :sortable => false
         table_column :actions, :width => '50px', :proc => Proc.new { |row|
-           key, bucket = get_key_and_bucket(row.identifier)
           dropdown = [
-           ['Download',  main_app.document_download_path(bucket, key)+ "?id=#{@employer_profile.id}&content_type=#{row.format}&filename=#{row.title.gsub(/[^0-9a-z]/i,'')}",'static'],
+           ['Download',  main_app.employer_attestation_documents_download(row.id) + "?id=#{@employer_profile.id}&content_type=#{row.format}&filename=#{row.title.gsub(/[^0-9a-z]/i,'')}",'static'],
            ['Delete', main_app.employers_employer_attestation_delete_attestation_documents_path(row.id), (@employer_profile.employer_attestation.editable? && row.submitted?) ? 'delete ajax with confirm' : 'disabled',  'Do you want to Delete this document?']
           ]
           render partial: 'datatables/shared/dropdown', locals: {dropdowns: dropdown, row_actions_id: "employer_actions_#{@employer_profile.id}"}, formats: :html

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_download_new_template.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_download_new_template.html.erb
@@ -1,7 +1,7 @@
 <div class="employee-upload">
   <i class="fa fa-times fa-3x pull-right modal-close"></i>
   <h4> <strong> Unrecognized Employee Census spreadsheet format.</strong> </h4>
-  <%= link_to(main_app.document_download_path(env_bucket_name("templates"), "b4c0e3e6-cf9b-4b00-8194-403b110b4e01") + "?contenttype=application/vnd.ms-excel&filename=DCHL Employee Census.xlsx", class: "download") do %>
+  <%= link_to(main_app.document_employees_template_download_path+"?contenttype=application/vnd.ms-excel&filename=DCHL Employee Census.xlsx", class: "download") do %>
       <h4>Need the new template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
             Download it now.
       <% end %>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_download_new_template.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_download_new_template.html.erb
@@ -1,7 +1,7 @@
 <div class="employee-upload">
   <i class="fa fa-times fa-3x pull-right modal-close"></i>
   <h4> <strong> Unrecognized Employee Census spreadsheet format.</strong> </h4>
-  <%= link_to(main_app.document_employees_template_download_path+"?contenttype=application/vnd.ms-excel&filename=DCHL Employee Census.xlsx", class: "download") do %>
+  <%= sanitize link_to(main_app.document_employees_template_download_path+"?contenttype=application/vnd.ms-excel&filename=DCHL Employee Census.xlsx", class: "download") do %>
       <h4>Need the new template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
             Download it now.
       <% end %>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_upload_employee_roster.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_upload_employee_roster.html.erb
@@ -10,7 +10,7 @@
         <h2>Upload Employee Roster</h2>
         <h4>If you completed your employee roster offline using our Microsoft Excel template, find the file on your
           computer and upload it here.</h4>
-        <%= link_to(main_app.document_employees_template_download_path(content_type: 'application/vnd.ms-excel', filename: sanitize("#{aca_shop_market_census_employees_template_file}.xlsx")), class: "download") do %>
+        <%= sanitize link_to(main_app.document_employees_template_download_path(content_type: 'application/vnd.ms-excel', filename: "#{aca_shop_market_census_employees_template_file}.xlsx"), class: "download") do %>
           <h4>Need the template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
               Download it now.
           </h4>
@@ -39,5 +39,4 @@
   window.onload = function() {
     document.getElementById('file').value = "";
   }
-
 </script>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_upload_employee_roster.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_upload_employee_roster.html.erb
@@ -10,7 +10,7 @@
         <h2>Upload Employee Roster</h2>
         <h4>If you completed your employee roster offline using our Microsoft Excel template, find the file on your
           computer and upload it here.</h4>
-        <%= link_to(main_app.document_employees_template_download_path(contenttype: 'application/vnd.ms-excel', filename: "#{aca_shop_market_census_employees_template_file}.xlsx"), class: "download") do %>
+        <%= link_to(main_app.document_employees_template_download_path(content_type: 'application/vnd.ms-excel', filename: sanitize("#{aca_shop_market_census_employees_template_file}.xlsx")), class: "download") do %>
           <h4>Need the template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
               Download it now.
           </h4>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_upload_employee_roster.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_upload_employee_roster.html.erb
@@ -10,12 +10,11 @@
         <h2>Upload Employee Roster</h2>
         <h4>If you completed your employee roster offline using our Microsoft Excel template, find the file on your
           computer and upload it here.</h4>
-        <%= sanitize link_to(main_app.document_employees_template_download_path+"?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
+        <%= link_to(main_app.document_employees_template_download_path(contenttype: 'application/vnd.ms-excel', filename: "#{aca_shop_market_census_employees_template_file}.xlsx"), class: "download") do %>
           <h4>Need the template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
               Download it now.
-          <% end %>
-        </h4>
-
+          </h4>
+        <% end %>
       </div>
       <%= form_for @employer_profile, {:url => profiles_employers_employer_profile_bulk_employee_upload_path(@employer_profile.id), method: 'post', :html => { :multipart => true }} do |f| %>
       <%= file_field_tag :file, accept: (FileUploadValidator::CSV_TYPES + FileUploadValidator::XLS_TYPES).join(',') %>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_upload_employee_roster.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_upload_employee_roster.html.erb
@@ -10,7 +10,7 @@
         <h2>Upload Employee Roster</h2>
         <h4>If you completed your employee roster offline using our Microsoft Excel template, find the file on your
           computer and upload it here.</h4>
-        <%= link_to(main_app.document_download_path(env_bucket_name("templates"), "b4c0e3e6-cf9b-4b00-8194-403b110b4e01") + "?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
+        <%= link_to(main_app.document_employees_template_download_path+"?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
           <h4>Need the template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
               Download it now.
           <% end %>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_upload_employee_roster.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/_upload_employee_roster.html.erb
@@ -10,7 +10,7 @@
         <h2>Upload Employee Roster</h2>
         <h4>If you completed your employee roster offline using our Microsoft Excel template, find the file on your
           computer and upload it here.</h4>
-        <%= link_to(main_app.document_employees_template_download_path+"?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
+        <%= sanitize link_to(main_app.document_employees_template_download_path+"?contenttype=application/vnd.ms-excel&filename=#{aca_shop_market_census_employees_template_file}.xlsx", class: "download") do %>
           <h4>Need the template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
               Download it now.
           <% end %>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/_documents.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/_documents.html.erb
@@ -25,11 +25,11 @@
               <h4>MA DOR FORM-X</h4>
               <p class='document-modal-buttons'>
                  <% key, bucket = get_key_and_bucket(doc.identifier) %>
-                 <a href="<%= main_app.document_download_path(bucket, key) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}" %>" ><button class="btn btn-default"><span class="glyphicons glyphicons-cloud-download"></span> Download</button></a>
+                 <a href="<%= main_app.employer_attestation_documents_download(row.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}" %>" ><button class="btn btn-default"><span class="glyphicons glyphicons-cloud-download"></span> Download</button></a>
                 <button class="btn btn-default" onclick='printDoc("<%=doc.id%>")'>Print</button>
               </p>
               <p id="print_<%=doc.id%>">
-                <iframe src="<%= main_app.document_download_path(bucket, key) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}&disposition=inline" %>" width="100%" height="600" frameborder="0" scrolling="no" name="iframe_<%= doc.id%>"></iframe>
+                <iframe src="<%= main_app.employer_attestation_documents_download(row.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}&disposition=inline" %>" width="100%" height="600" frameborder="0" scrolling="no" name="iframe_<%= doc.id%>"></iframe>
               </p>
             </div>
           </div>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/_documents.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/_documents.html.erb
@@ -25,11 +25,11 @@
               <h4>MA DOR FORM-X</h4>
               <p class='document-modal-buttons'>
                  <% key, bucket = get_key_and_bucket(doc.identifier) %>
-                 <a href="<%= main_app.employer_attestation_documents_download(row.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}" %>" ><button class="btn btn-default"><span class="glyphicons glyphicons-cloud-download"></span> Download</button></a>
+                 <a href="<%= main_app.document_employer_attestation_document_download_path(row.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}" %>" ><button class="btn btn-default"><span class="glyphicons glyphicons-cloud-download"></span> Download</button></a>
                 <button class="btn btn-default" onclick='printDoc("<%=doc.id%>")'>Print</button>
               </p>
               <p id="print_<%=doc.id%>">
-                <iframe src="<%= main_app.employer_attestation_documents_download(row.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}&disposition=inline" %>" width="100%" height="600" frameborder="0" scrolling="no" name="iframe_<%= doc.id%>"></iframe>
+                <iframe src="<%= main_app.document_employer_attestation_document_download_path(row.id) + "?id=#{@employer_profile.id}&content_type=#{doc.format}&filename=#{doc.title.gsub(/[^0-9a-z]/i,'')}&disposition=inline" %>" width="100%" height="600" frameborder="0" scrolling="no" name="iframe_<%= doc.id%>"></iframe>
               </p>
             </div>
           </div>

--- a/components/benefit_sponsors/spec/dummy/config/routes.rb
+++ b/components/benefit_sponsors/spec/dummy/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   devise_for :users
 
   root "welcome#index"
-  get "document/download/:bucket/:key" => "documents#download", as: :document_download
+  get "document/employer_attestation_documents_download/:document_id" => "documents#employer_attestation_documents_download", as: :document_employer_attestation_documents_download
+  get "document/employees_template_download" => "documents#employees_template_download", as: :document_employees_template_download
+  get "document/product_sbc_download/:product_id" => "documents#product_sbc_download", as: :document_product_sbc_download
 
   match 'broker_registration', to: redirect('benefit_sponsors/profiles/registrations/new?profile_type=broker_agency'), via: [:get]
 

--- a/components/benefit_sponsors/spec/dummy/config/routes.rb
+++ b/components/benefit_sponsors/spec/dummy/config/routes.rb
@@ -5,11 +5,14 @@ Rails.application.routes.draw do
   devise_for :users
 
   root "welcome#index"
-  get "document/employer_attestation_documents_download/:document_id" => "documents#employer_attestation_documents_download", as: :document_employer_attestation_documents_download
-  get "document/employees_template_download" => "documents#employees_template_download", as: :document_employees_template_download
-  get "document/product_sbc_download/:product_id" => "documents#product_sbc_download", as: :document_product_sbc_download
 
   match 'broker_registration', to: redirect('benefit_sponsors/profiles/registrations/new?profile_type=broker_agency'), via: [:get]
+
+  get "document/employees_template_download" => "documents#employees_template_download", as: :document_employees_template_download
+  resources :documents, only: [:destroy] do
+    get :product_sbc_download
+    get :employer_attestation_document_download
+  end
 
   namespace :employers do
 

--- a/components/benefit_sponsors/spec/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/_census_employees.html.erb_spec.rb
+++ b/components/benefit_sponsors/spec/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/_census_employees.html.erb_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe "views/benefit_sponsors/profiles/employers/employer_profiles/my_a
     let!(:sponsored_benefit) {benefit_sponsorship.benefit_applications.first.benefit_packages.first.health_sponsored_benefit}
     let!(:update_sponsored_benefit) {sponsored_benefit.update_attributes(product_package_kind: :single_product)}
     let(:employer_profile) { benefit_sponsorship.profile }
-
-
     let(:person) {FactoryBot.create(:person)}
     let(:census_employee) { create(:census_employee, benefit_sponsorship: benefit_sponsorship, employer_profile: benefit_sponsorship.profile) }
     let!(:employee_role) { FactoryBot.create(:employee_role, person: person, census_employee: census_employee, employer_profile: benefit_sponsorship.profile) }

--- a/components/benefit_sponsors/spec/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/_census_employees.html.erb_spec.rb
+++ b/components/benefit_sponsors/spec/views/benefit_sponsors/profiles/employers/employer_profiles/my_account/_census_employees.html.erb_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "views/benefit_sponsors/profiles/employers/employer_profiles/my_a
       view.extend Config::AcaHelper
 
       assign(:employer_profile, employer_profile)
+      allow(view).to receive(:link_to).and_return("/")
       allow(view).to receive(:plan_match_tool_is_enabled?).and_return(false)
       allow(view).to receive(:render_datatable).and_return(true)
       allow(view).to receive(:show_oop_pdf_link).and_return(false)
@@ -50,6 +51,5 @@ RSpec.describe "views/benefit_sponsors/profiles/employers/employer_profiles/my_a
       render template: "benefit_sponsors/profiles/employers/employer_profiles/my_account/_census_employees.html.erb"
       expect(rendered).to_not match(/Terminate Employee Roster Enrollments/)
     end
-
   end
 end

--- a/components/sponsored_benefits/app/views/sponsored_benefits/census_members/plan_design_census_employees/_upload_employees.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/census_members/plan_design_census_employees/_upload_employees.html.erb
@@ -2,7 +2,7 @@
   <i class="fa fa-times fa-3x pull-right modal-close"></i>
   <h2>Upload Employee Roster</h2>
   <h4>If you completed your employee roster offline using our Microsoft Excel template, find the file on your computer and upload it here.</h4>
-  <%= link_to(main_app.document_employees_template_download_path+"?contenttype=application/vnd.ms-excel&filename=DCHL Employee Census.xlsx", class: "download") do %>
+  <%= sanitize link_to(main_app.document_employees_template_download_path+"?contenttype=application/vnd.ms-excel&filename=DCHL Employee Census.xlsx", class: "download") do %>
   <h4>Need the template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
         Download it now.
     <% end %>

--- a/components/sponsored_benefits/app/views/sponsored_benefits/census_members/plan_design_census_employees/_upload_employees.html.erb
+++ b/components/sponsored_benefits/app/views/sponsored_benefits/census_members/plan_design_census_employees/_upload_employees.html.erb
@@ -2,7 +2,7 @@
   <i class="fa fa-times fa-3x pull-right modal-close"></i>
   <h2>Upload Employee Roster</h2>
   <h4>If you completed your employee roster offline using our Microsoft Excel template, find the file on your computer and upload it here.</h4>
-  <%= link_to(main_app.document_download_path(env_bucket_name("templates"), "b4c0e3e6-cf9b-4b00-8194-403b110b4e01") + "?contenttype=application/vnd.ms-excel&filename=DCHL Employee Census.xlsx", class: "download") do %>
+  <%= link_to(main_app.document_employees_template_download_path+"?contenttype=application/vnd.ms-excel&filename=DCHL Employee Census.xlsx", class: "download") do %>
   <h4>Need the template? <i class="fa fa-arrow-circle-o-down fa-lg"></i>
         Download it now.
     <% end %>

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -261,6 +261,8 @@ registry:
             item: 20
           - key: :default_password_length_range
             item: 8..20
+          - key: :employees_template_key
+            item: "b4c0e3e6-cf9b-4b00-8194-403b110b4e01"
       - key: :data_seeds_ui
         item: :data_seed_ui
         is_enabled: true

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -280,6 +280,8 @@ registry:
             item: 20
           - key: :default_password_length_range
             item: 8..20
+          - key: :employees_template_key
+            item: "b4c0e3e6-cf9b-4b00-8194-403b110b4e01"
       - key: :data_seeds_ui
         item: :data_seeds_ui
         is_enabled: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -618,7 +618,9 @@ Rails.application.routes.draw do
     end
   end
 
-  get "document/download/:bucket/:key" => "documents#download", as: :document_download
+  get "document/employer_attestation_documents_download/:document_id" => "documents#employer_attestation_documents_download", as: :document_employer_attestation_documents_download
+  get "document/employees_template_download" => "documents#employees_template_download", as: :document_employees_template_download
+  get "document/product_sbc_download/:product_id" => "documents#product_sbc_download", as: :document_product_sbc_download
   get "document/authorized_download/:model/:model_id/:relation/:relation_id" => "documents#authorized_download", as: :authorized_document_download
   get "document/cartafact_download/:model/:model_id/:relation/:relation_id" => "documents#cartafact_download", as: :cartafact_document_download
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -618,13 +618,13 @@ Rails.application.routes.draw do
     end
   end
 
-  get "document/employer_attestation_documents_download/:document_id" => "documents#employer_attestation_documents_download", as: :document_employer_attestation_documents_download
   get "document/employees_template_download" => "documents#employees_template_download", as: :document_employees_template_download
-  get "document/product_sbc_download/:product_id" => "documents#product_sbc_download", as: :document_product_sbc_download
   get "document/authorized_download/:model/:model_id/:relation/:relation_id" => "documents#authorized_download", as: :authorized_document_download
   get "document/cartafact_download/:model/:model_id/:relation/:relation_id" => "documents#cartafact_download", as: :cartafact_document_download
 
   resources :documents, only: [:destroy] do
+    get :product_sbc_download
+    get :employer_attestation_document_download
     get :autocomplete_organization_legal_name, :on => :collection
     collection do
       put :change_person_aasm_state

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -533,4 +533,170 @@ RSpec.describe DocumentsController, dbclean: :after_each, :type => :controller d
       end
     end
   end
+
+  describe "GET employees_template_download" do
+    include_context "setup benefit market with market catalogs and product packages"
+    include_context "setup initial benefit application"
+
+    let(:profile) { benefit_sponsorship.organization.profiles.first }
+    let(:employer_staff_person) { FactoryBot.create(:person) }
+    let(:employer_staff_user) { FactoryBot.create(:user, person: employer_staff_person) }
+    let(:er_staff_role) { FactoryBot.create(:benefit_sponsor_employer_staff_role, benefit_sponsor_employer_profile_id: benefit_sponsorship.organization.employer_profile.id) }
+    let(:document) {profile.documents.create(identifier: "urn:opentest:terms:t1:test_storage:t3:bucket:test-test-id-verification-test#sample-key")}
+
+    context 'employer staff role' do
+      context 'for a user with POC role' do
+        before do
+          employer_staff_person.employer_staff_roles << er_staff_role
+          employer_staff_person.save!
+          sign_in employer_staff_user
+        end
+
+        it 'current user employer should be able to download' do
+          get :employees_template_download
+          expect(response).to be_successful
+        end
+      end
+
+      context 'for a user without POC role' do
+
+        before do
+          sign_in employer_staff_user
+        end
+
+        it 'current user without employer staff role should not be able to download' do
+          get :employees_template_download
+          expect(response).to have_http_status(:found)
+          expect(flash[:error]).to eq("Access not allowed for user_policy.can_download_employees_template?, (Pundit policy)")
+        end
+      end
+    end
+
+    context 'broker role' do
+      context 'with authorized account' do
+        before do
+          profile.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id,
+                                                                                               writing_agent_id: broker_role.id,
+                                                                                               start_on: Time.now,
+                                                                                               is_active: true)
+          sign_in broker_role_user
+        end
+
+        it 'broker should be able to download' do
+          get :employees_template_download
+          expect(response).to be_successful
+        end
+      end
+
+      context 'with inactive broker role' do
+        before do
+          broker_role.update!(aasm_state: 'inactive')
+          sign_in broker_role_user
+        end
+
+        it 'broker should be able to download' do
+          get :employees_template_download
+          expect(response).to have_http_status(:found)
+          expect(flash[:error]).to eq("Access not allowed for user_policy.can_download_employees_template?, (Pundit policy)")
+        end
+      end
+    end
+
+    context 'hbx staff role' do
+      context 'with permission to access' do
+        before do
+          sign_in admin_user
+        end
+
+        it 'hbx staff should be able to download' do
+          get :employees_template_download
+          expect(response).to be_successful
+        end
+      end
+    end
+  end
+
+  describe "GET product_sbc_download" do
+    include_context "setup benefit market with market catalogs and product packages"
+    include_context "setup initial benefit application"
+
+    let(:profile) { benefit_sponsorship.organization.profiles.first }
+    let(:employee_person) { FactoryBot.create(:person, :with_family, :with_employee_role) }
+    let(:census_employee) { FactoryBot.create(:census_employee, employer_profile: profile, employee_role_id: person.employee_role.id) }
+    let(:employee_user) { FactoryBot.create(:user, person: employee_person) }
+    let(:product) do
+      product = FactoryBot.create(:benefit_markets_products_health_products_health_product, benefit_market_kind: :aca_individual, kind: :health, csr_variant_id: '01')
+      product.create_sbc_document(identifier: "urn:opentest:terms:t1:test_storage:t3:bucket:test-test-id-verification-test#sample-key")
+      product.save
+      product
+    end
+
+    context 'employee role' do
+      context 'for a user with employee role' do
+        it 'current user employer should be able to download' do
+          sign_in employee_user
+
+          get :product_sbc_download, params: {product_id: product.id }
+          expect(response).to be_successful
+        end
+      end
+
+      context 'for a user without any role' do
+        let(:user_without_roles) { FactoryBot.create(:user, person: FactoryBot.create(:person)) }
+        before do
+          sign_in user_without_roles
+        end
+
+        it 'current user without any role should not be able to download' do
+          get :product_sbc_download, params: {product_id: product.id }
+          expect(response).to have_http_status(:found)
+          expect(flash[:error]).to eq("Access not allowed for person_policy.can_download_sbc_documents?, (Pundit policy)")
+        end
+      end
+    end
+
+    context 'broker role' do
+      context 'with authorized account' do
+        before do
+          broker_agency_profile.update!(market_kind: 'both')
+          employee_person.primary_family.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id,
+                                                                                                                      writing_agent_id: broker_role.id,
+                                                                                                                      start_on: Time.now,
+                                                                                                                      is_active: true)
+          sign_in broker_role_user
+        end
+
+        it 'broker should be able to download' do
+          get :product_sbc_download, params: { product_id: product.id }, session: { person_id: employee_person.id }
+          expect(response).to be_successful
+        end
+      end
+
+      context 'with inactive broker role' do
+        before do
+          broker_role.update!(aasm_state: 'inactive')
+          sign_in broker_role_user
+        end
+
+        it 'broker should be able to download' do
+          get :product_sbc_download, params: { product_id: product.id }, session: { person_id: employee_person.id }
+          expect(response).to have_http_status(:found)
+          expect(flash[:error]).to eq("Access not allowed for person_policy.can_download_sbc_documents?, (Pundit policy)")
+        end
+      end
+    end
+
+    context 'hbx staff role' do
+      context 'with permission to access' do
+        before do
+          sign_in admin_user
+        end
+
+        it 'hbx staff should be able to download' do
+          get :product_sbc_download, params: { product_id: product.id }
+          expect(response).to be_successful
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -636,7 +636,7 @@ RSpec.describe DocumentsController, dbclean: :after_each, :type => :controller d
         it 'current user employer should be able to download' do
           sign_in employee_user
 
-          get :product_sbc_download, params: {product_id: product.id }
+          get :product_sbc_download, params: { document_id: product.sbc_document.id, product_id: product.id }
           expect(response).to be_successful
         end
       end
@@ -648,7 +648,7 @@ RSpec.describe DocumentsController, dbclean: :after_each, :type => :controller d
         end
 
         it 'current user without any role should not be able to download' do
-          get :product_sbc_download, params: {product_id: product.id }
+          get :product_sbc_download, params: { document_id: product.sbc_document.id, product_id: product.id }
           expect(response).to have_http_status(:found)
           expect(flash[:error]).to eq("Access not allowed for person_policy.can_download_sbc_documents?, (Pundit policy)")
         end
@@ -667,7 +667,7 @@ RSpec.describe DocumentsController, dbclean: :after_each, :type => :controller d
         end
 
         it 'broker should be able to download' do
-          get :product_sbc_download, params: { product_id: product.id }, session: { person_id: employee_person.id }
+          get :product_sbc_download, params: { document_id: product.sbc_document.id, product_id: product.id }, session: { person_id: employee_person.id }
           expect(response).to be_successful
         end
       end
@@ -679,7 +679,7 @@ RSpec.describe DocumentsController, dbclean: :after_each, :type => :controller d
         end
 
         it 'broker should be able to download' do
-          get :product_sbc_download, params: { product_id: product.id }, session: { person_id: employee_person.id }
+          get :product_sbc_download, params: { document_id: product.sbc_document.id, product_id: product.id }, session: { person_id: employee_person.id }
           expect(response).to have_http_status(:found)
           expect(flash[:error]).to eq("Access not allowed for person_policy.can_download_sbc_documents?, (Pundit policy)")
         end
@@ -693,7 +693,7 @@ RSpec.describe DocumentsController, dbclean: :after_each, :type => :controller d
         end
 
         it 'hbx staff should be able to download' do
-          get :product_sbc_download, params: { product_id: product.id }
+          get :product_sbc_download, params: { document_id: product.sbc_document.id, product_id: product.id }
           expect(response).to be_successful
         end
       end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -5,7 +5,7 @@ describe UserPolicy do
 
   describe "given a current user with no person" do
     let(:current_user_person) { nil }
-    let(:target_user) { instance_double(User) }
+    let(:target_user) { instance_double(User, :person => nil) }
     subject { UserPolicy.new(user, target_user) }
 
     it "is not lockable" do
@@ -21,7 +21,7 @@ describe UserPolicy do
     - a current user with a person
     - who does not have an hbx_staff_role
   " do
-    let(:current_user_person) { instance_double(Person, :hbx_staff_role => nil) }
+    let(:current_user_person) { instance_double(Person, :hbx_staff_role => nil, :primary_family => nil) }
     let(:user) { instance_double(User, :person => current_user_person) }
     let(:target_user) { instance_double(User) }
     subject { UserPolicy.new(user, target_user) }
@@ -42,7 +42,7 @@ describe UserPolicy do
   " do
     let(:hbx_staff_role) { instance_double(HbxStaffRole, :permission => nil) }
 
-    let(:current_user_person) { instance_double(Person, :hbx_staff_role => hbx_staff_role) }
+    let(:current_user_person) { instance_double(Person, :hbx_staff_role => hbx_staff_role, :primary_family => nil) }
     let(:user) { instance_double(User, :person => current_user_person) }
     let(:target_user) { instance_double(User) }
     subject { UserPolicy.new(user, target_user) }
@@ -76,7 +76,7 @@ describe UserPolicy do
 
     let(:hbx_staff_role) { instance_double(HbxStaffRole, :permission => permission ) }
 
-    let(:current_user_person) { instance_double(Person, :hbx_staff_role => hbx_staff_role) }
+    let(:current_user_person) { instance_double(Person, :hbx_staff_role => hbx_staff_role, :primary_family => nil) }
     let(:user) { instance_double(User, :person => current_user_person) }
     let(:target_user) { instance_double(User) }
     subject { UserPolicy.new(user, target_user) }
@@ -110,7 +110,7 @@ describe UserPolicy do
 
     let(:hbx_staff_role) { instance_double(HbxStaffRole, :permission => permission ) }
 
-    let(:current_user_person) { instance_double(Person, :hbx_staff_role => hbx_staff_role) }
+    let(:current_user_person) { instance_double(Person, :hbx_staff_role => hbx_staff_role, :primary_family => nil) }
     let(:user) { instance_double(User, :person => current_user_person) }
     let(:target_user) { instance_double(User) }
     subject { UserPolicy.new(user, target_user) }

--- a/spec/views/insured/families/_enrollment.html.erb_spec.rb
+++ b/spec/views/insured/families/_enrollment.html.erb_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe "insured/families/_enrollment.html.erb" do
 
     it "should open the sbc pdf" do
       expect(rendered).to have_selector(
-        "a[href='#{"/document/product_sbc_download/#{product.id}?content_type=application/pdf&filename=APlanName.pdf"\
+        "a[href='#{"/documents/#{sbc_document.id}/product_sbc_download?product_id=#{product.id}&content_type=application/pdf&filename=APlanName.pdf"\
         '&disposition=inline'}']"
       )
     end

--- a/spec/views/insured/families/_enrollment.html.erb_spec.rb
+++ b/spec/views/insured/families/_enrollment.html.erb_spec.rb
@@ -248,8 +248,7 @@ RSpec.describe "insured/families/_enrollment.html.erb" do
 
     it "should open the sbc pdf" do
       expect(rendered).to have_selector(
-        "a[href='#{"/document/download/#{EnrollRegistry[:enroll_app].setting(:s3_prefix).item}"\
-        "-enroll-sbc-#{aws_env}/7816ce0f-a138-42d5-89c5-25c5a3408b82?content_type=application/pdf&filename=APlanName.pdf"\
+        "a[href='#{"/document/product_sbc_download/#{product.id}?content_type=application/pdf&filename=APlanName.pdf"\
         '&disposition=inline'}']"
       )
     end

--- a/spec/views/insured/families/_enrollment_refactored.html.erb_spec.rb
+++ b/spec/views/insured/families/_enrollment_refactored.html.erb_spec.rb
@@ -295,8 +295,7 @@ RSpec.describe "insured/families/_enrollment_refactored.html.erb" do
 
     it "should open the sbc pdf" do
       expect(rendered).to have_selector(
-        "a[href='#{"/document/download/#{EnrollRegistry[:enroll_app].setting(:s3_prefix).item}"\
-        "-enroll-sbc-#{aws_env}/7816ce0f-a138-42d5-89c5-25c5a3408b82?content_type=application/pdf&filename=APlanName.pdf"\
+        "a[href='#{"/document/product_sbc_download/#{product.id}?content_type=application/pdf&filename=APlanName.pdf"\
         '&disposition=inline'}']"
       )
     end

--- a/spec/views/insured/families/_enrollment_refactored.html.erb_spec.rb
+++ b/spec/views/insured/families/_enrollment_refactored.html.erb_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe "insured/families/_enrollment_refactored.html.erb" do
 
     it "should open the sbc pdf" do
       expect(rendered).to have_selector(
-        "a[href='#{"/document/product_sbc_download/#{product.id}?content_type=application/pdf&filename=APlanName.pdf"\
+        "a[href='#{"/documents/#{sbc_document.id}/product_sbc_download?product_id=#{product.id}&content_type=application/pdf&filename=APlanName.pdf"\
         '&disposition=inline'}']"
       )
     end

--- a/spec/views/shared/_comparison.html.erb_spec.rb
+++ b/spec/views/shared/_comparison.html.erb_spec.rb
@@ -39,7 +39,7 @@ describe "shared/_comparison.html.erb", dbclean: :after_each do
   
   let(:mock_qhp){instance_double("Products::QhpCostShareVariance", :product => product, :plan => plan, :plan_marketing_name=> product.title)}
   let(:mock_qhps) {[mock_qhp]}
-  let(:sbc_document) { double("SbcDocument", identifier: "download#abc") }
+  let(:sbc_document) { double("SbcDocument", id: BSON::ObjectId.new, identifier: "download#abc") }
   let(:mock_family){ double("Family") }
 
   before :each do
@@ -79,7 +79,7 @@ describe "shared/_comparison.html.erb", dbclean: :after_each do
     before :each do
       assign :coverage_kind, "health"
       assign :market_kind, 'aca_shop'
-      allow(product).to receive(:sbc_document).and_return double("Document", :identifier => "identifier")
+      allow(product).to receive(:sbc_document).and_return double("Document", id: BSON::ObjectId.new, :identifier => "identifier")
       render "shared/comparison", :qhps => mock_qhps
     end
 

--- a/spec/views/shared/plan_shoppings/_sbc_link.html.erb_spec.rb
+++ b/spec/views/shared/plan_shoppings/_sbc_link.html.erb_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe "shared/plan_shoppings/_sbc_link.html.erb" do
 
   it "should have the sbc link" do
     expect(rendered).to have_selector(
-      "a[href='#{"/document/product_sbc_download/#{mock_plan.id}?content_type=application/"\
-      'pdf&filename=APlanName.pdf&disposition=inline'}']"
+      "a[href='#{"/documents/#{mock_plan.sbc_document.id}/product_sbc_download?product_id=#{mock_plan.id}&content_type=application/pdf&filename=APlanName.pdf"\
+      '&disposition=inline'}']"
     )
   end
 

--- a/spec/views/shared/plan_shoppings/_sbc_link.html.erb_spec.rb
+++ b/spec/views/shared/plan_shoppings/_sbc_link.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "shared/plan_shoppings/_sbc_link.html.erb" do
   let(:mock_plan) do
     double(
       "Plan",
+      :id => BSON::ObjectId.new,
       :name => "A Plan Name",
       :carrier_profile_id => "a carrier profile id",
       :carrier_profile => mock_carrier_profile,
@@ -38,8 +39,7 @@ RSpec.describe "shared/plan_shoppings/_sbc_link.html.erb" do
 
   it "should have the sbc link" do
     expect(rendered).to have_selector(
-      "a[href='#{"/document/download/#{EnrollRegistry[:enroll_app].setting(:s3_prefix).item}"\
-      "-enroll-sbc-#{aws_env}/7816ce0f-a138-42d5-89c5-25c5a3408b82?content_type=application/"\
+      "a[href='#{"/document/product_sbc_download/#{mock_plan.id}?content_type=application/"\
       'pdf&filename=APlanName.pdf&disposition=inline'}']"
     )
   end
@@ -53,7 +53,5 @@ RSpec.describe "shared/plan_shoppings/_sbc_link.html.erb" do
     it "should have the sbc link with dental text" do
       expect(rendered).to have_selector('a', text: 'Plan Summary')
     end
-
   end
-
 end

--- a/spec/views/ui-components/v1/cards/_summary.html.slim_spec.rb
+++ b/spec/views/ui-components/v1/cards/_summary.html.slim_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "_summary.html.slim.rb", :type => :view, dbclean: :after_each  do
 
     it "should have a link to download the sbc pdf" do
       expect(rendered).to have_selector(
-        "a[href='#{"/document/product_sbc_download/#{mock_product.id}?content_type=application/pdf&filename=APlanName.pdf"\
+        "a[href='#{"/documents/#{document.id}/product_sbc_download?product_id=#{mock_product.id}&content_type=application/pdf&filename=APlanName.pdf"\
         '&disposition=inline'}']"
       )
     end

--- a/spec/views/ui-components/v1/cards/_summary.html.slim_spec.rb
+++ b/spec/views/ui-components/v1/cards/_summary.html.slim_spec.rb
@@ -123,9 +123,8 @@ RSpec.describe "_summary.html.slim.rb", :type => :view, dbclean: :after_each  do
 
     it "should have a link to download the sbc pdf" do
       expect(rendered).to have_selector(
-        "a[href='#{"/document/download/#{EnrollRegistry[:enroll_app].setting(:s3_prefix).item}"\
-        '-enroll-sbc-qa/7816ce0f-a138-42d5-89c5-25c5a3408b82?content_type=application/pdf&filename'\
-        '=APlanName.pdf&disposition=inline'}']"
+        "a[href='#{"/document/product_sbc_download/#{mock_product.id}?content_type=application/pdf&filename=APlanName.pdf"\
+        '&disposition=inline'}']"
       )
     end
 

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -261,6 +261,8 @@ registry:
             item: 20
           - key: :default_password_length_range
             item: 8..20
+          - key: :employees_template_key
+            item: "b4c0e3e6-cf9b-4b00-8194-403b110b4e01"
       - key: :data_seeds_ui
         item: :data_seed_ui
         is_enabled: true


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/n/projects/2640059/stories/187186037#

# A brief description of the changes

Current behavior: No authorization for the `download` endpoint of the DocumentsController.

New behavior: The download endpoint is split into multiple endpoints based on the responsibility.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.