### PR TITLE
remove disagree placeholder text

### DIFF
--- a/app/views/insured/consumer_roles/ridp_agreement.html.erb
+++ b/app/views/insured/consumer_roles/ridp_agreement.html.erb
@@ -12,10 +12,6 @@
     <legend>
       <%= l10n("insured.consumer_roles.ridp_agreement.ridp_agreement_label") %>
     </legend>
-    <div class="disagree_placeholder_text">
-      <!-- when should this appear? does it ever -->
-      <%= l10n("insured.consumer_roles.ridp_agreement.disagree_placeholder_text", contact_center_name: contact_center_name, contact_center_phone_number: contact_center_phone_number) %>
-    </div>
     <div class="d-flex align-items-center">
       <label for="agreement_agree" tabindex="0" class="radio" data-radio-event="agreement_disagree">
         <%= radio_button_tag :agreement, "agree", class: "required", id: 'agreement_agree' %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187597036

# A brief description of the changes

Current behavior: Disagree placeholder text is displayed

New behavior: Disagree placeholder text is no longer displayed

# Additional Context
This element is shown with the BS4 flag on, as we lifted this element from the legacy page when modernizing it recently. In legacy, it was a hidden element. With BS4, it was visible.

There are no references to the element's id in the codebase, and looking through this file's git history shows:
1. 0ddf8874200e2c2f61466c2b14b69c5634e882fb, 8 years ago: commented out style toggle to show the element and replaced entirely with an alert
2. f357e3dcc333700aad1bd47687e006b3df479de0, 6 years ago: removed alert and replaced with style toggle to show an entirely different element (what is now the disclosure footer)

Based on this, there should be no harm in outright removing this element. Although, semi-relatedly, that disclosure footer mentioned above in the commit history needs cleaning up for BS4.
