### PR TITLE
limit responses of security question responses controller mime types

### DIFF
--- a/app/controllers/users/security_question_responses_controller.rb
+++ b/app/controllers/users/security_question_responses_controller.rb
@@ -1,5 +1,6 @@
 class Users::SecurityQuestionResponsesController < ApplicationController
   include Config::ContactCenterConcern
+  respond_to :js, only: [:create, :authenticate, :challenge]
 
   def create
     responses = params[:security_question_responses]
@@ -38,6 +39,7 @@ class Users::SecurityQuestionResponsesController < ApplicationController
       @form_name = "form#new_user"
       user.identity_confirmed_token = @success_token
       user.save!
+      respond_to :js
     else
       flash[:error] = "That doesn't seem to be the correct response"
       render :error_response

--- a/app/controllers/users/security_question_responses_controller.rb
+++ b/app/controllers/users/security_question_responses_controller.rb
@@ -39,7 +39,6 @@ class Users::SecurityQuestionResponsesController < ApplicationController
       @form_name = "form#new_user"
       user.identity_confirmed_token = @success_token
       user.save!
-      respond_to :js
     else
       flash[:error] = "That doesn't seem to be the correct response"
       render :error_response


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit
)
- [x] Tests for the changes have been added (for bugfixes/features)

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187466649

# A brief description of the changes

Current behavior: No mime-type validations for security question responses controller

New behavior: Security question responses controller now will only respond to valid mime-types

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.