### PR TITLE
block plan shopping on an submitted enrollment

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -14,8 +14,8 @@ class Insured::PlanShoppingsController < ApplicationController
   before_action :set_current_person, :only => [:receipt, :thankyou, :waive, :show, :plans, :checkout, :terminate, :plan_selection_callback]
   before_action :set_kind_for_market_and_coverage, only: [:thankyou, :show, :plans, :checkout, :receipt, :set_elected_aptc, :plan_selection_callback]
   before_action :validate_rating_address, only: [:show]
-  before_action :check_enrollment_state, only: [:thankyou]
-  before_action :set_cache_headers, only: [:thankyou]
+  before_action :check_enrollment_state, only: [:show, :thankyou]
+  before_action :set_cache_headers, only: [:show, :thankyou]
 
   def checkout
     (redirect_back(fallback_location: root_path) and return) unless agreed_to_thankyou_ivl_page_terms
@@ -328,7 +328,7 @@ class Insured::PlanShoppingsController < ApplicationController
     return if @hbx_enrollment.shopping?
 
     flash[:notice] = l10n("insured.active_enrollment_warning")
-    redirect_to family_account_path
+    redirect_to receipt_insured_plan_shopping_path(change_plan: params[:change_plan], enrollment_kind: params[:enrollment_kind])
   end
 
   def show_ivl(hbx_enrollment_id)

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -574,7 +574,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.ssn_configuration_warning' => "This Social Security Number and Date-of-Birth is invalid in our records.  Please verify the entry, and if correct, contact the DC Customer help center at %{site_phone_number}.",
   :'en.insured.match_person.ssn_dob_name_error' => "This Social Security Number, Date-of-Birth and Name are invalid in our records. Please verify the entry, and if correct, contact the %{contact_center_name} at %{contact_center_phone_number}.",
   :'en.insured.out_of_state_error_message' => "Address is out of state or the supported area, please review your application details to update your address",
-    :'en.insured.active_enrollment_warning' => "To choose a new plan, select 'Shop for Plans'",
+    :'en.insured.active_enrollment_warning' => "Your enrollment has been submitted and cannot be changed by clicking the back button. To make any changes, continue to your account.",
   :'en.enrollment.details.header' => 'Enrollment Detail',
   :'en.enrollment.members.header' => 'Enrollment Member Detail',
   :'en.enrollment.effective_on' => 'Effective Date: ',

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -573,7 +573,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.ssn_configuration_warning' => "Please check your information and try again. If you’ve already done an application with Healthcare.gov, the Maine Office for Family Independence, or %{site_short_name}, you’ll need to enter your information the same way here. If you have questions, call the %{site_short_name} Consumer Assistance Center at %{site_phone_number} TTY: %{site_tty_number}.",
   :'en.insured.match_person.ssn_dob_name_error' => "Please check your information and try again. If you’ve already done an application with Healthcare.gov, the Maine Office for Family Independence, or %{site_short_name}, you’ll need to enter your information the same way here. If you have questions, call the %{contact_center_name} at %{contact_center_phone_number} TTY: %{contact_center_tty_number}.",
   :'en.insured.out_of_state_error_message' => "Address is out of state or the supported area, please review your application details to update your address",
-  :'en.insured.active_enrollment_warning' => "To choose a new plan, select 'Shop for Plans'",
+  :'en.insured.active_enrollment_warning' => "Your enrollment has been submitted and cannot be changed by clicking the back button. To make any changes, continue to your account.",
   :'en.enrollment.details.header' => 'Enrollment Detail',
   :'en.enrollment.members.header' => 'Enrollment Member Detail',
   :'en.enrollment.effective_on' => 'Effective Date: ',

--- a/features/insured/individual_plan_shopping.feature
+++ b/features/insured/individual_plan_shopping.feature
@@ -14,4 +14,4 @@ Feature: Consumer plan shopping
     And I click on purchase confirm button for matched person
     Then I should see pay now button
     When user clicks browser back button
-    Then user should redirect to home page and should see a flash message
+    Then user should redirect to receipt page and should see a flash message

--- a/features/insured/step_definitions/individual_steps.rb
+++ b/features/insured/step_definitions/individual_steps.rb
@@ -45,7 +45,8 @@ When(/(.*) clicks browser back button/) do |_name|
   @browser.execute_script('window.history.back()')
 end
 
