### PR TITLE
new scope to fetch eligibile families for pvc

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -215,7 +215,7 @@ class Family
   scope :by_datetime_range,                     ->(start_at, end_at){ where(:created_at.gte => start_at).and(:created_at.lte => end_at) }
   scope :all_enrollments,                       ->{  where(:"_id".in => HbxEnrollment.enrolled_statuses.distinct(:family_id)) }
   scope :all_enrolled_and_renewal_enrollments, ->{  where(:"_id".in => HbxEnrollment.enrolled_and_renewal.distinct(:family_id)) }  # rubocop:disable Style/SymbolLiteral
-  scope :aptc_csr_active_or_renewal_enrollments, ->(csr_list) {  where(:"_id".in => HbxEnrollment.enrolled_and_renewal.where('$or' => [{ :"applied_aptc_amount.cents".gt => 0 }, { :"product.csr_variant_id".in => csr_list }]).distinct(:family_id))}
+  scope :aptc_csr_active_or_renewal_enrollments, ->(csr_list) {  where(:_id.in => HbxEnrollment.enrolled_and_renewal.where('$or' => [{ :"applied_aptc_amount.cents".gt => 0 }, { :"product.csr_variant_id".in => csr_list }]).distinct(:family_id))}
   scope :all_enrollments_by_writing_agent_id,   ->(broker_id) { where(:"_id".in => HbxEnrollment.by_writing_agent_id(broker_id).distinct(:family_id)) }
   scope :all_enrollments_by_benefit_group_ids,   ->(benefit_group_ids) { where(:"_id".in => HbxEnrollment.by_benefit_group_ids(benefit_group_ids).distinct(:family_id)) }
   scope :all_enrollments_by_benefit_sponsorship_id, ->(benefit_sponsorship_id){ where(:"_id".in => HbxEnrollment.by_benefit_sponsorship_id(benefit_sponsorship_id).distinct(:family_id))}

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -215,6 +215,7 @@ class Family
   scope :by_datetime_range,                     ->(start_at, end_at){ where(:created_at.gte => start_at).and(:created_at.lte => end_at) }
   scope :all_enrollments,                       ->{  where(:"_id".in => HbxEnrollment.enrolled_statuses.distinct(:family_id)) }
   scope :all_enrolled_and_renewal_enrollments, ->{  where(:"_id".in => HbxEnrollment.enrolled_and_renewal.distinct(:family_id)) }  # rubocop:disable Style/SymbolLiteral
+  scope :aptc_csr_active_or_renewal_enrollments, ->(csr_list) {  where(:"_id".in => HbxEnrollment.enrolled_and_renewal.where('$or' => [{ :"applied_aptc_amount.cents".gt => 0 }, { :"product.csr_variant_id".in => csr_list }]).distinct(:family_id))}
   scope :all_enrollments_by_writing_agent_id,   ->(broker_id) { where(:"_id".in => HbxEnrollment.by_writing_agent_id(broker_id).distinct(:family_id)) }
   scope :all_enrollments_by_benefit_group_ids,   ->(benefit_group_ids) { where(:"_id".in => HbxEnrollment.by_benefit_group_ids(benefit_group_ids).distinct(:family_id)) }
   scope :all_enrollments_by_benefit_sponsorship_id, ->(benefit_sponsorship_id){ where(:"_id".in => HbxEnrollment.by_benefit_sponsorship_id(benefit_sponsorship_id).distinct(:family_id))}

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -215,7 +215,10 @@ class Family
   scope :by_datetime_range,                     ->(start_at, end_at){ where(:created_at.gte => start_at).and(:created_at.lte => end_at) }
   scope :all_enrollments,                       ->{  where(:"_id".in => HbxEnrollment.enrolled_statuses.distinct(:family_id)) }
   scope :all_enrolled_and_renewal_enrollments, ->{  where(:"_id".in => HbxEnrollment.enrolled_and_renewal.distinct(:family_id)) }  # rubocop:disable Style/SymbolLiteral
