### PR TITLE
responds only to valid MIME types for users controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,8 @@ class ApplicationController < ActionController::Base
   # for current_user
   before_action :set_current_user
 
+  rescue_from ActionController::UnknownFormat, with: :render_unsupported_format
+
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   rescue_from ActionController::InvalidCrossOriginRequest do |exception|
@@ -106,6 +108,20 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def render_unsupported_format
+    respond_to do |format|
+      format.html { render plain: 'Unsupported format', status: :not_acceptable }
+      format.json { render json: { error: 'Unsupported format' }, status: :not_acceptable }
+      format.xml  { render xml: '<error>Unsupported format</error>', status: :not_acceptable }
+      format.csv  { render plain: 'Unsupported format', status: :not_acceptable }
+      format.text { render plain: 'Unsupported format', status: :not_acceptable }
+      format.js   { render plain: 'Unsupported format', status: :not_acceptable }
+
+      # Default handler for any other format
+      format.any  { render plain: 'Unsupported format', status: :not_acceptable }
+    end
+  end
 
   def redirect_if_prod
     redirect_to root_path, :flash => { :error => "Unable to run seeds on prod environment." } unless ENV['ENROLL_REVIEW_ENVIRONMENT'] == 'true' || !Rails.env.production?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,13 @@ class ApplicationController < ActionController::Base
   # for current_user
   before_action :set_current_user
 
+  # Handles ActionController::UnknownFormat exception by calling the +render_unsupported_format+ method.
+  #
+  # @see #render_unsupported_format
+  #
+  # @example
+  #   rescue_from ActionController::UnknownFormat, with: :render_unsupported_format
+  #
   rescue_from ActionController::UnknownFormat, with: :render_unsupported_format
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
@@ -109,6 +116,13 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # Renders an 'Unsupported format' message with a status of :not_acceptable for various formats.
+  # This method is used to handle requests in unsupported formats.
+  #
+  # @example
+  #   render_unsupported_format
+  #
+  # @return [ActionController::Response] A response with a plain text body and a status of :not_acceptable.
   def render_unsupported_format
     respond_to do |format|
       format.html { render plain: 'Unsupported format', status: :not_acceptable }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 
+# UsersController handles actions related to User in the context of HbxProfile.
+#
+# @see ApplicationController
 class UsersController < ApplicationController
+
+  # Sets the user before each action, except for :confirm_lock and :unsupported_browser.
   before_action :set_user, except: [:confirm_lock, :unsupported_browser]
 
+  # Confirms the lock action for a user.
+  #
+  # @return [void]
+  # @response_to JS
   def confirm_lock
     authorize HbxProfile, :confirm_lock?
     @user_id  = params[:user_action_id]
@@ -12,6 +21,10 @@ class UsersController < ApplicationController
     end
   end
 
+  # Locks a user.
+  #
+  # @return [void]
+  # @response_to JS
   def lockable
     authorize HbxProfile, :lockable?
     @user.lock!
@@ -22,6 +35,10 @@ class UsersController < ApplicationController
     end
   end
 
+  # Resets a user's password.
+  #
+  # @return [void]
+  # @response_to JS
   def reset_password
     authorize HbxProfile, :reset_password?
 
@@ -30,6 +47,10 @@ class UsersController < ApplicationController
     end
   end
 
+  # Confirms the reset password action for a user.
+  #
+  # @return [void]
+  # @response_to JS
   def confirm_reset_password
     authorize HbxProfile, :confirm_reset_password?
     @error = nil
@@ -47,6 +68,10 @@ class UsersController < ApplicationController
     end
   end
 
+  # Changes a user's username and email.
+  #
+  # @return [void]
+  # @response_to JS
   def change_username_and_email
     authorize HbxProfile, :change_username_and_email?
     @user_id = params[:user_id]
@@ -56,6 +81,10 @@ class UsersController < ApplicationController
     end
   end
 
+  # Confirms the change username and email action for a user.
+  #
+  # @return [void]
+  # @response_to JS
   def confirm_change_username_and_email
     authorize HbxProfile, :confirm_change_username_and_email?
     @element_to_replace_id = params[:family_actions_id]
