### PR TITLE
Fix general agency inbox authorization

### DIFF
--- a/components/benefit_sponsors/app/policies/benefit_sponsors/organizations/general_agency_profile_policy.rb
+++ b/components/benefit_sponsors/app/policies/benefit_sponsors/organizations/general_agency_profile_policy.rb
@@ -31,6 +31,10 @@ module BenefitSponsors
         show?
       end
 
+      def can_download_document?
+        show?
+      end
+
       def user_has_benefit_sponsors_ga_profile?
         ga_staff_roles = user.person&.general_agency_staff_roles
         ga_staff_roles&.pluck(:benefit_sponsors_general_agency_profile_id)&.include?(record.id)

--- a/components/benefit_sponsors/spec/policies/benefit_sponsors/organizations/general_agency_profile_policy_spec.rb
+++ b/components/benefit_sponsors/spec/policies/benefit_sponsors/organizations/general_agency_profile_policy_spec.rb
@@ -19,12 +19,14 @@ module BenefitSponsors
         policy = BenefitSponsors::Organizations::GeneralAgencyProfilePolicy.new(user_with_hbx_staff_role, nil)
         expect(policy.can_read_inbox?).to be true
         expect(policy.show?).to be true
+        expect(policy.can_download_document?).to be true
       end
 
       it 'returns false if user has no valid role' do
         policy = BenefitSponsors::Organizations::GeneralAgencyProfilePolicy.new(user, nil)
         expect(policy.can_read_inbox?).to be false
         expect(policy.show?).to be false
+        expect(policy.can_download_document?).to be false
       end
     end
 
@@ -39,6 +41,7 @@ module BenefitSponsors
 
         expect(policy.can_read_inbox?).to be true
         expect(policy.show?).to be true
+        expect(policy.can_download_document?).to be true
       end
 
       it 'returns false if random record is passed' do
@@ -46,6 +49,7 @@ module BenefitSponsors
 
         expect(policy.can_read_inbox?).to be false
         expect(policy.show?).to be false
+        expect(policy.can_download_document?).to be false
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640059/stories/187557780

# A brief description of the changes

Current behavior:
Users getting we’re sorry errors when trying to view/open a general agencies inbox

New behavior:
Users can view/open a general agencies inbox

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [x] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
