### PR TITLE
fix account transfer of middle name

### DIFF
--- a/app/event_source/subscribers/atp_subscriber.rb
+++ b/app/event_source/subscribers/atp_subscriber.rb
@@ -28,10 +28,9 @@ module Subscribers
         logger.info "AtpSubscriber: acked with success: #{result.success}"
       else
         transfer_details[:result] = "Failed"
-        transfer_details[:failure] = "Unsuccessfully ingested by Enroll - #{result.failure.full_messages.join(', ')}"
-        errors = result.failure
+        transfer_details[:failure] = "Unsuccessfully ingested by Enroll - #{result.failure}"
         nack(delivery_info.delivery_tag)
-        logger.info "AtpSubscriber: nacked with failure, errors: #{errors.full_messages.join(', ')}"
+        logger.info "AtpSubscriber: nacked with failure, errors: #{result.failure}"
       end
       FinancialAssistance::Operations::Transfers::MedicaidGateway::PublishTransferResponse.new.call(transfer_details)
     rescue StandardError => e

--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -463,6 +463,7 @@ module FinancialAssistance
             phash = {
               first_name: person_hash['person_name']['first_name'],
               last_name: person_hash['person_name']['last_name'],
+              middle_name: person_hash['person_name']['middle_name'],
               full_name: person_hash['person_name']['full_name'],
               ssn: person_hash['person_demographics']['ssn'],
               no_ssn: transform_no_ssn(person_hash['person_demographics']['ssn']), # update in aca entities contracts to receive as string

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
         expect(app.transferred_at).not_to eq nil
       end
 
+      it 'should persist the person name' do
+        app = FinancialAssistance::Application.find(@result.value!)
+        @transformed.deep_symbolize_keys!
+        expect(app.applicants.first.first_name).to eq(@transformed[:family][:family_members][0][:person][:person_name][:first_name])
+        expect(app.applicants.first.last_name).to eq(@transformed[:family][:family_members][0][:person][:person_name][:last_name])
+        expect(app.applicants.first.middle_name).to eq(@transformed[:family][:family_members][0][:person][:person_name][:middle_name])
+      end
+
       context "two applicants share the same first and last name" do
         before do
           record = serializer.parse(xml)

--- a/components/financial_assistance/spec/shared_examples/medicaid_gateway/Simple_Test_Case_E_New.json
+++ b/components/financial_assistance/spec/shared_examples/medicaid_gateway/Simple_Test_Case_E_New.json
@@ -5,7 +5,7 @@
             {
                 "person": {
                     "ext_app_id": "pe1992374604681766994",
-                    "person_name": { "first_name": "Laura", "middle_name": null, "last_name": "Banfield", "full_name": "Laura Banfield" },
+                    "person_name": { "first_name": "Laura", "middle_name": "Shelby", "last_name": "Banfield", "full_name": "Laura Shelby Banfield" },
                     "hbx_id": "1234",
                     "person_health": { "is_tobacco_user": "unknown", "is_physically_disabled": null },
                     "is_homeless": false,
@@ -59,7 +59,7 @@
                     ],
                     "emails": [{ "address": "LB37@gmail.com", "kind": "home" }],
                     "phones": [{ "full_phone_number": "9991510341", "kind": "mobile", "primary": true, "start_on": null, "end_on": null, "extension": null, "area_code": "999", "number": "1510341" }],
-                    "person_relationships": [{ "relative": { "hbx_id": "1234", "first_name": "Laura", "last_name": "Banfield", "gender": "Female", "dob": "1984-01-01", "ssn": null }, "kind": "self" }]
+                    "person_relationships": [{ "relative": { "hbx_id": "1234", "first_name": "Laura", "middle_name": "Shelby", "last_name": "Banfield", "gender": "Female", "dob": "1984-01-01", "ssn": null }, "kind": "self" }]
                 },
                 "ethnicity": [],
                 "is_consent_applicant": null,
@@ -123,7 +123,7 @@
                     ],
                     "emails": [{ "address": "LB37@gmail.com", "kind": "home" }],
                     "phones": [{ "full_phone_number": "9992228341", "kind": "mobile", "primary": false, "start_on": null, "end_on": null, "extension": null, "area_code": "999", "number": "2228341" }],