-  scope :aptc_csr_active_or_renewal_enrollments, ->(csr_list) {  where(:_id.in => HbxEnrollment.enrolled_and_renewal.where('$or' => [{ :"applied_aptc_amount.cents".gt => 0 }, { :"product.csr_variant_id".in => csr_list }]).distinct(:family_id))}
+  scope :with_applied_aptc_or_csr_active_enrollments, lambda { |csr_list|
+                                                        where(:_id.in => HbxEnrollment.enrolled_and_renewal.where('$or' => [{ :"applied_aptc_amount.cents".gt => 0 },
+                                                                                                                            {:product_id.in => BenefitMarkets::Products::Product.where(:csr_variant_id.in => csr_list).pluck(:id) }]).distinct(:family_id))
+                                                      }
   scope :all_enrollments_by_writing_agent_id,   ->(broker_id) { where(:"_id".in => HbxEnrollment.by_writing_agent_id(broker_id).distinct(:family_id)) }
   scope :all_enrollments_by_benefit_group_ids,   ->(benefit_group_ids) { where(:"_id".in => HbxEnrollment.by_benefit_group_ids(benefit_group_ids).distinct(:family_id)) }
   scope :all_enrollments_by_benefit_sponsorship_id, ->(benefit_sponsorship_id){ where(:"_id".in => HbxEnrollment.by_benefit_sponsorship_id(benefit_sponsorship_id).distinct(:family_id))}

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/submit_pvc_set.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/submit_pvc_set.rb
@@ -16,7 +16,7 @@ module FinancialAssistance
           include EventSource::Logging
           include FinancialAssistance::JobsHelper
 
-          PVC_CSR_LIST = [02, 04, 05, 06].freeze
+          PVC_CSR_LIST = ['02', '04', '05', '06'].freeze
 
           # @param [Int] assistance_year
           # @param [Array] csr_list

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/submit_pvc_set.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/pvc/submit_pvc_set.rb
@@ -16,8 +16,7 @@ module FinancialAssistance
           include EventSource::Logging
           include FinancialAssistance::JobsHelper
 
-          # "02", "04", "05", "06" are already converted
-          PVC_CSR_LIST = [100, 73, 87, 94].freeze
+          PVC_CSR_LIST = [02, 04, 05, 06].freeze
 
           # @param [Int] assistance_year
           # @param [Array] csr_list
@@ -43,7 +42,7 @@ module FinancialAssistance
 
           def find_families(params)
             if EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
-              Family.with_active_coverage_and_aptc_csr_grants_for_year(params[:assistance_year], params[:csr_list]).distinct(:_id)
+              Family.with_applied_aptc_or_csr_active_enrollments(params[:csr_list]).distinct(:_id)
             else
               Family.periodic_verifiable_for_assistance_year(params[:assistance_year], params[:csr_list]).distinct(:_id)
             end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/pvc/submit_pvc_set_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/pvc/submit_pvc_set_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Pvc::SubmitPvcSe
     allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:non_esi_mec_determination).and_return(true)
     allow(FinancialAssistanceRegistry).to receive(:feature_enabled?).with(:ifsv_determination).and_return(true)
 
-    allow(Family).to receive(:with_active_coverage_and_aptc_csr_grants_for_year).and_return([family.id])
+    allow(Family).to receive(:with_applied_aptc_or_csr_active_enrollments).and_return([family.id])
   end
 
   context 'success' do

--- a/script/export_pvc_determined_families.rb
+++ b/script/export_pvc_determined_families.rb
@@ -6,9 +6,9 @@
 # bundle exec rails runner script/export_pvc_families.rb assistance_year='2023'
 
 assistance_year = ENV['assistance_year'].to_i
-csr_list = [100, 73, 87, 94].freeze
+csr_list = [02, 04, 05, 06].freeze
 
