### PR TITLE
add account_expired to saml_controller

### DIFF
--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -23,7 +23,7 @@ class SamlController < ApplicationController
 
       if oim_user.present?
         if oim_user.expired?
-          redirect_to account_expired_saml_index_path 
+          redirect_to account_expired_saml_index_path
           return
         end
 

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -7,7 +7,6 @@ class SamlController < ApplicationController
   #   redirect_to(request.create(saml_settings))
   # end
 
-
   def account_expired
     flash[:error] = l10n('devise.failure.expired')
   end

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -7,6 +7,11 @@ class SamlController < ApplicationController
   #   redirect_to(request.create(saml_settings))
   # end
 
+
+  def account_expired
+    flash[:error] = l10n('devise.failure.expired')
+  end
+
   def login
     response          = OneLogin::RubySaml::Response.new(params[:SAMLResponse], :allowed_clock_drift => 5.seconds)
     response.settings = saml_settings
@@ -19,7 +24,7 @@ class SamlController < ApplicationController
 
       if oim_user.present?
         if oim_user.expired?
-          redirect_to main_app.root_path, flash: { error: l10n('devise.failure.expired') }
+          redirect_to account_expired_saml_index_path 
           return
         end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
       post :redirection_test
       get :logout
       get :navigate_to_assistance
+      get :account_expired
     end
   end
 

--- a/spec/controllers/saml_controller_spec.rb
+++ b/spec/controllers/saml_controller_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe SamlController do
       let(:attributes_double) { { 'mail' => admin_user.email} }
 
       before :each do
-        admin_person.user.update_attributes!(last_activity_at: Time.now - 61.days)
         allow(OneLogin::RubySaml::Response).to receive(:new).with(sample_xml, :allowed_clock_drift => 5.seconds).and_return(valid_saml_response)
       end
 
@@ -35,14 +34,23 @@ RSpec.describe SamlController do
           hbx_staff_role
         end
 
-        it "redirects to root path" do
-          post :login, params: {SAMLResponse: sample_xml}
-          expect(response).to redirect_to(root_path)
+        context "with last activity at greater than 60 days" do
+          before do
+            admin_user.update_attributes!(last_activity_at: 61.days.ago)
+          end
+        
+          it "redirects to account expired path" do
+            post :login, params: {SAMLResponse: sample_xml}
+            expect(response).to redirect_to(account_expired_saml_index_path)
+          end
         end
 
-        it "shows error message" do
-          post :login, params: {SAMLResponse: sample_xml}
-          expect(flash[:error]).to eq l10n('devise.failure.expired')
+        context "with last activity at less than 60 days" do
+        
+          it "redirects to last portal visited" do
+            post :login, params: {SAMLResponse: sample_xml}
+            expect(response).to redirect_to(admin_user.last_portal_visited)
+          end
         end
       end
 
@@ -211,6 +219,13 @@ RSpec.describe SamlController do
           expect(response).to have_http_status(403)
         end
       end
+    end
+  end
+
+  describe "GET account_expired", db_clean: :after_each do
+    it "shows error message" do
+      get :account_expired
+      expect(flash[:error]).to eq l10n('devise.failure.expired')
     end
   end
 

--- a/spec/controllers/saml_controller_spec.rb
+++ b/spec/controllers/saml_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe SamlController do
           before do
             admin_user.update_attributes!(last_activity_at: 61.days.ago)
           end
-        
+
           it "redirects to account expired path" do
             post :login, params: {SAMLResponse: sample_xml}
             expect(response).to redirect_to(account_expired_saml_index_path)
@@ -46,7 +46,7 @@ RSpec.describe SamlController do
         end
 
         context "with last activity at less than 60 days" do
-        
+
           it "redirects to last portal visited" do
             post :login, params: {SAMLResponse: sample_xml}
             expect(response).to redirect_to(admin_user.last_portal_visited)


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/187444823

# A brief description of the changes

Current behavior: When logging in via Keycloak, if an account is expired, we are not displaying a message

New behavior: We will display an error message. 

Please note: We are adding the endpoint: account_expired. This is only displaying an error message.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: ADMIN_ACCOUNT_AUTOLOCK_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
