### PR TITLE
adds authorization for security questions controller

### DIFF
--- a/app/controllers/exchanges/security_questions_controller.rb
+++ b/app/controllers/exchanges/security_questions_controller.rb
@@ -8,14 +8,17 @@ class Exchanges::SecurityQuestionsController < ApplicationController
   before_action :check_feature_enabled
 
   def index
+    authorize SecurityQuestion, :index?
     @questions = SecurityQuestion.all
   end
 
   def new
+    authorize SecurityQuestion, :new?
     @question = SecurityQuestion.new
   end
 
   def create
+    authorize SecurityQuestion, :create?
     @question = SecurityQuestion.new(security_question_params)
     if @question.save
       redirect_to exchanges_security_questions_path, notice: 'Question was successfully created'
@@ -25,10 +28,12 @@ class Exchanges::SecurityQuestionsController < ApplicationController
   end
 
   def edit
+    authorize SecurityQuestion, :edit?
     @question = SecurityQuestion.find(params[:id])
   end
 
   def update
+    authorize SecurityQuestion, :update?
     @question = SecurityQuestion.find(params[:id])
     if @question.safe_to_edit_or_delete? && @question.update_attributes(security_question_params)
       redirect_to exchanges_security_questions_path, notice: 'Question was updated successfully'
@@ -38,6 +43,7 @@ class Exchanges::SecurityQuestionsController < ApplicationController
   end
 
   def destroy
+    authorize SecurityQuestion, :destroy?
     @question = SecurityQuestion.find(params[:id])
     if @question.safe_to_edit_or_delete?
       @question.destroy

--- a/app/policies/security_question_policy.rb
+++ b/app/policies/security_question_policy.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Policy class for security questions.
+# Currently, this feature is turned off for both ME and DC and this is the reason all the policies are literally returning false.
+# In future when we enable the feature for a client then we should implement the access rules/permission.
+#
+# @note This class inherits from ApplicationPolicy.
+class SecurityQuestionPolicy < ApplicationPolicy
+  # Determines if the user can view the index page of security questions.
+  # @return [Boolean] Returns false as this feature is currently turned off.
+  def index?
+    false
+  end
+
+  # Determines if the user can view the new security question page.
+  # @return [Boolean] Returns false as this feature is currently turned off.
+  def new?
+    index?
+  end
+
+  # Determines if the user can create a new security question.
+  # @return [Boolean] Returns false as this feature is currently turned off.
+  def create?
+    index?
+  end
+
+  # Determines if the user can view the edit security question page.
+  # @return [Boolean] Returns false as this feature is currently turned off.
+  def edit?
+    index?
+  end
+
+  # Determines if the user can update a security question.
+  # @return [Boolean] Returns false as this feature is currently turned off.
+  def update?
+    index?
+  end
+
+  # Determines if the user can destroy a security question.
+  # @return [Boolean] Returns false as this feature is currently turned off.
+  def destroy?
+    index?
+  end
+end

--- a/spec/controllers/exchanges/security_questions_controller_spec.rb
+++ b/spec/controllers/exchanges/security_questions_controller_spec.rb
@@ -1,120 +1,124 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe Exchanges::SecurityQuestionsController, dbclean: :after_each do
+# Update the SecurityQuestionPolicy to properly handle access permissions when the feature is enabled.
+if SecurityQuestionPolicy.new('user', 'SecurityQuestion').index?
+  RSpec.describe Exchanges::SecurityQuestionsController, dbclean: :after_each do
 
-  let(:user) { FactoryBot.create(:user, with_security_questions: false) }
-  let(:person) { FactoryBot.create(:person, user: user) }
-  let(:hbx_staff_role) { FactoryBot.create(:hbx_staff_role, person: person) }
-  let(:question) { instance_double("SecurityQuestion", title: 'Your Question', id: '1') }
+    let(:user) { FactoryBot.create(:user, with_security_questions: false) }
+    let(:person) { FactoryBot.create(:person, user: user) }
+    let(:hbx_staff_role) { FactoryBot.create(:hbx_staff_role, person: person) }
+    let(:question) { instance_double("SecurityQuestion", title: 'Your Question', id: '1') }
 
