### PR TITLE
remove extra personal info contact text

### DIFF
--- a/app/views/insured/consumer_roles/_form.html.erb
+++ b/app/views/insured/consumer_roles/_form.html.erb
@@ -28,7 +28,6 @@
     </section>
     <section class="mb-4">
       <h4 class="gamma mb-0"><%= l10n("insured.consumer_roles.phone_and_email") %></h4>
-      <p><%= l10n("insured.consumer_roles.please_provide") %></p>
       <%= render partial: 'shared/phone_fields', locals: {f: f, bs4: true} %>
       <div id="email_info" class="">
         <div class="email d-flex mb-md-4 row col-sm">

--- a/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
@@ -141,6 +141,7 @@
     </div>
   </div>
 
+<<<<<<< HEAD
 <div class="row">
   <div class="col-xs-12">
     <%= (link_to 'Documents FAQ', ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, class: "btn btn-default btn-small pull-right", target: '_blank', rel: "noopener noreferrer") %>

--- a/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
@@ -141,7 +141,6 @@
     </div>
   </div>
 
-<<<<<<< HEAD
 <div class="row">
   <div class="col-xs-12">
     <%= (link_to 'Documents FAQ', ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, class: "btn btn-default btn-small pull-right", target: '_blank', rel: "noopener noreferrer") %>

--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -31,7 +31,6 @@ How to find the SEVIS ID: On the DS-2019, the number is on the top right hand si
   :"en.insured.consumer_roles.contact_info_for" => "Contact Information for",
   :"en.insured.consumer_roles.home_address" => "Home Address",
   :"en.insured.consumer_roles.phone_and_email" => "Phone and Email",
-  :"en.insured.consumer_roles.please_provide" => "Please provide as much information as possible",
   :"en.insured.consumer_roles.immigration_field_warning1" => "It's important to enter as many fields from your immigration documents as possible",
   :'en.your_information' => "Privacy & Use of Your Information",
   :'en.insured.consumer_roles.help_question_info' => "Enter your personal information and answer the following questions. When you're finished, select CONTINUE.",

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -59,7 +59,6 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :"en.insured.consumer_roles.contact_info_for" => "Contact Information for",
   :"en.insured.consumer_roles.home_address" => "Home Address",
   :"en.insured.consumer_roles.phone_and_email" => "Phone and Email",
-  :"en.insured.consumer_roles.please_provide" => "Please provide as much information as possible",
   :"en.insured.consumer_roles.immigration_field_warning1" => "It's important to enter as many fields from your immigration documents as possible",
   :'en.your_information' => "Privacy & Use of Your Information",
   :'en.continue_next' => "Continue to Next Step",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -36,7 +36,6 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :"en.insured.consumer_roles.contact_info_for" => "Contact Information for",
   :"en.insured.consumer_roles.home_address" => "Home Address",
   :"en.insured.consumer_roles.phone_and_email" => "Phone and Email",
-  :"en.insured.consumer_roles.please_provide" => "Please provide as much information as possible",
   :"en.insured.consumer_roles.immigration_field_warning1" => "It's important to enter as many fields from your immigration documents as possible",
   :'en.insured.consumer_roles.help_question_info' => "Enter your personal information and answer the following questions. When you're finished, select CONTINUE.",
   :'en.required_field' => "required field",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187605141

# A brief description of the changes

Current behavior: "Please enter as much info as possible" text is present below contact section title

New behavior: "Please enter as much info as possible" text is now removed

<img width="520" alt="Screenshot 2024-05-15 at 3 10 07 PM" src="https://github.com/ideacrew/enroll/assets/167465598/18a13a10-5e8f-430c-8040-2be626c612ab">


