### PR TITLE
turn on NPN validation for form

### DIFF
--- a/app/views/ui-components/v1/forms/broker_registration/_personal_information.html.slim
+++ b/app/views/ui-components/v1/forms/broker_registration/_personal_information.html.slim
@@ -33,7 +33,7 @@ fieldset
     .col-md-4.mb-2
         label for="inputNPN"  NPN *
 
-        = f.text_field :npn, placeholder:'NPN', required: !EnrollRegistry.feature_enabled?(:allow_alphanumeric_npn), id:'inputNPN', class:'form-control', maxlength:'10', onkeypress: EnrollRegistry.feature_enabled?(:allow_alphanumeric_npn) ? 'return isAlphaNumeric(event);' : 'return isNumberKey(event);'
+        = f.text_field :npn, placeholder:'NPN', required: 'true', id:'inputNPN', class:'form-control', maxlength:'10', onkeypress: EnrollRegistry.feature_enabled?(:allow_alphanumeric_npn) ? 'return isAlphaNumeric(event);' : 'return isNumberKey(event);'
         .invalid-feedback
           |
             Please provide a NPN.
@@ -44,7 +44,7 @@ javascript:
 	    date: true,
 	    datePattern: ['m', 'd', 'Y']
 	});
-	
+
 	function validDob(element) {
 		if (element.value && element.value.length < 10) {
 			swal({

--- a/app/views/ui-components/v1/forms/broker_registration/_personal_information.html.slim
+++ b/app/views/ui-components/v1/forms/broker_registration/_personal_information.html.slim
@@ -32,8 +32,13 @@ fieldset
 
     .col-md-4.mb-2
         label for="inputNPN"  NPN *
-
-        = f.text_field :npn, placeholder:'NPN', required: 'true', id:'inputNPN', class:'form-control', maxlength:'10', onkeypress: EnrollRegistry.feature_enabled?(:allow_alphanumeric_npn) ? 'return isAlphaNumeric(event);' : 'return isNumberKey(event);'
+        = f.text_field :npn,
+          placeholder: 'NPN',
+          required: controller.action_name == 'new' ? 'true' : !EnrollRegistry.feature_enabled?(:allow_alphanumeric_npn),
+          id: 'inputNPN',
+          class: 'form-control',
+          maxlength: '10',
+          onkeypress: EnrollRegistry.feature_enabled?(:allow_alphanumeric_npn) ? 'return isAlphaNumeric(event);' : 'return isNumberKey(event);'
         .invalid-feedback
           |
             Please provide a NPN.

--- a/features/brokers/broker_registration.feature
+++ b/features/brokers/broker_registration.feature
@@ -29,7 +29,7 @@ Feature: Broker Agency Registration
     Then Primary Broker should see the create account page
     When Primary Broker registers with valid information
     Then they should see a welcome message
-    
+
 
   @broken
   Scenario: When the broker is hired as a census employee and registration is complete through employee role
@@ -68,3 +68,16 @@ Feature: Broker Agency Registration
     Then Employee should not see phone main field in the personal information fields
     And Employee Ricky Martin should only have phone with work kind
 
+  Scenario: Broker registration without NPN
+    Given the shop market configuration is enabled
+    And EnrollRegistry broker_attestation_fields feature is disabled
+    And EnrollRegistry broker_approval_period feature is enabled
+    And EnrollRegistry broker_invitation feature is enabled
+    Given a CCA site exists with a benefit market
+    When Primary Broker visits the HBX Broker Registration form
+    Given Primary Broker has not signed up as an HBX user
+    Then Primary Broker should see the New Broker Agency form
+    When Primary Broker enters personal information without npn
+    And And Primary Broker enters broker agency information for SHOP markets
+    And Primary Broker enters office location for default_office_location
+    Then Primary Broker should see broker npn validation error message

--- a/features/step_definitions/brokers_steps.rb
+++ b/features/step_definitions/brokers_steps.rb
@@ -26,6 +26,13 @@ When(/^.+ enters personal information$/) do
   fill_in 'agency[staff_roles_attributes][0][npn]', with: '109109109'
 end
 
+When(/^.+ enters personal information without npn$/) do
+  fill_in 'agency[staff_roles_attributes][0][first_name]', with: 'Ricky'
+  fill_in 'agency[staff_roles_attributes][0][last_name]', with: 'Martin'
+  fill_in 'inputDOB', with: '10/10/1984'
+  fill_in 'inputEmail', with: 'ricky.martin@example.com'
+end
+
 
 And(/^.+ enters broker agency information for individual markets$/) do
   fill_in 'organization[legal_name]', with: "Logistics Inc"
@@ -112,6 +119,10 @@ end
 Then(/^.+ should see broker registration successful message$/) do
   expect(page).to have_content("Complete the following requirements to become a #{EnrollRegistry[:enroll_app].setting(:short_name).item} Registered Broker") if broker_approval_period_enabled?
   expect(page).to have_content('Your registration has been submitted. A response will be sent to the email address you provided once your application is reviewed.')
+end
+
+Then(/^.+ should see broker npn validation error message$/) do
+  expect(page).to have_content('Please provide a NPN.')
 end
 
 def broker_approval_period_enabled?


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/story/show/187466998

The NPN field should always be present for registration (new controller action)


# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
