### PR TITLE
right align header account links

### DIFF
--- a/app/views/ui-components/bs4/v1/navs/_header.html.erb
+++ b/app/views/ui-components/bs4/v1/navs/_header.html.erb
@@ -17,7 +17,7 @@
         </li>
       </ul>
       <ul class="navbar-nav">
-        <li class="nav-item d-flex flex-column">
+        <li class="nav-item d-flex flex-column align-items-end">
           <span><%= image_pack_tag "icons/phone.svg", alt: "phone icon" %><%= l10n("layout.header.customer_service") %></span>
           <% contact_center_short_number = EnrollRegistry[:enroll_app].settings(:contact_center_short_number).item %>
           <a href="tel:<%= contact_center_short_number %>">
@@ -26,9 +26,9 @@
         </li>
         <% if signed_in? %>
           <li class="nav-item-divider"></li>
-          <li class="nav-item d-flex flex-column">
+          <li class="nav-item d-flex flex-column align-items-end">
             <span><%= image_pack_tag "icons/user-small.svg", alt:"user icon" %><%= l10n('layout.header.user_and_id', name: user_first_name_last_name_and_suffix, id: current_user.try(:person).try(:hbx_id)) %></span>
-            <span class="horizontal-links ml-auto">
+            <span class="horizontal-links">
               <%= render partial: "shared/my_portal_links" %>
               <span>
                 <%= sanitize(link_to l10n('layout.header.help'), 'https://dchealthlink.com/help', target: '_blank', rel: "noopener noreferrer") %>

--- a/app/views/ui-components/bs4/v1/navs/_header.html.erb
+++ b/app/views/ui-components/bs4/v1/navs/_header.html.erb
@@ -29,7 +29,7 @@
           <li class="nav-item d-flex flex-column">
             <span><%= image_pack_tag "icons/user-small.svg", alt:"user icon" %><%= l10n('layout.header.user_and_id', name: user_first_name_last_name_and_suffix, id: current_user.try(:person).try(:hbx_id)) %></span>
             <span class="horizontal-links ml-auto">
-              <span><%= render partial: "shared/my_portal_links" %></span>
+              <%= render partial: "shared/my_portal_links" %>
               <span><%= sanitize(link_to l10n('layout.header.help'), 'https://dchealthlink.com/help', target: '_blank', rel: "noopener noreferrer") %></span>
               <span><%= sanitize(link_to l10n('layout.header.logout'), main_app.destroy_user_session_path, method: 'delete') %></span>
             </span>

--- a/app/views/ui-components/bs4/v1/navs/_header.html.erb
+++ b/app/views/ui-components/bs4/v1/navs/_header.html.erb
@@ -28,8 +28,8 @@
           <li class="nav-item-divider"></li>
           <li class="nav-item d-flex flex-column">
             <span><%= image_pack_tag "icons/user-small.svg", alt:"user icon" %><%= l10n('layout.header.user_and_id', name: user_first_name_last_name_and_suffix, id: current_user.try(:person).try(:hbx_id)) %></span>
-            <span class="horizontal-links">
-              <%= render partial: "shared/my_portal_links" %>
+            <span class="horizontal-links ml-auto">
+              <span><%= render partial: "shared/my_portal_links" %></span>
               <span><%= sanitize(link_to l10n('layout.header.help'), 'https://dchealthlink.com/help', target: '_blank', rel: "noopener noreferrer") %></span>
               <span><%= sanitize(link_to l10n('layout.header.logout'), main_app.destroy_user_session_path, method: 'delete') %></span>
             </span>

--- a/app/views/ui-components/bs4/v1/navs/_header.html.erb
+++ b/app/views/ui-components/bs4/v1/navs/_header.html.erb
@@ -30,8 +30,12 @@
             <span><%= image_pack_tag "icons/user-small.svg", alt:"user icon" %><%= l10n('layout.header.user_and_id', name: user_first_name_last_name_and_suffix, id: current_user.try(:person).try(:hbx_id)) %></span>
             <span class="horizontal-links ml-auto">
               <%= render partial: "shared/my_portal_links" %>
-              <span><%= sanitize(link_to l10n('layout.header.help'), 'https://dchealthlink.com/help', target: '_blank', rel: "noopener noreferrer") %></span>
-              <span><%= sanitize(link_to l10n('layout.header.logout'), main_app.destroy_user_session_path, method: 'delete') %></span>
+              <span>
+                <%= sanitize(link_to l10n('layout.header.help'), 'https://dchealthlink.com/help', target: '_blank', rel: "noopener noreferrer") %>
+              </span>
+              <span>
+                <%= sanitize(link_to l10n('layout.header.logout'), main_app.destroy_user_session_path, method: 'delete') %>
+              </span>
             </span>
           </li>
         <% end %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187578801

# A brief description of the changes

Current behavior: Header columns were stretch aligned.

New behavior: Header columns are now right-aligned.

I've also updated the spans to be newline-separated... this seemingly helped align the "|" used in the `horizontal-links` class. Without those newlines, the "|" seemed to not center correctly between the links.



<img width="387" alt="Screenshot 2024-05-14 at 1 08 08 PM" src="https://github.com/ideacrew/enroll/assets/167465598/1746f95f-55e2-4812-91fe-b3962c472c7d">

