### PR TITLE
block plan shopping on an submitted enrollment

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -293,6 +293,23 @@ class Insured::PlanShoppingsController < ApplicationController
     false
   end
 
+  # Sets the HTTP response headers to prevent caching.
+  #
+  # This method sets the `Cache-Control` and `Pragma` headers in the HTTP response
+  # to instruct browsers and caches to always request a fresh copy of the response
+  # from the server, rather than serving a cached version.
+  #
+  # The `Cache-Control` header is set with the following directives:
+  #
+  # - `no-cache`: The response may be stored by caches, but they must first validate
+  #   the response with the server before using it.
+  # - `no-store`: The response must not be stored in any cache, including browser caches.
+  # - `private`: The response should only be cached by a single user's browser, not by
+  #   shared caches.
+  # - `must-revalidate`: Caches must verify the status of the response with the server
+  #   before using a cached copy.
+  #
+  # @return [void]
   def set_cache_headers
     response.headers["Cache-Control"] = "no-cache, no-store, private, must-revalidate"
     response.headers["Pragma"] = "no-cache"

--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -298,7 +298,6 @@ class Insured::PlanShoppingsController < ApplicationController
     response.headers["Pragma"] = "no-cache"
   end
 
-
   # Determines if the user has already submitted an enrollment.
   # The user has already submitted an enrollment if the current enrollment is not in the shopping state.
   #

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -574,6 +574,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.ssn_configuration_warning' => "This Social Security Number and Date-of-Birth is invalid in our records.  Please verify the entry, and if correct, contact the DC Customer help center at %{site_phone_number}.",
   :'en.insured.match_person.ssn_dob_name_error' => "This Social Security Number, Date-of-Birth and Name are invalid in our records. Please verify the entry, and if correct, contact the %{contact_center_name} at %{contact_center_phone_number}.",
   :'en.insured.out_of_state_error_message' => "Address is out of state or the supported area, please review your application details to update your address",
+  :'en.insured.active_enrollment_warning' => "You already have an active enrollment. If you wish to change it, please use the Shop for Plans option.",
   :'en.enrollment.details.header' => 'Enrollment Detail',
   :'en.enrollment.members.header' => 'Enrollment Member Detail',
   :'en.enrollment.effective_on' => 'Effective Date: ',

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -574,7 +574,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.ssn_configuration_warning' => "This Social Security Number and Date-of-Birth is invalid in our records.  Please verify the entry, and if correct, contact the DC Customer help center at %{site_phone_number}.",
   :'en.insured.match_person.ssn_dob_name_error' => "This Social Security Number, Date-of-Birth and Name are invalid in our records. Please verify the entry, and if correct, contact the %{contact_center_name} at %{contact_center_phone_number}.",
   :'en.insured.out_of_state_error_message' => "Address is out of state or the supported area, please review your application details to update your address",
-  :'en.insured.active_enrollment_warning' => "You already have an active enrollment. If you wish to change it, please use the Shop for Plans option.",
+    :'en.insured.active_enrollment_warning' => "To choose a new plan, select 'Shop for Plans'",
   :'en.enrollment.details.header' => 'Enrollment Detail',
   :'en.enrollment.members.header' => 'Enrollment Member Detail',
   :'en.enrollment.effective_on' => 'Effective Date: ',

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -573,6 +573,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.ssn_configuration_warning' => "Please check your information and try again. If you’ve already done an application with Healthcare.gov, the Maine Office for Family Independence, or %{site_short_name}, you’ll need to enter your information the same way here. If you have questions, call the %{site_short_name} Consumer Assistance Center at %{site_phone_number} TTY: %{site_tty_number}.",
   :'en.insured.match_person.ssn_dob_name_error' => "Please check your information and try again. If you’ve already done an application with Healthcare.gov, the Maine Office for Family Independence, or %{site_short_name}, you’ll need to enter your information the same way here. If you have questions, call the %{contact_center_name} at %{contact_center_phone_number} TTY: %{contact_center_tty_number}.",
   :'en.insured.out_of_state_error_message' => "Address is out of state or the supported area, please review your application details to update your address",
+  :'en.insured.active_enrollment_warning' => "You already have an active enrollment. If you wish to change it, please use the Shop for Plans option.",
   :'en.enrollment.details.header' => 'Enrollment Detail',
   :'en.enrollment.members.header' => 'Enrollment Member Detail',
   :'en.enrollment.effective_on' => 'Effective Date: ',

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -573,7 +573,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.ssn_configuration_warning' => "Please check your information and try again. If you’ve already done an application with Healthcare.gov, the Maine Office for Family Independence, or %{site_short_name}, you’ll need to enter your information the same way here. If you have questions, call the %{site_short_name} Consumer Assistance Center at %{site_phone_number} TTY: %{site_tty_number}.",
   :'en.insured.match_person.ssn_dob_name_error' => "Please check your information and try again. If you’ve already done an application with Healthcare.gov, the Maine Office for Family Independence, or %{site_short_name}, you’ll need to enter your information the same way here. If you have questions, call the %{contact_center_name} at %{contact_center_phone_number} TTY: %{contact_center_tty_number}.",
   :'en.insured.out_of_state_error_message' => "Address is out of state or the supported area, please review your application details to update your address",
