### PR TITLE
Update state for review and reject evidence IfsvEligibilityDetermination

### DIFF
--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -392,7 +392,7 @@ module Eligibilities
     end
 
     def is_previous_state?(state)
-      workflow_state_transitions.order_by(:transition_at.desc)&.first&.from_state === state
+      workflow_state_transitions.order_by(:transition_at.desc)&.first&.from_state == state
     end
 
     def type_verified?

--- a/app/models/eligibilities/evidence.rb
+++ b/app/models/eligibilities/evidence.rb
@@ -391,6 +391,10 @@ module Eligibilities
       !type_verified?
     end
 
+    def is_previous_state?(state)
+      workflow_state_transitions.order_by(:transition_at.desc)&.first&.from_state === state
+    end
+
     def type_verified?
       ["verified", "attested"].include? aasm_state
     end

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination.rb
@@ -72,7 +72,13 @@ module FinancialAssistance
                 applicant.set_income_evidence_verified
               when "outstanding"
                 if income_evidence.enrolled_in_any_aptc_csr_enrollments?(enrollments)
-                  applicant.set_evidence_outstanding(income_evidence)
+                  if income_evidence.is_previous_state?('review')
+                    income_evidence.move_to_review
+                  elsif income_evidence.is_previous_state?('rejected')
+                    applicant.set_evidence_rejected(income_evidence)
+                  else
+                    applicant.set_evidence_outstanding(income_evidence)
+                  end
                 else
                   applicant.set_evidence_to_negative_response(income_evidence)
                 end
@@ -92,6 +98,7 @@ module FinancialAssistance
               end
               applicant.save!
             end
+
           end
         end
       end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/ifsv/h9t/ifsv_eligibility_determination_spec.rb
@@ -122,6 +122,38 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Ifsv::H9t::IfsvE
             expect(@result).to be_success
           end
 
+          context 'and income_evidence in state review' do
+            context 'with aptc used' do
+              let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_aptc_enrollment_members, :with_health_product, family: family, enrollment_members: family.family_members) }
+
+              it 'returns review' do
+                income_evidence = @applicant.income_evidence
+                income_evidence.move_to_review
+                subject.call(payload: response_payload)
+                enrollment_member = enrollment.hbx_enrollment_members.first
+                enrollment_member.person.update(hbx_id: '1629165429385938')
+                income_evidence = @applicant.income_evidence
+                expect(income_evidence.review?).to be_truthy
+              end
+            end
+          end
+
+          context 'and income_evidence in state rejected' do
+            context 'with aptc used' do
+              let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_aptc_enrollment_members, :with_health_product, family: family, enrollment_members: family.family_members) }
+
+              it 'returns rejected' do
+                income_evidence = @applicant.income_evidence
+                @applicant.set_evidence_rejected(income_evidence)
+                subject.call(payload: response_payload)
+                enrollment_member = enrollment.hbx_enrollment_members.first
+                enrollment_member.person.update(hbx_id: '1629165429385938')
+                income_evidence = @applicant.income_evidence
+                expect(income_evidence.rejected?).to be_truthy
+              end
+            end
+          end
+
           context 'with aptc used' do
 
             let(:enrollment) { FactoryBot.create(:hbx_enrollment, :with_aptc_enrollment_members, :with_health_product, family: family, enrollment_members: family.family_members) }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
[Determination Income Hub Response Result in Incorrect Evidence Status](https://www.pivotaltracker.com/n/projects/2640060/stories/187423449)


# A brief description of the changes

For initial Review and Reject status with is_ifsv_eligible"=>false, return status to initial.


# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