-family_ids = Family.with_active_coverage_and_aptc_csr_grants_for_year(assistance_year, csr_list).distinct(:_id)
+family_ids = Family.with_applied_aptc_or_csr_active_enrollments(csr_list).distinct(:_id)
 
 p "found #{family_ids.count} families"  unless Rails.env.test?
 

--- a/spec/models/family_spec_2.rb
+++ b/spec/models/family_spec_2.rb
@@ -132,8 +132,13 @@ RSpec.describe Family, dbclean: :around_each do
                         enrollment_members: [primary_applicant],
                         effective_on: date.beginning_of_month,
                         family: family,
-                        aasm_state: :coverage_selected)
+                        aasm_state: :coverage_selected,
+                        applied_aptc_amount: applied_aptc_amount)
     end
+
+    let!(:silver_03) { FactoryBot.create(:benefit_markets_products_health_products_health_product, :silver, hios_id: '41842ME12345S-03', csr_variant_id: '03') }
+    let!(:silver_04) { FactoryBot.create(:benefit_markets_products_health_products_health_product, :silver, hios_id: '41842ME12345S-04', csr_variant_id: '04') }
+
     let!(:thh_start_on) { tax_household_current.effective_starting_on }
 
     let(:family_member1) { family.family_members[0] }
@@ -212,6 +217,7 @@ RSpec.describe Family, dbclean: :around_each do
       let(:yearly_expected_contribution_current) { 125.00 * 12 }
       let(:yearly_expected_contribution_previous) { 1000 }
       let(:members_csr_set) { {family_member1 => '87', family_member2 => '87'} }
+      let!(:applied_aptc_amount) { 0 }
 
       it 'returns families with active assisted tax households for the given year' do
         result = Family.with_aptc_csr_grants_for_year(assistance_year, csr)
@@ -225,6 +231,7 @@ RSpec.describe Family, dbclean: :around_each do
       let(:yearly_expected_contribution_current) { 0 }
       let(:yearly_expected_contribution_previous) { 1000 }
       let(:members_csr_set) { {family_member1 => '87', family_member2 => '87'} }
+      let!(:applied_aptc_amount) { 0 }
 
       it 'should not return families' do
         result = Family.with_aptc_csr_grants_for_year(assistance_year, csr)
@@ -237,6 +244,7 @@ RSpec.describe Family, dbclean: :around_each do
       let(:yearly_expected_contribution_current) { 1000 }
       let(:yearly_expected_contribution_previous) { 1000 }
       let(:members_csr_set) { {family_member1 => '0', family_member2 => '0'} }
+      let!(:applied_aptc_amount) { 0 }
 
       it 'should not return families' do
         result = Family.with_aptc_csr_grants_for_year(assistance_year, csr)
@@ -249,6 +257,7 @@ RSpec.describe Family, dbclean: :around_each do
       let(:yearly_expected_contribution_current) { 0 }
       let(:yearly_expected_contribution_previous) { 0 }
       let(:members_csr_set) { {family_member1 => '87', family_member2 => '87'} }
+      let!(:applied_aptc_amount) { 0 }
 
       it 'should not return families' do
         result = Family.with_aptc_csr_grants_for_year(assistance_year - 1, csr)
@@ -257,10 +266,68 @@ RSpec.describe Family, dbclean: :around_each do
       end
     end
 