@@ -79,6 +108,10 @@ class UsersController < ApplicationController
     end
   end
 
+  # Shows a user's login history.
+  #
+  # @return [void]
+  # @response_to JS
   def login_history
     authorize HbxProfile, :login_history?
     @user_login_history = SessionIdHistory.for_user(user_id: @user.id).order('created_at DESC').page(params[:page]).per(15)
@@ -88,7 +121,11 @@ class UsersController < ApplicationController
     end
   end
 
-  # Auth not required
+  # Shows the unsupported browser page.
+  #
+  # @return [void]
+  # @response_to HTML
+  # @note Authentication and Authorization are not required
   def unsupported_browser
     respond_to do |format|
       format.html { render 'unsupported_browser' }
@@ -111,10 +148,16 @@ class UsersController < ApplicationController
               end
   end
 
+  # Returns the user.
+  #
+  # @return [User] The user.
   def user
     @user ||= User.find(params[:id])
   end
 
+  # Sets the user.
+  #
+  # @return [void]
   def set_user
     @user = User.find(params[:id])
   end

--- a/spec/controllers/users_controller_mime_types_spec.rb
+++ b/spec/controllers/users_controller_mime_types_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UsersController, type: :controller do
+
+  before :all do
+    DatabaseCleaner.clean
+  end
+
+  after :all do
+    DatabaseCleaner.clean
+  end
+
+
+  describe 'with authorization and authentication' do
+    let(:person) { FactoryBot.create(:person, :with_hbx_staff_role) }
+    let(:hbx_staff_role) { person.hbx_staff_role }
+    let(:permission) { FactoryBot.create(:permission, :full_access_super_admin) }
+    let(:admin) { FactoryBot.create(:user, person: person) }
+
+    let(:user_person) { FactoryBot.create(:person) }
+    let(:user) { FactoryBot.create(:user, person: user_person) }
+    let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: user_person) }
+
+    before do
+      hbx_staff_role.update_attributes!(permission_id: permission.id)
+      sign_in(admin)
+    end
+
+    describe 'GET #confirm_lock' do
+      shared_examples 'responds_to_mime_type for GET endpoint confirm_lock' do |unsupported_mime_types|
+        unsupported_mime_types.each do |mime_type|
+          it "rejects #{mime_type}" do
+            get :confirm_lock, params: { id: user.id, format: mime_type }
+            expect(response).to have_http_status(:not_acceptable)
+          end
+        end
+      end
+
+      include_examples 'responds_to_mime_type for GET endpoint confirm_lock', [:html, :json, :xml, :csv, :text]
+    end
+
+    describe 'GET #lockable' do
+      shared_examples 'responds_to_mime_type for GET endpoint lockable' do |unsupported_mime_types|
+        unsupported_mime_types.each do |mime_type|
+          it "rejects #{mime_type}" do
+            get :lockable, params: { id: user.id, format: mime_type }
+            expect(response).to have_http_status(:not_acceptable)
+          end
+        end
+      end
+
+      include_examples 'responds_to_mime_type for GET endpoint lockable', [:html, :json, :xml, :csv, :text]
+    end
+
+    describe 'GET #reset_password' do
+      shared_examples 'responds_to_mime_type for GET endpoint reset_password' do |unsupported_mime_types|
+        unsupported_mime_types.each do |mime_type|
+          it "rejects #{mime_type}" do
+            get :reset_password, params: { id: user.id, format: mime_type }
+            expect(response).to have_http_status(:not_acceptable)
+          end
+        end
+      end
+
+      include_examples 'responds_to_mime_type for GET endpoint reset_password', [:html, :json, :xml, :csv, :text]
+    end
+
+    describe 'PUT #confirm_reset_password' do
+      shared_examples 'responds_to_mime_type for PUT endpoint confirm_reset_password' do |unsupported_mime_types|
+        unsupported_mime_types.each do |mime_type|
+          it "rejects #{mime_type}" do
+            put :confirm_reset_password, params: { id: user.id, format: mime_type }
+            expect(response).to have_http_status(:not_acceptable)
+          end
+        end
+      end
+
+      include_examples 'responds_to_mime_type for PUT endpoint confirm_reset_password', [:html, :json, :xml, :csv, :text]
+    end
+
+    describe 'GET #change_username_and_email' do
+      shared_examples 'responds_to_mime_type for GET endpoint change_username_and_email' do |unsupported_mime_types|
+        unsupported_mime_types.each do |mime_type|
+          it "rejects #{mime_type}" do
+            get :change_username_and_email, params: {
+              id: user.id,
+              format: mime_type
+            }
+            expect(response).to have_http_status(:not_acceptable)
+          end
+        end
+      end
+
+      include_examples 'responds_to_mime_type for GET endpoint change_username_and_email', [:html, :json, :xml, :csv, :text]
+    end
+
+    describe 'POST #confirm_change_username_and_email' do
+      let(:person2) { FactoryBot.create(:person) }
+      let(:user2) { FactoryBot.create(:user, person: person2) }
+
+      shared_examples 'responds_to_mime_type for POST endpoint confirm_change_username_and_email' do |unsupported_mime_types|
+        unsupported_mime_types.each do |mime_type|
+          it "rejects #{mime_type}" do
+            post :confirm_change_username_and_email, params: {
+              id: user.id,
+              family_actions_id: family.id,
+              new_email: user2.email,
+              new_oim_id: user2.oim_id,
+              format: mime_type
+            }
+            expect(response).to have_http_status(:not_acceptable)
+          end
+        end
+      end
+
+      include_examples 'responds_to_mime_type for POST endpoint confirm_change_username_and_email', [:html, :json, :xml, :csv, :text]
+    end
+
+    describe 'GET #login_history' do
+      shared_examples 'responds_to_mime_type for GET endpoint login_history' do |unsupported_mime_types|
+        unsupported_mime_types.each do |mime_type|
+          it "rejects #{mime_type}" do
+            get :login_history, params: {
+              id: user.id,
+              format: mime_type
+            }
+            expect(response).to have_http_status(:not_acceptable)
+          end
+        end
+      end
+
+      include_examples 'responds_to_mime_type for GET endpoint login_history', [:html, :json, :xml, :csv, :text]
+    end
+  end
+
+  describe 'without authorization and authentication' do
+
+    describe 'GET #unsupported_browser' do
+      shared_examples 'responds_to_mime_type for GET endpoint unsupported_browser' do |unsupported_mime_types|
+        unsupported_mime_types.each do |mime_type|
+          it "rejects #{mime_type}" do
+            get :unsupported_browser, params: { format: mime_type }
+            expect(response).to have_http_status(:not_acceptable)
+          end
+        end
+      end
+
+      include_examples 'responds_to_mime_type for GET endpoint unsupported_browser', [:js, :json, :xml, :csv, :text]
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -29,7 +29,7 @@ describe UsersController, dbclean: :after_each do
         sign_in(admin)
       end
       it "renders the change username form" do
