### PR TITLE
Update Broker registration validation for create too

### DIFF
--- a/app/views/ui-components/v1/forms/broker_registration/_personal_information.html.slim
+++ b/app/views/ui-components/v1/forms/broker_registration/_personal_information.html.slim
@@ -34,7 +34,7 @@ fieldset
         label for="inputNPN"  NPN *
         = f.text_field :npn,
           placeholder: 'NPN',
-          required: controller.action_name == 'new' ? 'true' : !EnrollRegistry.feature_enabled?(:allow_alphanumeric_npn),
+          required: %w[new create].include?(controller.action_name) ? 'true' : !EnrollRegistry.feature_enabled?(:allow_alphanumeric_npn),
           id: 'inputNPN',
           class: 'form-control',
           maxlength: '10',

--- a/features/brokers/broker_registration.feature
+++ b/features/brokers/broker_registration.feature
@@ -82,7 +82,6 @@ Feature: Broker Agency Registration
     And Primary Broker enters office location for default_office_location
     Then Primary Broker should see broker npn validation error message
 
-
   Scenario: Broker registration with already used NPN and then pass empty NPN
     Given the shop market configuration is enabled
     And EnrollRegistry broker_attestation_fields feature is disabled

--- a/features/brokers/broker_registration.feature
+++ b/features/brokers/broker_registration.feature
@@ -81,3 +81,21 @@ Feature: Broker Agency Registration
     And And Primary Broker enters broker agency information for SHOP markets
     And Primary Broker enters office location for default_office_location
     Then Primary Broker should see broker npn validation error message
+
+
+  Scenario: Broker registration with already used NPN and then pass empty NPN
+    Given the shop market configuration is enabled
+    And EnrollRegistry broker_attestation_fields feature is disabled
+    And EnrollRegistry broker_approval_period feature is enabled
+    And EnrollRegistry broker_invitation feature is enabled
+    Given a CCA site exists with a benefit market
+    And broker with a specific NPN already exists
+    When Primary Broker visits the HBX Broker Registration form
+    Given Primary Broker has not signed up as an HBX user
+    Then Primary Broker should see the New Broker Agency form
+    When Primary Broker enters personal information with specific NPN
+    And And Primary Broker enters broker agency information for SHOP markets
+    And Primary Broker enters office location for default_office_location
+    Then Primary Broker should see the NPN already taken message
+    When Primary Broker delete NPN and submit form
+    Then Primary Broker should see broker npn validation error message

--- a/features/step_definitions/brokers_steps.rb
+++ b/features/step_definitions/brokers_steps.rb
@@ -26,6 +26,14 @@ When(/^.+ enters personal information$/) do
   fill_in 'agency[staff_roles_attributes][0][npn]', with: '109109109'
 end
 
+When(/^.+ enters personal information with specific NPN$/) do
+  fill_in 'agency[staff_roles_attributes][0][first_name]', with: 'Ricky'
+  fill_in 'agency[staff_roles_attributes][0][last_name]', with: 'Martin'
+  fill_in 'inputDOB', with: '10/10/1984'
+  fill_in 'inputEmail', with: 'ricky.martin@example.com'
+  fill_in 'agency[staff_roles_attributes][0][npn]', with: BrokerRegistration.alphabetic_npn
+end
+
 When(/^.+ enters personal information without npn$/) do
   fill_in 'agency[staff_roles_attributes][0][first_name]', with: 'Ricky'
   fill_in 'agency[staff_roles_attributes][0][last_name]', with: 'Martin'

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -410,7 +410,7 @@ When(/(^.+) enters? office location for (.+)$/) do |role, location|
   find('#broker-btn').click
 end
 
-When(/(^.+) delete NPN and submit form$/) do
+When(/^.+ delete NPN and submit form$/) do
   fill_in 'agency[staff_roles_attributes][0][npn]', with: ''
   find('#broker-btn').click
 end

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -410,6 +410,11 @@ When(/(^.+) enters? office location for (.+)$/) do |role, location|
   find('#broker-btn').click
 end
 
+When(/(^.+) delete NPN and submit form$/) do
+  fill_in 'agency[staff_roles_attributes][0][npn]', with: ''
+  find('#broker-btn').click
+end
+
 When(/^.+ updates office location from (.+) to (.+)$/) do |old_add, new_add|
   old_add = eval(old_add) if old_add.class == String
   new_add = eval(new_add) if new_add.class == String


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 

Update for ticket https://www.pivotaltracker.com/n/projects/2640060/stories/187466998
Initial PR https://github.com/ideacrew/enroll/pull/3782

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
