### PR TITLE
adds ssn to the sensitive parameters list

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
-# Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :question_answer, :password_confirmation, :new_password]
+# Configure Rails to filter out sensitive parameters from the logs.
+# The parameters :password, :question_answer, :password_confirmation, :new_password, and :ssn will be replaced with [FILTERED] in the logs.
+Rails.application.config.filter_parameters += [:password, :question_answer, :password_confirmation, :new_password, :ssn]

--- a/features/insured/individual_curam_document.feature
+++ b/features/insured/individual_curam_document.feature
@@ -42,6 +42,7 @@ Feature: Customers go to Curam to view notices and verifications
     Then there will be text to the left of the MEDICAID & TAX CREDITS button
     Then Hbx Admin logs out
 
+  @flaky
   Scenario: Broker can see the Navigation Button
     Given an individual market broker exists
     And a consumer role family exists with broker

--- a/spec/controllers/insured/consumer_roles_controller_spec.rb
+++ b/spec/controllers/insured/consumer_roles_controller_spec.rb
@@ -105,6 +105,31 @@ RSpec.describe Insured::ConsumerRolesController, dbclean: :after_each, :type => 
       allow(mock_resident_candidate).to receive(:valid?).and_return(false)
     end
 
+    context 'sensitive params are filtered in logs' do
+      let(:validation_result) { true }
+      let(:found_person) { [] }
+
+      let(:person_parameters) do
+        {
+          'dob' => '1990-01-01',
+          'first_name' => 'dummy',
+          'gender' => 'male',
+          'last_name' => 'testing',
+          'middle_name' => 'enroll',
+          'name_sfx' => '',
+          'ssn' => '111111111'
+        }
+      end
+
+      let(:filtered_person_parameters) { person_parameters.merge('ssn' => '[FILTERED]') }
+
+      it 'confirms the ssn param is filtered' do
+        post :match, params: { person: person_parameters }
+        expect(response).to have_http_status(:success)
+        expect(File.read('log/test.log')).to include(filtered_person_parameters.to_s)
+      end
+    end
+
     context "given invalid parameters", dbclean: :after_each do
       let(:validation_result) { false }
       let(:found_person) { [] }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 187413531](https://www.pivotaltracker.com/story/show/187413531)

# A brief description of the changes

Current behavior: The value of the SSN is logged without filtering in the logs.

New behavior: The value of the SSN is now logged as `[FILTERED]` in the logs as `ssn` is included in the list of filter parameters.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
I tagged a cucumber as flaky as it has been flickering a lot. A follow-up ticket is created to fix the issue [Flickering cucumber fix](https://www.pivotaltracker.com/story/show/187314337).

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.