### PR TITLE
adds persistence data models for alive status

### DIFF
--- a/app/models/alive_status.rb
+++ b/app/models/alive_status.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Class representing the alive status of a person.
+# This class is embedded in the DemographicsGroup model.
+# By default, a person is considered alive unless a source indicates otherwise.
+# If the person is deceased, the date of death is stored in the date_of_death field.
+# This class does not implement DocumentVersion as it has an evidence that has verification history.
+class AliveStatus
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  # @!attribute [rw] demographics_group
+  #   @return [DemographicsGroup] The demographics group associated with the alive status.
+  #   This is an instance of the DemographicsGroup class.
+  embedded_in :demographics_group, class_name: 'DemographicsGroup'
+
+  # @!attribute [rw] alive_evidence
+  #   @return [Eligibilities::Evidence] The evidence associated with the alive status.
+  #   This is an instance of the Eligibilities::Evidence class.
+  embeds_one :alive_evidence, class_name: "::Eligibilities::Evidence", as: :evidenceable, cascade_callbacks: true
+
+  # @!attribute [rw] is_deceased
+  #   @return [Boolean] A flag indicating if the person is deceased. Default is false.
+  field :is_deceased, type: Boolean, default: false
+
+  # @!attribute [rw] date_of_death
+  #   @return [Date] The date of death of the person.
+  field :date_of_death, type: Date
+
+  # @note The boolean return value of `alive_status.alive_evidence.is_satisfied` determines the alive status of the person.
+  # If it returns true, the person is considered alive. If it returns false, the person is considered deceased.
+end

--- a/app/models/demographics_group.rb
+++ b/app/models/demographics_group.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Class representing a group of demographic information for a person.
+# This class is embedded in any model that declares itself as 'demographicable'.
+class DemographicsGroup
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  # @!attribute [rw] demographicable
+  #   @return [Object] The object that this DemographicsGroup instance is associated with.
+  #   This is a polymorphic association, so it can be any object that declares itself as 'demographicable'.
+  embedded_in :demographicable, polymorphic: true
+
+  # @!attribute [rw] alive_status
+  #   @return [AliveStatus] The alive status of the person.
+  #   This model is embedded in the DemographicsGroup model.
+  #   It contains information about the person's status, such as whether they are alive or deceased.
+  #   It does not implement DocumentVersion as this model has an evidence that has verification history.
+  embeds_one :alive_status, class_name: "AliveStatus", cascade_callbacks: true
+
+  # @note The birth_entries is not implemented yet.
+  # embeds_many :birth_entries, class_name: 'BirthEntry', cascade_callbacks: true, validate: true
+
+  # @note The gender_entries is not implemented yet.
+  # embeds_many :gender_entries, class_name: 'GenderEntry', cascade_callbacks: true, validate: true
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -174,6 +174,11 @@ class Person
   embeds_many :documents, as: :documentable
   embeds_many :verification_types, cascade_callbacks: true, validate: true
 
+  # @!attribute [rw] demographics_group
+  #   @return [DemographicsGroup] The demographics information for the person.
+  #   This is a polymorphic association that can be associated with any model that can have demographics information.
+  embeds_one :demographics_group, as: :demographicable, class_name: 'DemographicsGroup'
+
   attr_accessor :effective_date, :skip_person_updated_event_callback, :is_consumer_role, :is_resident_role
 
   accepts_nested_attributes_for :consumer_role, :resident_role, :broker_role, :hbx_staff_role,

