### PR TITLE
add logger files for tracking pvc errors

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -14,8 +14,8 @@ class Insured::PlanShoppingsController < ApplicationController
   before_action :set_current_person, :only => [:receipt, :thankyou, :waive, :show, :plans, :checkout, :terminate, :plan_selection_callback]
   before_action :set_kind_for_market_and_coverage, only: [:thankyou, :show, :plans, :checkout, :receipt, :set_elected_aptc, :plan_selection_callback]
   before_action :validate_rating_address, only: [:show]
-  before_action :check_enrollment_state, only: [:thankyou]
-  before_action :set_cache_headers, only: [:thankyou]
+  before_action :check_enrollment_state, only: [:show, :thankyou]
+  before_action :set_cache_headers, only: [:show, :thankyou]
 
   def checkout
     (redirect_back(fallback_location: root_path) and return) unless agreed_to_thankyou_ivl_page_terms
@@ -328,7 +328,7 @@ class Insured::PlanShoppingsController < ApplicationController
     return if @hbx_enrollment.shopping?
 
     flash[:notice] = l10n("insured.active_enrollment_warning")
-    redirect_to family_account_path
+    redirect_to receipt_insured_plan_shopping_path(change_plan: params[:change_plan], enrollment_kind: params[:enrollment_kind])
   end
 
   def show_ivl(hbx_enrollment_id)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/create_pvc_request.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/create_pvc_request.rb
@@ -43,8 +43,8 @@ module FinancialAssistance
             if application.present?
               Success(application)
             else
-              pvc_logger.error("No applicationfound with hbx_id #{params[:application_hbx_id]}")
-              Failure("No applicationfound with hbx_id #{params[:application_hbx_id]}")
+              pvc_logger.error("No application found with hbx_id #{params[:application_hbx_id]}")
+              Failure("No application found with hbx_id #{params[:application_hbx_id]}")
             end
           end
 

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/submit_pvc_set.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/submit_pvc_set.rb
@@ -26,8 +26,8 @@ module FinancialAssistance
           # @return [ Success ] Job successfully completed
           def call(params)
             values = yield validate(params)
-            families = find_families(values)
-            submit(params, families)
+            family_ids = find_families(values)
+            submit(params, family_ids)
 
             Success("Successfully Submitted PVC Set")
           end
@@ -43,7 +43,7 @@ module FinancialAssistance
 
           def find_families(params)
             if EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
-              Family.with_active_coverage_and_aptc_csr_grants_for_year(params[:assistance_year], params[:csr_list])
+              Family.with_active_coverage_and_aptc_csr_grants_for_year(params[:assistance_year], params[:csr_list]).distinct(:_id)
             else
               Family.periodic_verifiable_for_assistance_year(params[:assistance_year], params[:csr_list]).distinct(:_id)
             end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/pvc/submit_pvc_set_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/pvc/submit_pvc_set_spec.rb
@@ -74,24 +74,4 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Pvc::SubmitPvcSe
       expect(result).to be_success
     end
   end
-
-  context 'failure' do
-    before do
-      application.destroy
-    end
-
-    # NOTE: while checking a logger file usually isn't the best test case,
-    # we still want a test case to cover the sad path that will note a change in behavior vs. the happy path
-    it 'should but success but log error' do
-      result = subject.call(assistance_year: assistance_year)
-      expect(result).to be_success
-
-      date = TimeKeeper.date_of_record.strftime('%Y_%m_%d')
-      filename = "#{Rails.root}/log/pvc_non_esi_logger_#{date}.log"
-      error_log = File.readlines(filename)
-
-      error_message = "No Determined application found for family with primary person hbx_id #{person.hbx_id}"
-      expect(error_log.last).to include(error_message)
-    end
-  end
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
-# Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :question_answer, :password_confirmation, :new_password]
+# Configure Rails to filter out sensitive parameters from the logs.
+# The parameters :password, :question_answer, :password_confirmation, :new_password, and :ssn will be replaced with [FILTERED] in the logs.
+Rails.application.config.filter_parameters += [:password, :question_answer, :password_confirmation, :new_password, :ssn]

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -574,7 +574,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.ssn_configuration_warning' => "This Social Security Number and Date-of-Birth is invalid in our records.  Please verify the entry, and if correct, contact the DC Customer help center at %{site_phone_number}.",
   :'en.insured.match_person.ssn_dob_name_error' => "This Social Security Number, Date-of-Birth and Name are invalid in our records. Please verify the entry, and if correct, contact the %{contact_center_name} at %{contact_center_phone_number}.",
   :'en.insured.out_of_state_error_message' => "Address is out of state or the supported area, please review your application details to update your address",
