### PR TITLE
hide id in pre login

### DIFF
--- a/app/views/ui-components/bs4/v1/navs/_header.html.erb
+++ b/app/views/ui-components/bs4/v1/navs/_header.html.erb
@@ -27,7 +27,8 @@
         <% if signed_in? %>
           <li class="nav-item-divider"></li>
           <li class="nav-item d-flex flex-column align-items-end">
-            <span><%= image_pack_tag "icons/user-small.svg", alt:"user icon" %><%= l10n('layout.header.user_and_id', name: user_first_name_last_name_and_suffix, id: current_user.try(:person).try(:hbx_id)) %></span>
+            <% user_id = current_user.try(:person).try(:hbx_id) %>
+            <span><%= image_pack_tag "icons/user-small.svg", alt:"user icon" %><%= " #{user_first_name_last_name_and_suffix}#{" #{l10n('layout.header.id')} #{user_id}" unless user_id.blank?}" %></span>
             <span class="horizontal-links">
               <%= render partial: "shared/my_portal_links" %>
               <span>

--- a/db/seedfiles/translations/en/cca/layout.rb
+++ b/db/seedfiles/translations/en/cca/layout.rb
@@ -1,6 +1,6 @@
 LAYOUT_TRANSLATIONS = {
   "en.layout.header.customer_service" => "Call Customer Service",
-  "en.layout.header.user_and_id" => "%{name} ID: %{id}",
+  "en.layout.header.id" => "ID:",
   "en.layout.header.help" => "Help",
   "en.layout.header.logout" => "Logout",
   "en.layout.header.role.admin" => "Admin",

--- a/db/seedfiles/translations/en/dc/layout.rb
+++ b/db/seedfiles/translations/en/dc/layout.rb
@@ -1,6 +1,6 @@
 LAYOUT_TRANSLATIONS = {
   "en.layout.header.customer_service" => "Call Customer Service",
-  "en.layout.header.user_and_id" => "%{name} ID: %{id}",
+  "en.layout.header.id" => "ID:",
   "en.layout.header.help" => "Help",
   "en.layout.header.logout" => "Logout",
   "en.layout.header.role.admin" => "Admin",

--- a/db/seedfiles/translations/en/me/layout.rb
+++ b/db/seedfiles/translations/en/me/layout.rb
@@ -1,6 +1,6 @@
 LAYOUT_TRANSLATIONS = {
   "en.layout.header.customer_service" => "Call Customer Service",
-  "en.layout.header.user_and_id" => "%{name} ID: %{id}",
+  "en.layout.header.id" => "ID:",
   "en.layout.header.help" => "Help",
   "en.layout.header.logout" => "Logout",
   "en.layout.header.role.admin" => "Admin",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187578774

# A brief description of the changes

Current behavior: The ID substring was present when no ID had been assigned to the user.

New behavior: The ID substring is now only present once the ID is created.

Header before personal info submission:
<img width="520" alt="Screenshot 2024-05-15 at 2 45 24 PM" src="https://github.com/ideacrew/enroll/assets/167465598/6cc1bf10-b77c-4981-9e72-daf415111bd8">
Header after personal info submission:
<img width="520" alt="Screenshot 2024-05-15 at 2 46 15 PM" src="https://github.com/ideacrew/enroll/assets/167465598/2c4e1486-087d-4870-9dcf-c94ec535a4d8">