-                    "person_relationships": [{ "relative": { "hbx_id": "1234", "first_name": "Laura", "last_name": "Banfield", "gender": "Female", "dob": "1984-01-01", "ssn": null }, "kind": "parent" }]
+                    "person_relationships": [{ "relative": { "hbx_id": "1234", "first_name": "Laura", "middle_name": "Shelby", "last_name": "Banfield", "gender": "Female", "dob": "1984-01-01", "ssn": null }, "kind": "parent" }]
                 },
                 "ethnicity": [],
                 "is_consent_applicant": null,
@@ -188,7 +188,7 @@
                     ],
                     "emails": [{ "address": "JC60@gmail.com", "kind": "home" }],
                     "phones": [{ "full_phone_number": "4041768941", "kind": "mobile", "primary": false, "start_on": null, "end_on": null, "extension": null, "area_code": "404", "number": "1768941" }],
-                    "person_relationships": [{ "relative": { "hbx_id": "1234", "first_name": "Laura", "last_name": "Banfield", "gender": "Female", "dob": "1984-01-01", "ssn": null }, "kind": "domestic_partner" }]
+                    "person_relationships": [{ "relative": { "hbx_id": "1234", "first_name": "Laura", "middle_name": "Shelby", "last_name": "Banfield", "gender": "Female", "dob": "1984-01-01", "ssn": null }, "kind": "domestic_partner" }]
                 },
                 "ethnicity": [],
                 "is_consent_applicant": null,
@@ -217,7 +217,7 @@
                 "applicants": [
                     {
                         "is_primary_applicant": true,
-                        "name": { "first_name": "Laura", "middle_name": "", "last_name": "Banfield", "name_sfx": "", "name_pfx": "", "full_name": "Laura Banfield", "alternate_name": "nil" },
+                        "name": { "first_name": "Laura", "middle_name": "Shelby", "last_name": "Banfield", "name_sfx": "", "name_pfx": "", "full_name": "Laura Shelby Banfield", "alternate_name": "nil" },
                         "identifying_information": { "encrypted_ssn": null, "has_ssn": false },
                         "demographic": { "gender": "female", "dob": "01/01/1984", "ethnicity": [], "race": null, "is_veteran_or_active_military": false, "is_vets_spouse_or_child": null },
                         "attestation": { "is_self_attested_disabled": false, "is_self_attested_long_term_care": false, "is_self_attested_blind": false },
@@ -232,7 +232,7 @@
                         "is_applying_coverage": true,
                         "is_consent_applicant": null,
                         "vlp_document": null,
-                        "family_member_reference": { "family_member_hbx_id": "1234", "first_name": "Laura", "last_name": "Banfield", "person_hbx_id": "1234", "is_primary_family_member": true },
+                        "family_member_reference": { "family_member_hbx_id": "1234", "first_name": "Laura", "middle_name": "Shelby", "last_name": "Banfield", "person_hbx_id": "1234", "is_primary_family_member": true },
                         "person_hbx_id": "pe1992374604681766994",
                         "is_required_to_file_taxes": true,
                         "tax_filer_kind": null,


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187251362 && https://www.pivotaltracker.com/story/show/187279669

# A brief description of the changes

Current behavior: Middle name is not transferring over with MG account transfers; When there is an error with a transfer, the message is not being read out correctly

New behavior: Correction to the error handling and enroll now will hash out the middle name. Specs added.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

Error working screenshot:
<img width="872" alt="Screenshot 2024-03-27 at 9 09 27 AM" src="https://github.com/ideacrew/enroll/assets/45053146/d0711933-c74a-4d94-ab3f-3ccbc47761fe">


# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.