### PR TITLE
remove repeated header text

### DIFF
--- a/app/helpers/bs4/bs4_header_helper.rb
+++ b/app/helpers/bs4/bs4_header_helper.rb
@@ -11,48 +11,46 @@ module Bs4
       if current_user.nil?
         nil
       elsif current_user.try(:has_hbx_staff_role?)
-        link_to(l10n("Admin"), main_app.exchanges_hbx_profiles_root_path)
+        link_to(l10n("layout.header.role.admin"), main_app.exchanges_hbx_profiles_root_path)
       elsif display_i_am_broker_for_consumer?(current_user.person) && controller_path.exclude?('general_agencies')
-        link_to(l10n("Broker"), get_broker_profile_path)
+        link_to(l10n("layout.header.role.broker"), get_broker_profile_path)
       elsif current_user.try(:person).try(:csr_role) || current_user.try(:person).try(:assister_role)
-        link_to(l10n("Trained Expert"), main_app.home_exchanges_agents_path)
+        link_to(l10n("layout.header.role.trained_expert"), main_app.home_exchanges_agents_path)
       elsif current_user.person&.active_employee_roles&.any?
         if controller_path.include?('broker_agencies')
-          link_to(l10n("Broker"), get_broker_profile_path)
+          link_to(l10n("layout.header.role.broker"), get_broker_profile_path)
         elsif controller_path.include?('general_agencies')
-          link_to(l10n("General Agency"), benefit_sponsors.profiles_general_agencies_general_agency_profile_path(id: current_user.person.general_agency_staff_roles.first.benefit_sponsors_general_agency_profile_id))
+          link_to(l10n("layout.header.role.general_agency"), benefit_sponsors.profiles_general_agencies_general_agency_profile_path(id: current_user.person.general_agency_staff_roles.first.benefit_sponsors_general_agency_profile_id))
         elsif controller == 'employer_profiles' || controller_path.include?('employers')
           #current user has both broker_agency staff role and employee role but not employer_staff_roles
           if current_user.person.active_employer_staff_roles.present?
             employer_profile_path = benefit_sponsors.profiles_employers_employer_profile_path(id: current_user.person.active_employer_staff_roles.first.benefit_sponsor_employer_profile_id, :tab => 'home')
-            link_to(l10n("Employer"), employer_profile_path)
+            link_to(l10n("layout.header.role.employer"), employer_profile_path)
           elsif current_user.try(:has_broker_agency_staff_role?)
-            link_to(l10n("Broker"), get_broker_profile_path)
+            link_to(l10n("layout.header.role.broker"), get_broker_profile_path)
           end
         else
-          link_to(l10n("Employee"), main_app.family_account_path)
+          link_to(l10n("layout.header.role.employee"), main_app.family_account_path)
         end
       elsif (controller_path.include?("insured") && current_user.try(:has_consumer_role?)) ||
             (EnrollRegistry.feature_enabled?(:financial_assistance) && controller_path.include?("financial_assistance") && current_user.try(:has_consumer_role?))
         if current_user.identity_verified_date.present?
-          link_to(l10n("Individual and Family"), main_app.family_account_path)
+          link_to(l10n("layout.header.role.individual_and_family"), main_app.family_account_path)
         else
-          link_to(l10n("Individual and Family"), 'javascript:;')
+          link_to(l10n("layout.header.role.individual_and_family"), 'javascript:;')
         end
       # rubocop:disable Lint/DuplicateBranch
       elsif current_user.try(:has_broker_agency_staff_role?) && controller_path.exclude?('general_agencies') && controller_path.exclude?('employers')
-        link_to(l10n("Broker"), get_broker_profile_path)
+        link_to(l10n("layout.header.role.broker"), get_broker_profile_path)
       # rubocop:enable Lint/DuplicateBranch
       elsif current_user.try(:has_general_agency_staff_role?)
         if current_user.try(:has_employer_staff_role?) && controller_path.include?('employers')
-          link_to(l10n("Employer"), benefit_sponsors.profiles_employers_employer_profile_path(id: current_user.person.active_employer_staff_roles.first.benefit_sponsor_employer_profile_id, :tab => 'home'))
+          link_to(l10n("layout.header.role.employer"), benefit_sponsors.profiles_employers_employer_profile_path(id: current_user.person.active_employer_staff_roles.first.benefit_sponsor_employer_profile_id, :tab => 'home'))
         else
-          link_to(l10n("General Agency"), benefit_sponsors.profiles_general_agencies_general_agency_profile_path(id: current_user.person.active_general_agency_staff_roles.first.benefit_sponsors_general_agency_profile_id))
+          link_to(l10n("layout.header.role.general_agency"), benefit_sponsors.profiles_general_agencies_general_agency_profile_path(id: current_user.person.active_general_agency_staff_roles.first.benefit_sponsors_general_agency_profile_id))
         end
       elsif current_user.try(:has_employer_staff_role?)