-  before :each do
-    allow(Settings).to receive_message_chain('aca.security_questions').and_return(true)
-    allow(user).to receive(:has_hbx_staff_role?).and_return true
+    before :each do
+      allow(Settings.aca).to receive_message_chain('security_questions').and_return(true)
+      allow(user).to receive(:has_hbx_staff_role?).and_return true
 
-    allow(SecurityQuestion).to receive(:all).and_return([question])
-    allow(SecurityQuestion).to receive(:find).with(question.id).and_return(question)
-    sign_in user
-  end
+      allow(SecurityQuestion).to receive(:all).and_return([question])
+      allow(SecurityQuestion).to receive(:find).with(question.id).and_return(question)
+      sign_in user
+    end
 
-  describe 'GET index' do
-    before { get :index }
-    it { expect(assigns(:questions)).to eq([question]) }
-    it { expect(response).to have_http_status(:success) }
-    it { expect(response).to render_template('exchanges/security_questions/index') }
-  end
+    describe 'GET index' do
+      before { get :index }
+      it { expect(assigns(:questions)).to eq([question]) }
+      it { expect(response).to have_http_status(:success) }
+      it { expect(response).to render_template('exchanges/security_questions/index') }
+    end
 
-  describe 'GET new' do
-    before { get :new }
-    it { expect(assigns(:question)).to be_a(SecurityQuestion) }
-    it { expect(response).to have_http_status(:success) }
-    it { expect(response).to render_template('exchanges/security_questions/new') }
-  end
-
-  describe 'POST create' do
-    context 'When create a question with invalid params' do
-      before { post :create, params:{security_question: { title: nil } } }
-      it { expect(assigns(:question).title).to be_empty }
-      it { expect(assigns(:question).errors.full_messages).to eq(['Title can\'t be blank']) }
+    describe 'GET new' do
+      before { get :new }
+      it { expect(assigns(:question)).to be_a(SecurityQuestion) }
       it { expect(response).to have_http_status(:success) }
       it { expect(response).to render_template('exchanges/security_questions/new') }
     end
 
-    context 'When question is created successfully' do
-      before { post :create, params: {security_question: { title: 'First Question' } } }
-      it { expect(assigns(:question)).to be_a(SecurityQuestion) }
-      it { expect(SecurityQuestion.all).not_to eq([]) }
-      it { expect(assigns(:question).title).to eq('First Question') }
-      it { expect(response).to redirect_to('/exchanges/security_questions') }
-    end
-  end
-
-  describe 'GET edit' do
-    before { get :edit, params: {id: question.id } }
-    it { expect(assigns(:question)).to eq(question) }
-    it { expect(response).to have_http_status(:success) }
-    it { expect(response).to render_template('exchanges/security_questions/edit') }
-  end
-
-  describe 'PUT update' do
-    let(:true_if_allowed) { true }
-    let(:title) { 'Updated title' }
-    let(:params) {{ title: title } }
-    let(:nil_params) {{ title: "" } }
-    let(:strong_params){ActionController::Parameters.new(params).permit(:title)}
-    let(:strong_nil_params){ActionController::Parameters.new(nil_params).permit(:title)}
-
-    before do
-      allow(question).to receive(:safe_to_edit_or_delete?).and_return(true_if_allowed)
-      allow(question).to receive(:update_attributes).with( strong_params ).and_return(true)
-      allow(question).to receive(:title).and_return(title)
-      put :update, params: {id: question.id, security_question: strong_params }
-    end
-
-    context 'When update question with valid title' do
-      it { expect(assigns(:question)).to eq(question) }
-      it { expect(assigns(:question).title).to eq(title) }
-      it { expect(response).to redirect_to('/exchanges/security_questions') }
-    end
-
-    context "when updating a question that has been answered already" do
-      let!(:true_if_allowed) { false }
-
-      it { expect(assigns(:question)).to eq(question) }
-      it { expect(response).to have_http_status(:success) }
-      it { expect(response).to render_template('exchanges/security_questions/edit') }
-    end
-
-    context 'When update question with blank title' do
-      let(:errors) { double(:errors, full_messages: ["Title can't be blank"]) }
-      before do
-        allow(question).to receive(:errors).and_return(errors)
-        allow(question).to receive(:update_attributes).with(strong_nil_params).and_return(false)
-        put :update,params: {id: question.id, security_question: strong_nil_params}
+    describe 'POST create' do
+      context 'When create a question with invalid params' do
+        before { post :create, params: {security_question: { title: nil } } }
+        it { expect(assigns(:question).title).to be_empty }
+        it { expect(assigns(:question).errors.full_messages).to eq(['Title can\'t be blank']) }
+        it { expect(response).to have_http_status(:success) }
+        it { expect(response).to render_template('exchanges/security_questions/new') }
       end