-    :'en.insured.active_enrollment_warning' => "To choose a new plan, select 'Shop for Plans'",
+    :'en.insured.active_enrollment_warning' => "Your enrollment has been submitted and cannot be changed by clicking the back button. To make any changes, continue to your account.",
   :'en.enrollment.details.header' => 'Enrollment Detail',
   :'en.enrollment.members.header' => 'Enrollment Member Detail',
   :'en.enrollment.effective_on' => 'Effective Date: ',

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -573,7 +573,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.ssn_configuration_warning' => "Please check your information and try again. If you’ve already done an application with Healthcare.gov, the Maine Office for Family Independence, or %{site_short_name}, you’ll need to enter your information the same way here. If you have questions, call the %{site_short_name} Consumer Assistance Center at %{site_phone_number} TTY: %{site_tty_number}.",
   :'en.insured.match_person.ssn_dob_name_error' => "Please check your information and try again. If you’ve already done an application with Healthcare.gov, the Maine Office for Family Independence, or %{site_short_name}, you’ll need to enter your information the same way here. If you have questions, call the %{contact_center_name} at %{contact_center_phone_number} TTY: %{contact_center_tty_number}.",
   :'en.insured.out_of_state_error_message' => "Address is out of state or the supported area, please review your application details to update your address",
-  :'en.insured.active_enrollment_warning' => "To choose a new plan, select 'Shop for Plans'",
+  :'en.insured.active_enrollment_warning' => "Your enrollment has been submitted and cannot be changed by clicking the back button. To make any changes, continue to your account.",
   :'en.enrollment.details.header' => 'Enrollment Detail',
   :'en.enrollment.members.header' => 'Enrollment Member Detail',
   :'en.enrollment.effective_on' => 'Effective Date: ',

--- a/features/insured/individual_curam_document.feature
+++ b/features/insured/individual_curam_document.feature
@@ -42,6 +42,7 @@ Feature: Customers go to Curam to view notices and verifications
     Then there will be text to the left of the MEDICAID & TAX CREDITS button
     Then Hbx Admin logs out
 
+  @flaky
   Scenario: Broker can see the Navigation Button
     Given an individual market broker exists
     And a consumer role family exists with broker

--- a/features/insured/individual_plan_shopping.feature
+++ b/features/insured/individual_plan_shopping.feature
@@ -14,4 +14,4 @@ Feature: Consumer plan shopping
     And I click on purchase confirm button for matched person
     Then I should see pay now button
     When user clicks browser back button
-    Then user should redirect to home page and should see a flash message
+    Then user should redirect to receipt page and should see a flash message

--- a/features/insured/step_definitions/individual_steps.rb
+++ b/features/insured/step_definitions/individual_steps.rb
@@ -45,7 +45,8 @@ When(/(.*) clicks browser back button/) do |_name|
   @browser.execute_script('window.history.back()')
 end
 
-Then(/(.*) should redirect to home page and should see a flash message/) do |_name|
+Then(/(.*) should redirect to receipt page and should see a flash message/) do |_name|
+  expect(page).to have_content("Enrollment Submitted")
   expect(page).to have_content(l10n("insured.active_enrollment_warning"))
 end
 

