### PR TITLE
script to generate a report of pvc determined families

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/submit_pvc_set.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/submit_pvc_set.rb
@@ -26,8 +26,8 @@ module FinancialAssistance
           # @return [ Success ] Job successfully completed
           def call(params)
             values = yield validate(params)
-            families = find_families(values)
-            submit(params, families)
+            family_ids = find_families(values)
+            submit(params, family_ids)
 
             Success("Successfully Submitted PVC Set")
           end
@@ -43,7 +43,7 @@ module FinancialAssistance
 
           def find_families(params)
             if EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
-              Family.with_active_coverage_and_aptc_csr_grants_for_year(params[:assistance_year], params[:csr_list])
+              Family.with_active_coverage_and_aptc_csr_grants_for_year(params[:assistance_year], params[:csr_list]).distinct(:_id)
             else
               Family.periodic_verifiable_for_assistance_year(params[:assistance_year], params[:csr_list]).distinct(:_id)
             end

--- a/script/export_pvc_determined_families.rb
+++ b/script/export_pvc_determined_families.rb
@@ -45,11 +45,11 @@ CSV.open("export_pvc_determined_families_#{TimeKeeper.date_of_record.strftime('%
     determined_application.active_applicants.each do |applicant|
       non_esi_evidence = applicant.non_esi_evidence
       next if non_esi_evidence.blank?
-      request_result = non_esi_evidence.request_results.max_by(&:created_at)
+      request_result = non_esi_evidence.request_results.max_by(&:date_of_action)
       pvc_determination = request_result&.result || 'no pvc result found'
       workflow_transition = non_esi_evidence.workflow_state_transitions.max_by(&:created_at)
 
-      verification_history = non_esi_evidence.verification_histories.max_by(&:created_at)
+      verification_history = non_esi_evidence.verification_histories.max_by(&:date_of_action)
 
       counter += 1
 

--- a/script/export_pvc_determined_families.rb
+++ b/script/export_pvc_determined_families.rb
@@ -12,22 +12,11 @@ family_ids = Family.with_active_coverage_and_aptc_csr_grants_for_year(assistance
 
 p "found #{family_ids.count} families"  unless Rails.env.test?
 
-CSV.open("export_pvc_families_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv", "w") do |csv|
-  csv << [
-    'Primary HbxId',
-    "Most recent determined #{assistance_year} application ID",
-    "Most recent determined #{assistance_year} application determination date",
-    "Latest active #{assistance_year} health plan HIOS-ID",
-    "Latest active #{assistance_year} health plan state (autorenewing, coverage_selected etc)",
-    'APTC applied on latest active health plan',
-    'Applicants person hbx_id with out SSN'
-  ]
-
+CSV.open("export_pvc_determined_families_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv", "w") do |csv|
   csv << [
       "Primary Person Hbx ID",
       "Applicant Person Hbx ID",
-      "Determined Application Hbx ID",
-      "Determined At",
+      "Most recent Determined #{assistance_year} Application Hbx ID",
       "Is SSN Present",
       "Non ESI Evidence Title",
       "Workflow Transition From State",
@@ -68,7 +57,6 @@ CSV.open("export_pvc_families_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.
           primary_person.hbx_id,
           applicant.person_hbx_id,
           determined_application.hbx_id,
-          determined_at&.strftime('%m/%d/%Y'),
           applicant.encrypted_ssn.present?,
           non_esi_evidence.title,
           workflow_transition&.from_state,

--- a/script/export_pvc_families.rb
+++ b/script/export_pvc_families.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# This script generates a CSV report with information about families with renewal determined applications for the assistance_year with no SSN applicants.
+
+# To run this on specific enrollments
+# bundle exec rails runner script/export_pvc_families.rb assistance_year='2023'
+
+assistance_year = ENV['assistance_year'].to_i
+csr_list = [100, 73, 87, 94].freeze
+
+family_ids = Family.with_active_coverage_and_aptc_csr_grants_for_year(assistance_year, csr_list).distinct(:_id)
+
+p "found #{family_ids.count} families"  unless Rails.env.test?
+
+CSV.open("export_pvc_families_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv", "w") do |csv|
+  csv << [
+    'Primary HbxId',
+    "Most recent determined #{assistance_year} application ID",
+    "Most recent determined #{assistance_year} application determination date",
+    "Latest active #{assistance_year} health plan HIOS-ID",
+    "Latest active #{assistance_year} health plan state (autorenewing, coverage_selected etc)",
+    'APTC applied on latest active health plan',
+    'Applicants person hbx_id with out SSN'
+  ]
+
+  csv << [
+      "Primary Person Hbx ID",
+      "Applicant Person Hbx ID",
+      "Determined Application Hbx ID",
+      "Determined At",
+      "Is SSN Present",
+      "Non ESI Evidence Title",
+      "Workflow Transition From State",
+      "Workflow Transition To State",
+      "Verification History Action",
+      "Verification History Update Reason",
+      "Verification History Updated By",
+      "Response Created At",
+      "PVC Determination"
+      ]
+
+  counter = 0
+
+  family_ids.each do |family_id|
+    family = Family.where(:_id => family_id).first
+    primary_person = family.primary_person
+
+    applications = ::FinancialAssistance::Application.where(:family_id => family.id,
+                                                            :assistance_year => assistance_year,
+                                                            :aasm_state => 'determined',
+                                                            :"applicants.is_ia_eligible" => true)
+
+    determined_application = applications.exists(:predecessor_id => true).max_by(&:submitted_at)
+    next if determined_application.blank?
+
+    determined_application.active_applicants.each do |applicant|
+      non_esi_evidence = applicant.non_esi_evidence
+      next if non_esi_evidence.blank?
+      request_result = non_esi_evidence.request_results.max_by(&:created_at)
+      pvc_determination = request_result&.result || 'no pvc result found'
+      workflow_transition = non_esi_evidence.workflow_state_transitions.max_by(&:created_at)
+
+      verification_history = non_esi_evidence.verification_histories.max_by(&:created_at)
+
+      counter += 1
+
+      csv << [
+          primary_person.hbx_id,
+          applicant.person_hbx_id,
+          determined_application.hbx_id,
+          determined_at&.strftime('%m/%d/%Y'),
+          applicant.encrypted_ssn.present?,
+          non_esi_evidence.title,
+          workflow_transition&.from_state,
+          workflow_transition&.to_state,
+          verification_history&.action,
+          verification_history&.update_reason,
+          verification_history&.updated_by,
+          request_result&.created_at,
+          pvc_determination
+      ]
+    end
+  end
+
+  p "processed #{counter} families"  unless Rails.env.test?
+end

--- a/spec/script/export_pvc_determined_families_spec.rb
+++ b/spec/script/export_pvc_determined_families_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'export_rrv_families' do
+  before do
+    DatabaseCleaner.clean
+  end
+
+  let(:date) { TimeKeeper.date_of_record }
+  let(:assistance_year) { date.year }
+  let(:csr) { ["87", "94"] }
+
+  let(:family) do
+    family = FactoryBot.build(:family, person: primary)
+    family.family_members = [
+      FactoryBot.build(:family_member, is_primary_applicant: true, is_active: true, family: family, person: primary),
+      FactoryBot.build(:family_member, is_primary_applicant: false, is_active: true, family: family, person: dependent)
+    ]
+
+    family.person.person_relationships.push PersonRelationship.new(relative_id: dependent.id, kind: 'spouse')
+    family.save
+    family
+  end
+
+  let(:dependent) { FactoryBot.create(:person) }
+  let(:primary) {  FactoryBot.create(:person, :with_consumer_role)}
+  let(:primary_applicant) { family.primary_applicant }
+  let(:dependents) { family.dependents }
+  let!(:tax_household_group_current) do
+    family.tax_household_groups.create!(
+      assistance_year: assistance_year,
+      source: 'Admin',
+      start_on: date.beginning_of_year,
+      tax_households: [
+        FactoryBot.build(:tax_household, household: family.active_household, effective_starting_on: date.beginning_of_year, effective_ending_on: TimeKeeper.date_of_record.end_of_year, max_aptc: 1000.00)
+      ]
+    )
+  end
+
+  let(:tax_household_current) do
+    tax_household_group_current.tax_households.first
+  end
+
+  let!(:tax_household_member) { tax_household_current.tax_household_members.create(applicant_id: family.family_members[0].id, csr_percent_as_integer: 87, csr_eligibility_kind: "csr_87") }
+
+  let!(:hbx_enrollment) do
+    FactoryBot.create(:hbx_enrollment,
+                      :individual_shopping,
+                      :with_silver_health_product,
+                      :with_enrollment_members,
+                      enrollment_members: [primary_applicant],
+                      effective_on: date.beginning_of_month,
+                      family: family,
+                      aasm_state: :coverage_selected)
+  end
+  let!(:thh_start_on) { tax_household_current.effective_starting_on }
+
+  let(:family_member1) { family.family_members[0] }
+  let(:family_member2) { family.family_members[1] }
+  let!(:ivl_enr_member2)   { FactoryBot.create(:hbx_enrollment_member, applicant_id: family_member2.id, hbx_enrollment: hbx_enrollment, eligibility_date: thh_start_on) }
+
+  let(:yearly_expected_contribution_current) { 125.00 * 12 }
+  let(:members_csr_set) { {family_member1 => '87', family_member2 => '87'} }
+  let!(:eligibility_determination_current) do
+    determination = family.create_eligibility_determination(effective_date: date.beginning_of_year)
+    determination.grants.create(
+      key: "AdvancePremiumAdjustmentGrant",
+      value: yearly_expected_contribution_current,
+      start_on: date.beginning_of_year,
+      end_on: date.end_of_year,
+      assistance_year: date.year,
+      member_ids: family.family_members.map(&:id).map(&:to_s),
+      tax_household_id: tax_household_current.id
+    )
+
+    members_csr_set.each do |family_member, csr_value|
+      subject = determination.subjects.create(
+        gid: "gid://enroll/FamilyMember/#{family_member.id}",
+        is_primary: family_member.is_primary_applicant,
+        person_id: family_member.person.id
+      )
+
+      state = subject.eligibility_states.create(eligibility_item_key: 'aptc_csr_credit')
+      state.grants.create(
+        key: "CsrAdjustmentGrant",
+        value: csr_value,
+        start_on: TimeKeeper.date_of_record.beginning_of_year,
+        end_on: TimeKeeper.date_of_record.end_of_year,
+        assistance_year: TimeKeeper.date_of_record.year,
+        member_ids: family.family_members.map(&:id)
+      )
+    end
+
+    determination
+  end
+
+  let!(:non_esi_evidence) do
+    applicant.non_esi_evidence = FactoryBot.build(:evidence, :with_request_results, key: :non_esi_mec, title: 'Non ESI MEC')
+    applicant.save!
+    applicant.non_esi_evidence
+  end
+
+  let!(:non_esi_evidence2) do
+    applicant2.non_esi_evidence = FactoryBot.build(:evidence, :with_request_results, key: :non_esi_mec, title: 'Non ESI MEC')
+    applicant2.save!
+    applicant2.non_esi_evidence
+  end
+
+  let!(:verification_history) { non_esi_evidence&.add_verification_history('PVC_Submitted', 'PVC - Renewal verifications submitted', 'system') }
+  let!(:verification_history2) { non_esi_evidence2&.add_verification_history('PVC_Submitted', 'PVC - Renewal verifications submitted', 'system') }
+  let(:yesterday) { Time.now.getlocal.prev_day }
+  let!(:application) do
+    FactoryBot.create(
+      :financial_assistance_application,
+      submitted_at: yesterday,
+      family_id: family.id,
+      predecessor_id: BSON::ObjectId.new
+    )
+  end
+
+  let!(:applicant) do
+    FactoryBot.create(
+      :financial_assistance_applicant,
+      :with_home_address,
+      application: application,
+      family_member_id: family_member1.id,
+      is_primary_applicant: true,
+      citizen_status: 'us_citizen',
+      is_ia_eligible: true,
+      is_medicaid_chip_eligible: false,
+      csr_percent_as_integer: 73,
+      first_name: primary.first_name,
+      last_name: primary.last_name,
+      gender: primary.gender,
+      dob: primary.dob,
+      encrypted_ssn: primary.encrypted_ssn,
+      magi_as_percentage_of_fpl: 1.3
+    )
+  end
+
+  let!(:applicant2) do
+    FactoryBot.create(
+      :financial_assistance_applicant,
+      :spouse,
+      :with_home_address,
+      application: application,
+      family_member_id: family_member2.id,
+      citizen_status: 'alien_lawfully_present',
+      is_ia_eligible: false,
+      is_medicaid_chip_eligible: true,
+      csr_percent_as_integer: 87,
+      first_name: dependent.first_name,
+      last_name: dependent.last_name,
+      gender: dependent.gender,
+      dob: dependent.dob,
+      encrypted_ssn: nil,
+      magi_as_percentage_of_fpl: 1.3
+    )
+  end
+
+  let(:field_names) do
+    [
+        "Primary Person Hbx ID",
+        "Applicant Person Hbx ID",
+        "Most recent Determined #{assistance_year} Application Hbx ID",
+        "Is SSN Present",
+        "Non ESI Evidence Title",
+        "Workflow Transition From State",
+        "Workflow Transition To State",
+        "Verification History Action",
+        "Verification History Update Reason",
+        "Verification History Updated By",
+        "Response Created At",
+        "PVC Determination"
+        ]
+  end
+
+  before :each do
+    application.non_primary_applicants.each{|applicant| application.ensure_relationship_with_primary(applicant, applicant.relationship) }
+    invoke_export_pvc_determined_families_report
+    @file_content = CSV.read("#{Rails.root}/export_pvc_determined_families_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv")
+  end
+
+  it 'should add data to the file' do
+    expect(@file_content.size).to be > 1
+  end
+
+  it 'should contain the requested fields' do
+    expect(@file_content[0]).to eq(field_names)
+  end
+
+  after :each do
+    FileUtils.rm_rf("#{Rails.root}/export_pvc_determined_families_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv")
+  end
+end
+
+def invoke_export_pvc_determined_families_report
+  ENV['assistance_year'] = yesterday.year.to_s
+  export_pvc_determined_families_report = File.join(Rails.root, "script/export_pvc_determined_families.rb")
+  load export_pvc_determined_families_report
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Script
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187032572

# A brief description of the changes

New behavior: Script generates a CSV report with information about pvc determined families with renewal determined applications for the assistance_year.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.