### PR TITLE
some methods that are not endpoints are made private

### DIFF
--- a/app/controllers/insured/fdsh_ridp_verifications_controller.rb
+++ b/app/controllers/insured/fdsh_ridp_verifications_controller.rb
@@ -122,6 +122,8 @@ module Insured
       render "failed_validation"
     end
 
+    private
+
     def received_response(event_kind)
       find_params = {primary_member_hbx_id: @person.primary_family.primary_applicant.hbx_id, event_kind: event_kind}
       Operations::Fdsh::Ridp::FindEligibilityResponse.new.call(find_params)

--- a/spec/controllers/insured/fdsh_ridp_verifications_controller_spec.rb
+++ b/spec/controllers/insured/fdsh_ridp_verifications_controller_spec.rb
@@ -19,13 +19,13 @@ describe Insured::FdshRidpVerificationsController do
     end
 
     it 'finds a primary response' do
-      expect(controller.find_response('primary')).to eq(primary_event)
+      expect(controller.send(:find_response, 'primary')).to eq(primary_event)
     end
 
     context "with nil deleted at dates" do
 
       it "should not include eligibility response models" do
-        expect(controller.find_response('primary').to_a.count).to eql(1)
+        expect(controller.send(:find_response, 'primary').to_a.count).to eql(1)
       end
     end
 
@@ -35,7 +35,7 @@ describe Insured::FdshRidpVerificationsController do
       end
 
       it "should return nil" do
-        expect(controller.find_response('primary')).to eql(nil)
+        expect(controller.send(:find_response, 'primary')).to eql(nil)
       end
     end
 
@@ -46,7 +46,7 @@ describe Insured::FdshRidpVerificationsController do
       end
 
       it "should only return records related to one primary hbx_id" do
-        expect(controller.find_response('primary').to_a.count).to eql(1)
+        expect(controller.send(:find_response, 'primary').to_a.count).to eql(1)
       end
     end
 

--- a/spec/controllers/insured/fdsh_ridp_verifications_controller_spec.rb
+++ b/spec/controllers/insured/fdsh_ridp_verifications_controller_spec.rb
@@ -53,7 +53,7 @@ describe Insured::FdshRidpVerificationsController do
     context "with different event kinds" do
 
       it "should only return one event kind" do
-        expect(controller.find_response('secondary')).to eql(fifth_event)
+        expect(controller.send(:find_response, 'secondary')).to eql(fifth_event)
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 187293777](https://www.pivotaltracker.com/story/show/187293777)

# A brief description of the changes

Current behavior: Some methods are not private, which should be private, as they are not routed endpoints in `Insured::FdshRidpVerificationsController`.

New behavior: Methods are made private as they are unrouted endpoints/methods in `Insured::FdshRidpVerificationsController`.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.