--- a/script/export_pvc_determined_families.rb
+++ b/script/export_pvc_determined_families.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# This script generates a CSV report with information about families with renewal determined applications for the assistance_year with no SSN applicants.
+
+# To run this on specific enrollments
+# bundle exec rails runner script/export_pvc_families.rb assistance_year='2023'
+
+assistance_year = ENV['assistance_year'].to_i
+csr_list = [100, 73, 87, 94].freeze
+
+family_ids = Family.with_active_coverage_and_aptc_csr_grants_for_year(assistance_year, csr_list).distinct(:_id)
+
+p "found #{family_ids.count} families"  unless Rails.env.test?
+
+CSV.open("export_pvc_determined_families_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv", "w") do |csv|
+  csv << [
+      "Primary Person Hbx ID",
+      "Applicant Person Hbx ID",
+      "Most recent Determined #{assistance_year} Application Hbx ID",
+      "Is SSN Present",
+      "Non ESI Evidence Title",
+      "Workflow Transition From State",
+      "Workflow Transition To State",
+      "Verification History Action",
+      "Verification History Update Reason",
+      "Verification History Updated By",
+      "Response Created At",
+      "PVC Determination"
+      ]
+
+  counter = 0
+
+  family_ids.each do |family_id|
+    family = Family.where(:_id => family_id).first
+    primary_person = family.primary_person
+
+    applications = ::FinancialAssistance::Application.where(:family_id => family.id,
+                                                            :assistance_year => assistance_year,
+                                                            :aasm_state => 'determined',
+                                                            :"applicants.is_ia_eligible" => true)
+
+    determined_application = applications.exists(:predecessor_id => true).max_by(&:submitted_at)
+    next if determined_application.blank?
+
+    determined_application.active_applicants.each do |applicant|
+      non_esi_evidence = applicant.non_esi_evidence
+      next if non_esi_evidence.blank?
+      request_result = non_esi_evidence.request_results.max_by(&:date_of_action)
+      pvc_determination = request_result&.result || 'no pvc result found'
+      workflow_transition = non_esi_evidence.workflow_state_transitions.max_by(&:created_at)
+
+      verification_history = non_esi_evidence.verification_histories.max_by(&:date_of_action)
+
+      counter += 1
+
+      csv << [
+          primary_person.hbx_id,
+          applicant.person_hbx_id,
+          determined_application.hbx_id,
+          applicant.encrypted_ssn.present?,
+          non_esi_evidence.title,
+          workflow_transition&.from_state,
+          workflow_transition&.to_state,
+          verification_history&.action,
+          verification_history&.update_reason,
+          verification_history&.updated_by,
+          request_result&.created_at,
+          pvc_determination
+      ]
+    end
+  end
+
+  p "processed #{counter} families"  unless Rails.env.test?
+end

--- a/spec/controllers/insured/consumer_roles_controller_spec.rb
+++ b/spec/controllers/insured/consumer_roles_controller_spec.rb
@@ -105,6 +105,31 @@ RSpec.describe Insured::ConsumerRolesController, dbclean: :after_each, :type => 
       allow(mock_resident_candidate).to receive(:valid?).and_return(false)
     end
 
+    context 'sensitive params are filtered in logs' do
+      let(:validation_result) { true }
+      let(:found_person) { [] }
+
+      let(:person_parameters) do
+        {
+          'dob' => '1990-01-01',
+          'first_name' => 'dummy',
+          'gender' => 'male',
+          'last_name' => 'testing',
+          'middle_name' => 'enroll',
+          'name_sfx' => '',
+          'ssn' => '111111111'
+        }
+      end
+
+      let(:filtered_person_parameters) { person_parameters.merge('ssn' => '[FILTERED]') }
+
+      it 'confirms the ssn param is filtered' do
+        post :match, params: { person: person_parameters }
+        expect(response).to have_http_status(:success)
+        expect(File.read('log/test.log')).to include(filtered_person_parameters.to_s)
+      end
+    end
+
     context "given invalid parameters", dbclean: :after_each do
       let(:validation_result) { false }
       let(:found_person) { [] }

--- a/spec/controllers/insured/plan_shoppings_controller_spec.rb
+++ b/spec/controllers/insured/plan_shoppings_controller_spec.rb
@@ -1114,6 +1114,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
 
     context "normal" do
       before :each do
