### PR TITLE
adds pundit authorization for all endpoints of paper applications controller

### DIFF
--- a/app/controllers/insured/paper_applications_controller.rb
+++ b/app/controllers/insured/paper_applications_controller.rb
@@ -1,10 +1,17 @@
+# frozen_string_literal: true
+
+# Controller for handling paper applications.
+# The endpoints of this controller are only applicable for the Coverall Market.
+#
+# @note This class inherits from ApplicationController.
 class Insured::PaperApplicationsController < ApplicationController
   include ApplicationHelper
 
   before_action :get_family
-  before_action :updateable?, only: [:upload]
 
   def upload
+    authorize @family, :upload_paper_application?
+
     if params[:file].nil?
       flash[:error] = "File not uploaded. Please select the file to upload."
       redirect_to upload_application_insured_families_path
@@ -33,6 +40,8 @@ class Insured::PaperApplicationsController < ApplicationController
   end
 
   def download
+    authorize @family, :download_paper_application?
+
     document = get_document(params[:key])
     if document.present?
       bucket = env_bucket_name('id-verification')
@@ -42,13 +51,9 @@ class Insured::PaperApplicationsController < ApplicationController
       flash[:error] = "File does not exist or you are not authorized to access it."
       redirect_to verification_insured_families_path
     end
-    #vlp_docs_clean(@person)
   end
 
   private
-  def updateable?
-    authorize Family, :updateable?
-  end
 
   def get_family
     set_current_person

--- a/app/policies/family_policy.rb
+++ b/app/policies/family_policy.rb
@@ -146,6 +146,26 @@ class FamilyPolicy < ApplicationPolicy
     show?
   end
 
+  # Determines if the user has permission to upload a paper application.
+  # This feature is only applicable for the Coverall Market.
+  # The user can upload a paper application if they are an admin in the coverall market.
+  #
+  # @return [Boolean] Returns true if the user has permission to upload a paper application, false otherwise.
+  # @note This method is used in the upload_paper_application action of the PaperApplicationsController.
+  def upload_paper_application?
+    coverall_market_admin?
+  end
+
+  # Determines if the user has permission to download a paper application.
+  # This feature is only applicable for the Coverall Market.
+  # The user can download a paper application if they are an admin in the coverall market.
+  #
+  # @return [Boolean] Returns true if the user has permission to download a paper application, false otherwise.
+  # @note This method is used in the download_paper_application action of the PaperApplicationsController.
+  def download_paper_application?
+    coverall_market_admin?
+  end
+
   def upload_application?
     admin_show?
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 187136944](https://www.pivotaltracker.com/story/show/187136944)

# A brief description of the changes

Current behavior: No authorization for all the endpoints of `Insured::PaperApplicationsController`.

New behavior: Adds authorization for all the endpoints of `Insured::PaperApplicationsController`.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.