### PR TITLE
localize my household fa left pane text

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/shared/_fa_left_nav.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/shared/_fa_left_nav.html.erb
@@ -4,7 +4,8 @@
       <li class="activer list-box step-tabs no-hover global-nav">
         <a href="<%= edit_application_path(@application) %>">
           <i class="fa fa-arrow-circle-left white-font hh-previous-icon" aria-hidden="true"></i>
-          My Household</a>
+          <%= l10n("faa.left_nav.my_household") %>
+        </a>
       </li>
       <li class="activer list-box step-tabs income-style no-hover">
         <%= content_tag("a", "Income and Coverage Info", :class => 'cna')  %>

--- a/components/financial_assistance/db/seedfiles/translations/en/dc/financial_assistance.rb
+++ b/components/financial_assistance/db/seedfiles/translations/en/dc/financial_assistance.rb
@@ -214,6 +214,8 @@ FINANCIAL_ASSISTANCE_TRANSLATIONS = {
   "en.faa.transfer_history" => "Transfer History",
   "en.faa.transfer_history_desc" => "Application transfers sent to or from %{site_short_name} related to this application are listed below.",
   "en.faa.no_history_available" => "No history available.",
+  # Left Nav Pane
+  "en.faa.left_nav.my_household" => "My Household",
   # Flash error display
   "en.faa.errors.should_be_answered" => "should be answered",
   "en.faa.errors.inconsistent_relationships_error" => "Some of the relationships you have listed are inconsistent. Review relationships and make sure each pair is correct.",

--- a/components/financial_assistance/db/seedfiles/translations/en/ic/financial_assistance.rb
+++ b/components/financial_assistance/db/seedfiles/translations/en/ic/financial_assistance.rb
@@ -204,6 +204,8 @@ FINANCIAL_ASSISTANCE_TRANSLATIONS = {
   "en.faa.transfer_history" => "Transfer History",
   "en.faa.transfer_history_desc" => "Application transfers sent to or from %{site_short_name} related to this application are listed below.",
   "en.faa.no_history_available" => "No history available.",
+  # Left Nav Pane
+  "en.faa.left_nav.my_household" => "My Household",
   # Flash error display
   "en.faa.errors.should_be_answered" => "should be answered",
   "en.faa.errors.inconsistent_relationships_error" => "Some of the relationships you have listed are inconsistent. Review relationships and make sure each pair is correct.",

--- a/components/financial_assistance/db/seedfiles/translations/en/me/financial_assistance.rb
+++ b/components/financial_assistance/db/seedfiles/translations/en/me/financial_assistance.rb
@@ -217,6 +217,8 @@ FINANCIAL_ASSISTANCE_TRANSLATIONS = {
   "en.faa.transfer_history" => "Transfer History",
   "en.faa.transfer_history_desc" => "Application transfers sent to or from %{site_short_name} related to this application are listed below.",
   "en.faa.no_history_available" => "No history available.",
+  # Left Nav Pane
+  "en.faa.left_nav.my_household" => "My Household",
   # Flash error display
   "en.faa.errors.should_be_answered" => "should be answered",
   "en.faa.errors.inconsistent_relationships_error" => "Some of the relationships you have listed are inconsistent. Review relationships and make sure each pair is correct.",

--- a/features/financial_assistance/step_definitions/applicant_level_navigation_steps.rb
+++ b/features/financial_assistance/step_definitions/applicant_level_navigation_steps.rb
@@ -13,7 +13,7 @@ Given(/^that the user is on the Tax Info page for a given applicant$/) do
 end
 
 When(/^the user clicks My Household section on the left navigation$/) do
-  click_link 'My Household'
+  click_link(l10n('faa.left_nav.my_household'))
 end
 
 Then(/^the user will navigate to the FAA Household Info page for the corresponding application\.$/) do

--- a/features/financial_assistance/step_definitions/tax_info_steps.rb
+++ b/features/financial_assistance/step_definitions/tax_info_steps.rb
@@ -34,7 +34,7 @@ When(/^the user clicks the ADD Info Button for a given household member$/) do
 end
 
 Given(/^the user is editing an application for financial assistance$/) do
-  click_link 'My Household'
+  click_link(l10n('faa.left_nav.my_household'))
 end
 
 When(/^the user navigates to the Tax Info page for a given applicant$/) do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640057/stories/187478199

# A brief description of the changes

Current behavior: "My Household" text in the FA Left Nav pane was hardcoded.

New behavior: "My Household" text in the FA Left Nav pane now supports localization.

# Screenshots

<img width="209" alt="Screenshot 2024-05-02 at 1 11 06 PM" src="https://github.com/ideacrew/enroll/assets/167465598/7a652e8d-097e-4a69-9799-43e1f51b205b">

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
The [other PR ](https://github.com/ideacrew/enroll/pull/3792) on this ticket (accidentally) tackled localizing the entire left nav pane for FA and was closed due to that scope. We can refer to it later should we need to localize the rest of the FA left nav pane.


# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
