### PR TITLE
Update logic evidence status Call Hub

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination.rb
@@ -71,7 +71,7 @@ module FinancialAssistance
               when "verified"
                 applicant.set_income_evidence_verified
               when "outstanding"
-                if enrolled?(applicant, enrollments) || is_aptc_used?(applicant, enrollments)
+                if enrolled?(applicant, enrollments) && is_aptc_used?(applicant, enrollments)
                   applicant.set_evidence_outstanding(income_evidence)
                 else
                   applicant.set_evidence_to_negative_response(income_evidence)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination.rb
@@ -71,7 +71,7 @@ module FinancialAssistance
               when "verified"
                 applicant.set_income_evidence_verified
               when "outstanding"
-                if enrolled?(applicant, enrollments) && is_aptc_used?(applicant, enrollments)
+                if income_evidence.enrolled_in_any_aptc_csr_enrollments?(enrollments)
                   applicant.set_evidence_outstanding(income_evidence)
                 else
                   applicant.set_evidence_to_negative_response(income_evidence)
@@ -91,21 +91,6 @@ module FinancialAssistance
                 income_evidence.request_results << Eligibilities::RequestResult.new(request_result.to_h)
               end
               applicant.save!
-            end
-
-            def is_aptc_used?(applicant, enrollments)
-              return false if enrollments.blank?
-
-              enrollment_members = enrollments.flat_map(&:hbx_enrollment_members)
-              enrollment_members.select{ |member| member.hbx_id == applicant.person_hbx_id && member.applied_aptc_amount > 0 }
-              enrollment_members.present?
-            end
-
-            def enrolled?(applicant, enrollments)
-              return false if enrollments.blank?
-
-              family_member_ids = enrollments.flat_map(&:hbx_enrollment_members).flat_map(&:applicant_id).uniq
-              family_member_ids.map(&:to_s).include?(applicant.family_member_id.to_s)
             end
           end
         end

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination.rb
@@ -97,7 +97,8 @@ module FinancialAssistance
               return false if enrollments.blank?
 
               enrollment_members = enrollments.flat_map(&:hbx_enrollment_members)
-              enrollment_members.select{|member| member.hbx_id == applicant.person_hbx_id && member.applied_aptc_amount > 0}
+              enrollment_members.select{ |member| member.hbx_id == applicant.person_hbx_id && member.applied_aptc_amount > 0 }
+              enrollment_members.present?
             end
 
             def enrolled?(applicant, enrollments)

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination_spec.rb
@@ -107,10 +107,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Ifsv::H9t::IfsvE
             expect(@result).to be_success
           end
 
-
-          # 2
           context 'with aptc used' do
-            let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_aptc_enrollment_members, family: family, enrollment_members: family.family_members) }
 
             it 'returns negative_response_received' do
               @applicant.reload
@@ -120,27 +117,22 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Ifsv::H9t::IfsvE
             end
           end
 
-          # 3
           context 'without aptc used' do
-            let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members,family: family, enrollment_members: family.family_members) }
 
             it 'returns outstanding' do
               @applicant.reload
               income_evidence = @applicant.income_evidence
-              expect(income_evidence.outstanding?).to be_truthy
-              expect(income_evidence.verification_outstanding).to be_truthy
+              expect(income_evidence.negative_response_received?).to be_truthy
+              expect(income_evidence.verification_outstanding).to be_falsey
             end
           end
         end
 
         context 'when enrolled' do
-          let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members, family: family, enrollment_members: family.family_members) }
-
           it 'should return success' do
             expect(@result).to be_success
           end
 
-          # 1
           context 'with aptc used' do
             let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_aptc_enrollment_members, family: family, enrollment_members: family.family_members) }
 
@@ -152,10 +144,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Ifsv::H9t::IfsvE
             end
           end
 
-          # 4
           context 'without aptc used' do
-            let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members,family: family, enrollment_members: family.family_members) }
-
             it 'returns negative_response_received' do
               @applicant.reload
               income_evidence = @applicant.income_evidence
