### PR TITLE
convert integers to string values at the base query

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -352,7 +352,7 @@ class Family
   scope :with_aptc_csr_grants_for_year, lambda { |assistance_year, csr_list|
                                           where({ "$and" => [
                                                               {"eligibility_determination.grants" => {"$elemMatch": {"key" => "AdvancePremiumAdjustmentGrant", "assistance_year" => assistance_year, "value" => { "$gt" => "0" }}}},
-                                                              {"eligibility_determination.subjects.eligibility_states.grants" => {"$elemMatch" => {"key" => "CsrAdjustmentGrant", "assistance_year" => assistance_year, "value" => {"$in" => csr_list}}}}
+                                                              {"eligibility_determination.subjects.eligibility_states.grants" => {"$elemMatch" => {"key" => "CsrAdjustmentGrant", "assistance_year" => assistance_year, "value" => {"$in" => csr_list.map(&:to_s)}}}}
                                                             ] })
                                         }
 

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -352,7 +352,8 @@ class Family
   scope :with_aptc_csr_grants_for_year, lambda { |assistance_year, csr_list|
                                           where({ "$and" => [
                                                               {"eligibility_determination.grants" => {"$elemMatch": {"key" => "AdvancePremiumAdjustmentGrant", "assistance_year" => assistance_year, "value" => { "$gt" => "0" }}}},
-                                                              {"eligibility_determination.subjects.eligibility_states.grants" => {"$elemMatch" => {"key" => "CsrAdjustmentGrant", "assistance_year" => assistance_year, "value" => {"$in" => csr_list.map(&:to_s)}}}}
+                                                              {"eligibility_determination.subjects.eligibility_states.grants" => {"$elemMatch" => {"key" => "CsrAdjustmentGrant", "assistance_year" => assistance_year,
+                                                                                                                                                   "value" => {"$in" => csr_list.map(&:to_s)}}}}
                                                             ] })
                                         }
 

--- a/spec/models/family_spec_2.rb
+++ b/spec/models/family_spec_2.rb
@@ -283,5 +283,18 @@ RSpec.describe Family, dbclean: :around_each do
         expect(result.count).to eq(0)
       end
     end
+
+    context 'enrolled family with aptc and csr_87 for all members' do
+      let(:yearly_expected_contribution_current) { 1000 }
+      let(:yearly_expected_contribution_previous) { 0 }
+      let(:members_csr_set) { {family_member1 => '87', family_member2 => '87'} }
+
+      it 'when csr is passed as array of integer values' do
+        result = Family.with_active_coverage_and_aptc_csr_grants_for_year(assistance_year, [87, 94])
+
+        expect(result).to include(family)
+        expect(result.count).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2648255/stories/187338788#

# A brief description of the changes

Current behavior: When csr values are passed as integer, query result in 0.

New behavior: Irrespective of the type string or integer value passed as param, query should be executed.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.