-        get :change_username_and_email, params: { id: user_id }, format: :js
+        get :change_username_and_email, params: { id: user_id, format: :js }
         expect(response).to render_template('change_username_and_email')
       end
     end
@@ -40,7 +40,7 @@ describe UsersController, dbclean: :after_each do
         sign_in(admin)
       end
       it "doesn't render the change username form" do
-        get :change_username_and_email, params: { id: user_id }, format: :js
+        get :change_username_and_email, params: { id: user_id, format: :js }
         expect(flash[:error]).to be_present
         expect(flash[:error]).to include('Access not allowed for hbx_profile_policy.change_username_and_email?, (Pundit policy)')
       end
@@ -128,10 +128,11 @@ describe UsersController, dbclean: :after_each do
 
       it "toggles the user lock" do
         expect(user).to receive(:lock!)
-        get :lockable, params: {id: user_id}
+        get :lockable, params: { id: user_id, format: :js }
       end
+
       it do
-        get :lockable, params: {id: user_id}
+        get :lockable, params: { id: user_id, format: :js }
         expect(flash[:notice]).to be_present
       end
     end
@@ -145,7 +146,7 @@ describe UsersController, dbclean: :after_each do
 
       it "toggles the user lock" do
         expect(user).to receive(:lock!)
-        get :lockable, params: {id: user_id}
+        get :lockable, params: { id: user_id, format: :js }
       end
     end
   end
