### PR TITLE
create alive status verification type

### DIFF
--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -149,7 +149,7 @@ module VerificationHelper
   def get_person_v_type_status(people)
     v_type_status_list = []
     people.each do |person|
-      person.verification_types.each do |v_type|
+      person.verification_types.reject { |type| ["Alive Status"].include?(type.type_name) }.each do |v_type|
         v_type_status_list << verification_type_status(v_type, person)
       end
     end

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -1153,8 +1153,10 @@ class ConsumerRole
   end
 
   def move_types_to_pending(*args)
-    verification_types.each do |type|
-      type.pending_type unless (type.type_name == LOCATION_RESIDENCY) || (type.type_name == "American Indian Status")
+    types_to_reject = ['American Indian Status', 'Alive Status', LOCATION_RESIDENCY]
+
+    verification_types.reject { |type| types_to_reject.include?(type.type_name) }.each do |type|
+      type.pending_type
     end
   end
 

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -1155,9 +1155,7 @@ class ConsumerRole
   def move_types_to_pending(*args)
     types_to_reject = ['American Indian Status', 'Alive Status', LOCATION_RESIDENCY]
 
-    verification_types.reject { |type| types_to_reject.include?(type.type_name) }.each do |type|
-      type.pending_type
-    end
+    verification_types.reject { |type| types_to_reject.include?(type.type_name) }.each(&:pending_type)
   end
 
   def pass_lawful_presence(*args)

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -781,30 +781,39 @@ class ConsumerRole
 
   # collect all verification types user can have based on information he provided
   def ensure_verification_types
-    if person
-      live_types = []
-      live_types << LOCATION_RESIDENCY if EnrollRegistry.feature_enabled?(:location_residency_verification_type)
-      live_types << 'Social Security Number' if ssn
-      if EnrollRegistry.feature_enabled?(:indian_alaskan_tribe_details)
-        live_types << 'American Indian Status' if !(tribal_state.nil? || tribal_state.empty?) && !(check_tribal_name.nil? || check_tribal_name.empty?)
-      else
-        live_types << 'American Indian Status' unless tribal_id.nil? || tribal_id.empty?
-      end
-      if us_citizen
-        live_types << 'Citizenship'
-      else
-        live_types << 'Immigration status' if us_citizen != nil
-      end
-      inactive = verification_types.map(&:type_name) - live_types
-      new_types = live_types - verification_types.active.map(&:type_name)
-      person.deactivate_types(inactive)
-      new_types.each do |new_type|
-        person.add_new_verification_type(new_type)
-      end
-      person.families.each do |family|
-        family.update_family_document_status!
-      end
+    return unless person
+
+    live_types = collect_live_types
+    create_or_update_verification_types(live_types)
+    update_family_document_status
+  end
+
+  def collect_live_types
+    live_types = []
+    live_types << LOCATION_RESIDENCY if EnrollRegistry.feature_enabled?(:location_residency_verification_type)
+    live_types.concat(['Social Security Number', 'Alive Status']) if ssn
+    live_types << 'American Indian Status' if ai_or_an?
+    live_types << (us_citizen ? 'Citizenship' : 'Immigration status') unless us_citizen.nil?
+    live_types
+  end
+
+  def ai_or_an?
+    if EnrollRegistry.feature_enabled?(:indian_alaskan_tribe_details)
+      !(tribal_state.nil? || tribal_state.empty?) && !(check_tribal_name.nil? || check_tribal_name.empty?)
+    else
+      !(tribal_id.nil? || tribal_id.empty?)
     end
+  end
+
+  def create_or_update_verification_types(live_types)
+    inactive = verification_types.map(&:type_name) - live_types
+    new_types = live_types - verification_types.active.map(&:type_name)
+    person.deactivate_types(inactive)
+    new_types.each { |new_type| person.add_new_verification_type(new_type) }
+  end
+
+  def update_family_document_status
+    person.families.each(&:update_family_document_status!)
   end
 
   def build_nested_models_for_person

--- a/app/models/subscribers/ssa_verification.rb
+++ b/app/models/subscribers/ssa_verification.rb
@@ -24,7 +24,7 @@ module Subscribers
         consumer_role = person.consumer_role
         event_response_record = EventResponse.new({received_at: Time.now, body: xml})
         consumer_role.lawful_presence_determination.ssa_responses << event_response_record