+    context 'family without applied aptc or csr product' do
+      let(:yearly_expected_contribution_current) { 0 }
+      let(:yearly_expected_contribution_previous) { 0 }
+      let(:members_csr_set) { {family_member1 => '100', family_member2 => '100'} }
+      let!(:applied_aptc_amount) { 0 }
+      let(:csr_product_variant) { '03' }
+
+      before do
+        hbx_enrollment.product = silver_03
+        hbx_enrollment.save!
+      end
+
+      it 'should not return families' do
+        result = Family.with_applied_aptc_or_csr_active_enrollments(['04', '05'])
+        expect(result).not_to include(family)
+        expect(result.count).to eq(0)
+      end
+    end
+
+    context 'family without csr product, but has applied aptc' do
+      let(:yearly_expected_contribution_current) { 100 }
+      let(:yearly_expected_contribution_previous) { 0 }
+      let(:members_csr_set) { {family_member1 => 'limited', family_member2 => 'limited'} }
+      let!(:applied_aptc_amount) { 100 }
+      let(:csr_product_variant) { '03' }
+
+      before do
+        hbx_enrollment.product = silver_03
+        hbx_enrollment.save!
+      end
+
+      it 'should return families' do
+        result = Family.with_applied_aptc_or_csr_active_enrollments(['04', '05'])
+        expect(result).to include(family)
+        expect(result.count).to eq(1)
+      end
+    end
+
+    context 'family without applied aptc, but has csr product' do
+      let(:yearly_expected_contribution_current) { 0 }
+      let(:yearly_expected_contribution_previous) { 0 }
+      let(:members_csr_set) { {family_member1 => '73', family_member2 => '73'} }
+      let!(:applied_aptc_amount) { 0 }
+      let(:csr_product_variant) { '04' }
+
+      before do
+        hbx_enrollment.product = silver_04
+        hbx_enrollment.save!
+      end
+
+      it 'should return families' do
+        result = Family.with_applied_aptc_or_csr_active_enrollments(['04', '05'])
+        expect(result).to include(family)
+        expect(result.count).to eq(1)
+      end
+    end
+
     context 'enrolled family with aptc and csr_87 for all members' do
       let(:yearly_expected_contribution_current) { 1000 }
       let(:yearly_expected_contribution_previous) { 0 }
       let(:members_csr_set) { {family_member1 => '87', family_member2 => '87'} }
+      let!(:applied_aptc_amount) { 0 }
 
       it 'returns families' do
         result = Family.with_active_coverage_and_aptc_csr_grants_for_year(assistance_year, csr)
@@ -274,6 +341,7 @@ RSpec.describe Family, dbclean: :around_each do
       let(:yearly_expected_contribution_current) { 1000 }
       let(:yearly_expected_contribution_previous) { 0 }
       let(:members_csr_set) { {family_member1 => '87', family_member2 => '87'} }
+      let!(:applied_aptc_amount) { 0 }
 
       it 'should not return families' do
         hbx_enrollment.update(aasm_state: 'coverage_canceled')
@@ -288,6 +356,7 @@ RSpec.describe Family, dbclean: :around_each do
       let(:yearly_expected_contribution_current) { 1000 }
       let(:yearly_expected_contribution_previous) { 0 }
       let(:members_csr_set) { {family_member1 => '87', family_member2 => '87'} }
+      let!(:applied_aptc_amount) { 0 }
 
       it 'when csr is passed as array of integer values' do
         result = Family.with_active_coverage_and_aptc_csr_grants_for_year(assistance_year, [87, 94])

--- a/spec/script/export_pvc_determined_families_spec.rb
+++ b/spec/script/export_pvc_determined_families_spec.rb
@@ -52,7 +52,8 @@ describe 'export_rrv_families' do
                       enrollment_members: [primary_applicant],
                       effective_on: date.beginning_of_month,
                       family: family,
-                      aasm_state: :coverage_selected)
+                      aasm_state: :coverage_selected,
+                      applied_aptc_amount: 1000.00)
   end
   let!(:thh_start_on) { tax_household_current.effective_starting_on }
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [pivotaltracker.com/n/projects/2648255/stories/187604896#](https://www.pivotaltracker.com/story/show/187604896)

# A brief description of the changes

Current behavior: Query families eligibilie for aptc and csr and actively enrolled in a plan.

New behavior: Query families that are actively enrolled in a csr plan or used aptc.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
