### PR TITLE
restrict response format for benefit_packages_controller actions

### DIFF
--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_packages/benefit_packages_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_packages/benefit_packages_controller.rb
@@ -2,6 +2,7 @@
 
 module BenefitSponsors
   module BenefitPackages
+    # This controller is used to create and update benefit packages
     class BenefitPackagesController < ::BenefitSponsors::ApplicationController
 
       before_action :check_for_late_rates, only: [:new]

--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_packages/benefit_packages_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_packages/benefit_packages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BenefitSponsors
   module BenefitPackages
     class BenefitPackagesController < ApplicationController
@@ -11,6 +13,10 @@ module BenefitSponsors
 
       def new
         authorize @benefit_package_form, :updateable?
+
+        respond_to do |format|
+          format.html
+        end
       end
 
       def create
@@ -28,13 +34,20 @@ module BenefitSponsors
           end
         else
           flash[:error] = error_messages(@benefit_package_form)
-          render :new
+
+          respond_to do |format|
+            format.html { render :new }
+          end
         end
       end
 
       def edit
         @benefit_package_form = BenefitSponsors::Forms::BenefitPackageForm.for_edit(params.permit(:id, :benefit_application_id), true)
         authorize @benefit_package_form, :updateable?
+
+        respond_to do |format|
+          format.html
+        end
       end
 
       def update
@@ -54,18 +67,27 @@ module BenefitSponsors
           end
         else
           flash[:error] = error_messages(@benefit_package_form)
-          render :edit
+
+          respond_to do |format|
+            format.html { render :edit }
+          end
         end
       end
 
       def calculate_employer_contributions
         @employer_contributions = BenefitSponsors::Forms::BenefitPackageForm.for_calculating_employer_contributions(benefit_package_params)
-        render json: @employer_contributions
+
+        respond_to do |format|
+          format.json { rrender json: @employer_contributions }
+        end
       end
 
       def calculate_employee_cost_details
         @employee_cost_details = BenefitSponsors::Forms::BenefitPackageForm.for_calculating_employee_cost_details(benefit_package_params)
-        render json: @employee_cost_details.to_json
+
+        respond_to do |format|
+          format.json { render json: @employee_cost_details.to_json }
+        end
       end
 
       def destroy
@@ -73,16 +95,21 @@ module BenefitSponsors
         authorize @benefit_package_form, :updateable?
         if @benefit_package_form.destroy
           flash[:notice] = "Benefit Package successfully deleted."
-          render :js => "window.location = #{profiles_employers_employer_profile_path(@benefit_package_form.service.benefit_application.benefit_sponsorship.profile, :tab=>'benefits').to_json}"
         else
           flash[:error] = error_messages(@benefit_package_form)
-          render :js => "window.location = #{profiles_employers_employer_profile_path(@benefit_package_form.service.benefit_application.benefit_sponsorship.profile, :tab=>'benefits').to_json}"
+        end
+
+        respond_to do |format|
+          format.js { render :js => "window.location = #{profiles_employers_employer_profile_path(@benefit_package_form.service.benefit_application.benefit_sponsorship.profile, :tab => 'benefits').to_json}" }
         end
       end
 
       def reference_product_summary
         @product_summary = BenefitSponsors::Forms::BenefitPackageForm.for_reference_product_summary(reference_product_params, params[:details])
-        render json: @product_summary
+
+        respond_to do |format|
+          format.json {  render json: @product_summary }
+        end
       end
 
       private

--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_packages/benefit_packages_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/benefit_packages/benefit_packages_controller.rb
@@ -2,7 +2,7 @@
 
 module BenefitSponsors
   module BenefitPackages
-    class BenefitPackagesController < ApplicationController
+    class BenefitPackagesController < ::BenefitSponsors::ApplicationController
 
       before_action :check_for_late_rates, only: [:new]
 

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_packages/benefit_packages_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_packages/benefit_packages_controller_spec.rb
@@ -236,7 +236,7 @@ module BenefitSponsors
 
       def sign_in_and_get_ref_prod
         sign_in user
-        get :reference_product_summary, params: { :reference_plan_id => product.id, :benefit_application_id => benefit_application_id, :benefit_sponsorship_id => benefit_sponsorship_id }
+        get :reference_product_summary, params: { :reference_plan_id => product.id, :benefit_application_id => benefit_application_id, :benefit_sponsorship_id => benefit_sponsorship_id }, format: :json
       end
 
       before do

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_packages/benefit_packages_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/benefit_packages/benefit_packages_controller_spec.rb
@@ -134,6 +134,16 @@ module BenefitSponsors
         get :new, params: { benefit_application_id: benefit_application_id, benefit_sponsorship_id: benefit_sponsorship_id }
       end
 
+      context "when request format is js" do
+        it "should not render new template" do
+          sign_in user
+          get :new, params: { benefit_application_id: benefit_application_id, benefit_sponsorship_id: benefit_sponsorship_id }, format: :js
+          expect(response.status).to eq 406
+          expect(response.body).to eq "Unsupported format"
+          expect(response.media_type).to eq "text/plain"
+        end
+      end
+
       it "should route to benefits tab if rates are not present" do
         future_date = TimeKeeper.date_of_record + 1.year
         benefit_application.effective_period = future_date.beginning_of_year..future_date.end_of_year
@@ -230,6 +240,16 @@ module BenefitSponsors
         sign_in_and_do_edit
         expect(response).to render_template("edit")
       end
+
+      context "when request format is js" do
+        it "should not render edit template" do
+          sign_in user
+          get :edit, params: { benefit_sponsorship_id: benefit_sponsorship_id, benefit_application_id: benefit_application_id, id: benefit_package.id.to_s }, format: :js
+          expect(response.status).to eq 406
+          expect(response.body).to eq "Unsupported format"
+          expect(response.media_type).to eq "text/plain"
+        end
+      end
     end
 
     describe "GET reference_product_summary details" do
@@ -252,6 +272,16 @@ module BenefitSponsors
       it "should initialize form" do
         sign_in_and_get_ref_prod
         expect(form_class).to respond_to(:for_reference_product_summary)
+      end
+
+      context "when request format is js" do
+        it "should not render reference_product_summary template" do
+          sign_in user
+          get :reference_product_summary, params: { :reference_plan_id => product.id, :benefit_application_id => benefit_application_id, :benefit_sponsorship_id => benefit_sponsorship_id }, format: :js
+          expect(response.status).to eq 406
+          expect(response.body).to eq "Unsupported format"
+          expect(response.media_type).to eq "text/plain"
+        end
       end
     end
 
@@ -318,6 +348,16 @@ module BenefitSponsors
               :reference_plan_id => nil
             }
           }
+        end
+
+        context "when request format is js" do
+          it "should not render update template" do
+            sign_in user
+            post :update, params: { :benefit_sponsorship_id => benefit_sponsorship_id, :benefit_application_id => benefit_application_id, :id => benefit_package.id.to_s, :benefit_package => benefit_package_params }, format: :js
+            expect(response.status).to eq 406
+            expect(response.body).to eq "Unsupported format"
+            expect(response.media_type).to eq "text/plain"
+          end
         end
 
         it "should redirect to edit" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2648255/stories/187465524#

# A brief description of the changes

Current behavior: benefit_packages_controller actions responds to all MIME types

New behavior: restrict response formats for benefit_packages_controller actions

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