-  :'en.insured.active_enrollment_warning' => "You already have an active enrollment. If you wish to change it, please use the Shop for Plans option.",
+  :'en.insured.active_enrollment_warning' => "To choose a new plan, select 'Shop for Plans'",
   :'en.enrollment.details.header' => 'Enrollment Detail',
   :'en.enrollment.members.header' => 'Enrollment Member Detail',
   :'en.enrollment.effective_on' => 'Effective Date: ',

--- a/features/insured/individual_plan_shopping.feature
+++ b/features/insured/individual_plan_shopping.feature
@@ -1,0 +1,17 @@
+Feature: Consumer plan shopping
+  Scenario: Consumer cannot update their plan using browser back after enrollment is submitted
+    Given a ME site exists
+    And that a person exists in EA
+    And the person fills in all personal info
+    And the person goes plan shopping in the individual for a new plan
+    And the person lands on home page
+    When person click the "Had a baby" in qle carousel
+    And the consumer select a future qle date
+    Then person should see family members page and clicks continue
+    Then person should see the group selection page
+    When person clicks continue on group selection page
+    And the person selects a plan
+    And I click on purchase confirm button for matched person
+    Then I should see pay now button
+    When user clicks browser back button
+    Then user should redirect to home page and should see a flash message

--- a/features/insured/step_definitions/individual_steps.rb
+++ b/features/insured/step_definitions/individual_steps.rb
@@ -41,6 +41,14 @@ When(/(.*) click the "(.*?)" in qle carousel/) do |_name, qle_event|
   click_link qle_event.to_s
 end
 
+When(/(.*) clicks browser back button/) do |_name|
+  @browser.execute_script('window.history.back()')
+end
+
+Then(/(.*) should redirect to home page and should see a flash message/) do |_name|
+  expect(page).to have_content(l10n("insured.active_enrollment_warning"))
+end
+
 Then(/(.*) should see family members page and clicks continue/) do |_name|
   expect(page).to have_content l10n('family_information').to_s
   find('#dependent_buttons .interaction-click-control-continue', :wait => 5).click

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -211,6 +211,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
                         :with_silver_health_product,
                         :individual_unassisted,
                         effective_on: start_of_year,
+                        aasm_state: "shopping",
                         family: family10,
                         household: family10.active_household,
                         coverage_kind: "health",
@@ -326,6 +327,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
                         :individual_unassisted,
                         effective_on: start_of_year.next_month,
                         family: family10,
+                        aasm_state: "shopping",
                         product_id: hbx_enrollment10.product_id,
                         household: family10.active_household,
                         coverage_kind: "health",
@@ -435,6 +437,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
     let(:product_delegator) { double }
 
     before do
+      hbx_enrollment.update_attributes(aasm_state: "shopping")
       allow(user).to receive(:person).and_return(person)
       allow(HbxEnrollment).to receive(:find).with("id").and_return(hbx_enrollment)
       allow(BenefitMarkets::Products::Product).to receive(:find).with("plan_id").and_return(product)
@@ -583,6 +586,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
                           product: product,
                           household: family.active_household,
                           coverage_kind: "health",
+                          aasm_state: "shopping",
                           kind: 'individual',
                           hbx_enrollment_members: [hbx_enrollment_member, hbx_enrollment_member_1],
                           aasm_state: 'coverage_selected')
@@ -592,6 +596,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
                           family: family,
                           product: product,
                           kind: 'individual',
+                          aasm_state: "shopping",
                           household: family.active_household,
                           coverage_kind: "health",
                           hbx_enrollment_members: [hbx_enrollment_member_1],
@@ -711,6 +716,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
                         family: family,
                         household: family.latest_household,
                         coverage_kind: 'health',
+                        aasm_state: "shopping",
                         effective_on: effective_on,
                         enrollment_kind: 'open_enrollment',
                         kind: 'individual',
@@ -722,6 +728,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
       FactoryBot.create(:hbx_enrollment, :with_product, sponsored_benefit_package_id: benefit_group_assignment.benefit_group.id,
                                                         family: household.family,
                                                         household: household,
+                                                        aasm_state: 'shopping',
                                                         hbx_enrollment_members: [hbx_enrollment_member],
                                                         coverage_kind: "health",
                                                         external_enrollment: false,
@@ -1410,6 +1417,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
     shared_examples_for "logged in user has no authorization roles" do |action|
       before do
         allow(HbxEnrollment).to receive(:find).with("id").and_return(hbx_enrollment)
+        hbx_enrollment.update_attributes(aasm_state: 'shopping') if action == :thankyou
       end
 
       it "redirects to root with flash message" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187329846

# A brief description of the changes

Current behavior: Users can plan shop and change the product on an already submitted enrollment by clicking the browser's back button

New behavior: Redirect users to the Families Home page when a user tries to update the Product using the browser back button on an already submitted enrollment

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.