### PR TITLE
allow primary to delete dependent's documents

### DIFF
--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -6,7 +6,7 @@
 class PersonPolicy < ApplicationPolicy
   def initialize(user, record)
     super
-    @family = record.primary_family if record.is_a?(Person)
+    @family = (record.primary_family || record.families.first) if record.is_a?(Person)
   end
 
   # Is the given entity allowed to complete RIDP on behalf of a given

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -509,3 +509,44 @@ describe PersonPolicy, "given a user who is active broker staff for that person"
     expect(subject.complete_ridp?).to be_truthy
   end
 end
+
+describe PersonPolicy, "given a user who is a primary family member" do
+
+  let(:user_person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+  let(:dependent_person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+  let(:family_members) { [user_person, dependent_person] }
+  let(:family) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: user_person, people: family_members) }
+
+  let(:user) {FactoryBot.create(:user, person: user_person)}
+
+  context "deletes own documents" do
+
+    let(:record) { user_person }
+
+    before do
+      user_person.consumer_role.update_attributes!(identity_validation: 'valid')
+    end
+
+
+    subject { described_class.new(user, record) }
+
+    it "may delete document" do
+      expect(subject.can_delete_document?).to be_truthy
+    end
+  end
+
+  context "deletes dependent's documents" do
+
+    let(:record) { family.family_members.last.person}
+
+    subject { described_class.new(user, record) }
+
+    before do
+      user_person.consumer_role.update_attributes!(identity_validation: 'valid')
+    end
+
+    it "may delete documents" do
+      expect(subject.can_delete_document?).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [ME-187565847](https://www.pivotaltracker.com/n/projects/2640060/stories/187565847)

# A brief description of the changes

Current behavior: Primary family members receive a pundit error while trying to delete their dependent's documents

New behavior: Primary family members are able to delete their dependent's docuements

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
