### PR TITLE
Add hash to third-party javascript to ensure integrity.

### DIFF
--- a/app/views/shared/customer_support/_live_chat_scripts.html.erb
+++ b/app/views/shared/customer_support/_live_chat_scripts.html.erb
@@ -1,5 +1,6 @@
 <script
   src="https://apps.usw2.pure.cloud/widgets/9.0/cxbus.min.js"
+  integrity="sha256-xu/77TCuC3IZ/W5KG2pVdVZz727kPOiK2MkVTlFBjEE=" crossorigin="anonymous"
   onload="javascript:CXBus.configure({debug:false,pluginsPath:'https://apps.usw2.pure.cloud/widgets/9.0/plugins/'}); CXBus.loadPlugin('widgets-core');"
 ></script>
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187408493

# A brief description of the changes

Current behavior: The tag for third-party chat javascript does not contain a hash to ensure integrity.

New behavior: There is now an integrity hash on the third-party chat javascript.