### PR TITLE
restrict response format for benefit_applications_controller

### DIFF
--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/application_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/application_controller.rb
@@ -13,6 +13,7 @@ module BenefitSponsors
 
     rescue_from Pundit::NotAuthorizedError, Pundit::NotDefinedError, with: :user_not_authorized
     rescue_from ActionController::InvalidAuthenticityToken, :with => :bad_token_due_to_session_expired
+    rescue_from ActionController::UnknownFormat, with: :respond_to_unsupported_format
 
     # for current_user
     before_action :set_current_user
@@ -163,6 +164,18 @@ module BenefitSponsors
         format.html { redirect_to main_app.root_path }
         format.js   { render plain: "window.location.assign('#{root_path}');" }
         format.json { redirect_to main_app.root_path }
+      end
+    end
+
+    def respond_to_unsupported_format
+      message = 'Unsupported format'
+      status = :not_acceptable
+      content_type = 'text/plain'
+
+      respond_to do |format|
+        format.json { render json: { error: message }, status: status }
+        format.xml  { render xml: { error: message }.to_xml, status: status }
+        format.all { render body: message, status: status, content_type: content_type }
       end
     end
   end

--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller.rb
@@ -1,15 +1,18 @@
 module BenefitSponsors
   module BenefitApplications
-    class BenefitApplicationsController < ApplicationController
+    # This controller is used to create and update benefit applications
+    class BenefitApplicationsController < ::BenefitSponsors::ApplicationController
       layout "two_column"
       include Pundit
       include HtmlScrubberUtil
 
-      before_action :check_request_format, only: [:new, :edit, :submit_application, :revert]
-
       def new
         @benefit_application_form = BenefitSponsors::Forms::BenefitApplicationForm.for_new(params.permit(:benefit_sponsorship_id))
         authorize @benefit_application_form, :updateable?
+
+        respond_to do |format|
+          format.html
+        end
       end
 
       def create
@@ -26,6 +29,10 @@ module BenefitSponsors
       def edit
         @benefit_application_form = BenefitSponsors::Forms::BenefitApplicationForm.for_edit(params.permit(:id, :benefit_sponsorship_id))
         authorize @benefit_application_form, :updateable?
+
+        respond_to do |format|
+          format.html
+        end
       end
 
       def update
@@ -55,7 +62,9 @@ module BenefitSponsors
         if @benefit_application_form.submit_application
           flash[:notice] = "Plan Year successfully published."
           flash[:error] = error_messages(@benefit_application_form)
-          render :js => "window.location = #{profiles_employers_employer_profile_path(@benefit_application_form.show_page_model.benefit_sponsorship.profile, tab: 'benefits').to_json}"
+          respond_to do |format|
+            format.js { render :js => "window.location = #{profiles_employers_employer_profile_path(@benefit_application_form.show_page_model.benefit_sponsorship.profile, tab: 'benefits').to_json}" }
+          end
         elsif @benefit_application_form.is_ineligible_to_submit?
           respond_to do |format|
             format.js
@@ -63,7 +72,9 @@ module BenefitSponsors
         else
           error_message_html = sanitize_html(@benefit_application_form.errors.messages.values.flatten.inject("") { |memo, error| "#{memo}<li>#{error}</li>" })
           flash[:error] = "Plan Year failed to publish. #{error_message_html}"
-          render :js => "window.location = #{profiles_employers_employer_profile_path(@benefit_application_form.show_page_model.benefit_sponsorship.profile, tab: 'benefits').to_json}"
+          respond_to do |format|
+            format.js { render :js => "window.location = #{profiles_employers_employer_profile_path(@benefit_application_form.show_page_model.benefit_sponsorship.profile, tab: 'benefits').to_json}" }
+          end
         end
       end
 
@@ -87,7 +98,10 @@ module BenefitSponsors
         else
           flash[:error] = sanitize_html("Plan Year could not be reverted to draft state. #{error_messages(@benefit_application_form)}")
         end
-        render :js => "window.location = #{profiles_employers_employer_profile_path(@benefit_application_form.show_page_model.benefit_sponsorship.profile, tab: 'benefits').to_json}"
+
+        respond_to do |format|
+          format.js { render :js => "window.location = #{profiles_employers_employer_profile_path(@benefit_application_form.show_page_model.benefit_sponsorship.profile, tab: 'benefits').to_json}" }
+        end
       end
 
       def late_rates_check