-        link_to(l10n("Employer"), benefit_sponsors.profiles_employers_employer_profile_path(id: current_user.person.active_employer_staff_roles.first.benefit_sponsor_employer_profile_id, :tab => 'home'))
-      else
-        link_to(l10n('welcome.index.byline', welcome_text: EnrollRegistry[:enroll_app].setting(:header_message).item.to_s).html_safe, 'javascript:;')
+        link_to(l10n("layout.header.role.employer"), benefit_sponsors.profiles_employers_employer_profile_path(id: current_user.person.active_employer_staff_roles.first.benefit_sponsor_employer_profile_id, :tab => 'home'))
       end
     end
 

--- a/db/seedfiles/translations/en/cca/layout.rb
+++ b/db/seedfiles/translations/en/cca/layout.rb
@@ -3,6 +3,13 @@ LAYOUT_TRANSLATIONS = {
   "en.layout.header.user_and_id" => "%{name} ID: %{id}",
   "en.layout.header.help" => "Help",
   "en.layout.header.logout" => "Logout",
+  "en.layout.header.role.admin" => "Admin",
+  "en.layout.header.role.broker" => "Broker",
+  "en.layout.header.role.trained_expert" => "Trained Expert",
+  "en.layout.header.role.general_agency" => "General Agency",
+  "en.layout.header.role.employer" => "Employer",
+  "en.layout.header.role.employee" => "Employee",
+  "en.layout.header.role.individual_and_family" => "Individual and Family",
   "en.layout.footer.all_rights" => "All Rights Reserved.",
   "en.layout.footer.get_help" => "Get Help",
 }

--- a/db/seedfiles/translations/en/dc/layout.rb
+++ b/db/seedfiles/translations/en/dc/layout.rb
@@ -3,6 +3,13 @@ LAYOUT_TRANSLATIONS = {
   "en.layout.header.user_and_id" => "%{name} ID: %{id}",
   "en.layout.header.help" => "Help",
   "en.layout.header.logout" => "Logout",
+  "en.layout.header.role.admin" => "Admin",
+  "en.layout.header.role.broker" => "Broker",
+  "en.layout.header.role.trained_expert" => "Trained Expert",
+  "en.layout.header.role.general_agency" => "General Agency",
+  "en.layout.header.role.employer" => "Employer",
+  "en.layout.header.role.employee" => "Employee",
+  "en.layout.header.role.individual_and_family" => "Individual and Family",
   "en.layout.footer.all_rights" => "All Rights Reserved.",
   "en.layout.footer.get_help" => "Get Help",
 }

--- a/db/seedfiles/translations/en/me/layout.rb
+++ b/db/seedfiles/translations/en/me/layout.rb
@@ -3,6 +3,13 @@ LAYOUT_TRANSLATIONS = {
   "en.layout.header.user_and_id" => "%{name} ID: %{id}",
   "en.layout.header.help" => "Help",
   "en.layout.header.logout" => "Logout",
+  "en.layout.header.role.admin" => "Admin",
+  "en.layout.header.role.broker" => "Broker",
+  "en.layout.header.role.trained_expert" => "Trained Expert",
+  "en.layout.header.role.general_agency" => "General Agency",
+  "en.layout.header.role.employer" => "Employer",
+  "en.layout.header.role.employee" => "Employee",
+  "en.layout.header.role.individual_and_family" => "Individual and Family",
   "en.layout.footer.all_rights" => "All Rights Reserved.",
   "en.layout.footer.get_help" => "Get Help",
 }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187572236

# A brief description of the changes

Current behavior: When the user does not know their role, the header contained doubled welcome elements.

New behavior: When the user does not know their role, the header now only has a single welcome element.

# Notes
This header column consists of two elements: 
- a static "Welcome..." label, and
- a role link (driven by our portal helper)

The portal helper drives role determination, the logic of which is dependent on a given user being at certain points in the signup flow. At least for Individual and Family accounts, this determination can only happen at Personal Info - Details. Prior to this PR, the portal helper had a fallback when the role could not be determined which returned a stale "Welcome..." link, which meant that both this fallback link _and_ the static "Welcome..." label above it had duplicated content.

To solve this, I outright removed the fallback case such that if the role for some session cannot be determined, only the static label is displayed without a role link. I'm not quite sure what the intended use of the fallback role link was anyway, as it did not have a destination.

I'm open to discussing other UI reqs for this edge case, or otherwise adjusting our role determination logic to be less dependent on session data while still being accurate, if at all possible.

Pre-role determination:
<img width="560" alt="Screenshot 2024-05-14 at 5 23 12 PM" src="https://github.com/ideacrew/enroll/assets/167465598/ca72491c-66e7-43d1-8595-fbc6cf832dd5">
Role determination (on Person Info - Details page):
<img width="560" alt="Screenshot 2024-05-14 at 5 24 24 PM" src="https://github.com/ideacrew/enroll/assets/167465598/11f769e8-c35d-409a-b8ec-bcdde7e5853e">

