### PR TITLE
phone number mask format

### DIFF
--- a/app/views/shared/_phone_fields.html.erb
+++ b/app/views/shared/_phone_fields.html.erb
@@ -52,8 +52,7 @@
   </div>
 <% end %>
 <script>
-  jQuery.inputMasks = () => {
-    $(".phone_number").mask("(999) 999-9999");
-  };
-  $.inputMasks();
+  $(document).ready(function() {
+    $.inputMasks();
+  });
 </script>

--- a/app/views/shared/_phone_fields.html.erb
+++ b/app/views/shared/_phone_fields.html.erb
@@ -11,7 +11,7 @@
             <div class="col-md-12 <%= phone.index.even? ? 'pl-0' : 'pr-0'%>">
               <% unless kind == 'FAX' && params[:action] == "personal" %>
                 <%= phone.label :full_phone_number, l10n(kind + "Phone") %>
-                <%= phone.text_field :full_phone_number, placeholder: "000-000-0000", class: "#{required} full-width #{kind.downcase}-phone-number" %>
+                <%= phone.text_field :full_phone_number, placeholder: "(000) 000-0000", class: "#{required} full-width phone_number #{kind.downcase}-phone-number" %>
               <% end %>
             </div>
           </div>
@@ -51,3 +51,9 @@
     </div>
   </div>
 <% end %>
+<script>
+  jQuery.inputMasks = () => {
+    $(".phone_number").mask("(999) 999-9999");
+  };
+  $.inputMasks();
+</script>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187585428

# A brief description of the changes

Current behavior: Phone number fields had no masking in the phone_fields partial.

New behavior: Phone number fields now use a mask for the phone number format, and the place holder is updated to reflect the format.
