### PR TITLE
replace header content

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -53,7 +53,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       #              can't accept a password with a standard hash.
       session["stashed_password"] = sign_up_params["password"]
       if resource.active_for_authentication?
-        set_flash_message :notice, :signed_up, site_name: EnrollRegistry[:enroll_app].setting(:short_name).item if is_flashing_format?
+        set_flash_message :notice, @bs4 ? :signed_up_bs4 : :signed_up, site_name: EnrollRegistry[:enroll_app].setting(:short_name).item if is_flashing_format?
         sign_up(resource_name, resource)
         location = after_sign_in_path_for(resource)
         flash[:warning] = current_user.get_announcements_by_roles_and_portal(location) if current_user.present?

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -39,6 +39,7 @@ en:
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome to %{site_name}. Your account has been created."
+      signed_up_bs4: "Welcome to %{site_name}, your account has been created."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187579400

# A brief description of the changes

Current behavior: The login flash message is using (slightly different) legacy content.

New behavior: The login flash message now uses the updated content when the BS4 flag is on.