### PR TITLE
getting person before authorize ridp failed validation

### DIFF
--- a/app/controllers/insured/fdsh_ridp_verifications_controller.rb
+++ b/app/controllers/insured/fdsh_ridp_verifications_controller.rb
@@ -113,11 +113,11 @@ module Insured
     end
 
     def failed_validation
-      authorize @person, :complete_ridp?
       @person = Person.find(params[:person_id]) if params[:person_id].present?
+      authorize @person, :complete_ridp?
+
       @step = params[:step]
       @verification_transaction_id = params[:verification_transaction_id]
-      @person = Person.find(params[:person_id]) if params[:person_id].present?
       @person.consumer_role.move_identity_documents_to_outstanding
       render "failed_validation"
     end

--- a/spec/controllers/insured/fdsh_ridp_verifications_controller_spec.rb
+++ b/spec/controllers/insured/fdsh_ridp_verifications_controller_spec.rb
@@ -62,18 +62,27 @@ describe Insured::FdshRidpVerificationsController do
     let(:user){ FactoryBot.create(:user, :consumer, person: person) }
     let(:person){ FactoryBot.create(:person, :with_consumer_role) }
 
-    context "GET failed_validation", dbclean: :after_each do
-      before(:each) do
-        sign_in user
-        allow(user).to receive(:person).and_return(person)
-      end
+    before(:each) do
+      sign_in user
+      allow(user).to receive(:person).and_return(person)
+    end
 
+    context "GET failed_validation", dbclean: :after_each do
       it "should render template" do
         allow_any_instance_of(ConsumerRole).to receive(:move_identity_documents_to_outstanding).and_return(true)
         get :failed_validation, params: {}
 
         expect(response).to have_http_status(:success)
         expect(response).to render_template("failed_validation")
+      end
+    end
+
+    context "when unauthorized person id is passed in params" do
+      let(:duplicate_person) { FactoryBot.create(:person, :with_consumer_role) }
+
+      it "should fail pundit policy" do
+        get :failed_validation, params: { person_id: duplicate_person.id }
+        expect(response.status).to eq 302
       end
     end
   end

--- a/spec/controllers/insured/fdsh_ridp_verifications_controller_spec.rb
+++ b/spec/controllers/insured/fdsh_ridp_verifications_controller_spec.rb
@@ -75,6 +75,14 @@ describe Insured::FdshRidpVerificationsController do
         expect(response).to have_http_status(:success)
         expect(response).to render_template("failed_validation")
       end
+
+      it "should render template when correct person id is passed" do
+        allow_any_instance_of(ConsumerRole).to receive(:move_identity_documents_to_outstanding).and_return(true)
+        get :failed_validation, params: { person_id: person.id }
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template("failed_validation")
+      end
     end
 
     context "when unauthorized person id is passed in params" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187324663

# A brief description of the changes

Current behavior: Authorize was before the person_id

New behavior: Authorize is after the person_id

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.