### PR TITLE
Fix benefit package selection bug

### DIFF
--- a/components/benefit_sponsors/app/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship.rb
@@ -559,8 +559,12 @@ module BenefitSponsors
       return nil unless termed_or_ineligible_app
 
       compare_date = termed_or_ineligible_app.enrollment_ineligible? ? termed_or_ineligible_app.start_on : termed_or_ineligible_app.end_on
-      application =  recent_bas.select { |recent_ba| recent_ba.start_on > compare_date && recent_ba.aasm_state != :canceled && exclude_renewal_and_renewal(recent_ba) }.first
+      application =  recent_bas.select { |recent_ba| recent_ba.start_on > compare_date && exclude_renewal_active_and_expired(recent_ba) }.first
       benefit_applications.map(&:reinstated_id).include?(application&.id) ? nil : application
+    end
+
+    def exclude_renewal_active_and_expired(recent_ba)
+      recent_ba.reinstated_id.blank? && recent_ba.predecessor_id.blank? && !(recent_ba.active? || recent_ba.expired?)
     end
 
     def exclude_renewal_and_renewal(recent_ba)

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship_spec.rb
@@ -11,7 +11,7 @@ module BenefitSponsors
     let!(:service_area) { create_default(:benefit_markets_locations_service_area) }
     let!(:next_rating_area) { create_default(:benefit_markets_locations_rating_area, active_year: Date.current.year + 1) }
     let!(:next_service_area) { create_default(:benefit_markets_locations_service_area, active_year: Date.current.year + 1) }
-  
+
     let(:site) { ::BenefitSponsors::SiteSpecHelpers.create_site_with_hbx_profile_and_benefit_market }
     let(:benefit_market)  { site.benefit_markets.first }
 
@@ -688,7 +688,7 @@ module BenefitSponsors
       end
 
       context '.may_end_open_enrollment?' do
-        context 'applications that are under enrollment_open state' do 
+        context 'applications that are under enrollment_open state' do
           let(:initial_application_state) { :enrollment_open }
           let(:renewal_application_state) { :enrollment_open }
 
@@ -698,7 +698,7 @@ module BenefitSponsors
           end
         end
 
-        context 'applications that are under enrollment_extended state' do 
+        context 'applications that are under enrollment_extended state' do
           let(:initial_application_state) { :enrollment_extended }
           let(:renewal_application_state) { :enrollment_extended }
 
@@ -781,7 +781,7 @@ module BenefitSponsors
           )
         end
 
-        it "should fetch only valid initial applications" do 
+        it "should fetch only valid initial applications" do
           applications = subject.may_transmit_initial_enrollment?(april_effective_date)
 
           expect((applications & april_sponsors).sort).to eq april_sponsors.sort
@@ -912,7 +912,7 @@ module BenefitSponsors
 
       end
 
-      context '.may_transition_as_initial_ineligible?' do 
+      context '.may_transition_as_initial_ineligible?' do
         let(:initial_application_state) { :enrollment_closed }
         let(:renewal_application_state) { :enrollment_closed }
         let(:april_enrollment_elgible_sponsor) { april_sponsors[0] }
@@ -1019,7 +1019,7 @@ module BenefitSponsors
 
       let(:april_application) { april_sponsor.benefit_applications.detect{|app| app.start_on == april_effective_date} }
 
- 
+
       context '.oe_extendable_benefit_applications' do
 
         let(:current_date)  { Date.new(this_year, 4, 10) }
@@ -1044,13 +1044,13 @@ module BenefitSponsors
 
             it "should not return application for enrollment extension" do
               expect(april_sponsor.oe_extendable_benefit_applications).to be_empty
-            end 
+            end
           end
 
           context "approved" do
             let(:aasm_state) { :approved }
 
-            it "should not return application for enrollment extension" do 
+            it "should not return application for enrollment extension" do
               expect(april_sponsor.oe_extendable_benefit_applications).to be_empty
             end
           end
@@ -1058,7 +1058,7 @@ module BenefitSponsors
           context "enrollment_extended" do
             let(:aasm_state) { :enrollment_extended }
 
