### PR TITLE
removing incorrect line from cms report updates

### DIFF
--- a/script/cms_daily_report.rb
+++ b/script/cms_daily_report.rb
@@ -843,7 +843,6 @@ def process_ivl_families_with_qhp_assistance(families, offset_count)
           medicaid_eligible = thhm_medicaid_members.any? { |th_member| th_member.applicant_id.to_s == aptc_thhm.applicant_id.to_s }
           if aptc_thhm&.person&.is_applying_coverage && !medicaid_eligible
             @total_members_with_qhp_assistance << aptc_thhm&.person&.hbx_id
-            # csv << [primary.hbx_id, primary.full_name, aptc, aptc_thhm&.person&.full_name, aptc_thhm&.is_ia_eligible, aptc_thhm&.csr_eligibility_kind]
           end
         end
         @total_member_counter_qhp_assistance += thhm_aptc_members.count

--- a/script/cms_daily_report.rb
+++ b/script/cms_daily_report.rb
@@ -843,7 +843,7 @@ def process_ivl_families_with_qhp_assistance(families, offset_count)
           medicaid_eligible = thhm_medicaid_members.any? { |th_member| th_member.applicant_id.to_s == aptc_thhm.applicant_id.to_s }
           if aptc_thhm&.person&.is_applying_coverage && !medicaid_eligible
             @total_members_with_qhp_assistance << aptc_thhm&.person&.hbx_id
-            csv << [primary.hbx_id, primary.full_name, aptc, aptc_thhm&.person&.full_name, aptc_thhm&.is_ia_eligible, aptc_thhm&.csr_eligibility_kind]
+            # csv << [primary.hbx_id, primary.full_name, aptc, aptc_thhm&.person&.full_name, aptc_thhm&.is_ia_eligible, aptc_thhm&.csr_eligibility_kind]
           end
         end
         @total_member_counter_qhp_assistance += thhm_aptc_members.count


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [x] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187578565

# A brief description of the changes

Current behavior: Extra line creating error message in cms report 

New behavior: Removed line missed in previous update

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