+
+      context 'When question is created successfully' do
+        before { post :create, params: {security_question: { title: 'First Question' } } }
+        it { expect(assigns(:question)).to be_a(SecurityQuestion) }
+        it { expect(SecurityQuestion.all).not_to eq([]) }
+        it { expect(assigns(:question).title).to eq('First Question') }
+        it { expect(response).to redirect_to('/exchanges/security_questions') }
+      end
+    end
+
+    describe 'GET edit' do
+      before { get :edit, params: {id: question.id } }
       it { expect(assigns(:question)).to eq(question) }
-      it { expect(assigns(:question).errors.full_messages).to eq(['Title can\'t be blank']) }
       it { expect(response).to have_http_status(:success) }
       it { expect(response).to render_template('exchanges/security_questions/edit') }
     end
-  end
 
-  describe 'DELETE destroy' do
-    let(:true_if_allowed) { true }
-    let(:this_many) { 1 }
-    before do
-      allow(question).to receive(:safe_to_edit_or_delete?).and_return(true_if_allowed)
-      expect(question).to receive(:destroy).exactly(this_many).times
+    describe 'PUT update' do
+      let(:true_if_allowed) { true }
+      let(:title) { 'Updated title' }
+      let(:params) {{ title: title } }
+      let(:nil_params) {{ title: "" } }
+      let(:strong_params){ActionController::Parameters.new(params).permit(:title)}
+      let(:strong_nil_params){ActionController::Parameters.new(nil_params).permit(:title)}
 
-      delete :destroy, params: { id: question.id }
+      before do
+        allow(question).to receive(:safe_to_edit_or_delete?).and_return(true_if_allowed)
+        allow(question).to receive(:update_attributes).with(strong_params).and_return(true)
+        allow(question).to receive(:title).and_return(title)
+        put :update, params: {id: question.id, security_question: strong_params }
+      end
+
+      context 'When update question with valid title' do
+        it { expect(assigns(:question)).to eq(question) }
+        it { expect(assigns(:question).title).to eq(title) }
+        it { expect(response).to redirect_to('/exchanges/security_questions') }
+      end
+
+      context "when updating a question that has been answered already" do
+        let!(:true_if_allowed) { false }
+
+        it { expect(assigns(:question)).to eq(question) }
+        it { expect(response).to have_http_status(:success) }
+        it { expect(response).to render_template('exchanges/security_questions/edit') }
+      end
+
+      context 'When update question with blank title' do
+        let(:errors) { double(:errors, full_messages: ["Title can't be blank"]) }
+        before do
+          allow(question).to receive(:errors).and_return(errors)
+          allow(question).to receive(:update_attributes).with(strong_nil_params).and_return(false)
+          put :update,params: {id: question.id, security_question: strong_nil_params}
+        end
+        it { expect(assigns(:question)).to eq(question) }
+        it { expect(assigns(:question).errors.full_messages).to eq(['Title can\'t be blank']) }
+        it { expect(response).to have_http_status(:success) }
+        it { expect(response).to render_template('exchanges/security_questions/edit') }
+      end
     end
 
