### PR TITLE
update race legend subtitle to be inline

### DIFF
--- a/app/views/shared/_race_and_ethnicity_options.html.erb
+++ b/app/views/shared/_race_and_ethnicity_options.html.erb
@@ -1,7 +1,11 @@
  <% if @bs4 %>
   <fieldset class="mb-4 d-block" >
-    <legend class="required"><%= l10n("insured.shared.race_ethicity_label") %></legend>
-    <small class="text-muted"><%= l10n("insured.shared.check_all_paranthetical") %></small>
+    <legend>
+      <span>
+        <%= l10n("insured.shared.race_ethicity_label") %>
+        <small class="text-muted pl-1"><%= l10n("insured.shared.check_all_paranthetical") %></small>
+      </span>
+    </legend>
     <div class="row col-sm ethnicity-container">
     <% ethnicity_collection.each do |ethnicity_set| %>
       <div class="mr-auto col-sm-12 col-md-6 col-lg-3 p-0">
@@ -19,8 +23,12 @@
   </fieldset>
   <fieldset class="mb check_box_collection">
     <div>
-      <legend><%= l10n("insured.shared.hispanic_label") %></legend>
-      <small class="text-muted"><%= l10n("insured.shared.check_all_paranthetical") %></small>
+      <legend>
+        <span>
+          <%= l10n("insured.shared.hispanic_label") %>
+          <small class="text-muted pl-1"><%= l10n("insured.shared.check_all_paranthetical") %></small>
+        </span>
+      </legend>
       <div class="row col-sm ethnicity-container">
       <% latino_collection.each do |ethnicity_set| %>
       <div class="mr-auto col-sm-12 col-md-6 col-lg-3 p-0">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