+        hbx_enrollment.update_attributes(aasm_state: "shopping")
         allow(cost_calculator).to receive(:groups_for_products).with(products).and_return(product_groups)
         allow_any_instance_of(Insured::PlanShoppingsController).to receive(:sort_member_groups).with(product_groups).and_return(member_group)
         allow(hbx_enrollment).to receive(:can_waive_enrollment?).and_return(true)
@@ -1135,6 +1136,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
 
     context "when sponsored_benefit package products are available" do
       before do
+        hbx_enrollment.update_attributes(aasm_state: 'shopping')
         allow(hbx_enrollment).to receive(:can_waive_enrollment?).and_return(true)
         sponsored_benefit_product_packages_product = hbx_enrollment.sponsored_benefit.products(hbx_enrollment.sponsored_benefit.rate_schedule_date).first
         sponsored_benefit_product_packages_product.update_attributes(hsa_eligibility: false)
@@ -1186,6 +1188,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
         let(:user)  { FactoryBot.create(:user, person: person) }
 
         before do
+          hbx_enrollment.update_attributes(aasm_state: 'shopping')
           allow(hbx_enrollment).to receive(:coverage_kind).and_return('health')
           allow(hbx_enrollment).to receive(:is_shop?).and_return(false)
           allow(hbx_enrollment).to receive(:is_coverall?).and_return(false)
@@ -1220,6 +1223,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
 
         context "without tax_household" do
           before :each do
+            hbx_enrollment.update_attributes(aasm_state: 'shopping')
             allow(household).to receive(:latest_active_tax_household_with_year).and_return nil
             allow(family).to receive(:enrolled_hbx_enrollments).and_return([])
             allow(person).to receive(:active_employee_roles).and_return []
@@ -1238,6 +1242,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
 
         context "without tax_household when has aptc session" do
           before :each do
+            hbx_enrollment.update_attributes(aasm_state: 'shopping')
             allow(household).to receive(:latest_active_tax_household_with_year).and_return nil
             allow(family).to receive(:enrolled_hbx_enrollments).and_return([])
             allow(person).to receive(:active_employee_roles).and_return []
@@ -1258,6 +1263,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
 
         context "with tax_household and plan shopping in shop market" do
           before :each do
+            hbx_enrollment.update_attributes(aasm_state: 'shopping')
             allow(household).to receive(:latest_active_tax_household_with_year).and_return tax_household
             allow(tax_household).to receive(:total_aptc_available_amount_for_enrollment).and_return(111)
             allow(family).to receive(:enrolled_hbx_enrollments).and_return([])
@@ -1290,6 +1296,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
       let(:hbx_enrollment) { FactoryBot.create(:hbx_enrollment, family: family1, household: family1.active_household, consumer_role_id: person1.consumer_role.id, kind: 'individual', product_id: product.id)}
 
       before :each do
+        hbx_enrollment.update_attributes(aasm_state: 'shopping')
         allow(EnrollRegistry[:enroll_app].setting(:geographic_rating_area_model)).to receive(:item).and_return('county')
         allow(EnrollRegistry[:enroll_app].setting(:rating_areas)).to receive(:item).and_return('county')
         ::BenefitMarkets::Locations::RatingArea.all.update_all(covered_states: nil)
@@ -1366,6 +1373,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
     end
 
     it 'should update the member coverage start on' do
+      hbx_enrollment.update_attributes(aasm_state: 'shopping')
       person.consumer_role.move_identity_documents_to_verified
       sign_in(user)
       allow_any_instance_of(HbxEnrollment).to receive(:decorated_elected_plans).and_return([])
@@ -1417,7 +1425,7 @@ RSpec.describe Insured::PlanShoppingsController, :type => :controller, dbclean: 
     shared_examples_for "logged in user has no authorization roles" do |action|
       before do
         allow(HbxEnrollment).to receive(:find).with("id").and_return(hbx_enrollment)
-        hbx_enrollment.update_attributes(aasm_state: 'shopping') if action == :thankyou
+        hbx_enrollment.update_attributes(aasm_state: 'shopping') if [:thankyou, :show].include?(action)
       end
 
       it "redirects to root with flash message" do

