### PR TITLE
ssn number mask format

### DIFF
--- a/app/views/shared/person/_consumer_information.html.erb
+++ b/app/views/shared/person/_consumer_information.html.erb
@@ -38,11 +38,11 @@
       <div class="mr-auto col-sm col-md-6 col-lg-3 p-0">
         <%= f.label :ssn, "Social Security" %>
         <% if EnrollRegistry.feature_enabled?(:ssn_ui_validation) %>
-          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required keep-label ssn",
+          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required keep-label mask-ssn",
             pattern: "(?!666|000|9\\d{2})\\d{3}[\\- ]{0,1}(?!00)\\d{2}[\\- ]{0,1}(?!0{4})\\d{4}", oninvalid: "this.setCustomValidity('Invalid Social Security number.')",
             oninput: "this.setCustomValidity('')", disabled: readonly_status, readonly: f.object.is_a?(Forms::EmployeeRole) %>
         <% else %>
-          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required ssn", disabled: readonly_status,
+          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required mask-ssn", disabled: readonly_status,
             readonly: f.object.is_a?(Forms::EmployeeRole) %>
         <% end %>
       </div>
@@ -65,10 +65,9 @@
   </div>
   <%= render 'shared/ssn_coverage_msg' %>
   <script>
-    jQuery.inputMasks = () => {
-      $(".ssn").mask("999-99-9999");
-    };
-    $.inputMasks();
+    $(document).ready(function() {
+      $.inputMasks();
+    });
   </script>
 <% else %>
   <div id="personal_info" class="focus_effect module">

--- a/app/views/shared/person/_consumer_information.html.erb
+++ b/app/views/shared/person/_consumer_information.html.erb
@@ -38,11 +38,11 @@
       <div class="mr-auto col-sm col-md-6 col-lg-3 p-0">
         <%= f.label :ssn, "Social Security" %>
         <% if EnrollRegistry.feature_enabled?(:ssn_ui_validation) %>
-          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required keep-label ssn_number",
+          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required keep-label ssn",
             pattern: "(?!666|000|9\\d{2})\\d{3}[\\- ]{0,1}(?!00)\\d{2}[\\- ]{0,1}(?!0{4})\\d{4}", oninvalid: "this.setCustomValidity('Invalid Social Security number.')",
             oninput: "this.setCustomValidity('')", disabled: readonly_status, readonly: f.object.is_a?(Forms::EmployeeRole) %>
         <% else %>
-          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required ssn_number", disabled: readonly_status,
+          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required ssn", disabled: readonly_status,
             readonly: f.object.is_a?(Forms::EmployeeRole) %>
         <% end %>
       </div>
@@ -66,7 +66,7 @@
   <%= render 'shared/ssn_coverage_msg' %>
   <script>
     jQuery.inputMasks = () => {
-      $(".ssn_number").mask("999-99-9999");
+      $(".ssn").mask("999-99-9999");
     };
     $.inputMasks();
   </script>

--- a/app/views/shared/person/_consumer_information.html.erb
+++ b/app/views/shared/person/_consumer_information.html.erb
@@ -38,11 +38,11 @@
       <div class="mr-auto col-sm col-md-6 col-lg-3 p-0">
         <%= f.label :ssn, "Social Security" %>
         <% if EnrollRegistry.feature_enabled?(:ssn_ui_validation) %>
-          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required keep-label",
+          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required keep-label ssn_number",
             pattern: "(?!666|000|9\\d{2})\\d{3}[\\- ]{0,1}(?!00)\\d{2}[\\- ]{0,1}(?!0{4})\\d{4}", oninvalid: "this.setCustomValidity('Invalid Social Security number.')",
             oninput: "this.setCustomValidity('')", disabled: readonly_status, readonly: f.object.is_a?(Forms::EmployeeRole) %>
         <% else %>
-          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required", disabled: readonly_status,
+          <%= f.text_field :ssn, placeholder: "000-00-0000", class: "required ssn_number", disabled: readonly_status,
             readonly: f.object.is_a?(Forms::EmployeeRole) %>
         <% end %>
       </div>
@@ -64,6 +64,12 @@
     </fieldset>
   </div>
   <%= render 'shared/ssn_coverage_msg' %>
+  <script>
+    jQuery.inputMasks = () => {
+      $(".ssn_number").mask("999-99-9999");
+    };
+    $.inputMasks();
+  </script>
 <% else %>
   <div id="personal_info" class="focus_effect module">
     <%= hidden_field "people","id" %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187595370

# A brief description of the changes

Current behavior: SSN field allows any input and format

New behavior: SSN field now enforces expected format through mask

# Additional Context
It seems there is a feature flag `SSN_UI_VALIDATION_IS_ENABLED` which turns on some post-submit pattern matching for this text field. I went ahead and added the masking in both ON and OFF cases for this flag as per the bugfix ticket, which may obviate some of the intended functionality of that flag for this use case.