@@ -111,10 +125,6 @@ module BenefitSponsors
           :start_on, :end_on, :fte_count, :pte_count, :msp_count,
           :open_enrollment_start_on, :open_enrollment_end_on, :benefit_sponsorship_id
         )
-      end
-
-      def check_request_format
-        raise ActionController::UnknownFormat unless request.format.js?
       end
     end
   end

--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller.rb
@@ -32,6 +32,7 @@ module BenefitSponsors
 
         respond_to do |format|
           format.html
+          format.js
         end
       end
 

--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller.rb
@@ -5,7 +5,7 @@ module BenefitSponsors
       include Pundit
       include HtmlScrubberUtil
 
-      before_action :check_request_format, only: [:new, :edit, :submit_application, :force_submit_application, :revert]
+      before_action :check_request_format, only: [:new, :edit, :submit_application, :revert]
 
       def new
         @benefit_application_form = BenefitSponsors::Forms::BenefitApplicationForm.for_new(params.permit(:benefit_sponsorship_id))

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller_spec.rb
@@ -141,7 +141,7 @@ module BenefitSponsors
       context "when request format is html" do
         it "should not render new template" do
           sign_in user
-          get :new, params: { benefit_sponsorship_id: benefit_sponsorship_id }
+          get :new, params: { benefit_sponsorship_id: benefit_sponsorship_id }, format: :js
           expect(response.status).to eq 406
           expect(response.body).to eq "Unsupported format"
           expect(response.media_type).to eq "text/plain"
@@ -180,7 +180,7 @@ module BenefitSponsors
 
       def sign_in_and_do_new(user)
         sign_in user
-        get :new, params: { benefit_sponsorship_id: benefit_sponsorship_id }, format: :js, xhr: true
+        get :new, params: { benefit_sponsorship_id: benefit_sponsorship_id }, format: :html
       end
     end
 
@@ -286,7 +286,7 @@ module BenefitSponsors
       context "when request format is html" do
         it "should not render edit template" do
           sign_in user
-          get :edit, params: {benefit_sponsorship_id: benefit_sponsorship_id, id: ben_app.id.to_s, benefit_application: benefit_application_params}
+          get :edit, params: {benefit_sponsorship_id: benefit_sponsorship_id, id: ben_app.id.to_s, benefit_application: benefit_application_params}, format: :js
           expect(response.status).to eq 406
           expect(response.body).to eq "Unsupported format"
           expect(response.media_type).to eq "text/plain"
@@ -432,7 +432,7 @@ module BenefitSponsors
         context "when request format is html" do
           it "should not render submit_application template" do
             sign_in user_with_broker_role
-            post :submit_application, params: { benefit_sponsorship_id: benefit_sponsorship_id.to_s, benefit_application_id: benefit_application_id }
+            post :submit_application, params: { benefit_sponsorship_id: benefit_sponsorship_id.to_s, benefit_application_id: benefit_application_id }, format: :html
             expect(response.status).to eq 406
             expect(response.body).to eq "Unsupported format"
             expect(response.media_type).to eq "text/plain"

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller_spec.rb
@@ -140,7 +140,7 @@ module BenefitSponsors
 
       def sign_in_and_do_new(user)
         sign_in user
-        get :new, params: { benefit_sponsorship_id: benefit_sponsorship_id }
+        get :new, params: { benefit_sponsorship_id: benefit_sponsorship_id }, format: :js, xhr: true
       end
     end
 
@@ -442,7 +442,7 @@ module BenefitSponsors
 
       def sign_in_and_revert(user)
         sign_in user
-        post :revert, params: { :benefit_application_id => benefit_application.id.to_s, benefit_sponsorship_id: benefit_sponsorship_id }
+        post :revert, params: { :benefit_application_id => benefit_application.id.to_s, benefit_sponsorship_id: benefit_sponsorship_id }, format: :js, xhr: true
       end
 
       context "when there is no eligible application to revert" do

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller_spec.rb
@@ -286,7 +286,7 @@ module BenefitSponsors
       context "when request format is html" do
         it "should not render edit template" do
           sign_in user
-          get :edit, params: {benefit_sponsorship_id: benefit_sponsorship_id, id: ben_app.id.to_s, benefit_application: benefit_application_params}, format: :js
+          get :edit, params: {benefit_sponsorship_id: benefit_sponsorship_id, id: ben_app.id.to_s, benefit_application: benefit_application_params}, format: :faketype
           expect(response.status).to eq 406
           expect(response.body).to eq "Unsupported format"
           expect(response.media_type).to eq "text/plain"

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_applications/benefit_applications_controller_spec.rb
@@ -138,6 +138,46 @@ module BenefitSponsors
         end
       end
 
