### PR TITLE
fix address and contact row spacing

### DIFF
--- a/app/javascript/css/forms.scss
+++ b/app/javascript/css/forms.scss
@@ -78,8 +78,8 @@ input.full-width, select.full-width, .input.full-width {
   width: 100%;
 }
 
-input + label,
-input + fieldset,
+input:not([type="hidden"]) + label,
+input:not([type="hidden"]) + fieldset,
 select + label,
 select + fieldset,
 .input + label,

--- a/app/views/shared/_consumer_home_address_fields.html.erb
+++ b/app/views/shared/_consumer_home_address_fields.html.erb
@@ -23,7 +23,7 @@
         <% end %>
       </div>
       <div class="address-row <%= div_class %> <%= display_class %>">
-        <div class="d-flex mb-md-4 row col-sm">
+        <div class="d-flex mb-md-2 row col-sm">
           <div class="col-sm col-md-6 p-0">
             <div class="col-md-12 pl-0">
               <span><%= address.hidden_field :kind, value: address.object.kind %>

--- a/app/views/shared/_email_fields.html.erb
+++ b/app/views/shared/_email_fields.html.erb
@@ -2,8 +2,10 @@
   <% kind = f.object.kind %>
   <div class="col-sm col-md-6 p-0">
     <div class="col-md-12 <%= f.index.even? ? 'pl-0' : 'pr-0'%>">
-      <%= f.hidden_field :kind %>
-      <%= f.hidden_field :_destroy %>
+      <span>
+        <%= f.hidden_field :kind %>
+        <%= f.hidden_field :_destroy %>
+      </span>
       <%= f.label :address, kind.upcase.eql?('HOME') ? l10n("personal_email_address") : l10n(kind + " Email Address").titleize %>
       <%= f.email_field :address, placeholder: "example@mail.com", class: "full-width" %>
     </div>

--- a/app/views/shared/_email_fields.html.erb
+++ b/app/views/shared/_email_fields.html.erb
@@ -2,10 +2,8 @@
   <% kind = f.object.kind %>
   <div class="col-sm col-md-6 p-0">
     <div class="col-md-12 <%= f.index.even? ? 'pl-0' : 'pr-0'%>">
-      <span>
-        <%= f.hidden_field :kind %>
-        <%= f.hidden_field :_destroy %>
-      </span>
+      <%= f.hidden_field :kind %>
+      <%= f.hidden_field :_destroy %>
       <%= f.label :address, kind.upcase.eql?('HOME') ? l10n("personal_email_address") : l10n(kind + " Email Address").titleize %>
       <%= f.email_field :address, placeholder: "example@mail.com", class: "full-width" %>
     </div>

--- a/app/views/shared/_phone_fields.html.erb
+++ b/app/views/shared/_phone_fields.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div id="phone_info">
-    <div class="phone d-flex mb-md-4 row col-sm">
+    <div class="phone d-flex mb-md-2 row col-sm">
       <%= f.fields_for :phones, errors: {}, fieldset: true do |phone|  %>
         <% kind = phone.object.kind.upcase %>
         <% required = kind == 'HOME' ? "required" : "" %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187605071

# A brief description of the changes

Current behavior: The first rows in both the address and contact sections have larger bottom margins.

New behavior: The first rows in both the address and contact sections now have smaller bottom margins.

<img width="845" alt="Screenshot 2024-05-14 at 8 29 17 PM" src="https://github.com/ideacrew/enroll/assets/167465598/6a90da75-01b0-4055-8a2f-a0c9027c4464">