--- a/spec/script/export_pvc_determined_families_spec.rb
+++ b/spec/script/export_pvc_determined_families_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'export_rrv_families' do
+  before do
+    DatabaseCleaner.clean
+  end
+
+  let(:date) { TimeKeeper.date_of_record }
+  let(:assistance_year) { date.year }
+  let(:csr) { ["87", "94"] }
+
+  let(:family) do
+    family = FactoryBot.build(:family, person: primary)
+    family.family_members = [
+      FactoryBot.build(:family_member, is_primary_applicant: true, is_active: true, family: family, person: primary),
+      FactoryBot.build(:family_member, is_primary_applicant: false, is_active: true, family: family, person: dependent)
+    ]
+
+    family.person.person_relationships.push PersonRelationship.new(relative_id: dependent.id, kind: 'spouse')
+    family.save
+    family
+  end
+
+  let(:dependent) { FactoryBot.create(:person) }
+  let(:primary) {  FactoryBot.create(:person, :with_consumer_role)}
+  let(:primary_applicant) { family.primary_applicant }
+  let(:dependents) { family.dependents }
+  let!(:tax_household_group_current) do
+    family.tax_household_groups.create!(
+      assistance_year: assistance_year,
+      source: 'Admin',
+      start_on: date.beginning_of_year,
+      tax_households: [
+        FactoryBot.build(:tax_household, household: family.active_household, effective_starting_on: date.beginning_of_year, effective_ending_on: TimeKeeper.date_of_record.end_of_year, max_aptc: 1000.00)
+      ]
+    )
+  end
+
+  let(:tax_household_current) do
+    tax_household_group_current.tax_households.first
+  end
+
+  let!(:tax_household_member) { tax_household_current.tax_household_members.create(applicant_id: family.family_members[0].id, csr_percent_as_integer: 87, csr_eligibility_kind: "csr_87") }
+
+  let!(:hbx_enrollment) do
+    FactoryBot.create(:hbx_enrollment,
+                      :individual_shopping,
+                      :with_silver_health_product,
+                      :with_enrollment_members,
+                      enrollment_members: [primary_applicant],
+                      effective_on: date.beginning_of_month,
+                      family: family,
+                      aasm_state: :coverage_selected)
+  end
+  let!(:thh_start_on) { tax_household_current.effective_starting_on }
+
+  let(:family_member1) { family.family_members[0] }
+  let(:family_member2) { family.family_members[1] }
+  let!(:ivl_enr_member2)   { FactoryBot.create(:hbx_enrollment_member, applicant_id: family_member2.id, hbx_enrollment: hbx_enrollment, eligibility_date: thh_start_on) }
+
+  let(:yearly_expected_contribution_current) { 125.00 * 12 }
+  let(:members_csr_set) { {family_member1 => '87', family_member2 => '87'} }
+  let!(:eligibility_determination_current) do
+    determination = family.create_eligibility_determination(effective_date: date.beginning_of_year)
+    determination.grants.create(
+      key: "AdvancePremiumAdjustmentGrant",
+      value: yearly_expected_contribution_current,
+      start_on: date.beginning_of_year,
+      end_on: date.end_of_year,
+      assistance_year: date.year,
+      member_ids: family.family_members.map(&:id).map(&:to_s),
+      tax_household_id: tax_household_current.id
+    )
+
+    members_csr_set.each do |family_member, csr_value|
+      subject = determination.subjects.create(
+        gid: "gid://enroll/FamilyMember/#{family_member.id}",
+        is_primary: family_member.is_primary_applicant,
+        person_id: family_member.person.id
+      )
+
+      state = subject.eligibility_states.create(eligibility_item_key: 'aptc_csr_credit')
+      state.grants.create(
+        key: "CsrAdjustmentGrant",
+        value: csr_value,
+        start_on: TimeKeeper.date_of_record.beginning_of_year,
+        end_on: TimeKeeper.date_of_record.end_of_year,
+        assistance_year: TimeKeeper.date_of_record.year,
+        member_ids: family.family_members.map(&:id)
+      )
+    end
+
+    determination
+  end
+
+  let!(:non_esi_evidence) do
+    applicant.non_esi_evidence = FactoryBot.build(:evidence, :with_request_results, key: :non_esi_mec, title: 'Non ESI MEC')
+    applicant.save!
+    applicant.non_esi_evidence
+  end
+
+  let!(:non_esi_evidence2) do
+    applicant2.non_esi_evidence = FactoryBot.build(:evidence, :with_request_results, key: :non_esi_mec, title: 'Non ESI MEC')
+    applicant2.save!
+    applicant2.non_esi_evidence
+  end
+
+  let!(:verification_history) { non_esi_evidence&.add_verification_history('PVC_Submitted', 'PVC - Renewal verifications submitted', 'system') }
+  let!(:verification_history2) { non_esi_evidence2&.add_verification_history('PVC_Submitted', 'PVC - Renewal verifications submitted', 'system') }
+  let(:yesterday) { Time.now.getlocal.prev_day }
+  let!(:application) do
+    FactoryBot.create(
+      :financial_assistance_application,
+      submitted_at: yesterday,
+      family_id: family.id,
+      predecessor_id: BSON::ObjectId.new
+    )
+  end
+
+  let!(:applicant) do
+    FactoryBot.create(
+      :financial_assistance_applicant,
+      :with_home_address,
+      application: application,
+      family_member_id: family_member1.id,
+      is_primary_applicant: true,
+      citizen_status: 'us_citizen',
+      is_ia_eligible: true,
+      is_medicaid_chip_eligible: false,
+      csr_percent_as_integer: 73,
+      first_name: primary.first_name,
+      last_name: primary.last_name,
+      gender: primary.gender,
+      dob: primary.dob,
+      encrypted_ssn: primary.encrypted_ssn,
+      magi_as_percentage_of_fpl: 1.3
+    )
+  end
+
+  let!(:applicant2) do
+    FactoryBot.create(
+      :financial_assistance_applicant,
+      :spouse,
+      :with_home_address,
+      application: application,
+      family_member_id: family_member2.id,
+      citizen_status: 'alien_lawfully_present',
+      is_ia_eligible: false,
+      is_medicaid_chip_eligible: true,
+      csr_percent_as_integer: 87,
+      first_name: dependent.first_name,
+      last_name: dependent.last_name,
+      gender: dependent.gender,
+      dob: dependent.dob,
+      encrypted_ssn: nil,
+      magi_as_percentage_of_fpl: 1.3
+    )
+  end
+
+  let(:field_names) do
+    [
+        "Primary Person Hbx ID",
+        "Applicant Person Hbx ID",
+        "Most recent Determined #{assistance_year} Application Hbx ID",
+        "Is SSN Present",
+        "Non ESI Evidence Title",
+        "Workflow Transition From State",
+        "Workflow Transition To State",
+        "Verification History Action",
+        "Verification History Update Reason",
+        "Verification History Updated By",
+        "Response Created At",
+        "PVC Determination"
+        ]
+  end
+
+  before :each do
+    application.non_primary_applicants.each{|applicant| application.ensure_relationship_with_primary(applicant, applicant.relationship) }
+    invoke_export_pvc_determined_families_report
+    @file_content = CSV.read("#{Rails.root}/export_pvc_determined_families_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv")
+  end
+
+  it 'should add data to the file' do
+    expect(@file_content.size).to be > 1
+  end
+
+  it 'should contain the requested fields' do
+    expect(@file_content[0]).to eq(field_names)
+  end
+
+  after :each do
+    FileUtils.rm_rf("#{Rails.root}/export_pvc_determined_families_#{TimeKeeper.date_of_record.strftime('%m_%d_%Y')}.csv")
+  end
+end
+
+def invoke_export_pvc_determined_families_report
+  ENV['assistance_year'] = yesterday.year.to_s
+  export_pvc_determined_families_report = File.join(Rails.root, "script/export_pvc_determined_families.rb")
+  load export_pvc_determined_families_report
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [187406127](https://www.pivotaltracker.com/story/show/187406127)

# A brief description of the changes

Current behavior: sparse logging throughout pvc request/response flow

New behavior: error tracking/logs more thoroughly placed throughout pvc request/response flow

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.