+      context "when request format is html" do
+        it "should not render new template" do
+          sign_in user
+          get :new, params: { benefit_sponsorship_id: benefit_sponsorship_id }
+          expect(response.status).to eq 406
+          expect(response.body).to eq "Unsupported format"
+          expect(response.media_type).to eq "text/plain"
+        end
+      end
+
+      context "when request format is BAC" do
+        it "should not render new template" do
+          sign_in user
+          get :new, params: { benefit_sponsorship_id: benefit_sponsorship_id }, format: :bac
+          expect(response.status).to eq 406
+          expect(response.body).to eq "Unsupported format"
+          expect(response.media_type).to eq "text/plain"
+        end
+      end
+
+      context "when request format is JSON" do
+        it "should not render new template" do
+          sign_in user
+          get :new, params: { benefit_sponsorship_id: benefit_sponsorship_id }, format: :json
+          expect(response.status).to eq 406
+          expect(response.body).to eq "{\"error\":\"Unsupported format\"}"
+          expect(response.media_type).to eq "application/json"
+        end
+      end
+
+      context "when request format is xml" do
+        it "should not render new template" do
+          sign_in user
+          get :new, params: { benefit_sponsorship_id: benefit_sponsorship_id }, format: :xml
+          expect(response.status).to eq 406
+          expect(response.body).to eq "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<hash>\n  <error>Unsupported format</error>\n</hash>\n"
+          expect(response.media_type).to eq "application/xml"
+        end
+      end
+
       def sign_in_and_do_new(user)
         sign_in user
         get :new, params: { benefit_sponsorship_id: benefit_sponsorship_id }, format: :js, xhr: true
@@ -242,6 +282,16 @@ module BenefitSponsors
           expect(form_class).to respond_to(:for_edit)
         end
       end
+
+      context "when request format is html" do
+        it "should not render edit template" do
+          sign_in user
+          get :edit, params: {benefit_sponsorship_id: benefit_sponsorship_id, id: ben_app.id.to_s, benefit_application: benefit_application_params}
+          expect(response.status).to eq 406
+          expect(response.body).to eq "Unsupported format"
+          expect(response.media_type).to eq "text/plain"
+        end
+      end
     end
 
     describe "POST update", :dbclean => :around_each do
@@ -292,6 +342,16 @@ module BenefitSponsors
           [user_with_hbx_staff_role, user, user_with_broker_role].each do |login_user|
             sign_in_and_do_update(login_user)
             expect(flash[:error]).to match(/Open enrollment end on can't be blank/)
+          end
+        end
+
+        context "when request format is html" do
+          it "should not render edit template" do
+            sign_in user
+            put :update, params: {:id => ben_app.id.to_s, :benefit_sponsorship_id => benefit_sponsorship_id, :benefit_application => benefit_application_params}
+            expect(response.status).to eq 406
+            expect(response.body).to eq "Unsupported format"
+            expect(response.media_type).to eq "text/plain"
           end
         end
       end
@@ -366,6 +426,16 @@ module BenefitSponsors
             post :submit_application, xhr: true, params: { benefit_sponsorship_id: benefit_sponsorship_id.to_s, benefit_application_id: benefit_application_id }
             expect(flash[:notice]).to eq "Plan Year successfully published."
             expect(flash[:error]).to eq "<li>Warning: You have 0 non-owner employees on your roster. In order to be able to enroll under employer-sponsored coverage, you must have at least one non-owner enrolled. Do you want to go back to add non-owner employees to your roster?</li>"
+          end
+        end
+
+        context "when request format is html" do
+          it "should not render submit_application template" do
+            sign_in user_with_broker_role
+            post :submit_application, params: { benefit_sponsorship_id: benefit_sponsorship_id.to_s, benefit_application_id: benefit_application_id }
+            expect(response.status).to eq 406
+            expect(response.body).to eq "Unsupported format"
+            expect(response.media_type).to eq "text/plain"
           end
         end
       end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [ ] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2648255/stories/187465510

# A brief description of the changes

Current behavior: benefit_applications_controller actions responds to all MIME types

New behavior: restrict response formats for benefit_applications_controller actions

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.