--- a/spec/factories/alive_statuses.rb
+++ b/spec/factories/alive_statuses.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :alive_status, class: 'AliveStatus' do
+    association :demographics_group
+
+    is_deceased { false }
+    date_of_death { nil }
+
+    trait :deceased do
+      is_deceased   { true }
+      date_of_death { TimeKeeper.date_of_record }
+    end
+
+    trait :with_alive_evidence do
+      after(:create) do |alive_status|
+        alive_status.create_alive_evidence(
+          key: :alive_status,
+          title: 'Alive Status',
+          aasm_state: 'pending',
+          due_on: TimeKeeper.date_of_record.prev_day,
+          verification_outstanding: true,
+          is_satisfied: true
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/demographics_groups.rb
+++ b/spec/factories/demographics_groups.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :demographics_group, class: 'DemographicsGroup' do
+
+    trait :with_alive_status do
+      after(:create) do |demographics_group, _evaluator|
+        create_list(:alive_status, 1, :with_alive_evidence, demographics_group: demographics_group)
+      end
+    end
+  end
+end

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -1,25 +1,22 @@
 FactoryBot.define do
   factory :person do
-    # name_pfx 'Mr'
     first_name { 'John' }
-    # middle_name 'X'
     sequence(:last_name) {|n| "Smith#{n}" }
-    # name_sfx 'Jr'
     dob { "1972-04-04".to_date }
     is_incarcerated { false }
     is_active { true }
 
     gender { "male" }
-    # us_citizen "true"
-    # indian_tribe_member "false"
-    # naturalized_citizen "false"
-    # association :employee_role, strategy: :build
 
     after(:create) do |p, evaluator|
       create_list(:address, 2, person: p)
       create_list(:phone, 2, person: p)
       create_list(:email, 2, person: p)
       create_list(:employee_role, 1, person: p) unless p.employee_roles
+    end
+
+    trait :with_demographics_group do
+      demographics_group { FactoryBot.build(:demographics_group) }
     end
 
     trait :with_mailing_address do

--- a/spec/models/alive_status_spec.rb
+++ b/spec/models/alive_status_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AliveStatus, type: :model do
+  let(:person) { FactoryBot.create(:person) }
+
+  describe 'associations' do
+    let(:demographics) do
+      FactoryBot.create(:demographics_group, :with_alive_status, demographicable: person)
+    end
+
+    let(:alive_status) { demographics.alive_status }
+
+    it 'returns correct parent association' do
+      expect(alive_status.demographics_group).to eq(demographics)
+      expect(alive_status.demographics_group).to be_a(DemographicsGroup)
+    end
+
+    it 'returns correct child association' do
+      expect(alive_status.alive_evidence).to be_a(Eligibilities::Evidence)
+    end
+  end
+end

--- a/spec/models/demographics_group_spec.rb
+++ b/spec/models/demographics_group_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DemographicsGroup, type: :model do
+  let(:person) { FactoryBot.create(:person) }
+  let(:demographics) do
+    FactoryBot.create(:demographics_group, :with_alive_status, demographicable: person)
+  end
+
+  describe 'associations' do
+    context 'parent association' do
+      it 'returns correct association' do
+        expect(demographics.demographicable).to eq(person)
+        expect(demographics.demographicable).to be_a(Person)
+      end
+    end
+
+    context 'child associations' do
+      context 'alive_status' do
+        it 'returns correct association' do
+          expect(demographics.alive_status).to be_a(AliveStatus)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/person_demographics_spec.rb
+++ b/spec/models/person_demographics_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Person, type: :model do
+  let(:person) { FactoryBot.create(:person, :with_demographics_group) }
+
+  describe 'associations' do
+    it 'returns correct association' do
+      expect(person.demographics_group).to be_a(DemographicsGroup)
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [Jolly Podgers - 187441810](https://www.pivotaltracker.com/story/show/187441810)

# A brief description of the changes

Current behavior: N/A

New behavior: Adds persistence data models for Alive Status and its verification.

# Feature Flag

- A feature flag is not implemented yet.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
- All the base work for this is included in the PR: https://github.com/ideacrew/enroll/pull/3561. [PR-3561](https://github.com/ideacrew/enroll/pull/3561) includes work related to CR-80(Death Verification) and CR-232,246(Race and Ethnicity). The combined work is now split into separate PRs.


# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.