-            it "should return only already extended application" do 
+            it "should return only already extended application" do
               expect(april_sponsor.oe_extendable_benefit_applications).to be_present
               expect(april_sponsor.oe_extendable_benefit_applications).to eq [april_application]
             end
@@ -1075,7 +1075,7 @@ module BenefitSponsors
           context "draft" do
             let(:aasm_state) { :draft }
 
-            it "should return application for enrollment extension" do 
+            it "should return application for enrollment extension" do
               expect(april_sponsor.oe_extendable_benefit_applications).to be_present
               expect(april_sponsor.oe_extendable_benefit_applications).to eq [new_application]
             end
@@ -1100,7 +1100,7 @@ module BenefitSponsors
             expect(april_sponsor.oe_extendable_benefit_applications).to be_present
             expect(april_sponsor.oe_extendable_benefit_applications).to eq [new_application]
           end
-        end 
+        end
       end
 
       context '.oe_extended_applications' do
@@ -1487,6 +1487,18 @@ module BenefitSponsors
         it "should return nil" do
           expect(active_benefit_sponsorship.off_cycle_benefit_application).to eq nil
         end
+      end
+
+      context 'employer has one draft and one expired application after terminated application' do
+        let(:start_on)                    { TimeKeeper.date_of_record.beginning_of_month.prev_month }
+        let(:termination_date)            { TimeKeeper.date_of_record.next_month.end_of_month }
+        let!(:renewal_effective_period)   { termination_date.next_day..termination_date.next_day.next_year.prev_day }
+        let!(:effective_period)           { start_on..termination_date }
+        let!(:term_application)           { FactoryBot.create(:benefit_sponsors_benefit_application, aasm_state: :termination_pending, default_effective_period: effective_period, benefit_sponsorship: active_benefit_sponsorship) }
+        let!(:canceled_app1)              { FactoryBot.create(:benefit_sponsors_benefit_application, aasm_state: :expired, default_effective_period: renewal_effective_period, benefit_sponsorship: active_benefit_sponsorship) }
+        let!(:draft_app)                  { FactoryBot.create(:benefit_sponsors_benefit_application, aasm_state: :draft, default_effective_period: renewal_effective_period, benefit_sponsorship: active_benefit_sponsorship) }
+
+        it { expect(active_benefit_sponsorship.off_cycle_benefit_application).to eq draft_app }
       end
     end
 

--- a/components/benefit_sponsors/spec/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/benefit_sponsorships/benefit_sponsorship_spec.rb
@@ -1445,13 +1445,13 @@ module BenefitSponsors
       it_behaves_like "for off-cycle employer", "canceled", nil, "draft", false
       it_behaves_like "for off-cycle employer", "enrollment_ineligible", nil, "draft", true
       it_behaves_like "for off-cycle employer", "enrollment_ineligible", nil, "enrollment_open", true
-      it_behaves_like "for off-cycle employer", "enrollment_ineligible", nil, "active", true
+      it_behaves_like "for off-cycle employer", "enrollment_ineligible", nil, "active", false
       it_behaves_like "for off-cycle employer", "terminated", nil, "draft", true
       it_behaves_like "for off-cycle employer", "terminated", nil, "enrollment_open", true
-      it_behaves_like "for off-cycle employer", "terminated", nil, "active", true
+      it_behaves_like "for off-cycle employer", "terminated", nil, "active", false
       it_behaves_like "for off-cycle employer", "termination_pending", nil, "draft", true
       it_behaves_like "for off-cycle employer", "termination_pending", nil, "enrollment_open", true
-      it_behaves_like "for off-cycle employer", "termination_pending", nil, "active", true
+      it_behaves_like "for off-cycle employer", "termination_pending", nil, "active", false
       it_behaves_like "for off-cycle employer", "active", nil, "", false
       it_behaves_like "for off-cycle employer", "active", "enrollment_ineligible", "draft", true
       it_behaves_like "for off-cycle employer", "active", "enrollment_open", nil, false


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/187466827

# A brief description of the changes

Current behavior:
The benefit package selection for off cycle application is not available if there is an existing active or expired benefit application present.

New behavior:
The benefit package selection for off cycle application is available if there is an existing active or expired benefit application present.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [x] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.