-        person.verification_types.active.reject{|type| [VerificationType::LOCATION_RESIDENCY, "American Indian Status", "Immigration status"].include? type.type_name}.each do |type|
+        person.verification_types.active.reject{|type| [VerificationType::LOCATION_RESIDENCY, "American Indian Status", "Immigration status", "Alive Status"].include? type.type_name}.each do |type|
           type.add_type_history_element(action: "SSA Hub Response",
                                         modifier: "external Hub",
                                         update_reason: "Hub response",

--- a/app/models/verification_type.rb
+++ b/app/models/verification_type.rb
@@ -60,6 +60,7 @@ class VerificationType
   scope :by_name, ->(type_name) { where(:type_name => type_name) }
   scope :ssn_type, -> { by_name("Social Security Number").active }
   scope :citizenship_type, -> { by_name("Citizenship").active }
+  scope :deceased_type, -> { by_name("Alive Status").active }
 
   # embeds_many :external_service_responses  -> needs datamigration
   embeds_many :type_history_elements

--- a/app/models/verification_type.rb
+++ b/app/models/verification_type.rb
@@ -60,7 +60,7 @@ class VerificationType
   scope :by_name, ->(type_name) { where(:type_name => type_name) }
   scope :ssn_type, -> { by_name("Social Security Number").active }
   scope :citizenship_type, -> { by_name("Citizenship").active }
-  scope :deceased_type, -> { by_name("Alive Status").active }
+  scope :alive_status_type, -> { by_name("Alive Status").active }
 
   # embeds_many :external_service_responses  -> needs datamigration
   embeds_many :type_history_elements

--- a/spec/models/consumer_role_spec.rb
+++ b/spec/models/consumer_role_spec.rb
@@ -712,7 +712,7 @@ RSpec.describe ConsumerRole, dbclean: :after_each, type: :model do
         describe "pending verification type updates" do
           it "updates validation status to pending for unverified consumers" do
             consumer.coverage_purchased!
-            expect(consumer.verification_types.map(&:validation_status)).to eq(["pending", "pending", "pending"])
+            expect(consumer.verification_types.map(&:validation_status)).to eq(["pending", "pending", "unverified" , "pending"])
           end
 
           it "updates indian tribe validition status to negative_response_received and to pending for the rest" do

--- a/spec/models/consumer_role_spec.rb
+++ b/spec/models/consumer_role_spec.rb
@@ -722,7 +722,7 @@ RSpec.describe ConsumerRole, dbclean: :after_each, type: :model do
               case verif.type_name
               when 'American Indian Status'
                 expect(verif.validation_status).to eq('negative_response_received')
-              when 'Citizenship'
+              when 'Citizenship', 'Alive Status'
                 # Validation Status stays same as we will not make DHS call for people who are 'us_citizen'
                 expect(verif.validation_status).to eq('unverified')
               else
@@ -1014,15 +1014,15 @@ RSpec.describe ConsumerRole, dbclean: :after_each, type: :model do
       end
 
       context "SSN + Citizen" do
-        it_behaves_like "collecting verification types for person", [VerificationType::LOCATION_RESIDENCY, "Social Security Number", "Citizenship"], 3, "2222222222", true, nil, 25
+        it_behaves_like "collecting verification types for person", [VerificationType::LOCATION_RESIDENCY, "Social Security Number", "Alive Status", "Citizenship"], 4, "2222222222", true, nil, 25
       end
 
       context "SSN + Immigrant" do
-        it_behaves_like "collecting verification types for person", [VerificationType::LOCATION_RESIDENCY, "Social Security Number", "Immigration status"], 3, "2222222222", false, nil, 20
+        it_behaves_like "collecting verification types for person", [VerificationType::LOCATION_RESIDENCY, "Social Security Number", "Alive Status", "Immigration status"], 4, "2222222222", false, nil, 20
       end
 
       context "SSN + Native Citizen" do
-        it_behaves_like "collecting verification types for person", [VerificationType::LOCATION_RESIDENCY, "Social Security Number", "Citizenship", "American Indian Status"], 4, "2222222222", true, "native", 20
+        it_behaves_like "collecting verification types for person", [VerificationType::LOCATION_RESIDENCY, "Social Security Number", "Alive Status", "Citizenship", "American Indian Status"], 5, "2222222222", true, "native", 20
       end
 
       context "Citizen with NO SSN" do

--- a/spec/models/consumer_role_spec.rb
+++ b/spec/models/consumer_role_spec.rb
@@ -712,7 +712,7 @@ RSpec.describe ConsumerRole, dbclean: :after_each, type: :model do
         describe "pending verification type updates" do
           it "updates validation status to pending for unverified consumers" do
             consumer.coverage_purchased!
-            expect(consumer.verification_types.map(&:validation_status)).to eq(["pending", "pending", "unverified" , "pending"])
+            expect(consumer.verification_types.map(&:validation_status)).to eq(["pending", "pending", "unverified", "pending"])
           end
 
           it "updates indian tribe validition status to negative_response_received and to pending for the rest" do

--- a/spec/models/subscribers/ssa_verification_spec.rb
+++ b/spec/models/subscribers/ssa_verification_spec.rb
@@ -42,7 +42,7 @@ describe Subscribers::SsaVerification do
         person.verification_types.each{|type| type.type_history_elements.delete_all }
         allow(subject).to receive(:find_person).with(individual_id).and_return(person)
         subject.call(nil, nil, nil, nil, payload)
-        expect(person.verification_types.active.map(&:type_history_elements).map(&:count)).to eq [0, 1, 1]
+        expect(person.verification_types.active.map(&:type_history_elements).map(&:count)).to eq [0, 1, 0, 1]
       end
 
       it "stores reference to EventResponse in verification history element" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://pivotaltracker.com/n/projects/2648255/stories/187106797

# A brief description of the changes

New behavior: create/update Alive status verification type whenever consumer role is created or updated

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
