### PR TITLE
remove predecessor_id requirement for pvc query

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/submit_pvc_set.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/submit_pvc_set.rb
@@ -56,7 +56,7 @@ module FinancialAssistance
                                                                     "applicants.is_ia_eligible": true)
 
 
-            applications.exists(:predecessor_id => true).max_by(&:created_at)
+            applications.max_by(&:submitted_at)
           end
 
           def submit(params, family_ids)

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/pvc/submit_pvc_set_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/pvc/submit_pvc_set_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Pvc::SubmitPvcSe
                       family_id: family.id,
                       aasm_state: 'determined',
                       hbx_id: "830293",
-                      predecessor_id: BSON::ObjectId.new,
                       assistance_year: TimeKeeper.date_of_record.year,
                       effective_date: TimeKeeper.date_of_record.beginning_of_year,
                       created_at: Date.new(2021, 10, 1))


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2648255/stories/187546216

# A brief description of the changes

Current behavior: PVC query to pull applications that have predecessor_id

New behavior: Fetch all the eligible applications irrespective of predecessor_id

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