-    it { expect(response).to redirect_to('/exchanges/security_questions') }
+    describe 'DELETE destroy' do
+      let(:true_if_allowed) { true }
+      let(:this_many) { 1 }
+      before do
+        allow(question).to receive(:safe_to_edit_or_delete?).and_return(true_if_allowed)
+        expect(question).to receive(:destroy).exactly(this_many).times
 
-    context "when attempting to delete a question that has been answered already" do
-      let!(:true_if_allowed) { false }
-      let(:this_many) { 0 }
+        delete :destroy, params: { id: question.id }
+      end
+
       it { expect(response).to redirect_to('/exchanges/security_questions') }
+
+      context "when attempting to delete a question that has been answered already" do
+        let!(:true_if_allowed) { false }
+        let(:this_many) { 0 }
+        it { expect(response).to redirect_to('/exchanges/security_questions') }
+      end
     end
   end
-
 end

--- a/spec/controllers/exchanges/user_authorization_security_questions_controller_spec.rb
+++ b/spec/controllers/exchanges/user_authorization_security_questions_controller_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Exchanges::SecurityQuestionsController, dbclean: :after_each do
+  let(:person) { FactoryBot.create(:person) }
+  let(:user) { FactoryBot.create(:user, person: person) }
+
+  before do
+    allow(Settings.aca).to receive_message_chain('security_questions').and_return(true)
+    sign_in(user)
+  end
+
+  describe 'GET #index' do
+    context 'security questions feature is disabled' do
+      it 'redirects to root with flash message' do
+        get :index
+        expect(response).to redirect_to(root_path)
+        expect(flash[:error]).to eq('Access not allowed for security_question_policy.index?, (Pundit policy)')
+      end
+    end
+  end
+
+  describe 'GET #new' do
+    context 'security questions feature is disabled' do
+      it 'redirects to root with flash message' do
+        get :new
+        expect(response).to redirect_to(root_path)
+        expect(flash[:error]).to eq('Access not allowed for security_question_policy.new?, (Pundit policy)')
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    context 'security questions feature is disabled' do
+      it 'redirects to root with flash message' do
+        post :create, params: {}
+        expect(response).to redirect_to(root_path)
+        expect(flash[:error]).to eq('Access not allowed for security_question_policy.create?, (Pundit policy)')
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    context 'security questions feature is disabled' do
+      it 'redirects to root with flash message' do
+        get :edit, params: { id: 'random_id' }
+        expect(response).to redirect_to(root_path)
+        expect(flash[:error]).to eq('Access not allowed for security_question_policy.edit?, (Pundit policy)')
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    context 'security questions feature is disabled' do
+      it 'redirects to root with flash message' do
+        patch :update, params: { id: 'random_id' }
+        expect(response).to redirect_to(root_path)
+        expect(flash[:error]).to eq('Access not allowed for security_question_policy.update?, (Pundit policy)')
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    context 'security questions feature is disabled' do
+      it 'redirects to root with flash message' do
+        delete :destroy, params: { id: 'random_id' }
+        expect(response).to redirect_to(root_path)
+        expect(flash[:error]).to eq('Access not allowed for security_question_policy.destroy?, (Pundit policy)')
+      end
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 187293767](https://www.pivotaltracker.com/story/show/187293767)

# A brief description of the changes

Current behavior: No Authorization for `Exchanges::SecurityQuestionsController`.

New behavior: Add pundit policies to `Exchanges::SecurityQuestionsController`.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.