### PR TITLE
remove renewal application requirement logic

### DIFF
--- a/script/export_pvc_determined_families.rb
+++ b/script/export_pvc_determined_families.rb
@@ -2,8 +2,8 @@
 
 # This script generates a CSV report with information about families with renewal determined applications for the assistance_year with no SSN applicants.
 
-# To run this on specific enrollments
-# bundle exec rails runner script/export_pvc_families.rb assistance_year='2023'
+# To run this for specific year
+# bundle exec rails runner script/export_pvc_families.rb assistance_year='2024'
 
 assistance_year = ENV['assistance_year'].to_i
 csr_list = [100, 73, 87, 94].freeze
@@ -39,7 +39,7 @@ CSV.open("export_pvc_determined_families_#{TimeKeeper.date_of_record.strftime('%
                                                             :aasm_state => 'determined',
                                                             :"applicants.is_ia_eligible" => true)
 
-    determined_application = applications.exists(:predecessor_id => true).max_by(&:submitted_at)
+    determined_application = applications.max_by(&:submitted_at)
     next if determined_application.blank?
 
     determined_application.active_applicants.each do |applicant|

--- a/spec/script/export_pvc_determined_families_spec.rb
+++ b/spec/script/export_pvc_determined_families_spec.rb
@@ -114,8 +114,7 @@ describe 'export_rrv_families' do
     FactoryBot.create(
       :financial_assistance_application,
       submitted_at: yesterday,
-      family_id: family.id,
-      predecessor_id: BSON::ObjectId.new
+      family_id: family.id
     )
   end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2648255/stories/187595492#

# A brief description of the changes

Current behavior: Renewal application criteria is required to pull the PVC families

New behavior: Remove renewal application logic to pull the PVC families
- To run this for specific year
  - bundle exec rails runner script/export_pvc_families.rb assistance_year='2024'

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