-Then(/(.*) should redirect to home page and should see a flash message/) do |_name|
+Then(/(.*) should redirect to receipt page and should see a flash message/) do |_name|
+  expect(page).to have_content("Enrollment Submitted")
   expect(page).to have_content(l10n("insured.active_enrollment_warning"))
 end
 

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -1114,6 +1114,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
 
     context "normal" do
       before :each do
+        hbx_enrollment.update_attributes(aasm_state: "shopping")
         allow(cost_calculator).to receive(:groups_for_products).with(products).and_return(product_groups)
         allow_any_instance_of(Insured::PlanShoppingsController).to receive(:sort_member_groups).with(product_groups).and_return(member_group)
         allow(hbx_enrollment).to receive(:can_waive_enrollment?).and_return(true)
@@ -1135,6 +1136,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
 
     context "when sponsored_benefit package products are available" do
       before do
+        hbx_enrollment.update_attributes(aasm_state: 'shopping')
         allow(hbx_enrollment).to receive(:can_waive_enrollment?).and_return(true)
         sponsored_benefit_product_packages_product = hbx_enrollment.sponsored_benefit.products(hbx_enrollment.sponsored_benefit.rate_schedule_date).first
         sponsored_benefit_product_packages_product.update_attributes(hsa_eligibility: false)
@@ -1186,6 +1188,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
         let(:user)  { FactoryBot.create(:user, person: person) }
 
         before do
+          hbx_enrollment.update_attributes(aasm_state: 'shopping')
           allow(hbx_enrollment).to receive(:coverage_kind).and_return('health')
           allow(hbx_enrollment).to receive(:is_shop?).and_return(false)
           allow(hbx_enrollment).to receive(:is_coverall?).and_return(false)
@@ -1220,6 +1223,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
 
         context "without tax_household" do
           before :each do
+            hbx_enrollment.update_attributes(aasm_state: 'shopping')
             allow(household).to receive(:latest_active_tax_household_with_year).and_return nil
             allow(family).to receive(:enrolled_hbx_enrollments).and_return([])
             allow(person).to receive(:active_employee_roles).and_return []
@@ -1238,6 +1242,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
 
         context "without tax_household when has aptc session" do
           before :each do
+            hbx_enrollment.update_attributes(aasm_state: 'shopping')
             allow(household).to receive(:latest_active_tax_household_with_year).and_return nil
             allow(family).to receive(:enrolled_hbx_enrollments).and_return([])
             allow(person).to receive(:active_employee_roles).and_return []
@@ -1258,6 +1263,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
 
         context "with tax_household and plan shopping in shop market" do
           before :each do
+            hbx_enrollment.update_attributes(aasm_state: 'shopping')
             allow(household).to receive(:latest_active_tax_household_with_year).and_return tax_household
             allow(tax_household).to receive(:total_aptc_available_amount_for_enrollment).and_return(111)
             allow(family).to receive(:enrolled_hbx_enrollments).and_return([])
@@ -1290,6 +1296,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
       let(:hbx_enrollment) { FactoryBot.create(:hbx_enrollment, family: family1, household: family1.active_household, consumer_role_id: person1.consumer_role.id, kind: 'individual', product_id: product.id)}
 
       before :each do
+        hbx_enrollment.update_attributes(aasm_state: 'shopping')
         allow(EnrollRegistry[:enroll_app].setting(:geographic_rating_area_model)).to receive(:item).and_return('county')
         allow(EnrollRegistry[:enroll_app].setting(:rating_areas)).to receive(:item).and_return('county')
         ::BenefitMarkets::Locations::RatingArea.all.update_all(covered_states: nil)
@@ -1366,6 +1373,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
     end
 
     it 'should update the member coverage start on' do
+      hbx_enrollment.update_attributes(aasm_state: 'shopping')
       person.consumer_role.move_identity_documents_to_verified
       sign_in(user)
       allow_any_instance_of(HbxEnrollment).to receive(:decorated_elected_plans).and_return([])
@@ -1417,7 +1425,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
     shared_examples_for "logged in user has no authorization roles" do |action|
       before do
         allow(HbxEnrollment).to receive(:find).with("id").and_return(hbx_enrollment)
-        hbx_enrollment.update_attributes(aasm_state: 'shopping') if action == :thankyou
+        hbx_enrollment.update_attributes(aasm_state: 'shopping') if [:thankyou, :show].include?(action)
       end
 
       it "redirects to root with flash message" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [X] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187406027

# A brief description of the changes

Current behavior: Displaying a flash message and redirecting to Users to families home page when they click browser back button after enrollment has submitted.

New behavior: Redirect to receipt page and display a flash message instead of redirecting to families home page

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.