### PR TITLE
add validation for sibling relationships

### DIFF
--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -627,7 +627,7 @@ module FinancialAssistance
       true
     end
 
-    def valid_sibling_relationship?(relative=self)
+    def valid_sibling_relationship?
       sibling_relationships = self.relationships.where(kind: 'sibling')
       return true unless sibling_relationships.present?
       sibling_relationships.each do |sibling_relationship|

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -612,7 +612,7 @@ module FinancialAssistance
     end
 
     def valid_family_relationships?
-      valid_spousal_relationship? && valid_child_relationship? && valid_in_law_relationship?
+      valid_spousal_relationship? && valid_child_relationship? && valid_in_law_relationship? && valid_sibling_relationship?
     end
 
     # Checks that an applicant cannot have more than one spousal relationship
@@ -624,6 +624,15 @@ module FinancialAssistance
                                                                 ]
                                                               })
       return false if partner_relationships.size > 2
+      true
+    end
+
+    def valid_sibling_relationship?(relative=self)
+      sibling_relationships = self.relationships.where(kind: 'sibling')
+      return true unless sibling_relationships.present?
+      sibling_relationships.each do |sibling_relationship|
+        return false unless sibling_relationship.relative.relationships.where(kind: 'sibling').count == sibling_relationships.count
+      end
       true
     end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/187423457#

# A brief description of the changes

Current behavior: When navigating to the family relationships page in the faa flow, we do not enforce incorrect sibling relationships

New behavior: New validation added to enforce correct sibling relationships in the faa flow

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