@@ -165,6 +154,8 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Ifsv::H9t::IfsvE
           end
 
           context 'with csr used' do
+            let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members,family: family, enrollment_members: family.family_members) }
+
             let!(:applicant) do
               FactoryBot.create(:financial_assistance_applicant,
                                 :with_income_evidence,

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination_spec.rb
@@ -107,11 +107,29 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Ifsv::H9t::IfsvE
             expect(@result).to be_success
           end
 
-          it 'should return negative_response_received' do
-            @applicant.reload
-            income_evidence = @applicant.income_evidence
-            expect(income_evidence.negative_response_received?).to be_truthy
-            expect(income_evidence.verification_outstanding).to be_falsey
+
+          # 2
+          context 'with aptc used' do
+            let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_aptc_enrollment_members, family: family, enrollment_members: family.family_members) }
+
+            it 'returns negative_response_received' do
+              @applicant.reload
+              income_evidence = @applicant.income_evidence
+              expect(income_evidence.negative_response_received?).to be_truthy
+              expect(income_evidence.verification_outstanding).to be_falsey
+            end
+          end
+
+          # 3
+          context 'without aptc used' do
+            let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members,family: family, enrollment_members: family.family_members) }
+
+            it 'returns outstanding' do
+              @applicant.reload
+              income_evidence = @applicant.income_evidence
+              expect(income_evidence.outstanding?).to be_truthy
+              expect(income_evidence.verification_outstanding).to be_truthy
+            end
           end
         end
 
@@ -122,13 +140,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Ifsv::H9t::IfsvE
             expect(@result).to be_success
           end
 
-          it 'returns outstanding' do
-            @applicant.reload
-            income_evidence = @applicant.income_evidence
-            expect(income_evidence.outstanding?).to be_truthy
-            expect(income_evidence.verification_outstanding).to be_truthy
-          end
-
+          # 1
           context 'with aptc used' do
             let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_aptc_enrollment_members, family: family, enrollment_members: family.family_members) }
 
@@ -140,14 +152,15 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Ifsv::H9t::IfsvE
             end
           end
 
+          # 4
           context 'without aptc used' do
             let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members,family: family, enrollment_members: family.family_members) }
 
-            it 'returns outstanding' do
+            it 'returns negative_response_received' do
               @applicant.reload
               income_evidence = @applicant.income_evidence
-              expect(income_evidence.outstanding?).to be_truthy
-              expect(income_evidence.verification_outstanding).to be_truthy
+              expect(income_evidence.negative_response_received?).to be_truthy
+              expect(income_evidence.verification_outstanding).to be_falsey
             end
           end
 

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Ifsv::H9t::IfsvE
         end
 
         context 'when enrolled' do
-          let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members, :with_health_product, family: family, enrollment_members: family.family_members ) }
+          let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members, :with_health_product, family: family, enrollment_members: family.family_members) }
 
           it 'should return success' do
             expect(@result).to be_success
@@ -158,7 +158,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Ifsv::H9t::IfsvE
           end
 
           context 'with csr used' do
-            let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members, :with_health_product, family: family, enrollment_members: family.family_members ) }
+            let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_enrollment_members, :with_health_product, family: family, enrollment_members: family.family_members) }
 
             let!(:applicant) do
               FactoryBot.create(:financial_assistance_applicant,


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 

https://www.pivotaltracker.com/n/projects/2640060/stories/187389438

# A brief description of the changes

### Current behavior:

During the hub call for Income DMI, we change DMI status with the following logic:

when is_ifsv_eligible is false

if applicant enrolled **OR** used APTC, then we set status to "Outstanding" 

### New behavior:
when is_ifsv_eligible is false

if applicant enrolled **AND** (used APTC or CSR), then we set status to "Outstanding" 

if applicant enrolled **AND** (not used APTC  or CSR), then we set status to "NRR"

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.