### PR TITLE
enforce respond to for applicants controller

### DIFF
--- a/components/financial_assistance/app/controllers/financial_assistance/applicants_controller.rb
+++ b/components/financial_assistance/app/controllers/financial_assistance/applicants_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module FinancialAssistance
+  # Applicant controller for Financial Assistance
   class ApplicantsController < FinancialAssistance::ApplicationController
     include ::UIHelpers::WorkflowController
 
@@ -70,7 +71,10 @@ module FinancialAssistance
       save_faa_bookmark(request.original_url)
       set_admin_bookmark_url
       @applicant = @application.active_applicants.find(params[:id])
-      render layout: 'financial_assistance_nav'
+
+      respond_to do |format|
+        format.html { render layout: 'financial_assistance_nav' }
+      end
     end
 
     def save_questions
@@ -87,7 +91,10 @@ module FinancialAssistance
       end
     end
 
+    #rubocop:disable Metrics/AbcSize
     def step
+      raise ActionController::UnknownFormat unless request.format.html?
+
       authorize @applicant, :step?
       save_faa_bookmark(request.original_url.gsub(%r{/step.*}, "/step/#{@current_step.to_i}"))
       set_admin_bookmark_url
@@ -120,10 +127,14 @@ module FinancialAssistance
         render 'workflow/step', layout: 'financial_assistance_nav'
       end
     end
+    #rubocop:enable Metrics/AbcSize
 
     def age_of_applicant
       authorize @applicant, :age_of_applicant?
-      render :plain => @applicant.age_of_the_applicant.to_s
+
+      respond_to do |format|
+        format.js { render :plain => @applicant.age_of_the_applicant.to_s }
+      end
     end
 
     def applicant_is_eligible_for_joint_filing
@@ -136,6 +147,8 @@ module FinancialAssistance
       return primary_applicant_has_spouse if applicant.is_primary_applicant
       # applicant is spouse of primary?
       applicant_is_spouse_of_primary(applicant)
+
+      respond_to :js
     end
 
     def immigration_document_options
@@ -151,6 +164,7 @@ module FinancialAssistance
       @vlp_doc_target = params[:vlp_doc_target]
       # vlp_doc_subject = params[:vlp_doc_subject]
       # @country = vlp_docs.detect{|doc| doc.subject == vlp_doc_subject }.try(:country_of_citizenship) if vlp_docs
+      respond_to :js
     end
 
     def destroy


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187465760

# A brief description of the changes

Current behavior: applicants controller responds to any request type.

New behavior: applicants controller respond to only fixed request type.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