@@ -223,7 +224,8 @@ describe UsersController, dbclean: :after_each do
       end
       it do
         put :confirm_reset_password, params: {id: user_id, user: { email: '' }, format: :js}
-        expect(response).to render_template('users/reset_password.js.erb')
+        expect(response.content_type).to eq('text/javascript')
+        expect(response).to render_template('users/reset_password')
       end
     end
 
@@ -258,7 +260,8 @@ describe UsersController, dbclean: :after_each do
       end
       it do
         put :confirm_reset_password, params:  {id: user_id, user: { email: user_email }, format: :js}
-        expect(response).to render_template('users/reset_password.js.erb')
+        expect(response.content_type).to eq('text/javascript')
+        expect(response).to render_template('users/reset_password')
       end
     end
 
@@ -276,9 +279,9 @@ describe UsersController, dbclean: :after_each do
 
       it do
         put :confirm_reset_password, params: {id: user_id, format: :js}
-        expect(response).to redirect_to(user_account_index_exchanges_hbx_profiles_url)
+        expect(response.status).to eq(302)
+        expect(response.location).to eq(user_account_index_exchanges_hbx_profiles_url)
       end
     end
   end
-
 end

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -199,5 +199,63 @@ FactoryBot.define do
       can_edit_osse_eligibility {true}
       can_edit_broker_agency_profile {true}
     end
+
+    trait :full_access_super_admin do
+      name { 'super_admin' }
+      modify_family { true }
+      modify_employer { true }
+      revert_application { true }
+      list_enrollments { true }
+      send_broker_agency_message { true }
+      approve_broker { true }
+      approve_ga { true }
+      modify_admin_tabs { true }
+      view_admin_tabs { true }
+      can_update_ssn { true }
+      can_complete_resident_application { true }
+      can_add_sep { true }
+      can_add_pdc { true }
+      can_lock_unlock { true }
+      can_view_username_and_email { true }
+      can_transition_family_members { true }
+      can_access_user_account_tab { true }
+      view_login_history { true }
+      can_change_username_and_email { true }
+      can_reset_password { true }
+      can_extend_open_enrollment { true }
+      can_modify_plan_year { true }
+      can_create_benefit_application { true }
+      can_change_fein { true }
+      can_force_publish { true }
+      view_the_configuration_tab { true }
+      can_submit_time_travel_request { true }
+      can_view_application_types { true }
+      view_personal_info_page { true }
+      can_access_new_consumer_application_sub_tab { true }
+      can_access_outstanding_verification_sub_tab { true }
+      can_access_identity_verification_sub_tab { true }
+      can_access_accept_reject_identity_documents { true }
+      can_access_accept_reject_paper_application_documents { true }
+      can_delete_identity_application_documents { true }
+      can_access_pay_now { true }
+      view_agency_staff { true }
+      manage_agency_staff { true }
+      can_access_age_off_excluded { true }
+      can_send_secure_message { true }
+      can_manage_qles { true }
+      can_edit_aptc { true }
+      can_view_sep_history { true }
+      can_reinstate_enrollment { true }
+      can_cancel_enrollment { true }
+      can_terminate_enrollment { true }
+      change_enrollment_end_date { true }
+      can_drop_enrollment_members { true }
+      can_call_hub { true }
+      can_edit_osse_eligibility { true }
+      can_edit_broker_agency_profile { true }
+      can_view_notice_templates { true }
+      can_edit_notice_templates { true }
+      can_view_audit_log { true }
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [IVL Product Development - 187415754](https://www.pivotaltracker.com/story/show/187415754)

# A brief description of the changes

Current behavior: Some endpoints of UserController respond to unsupported MIME types.

New behavior: All the endpoints of UserController will only respond to supported MIME types.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.