### PR TITLE
safe navigating params in ssa verifications subscriber

### DIFF
--- a/app/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor.rb
+++ b/app/domain/operations/fdsh/ssa/h3/ssa_verification_response_processor.rb
@@ -26,7 +26,8 @@ module Operations
             return Success({}) unless EnrollRegistry[:ssa_h3].setting(:use_transmittable).item
             person = find_person(params[:person_hbx_id], nil)
             subject = person.value!&.to_global_id&.uri if person.success?
-            result = Operations::Transmittable::GenerateResponseObjects.new.call({job_id: params[:metadata][:headers]["job_id"],
+            job_id = params[:metadata]&.to_h&.dig(:headers, "job_id")
+            result = Operations::Transmittable::GenerateResponseObjects.new.call({job_id: job_id,
                                                                                   key: :ssa_verification_response,
                                                                                   payload: params[:response],
                                                                                   correlation_id: params[:person_hbx_id],

--- a/app/event_source/subscribers/fdsh_gateway/ssa_verifications_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/ssa_verifications_subscriber.rb
@@ -10,8 +10,8 @@ module Subscribers
       subscribe(:on_ssa_verification_complete) do |delivery_info, metadata, response|
         logger.info "Ssa::SsaverificationsSubscriber: invoked on_ssa_verification_complete with delivery_info: #{delivery_info.inspect}, response: #{response.inspect}"
         payload = JSON.parse(response, :symbolize_names => true)
-	job_id = metadata.dig(:headers, "job_id")
-	status = metadata.dig(:headers, "status")
+        job_id = metadata.dig(:headers, "job_id")
+        status = metadata.dig(:headers, "status")
 
         if status == "failure"
           handle_failure_response(job_id)

--- a/app/event_source/subscribers/fdsh_gateway/ssa_verifications_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/ssa_verifications_subscriber.rb
@@ -10,8 +10,8 @@ module Subscribers
       subscribe(:on_ssa_verification_complete) do |delivery_info, metadata, response|
         logger.info "Ssa::SsaverificationsSubscriber: invoked on_ssa_verification_complete with delivery_info: #{delivery_info.inspect}, response: #{response.inspect}"
         payload = JSON.parse(response, :symbolize_names => true)
-        job_id = metadata.dig(:headers, "job_id")
-        status = metadata.dig(:headers, "status")
+        job_id = metadata.to_h.dig(:headers, "job_id")
+        status = metadata.to_h.dig(:headers, "status")
 
         if status == "failure"
           handle_failure_response(job_id)

--- a/app/event_source/subscribers/fdsh_gateway/ssa_verifications_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/ssa_verifications_subscriber.rb
@@ -10,8 +10,8 @@ module Subscribers
       subscribe(:on_ssa_verification_complete) do |delivery_info, metadata, response|
         logger.info "Ssa::SsaverificationsSubscriber: invoked on_ssa_verification_complete with delivery_info: #{delivery_info.inspect}, response: #{response.inspect}"
         payload = JSON.parse(response, :symbolize_names => true)
-        job_id = metadata[:headers]["job_id"]
-        status = metadata[:headers]["status"]
+	job_id = metadata.dig(:headers, "job_id")
+	status = metadata.dig(:headers, "status")
 
         if status == "failure"
           handle_failure_response(job_id)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/story/show/187413988

# A brief description of the changes

Current behavior:
Subscriber is failing if there is no headers in metadata(few params added for json)

New behavior:
Subscriber will pick and check if headers are available and proceeds if blank(not required for xml)

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.