### PR TITLE
unbold personal info immigration fields

### DIFF
--- a/app/views/insured/consumer_roles/_immigration_statuses.html.erb
+++ b/app/views/insured/consumer_roles/_immigration_statuses.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <fieldset id="immigration_doc_statuses" class="mt-4">
-    <legend><%= l10n("insured.consumer_roles.docs_shared.other_status_question") %></legend>
+    <legend class="weight-n"><%= l10n("insured.consumer_roles.docs_shared.other_status_question") %></legend>
     <div>
       <% ::ConsumerRole::IMMIGRATION_DOCUMENT_STATUSES.each_with_index do |status, index| %>
         <label for="<%= status.gsub(/[^\w\s_-]+/, '').gsub(/\s+/, '_') %>" class="mb-3">

--- a/app/views/insured/consumer_roles/docs_shared/_alien_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_alien_number.html.erb
@@ -2,7 +2,7 @@
   <div class="mt-4 mb-4">
     <% cert = (name == 'certificate_citizenship' || name == 'naturalization_certificate') %>
     <% description = cert ? l10n("insured.consumer_roles.docs_shared.certificate_alien_number_req") : l10n("insured.consumer_roles.docs_shared.alien_number_req") %>
-    <%= label_tag :alien_number, l10n("insured.consumer_roles.docs_shared.alien_number"), class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
+    <%= label_tag :alien_number, l10n("insured.consumer_roles.docs_shared.alien_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
     <%= v.text_field :alien_number, :placeholder => l10n("insured.consumer_roles.docs_shared.alien_number"),
                    :pattern => "\\d{9}",
                    :class => "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" }doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_card_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_card_number.html.erb
@@ -1,7 +1,7 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
     <% description = name == 'I-766' ? l10n("insured.consumer_roles.docs_shared.i_766_card_number_req") : l10n("insured.consumer_roles.docs_shared.card_number_req") %>
-    <%= label_tag :card_number, l10n("insured.consumer_roles.docs_shared.card_number"), class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
+    <%= label_tag :card_number, l10n("insured.consumer_roles.docs_shared.card_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
     <%= v.text_field :card_number, :placeholder => l10n("insured.consumer_roles.docs_shared.card_number"),
                    :pattern => "[a-zA-Z0-9]{13}",
                    :class => "#{FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "" : "required" } doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_citizenship_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_citizenship_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :citizenship_number, l10n("insured.consumer_roles.docs_shared.citizenship_number"), class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
+    <%= label_tag :citizenship_number, l10n("insured.consumer_roles.docs_shared.citizenship_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
     <%= v.text_field :citizenship_number, :placeholder => l10n("insured.consumer_roles.docs_shared.citizenship_number"),
                    :pattern => "[a-zA-Z0-9]{6,12}",
                    :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_country_of_citizenship.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_country_of_citizenship.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :country_of_citizenship, l10n("insured.consumer_roles.docs_shared.country_of_citizenship") %>
+    <%= label_tag :country_of_citizenship, l10n("insured.consumer_roles.docs_shared.country_of_citizenship"), class: "weight-n" %>
     <%= v.select :country_of_citizenship, options_for_select(::VlpDocument::COUNTRIES_LIST, @country||=l10n("insured.consumer_roles.docs_shared.country_of_citizenship")), prompt: l10n("insured.consumer_roles.docs_shared.country_of_citizenship"), class: "select_tag" %>
   </div>
 <% else %>

--- a/app/views/insured/consumer_roles/docs_shared/_document_description.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_document_description.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :description, l10n("insured.consumer_roles.docs_shared.document_description") %>
+    <%= label_tag :description, l10n("insured.consumer_roles.docs_shared.document_description"), class: "weight-n" %>
     <%= v.text_field :description, :placeholder => l10n("insured.consumer_roles.docs_shared.document_description"),
                       :pattern => ".{1,35}",
                       :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_expiration_date.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_expiration_date.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :doc_date_field, l10n("insured.consumer_roles.docs_shared.expiration_date", name: name), class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
+    <%= label_tag :doc_date_field, l10n("insured.consumer_roles.docs_shared.expiration_date", name: name), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
     <%= v.date_field :expiration_date, {id: "doc_date_field", class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" } date-field doc_fields", placeholder: l10n("insured.consumer_roles.docs_shared.expiration_date", name: name)} %>
   </div>
 <% else %>

--- a/app/views/insured/consumer_roles/docs_shared/_i_94_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_i_94_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :i94_number, l10n("insured.consumer_roles.docs_shared.i94_number") %>
+    <%= label_tag :i94_number, l10n("insured.consumer_roles.docs_shared.i94_number"), class: "weight-n" %>
     <%= v.text_field :i94_number, :placeholder => l10n("insured.consumer_roles.docs_shared.i94_number"),
                     :pattern => "[A-Za-z0-9]{11}",
                     :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_naturalization_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_naturalization_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :naturalization_number, l10n("insured.consumer_roles.docs_shared.naturalization_number") %>
+    <%= label_tag :naturalization_number, l10n("insured.consumer_roles.docs_shared.naturalization_number"), class: "weight-n" %>
     <%= v.text_field :naturalization_number, :placeholder => l10n("insured.consumer_roles.docs_shared.naturalization_number"),
                     :pattern => "[a-zA-Z0-9]{6,12}",
                     :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_passport_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_passport_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :passport_number, l10n("insured.passport_number") %>
+    <%= label_tag :passport_number, l10n("insured.passport_number"), class: "weight-n" %>
     <%= v.text_field :passport_number, :placeholder => l10n("insured.passport_number"),
                     :pattern => "[a-zA-Z0-9]{6,12}",
                     :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_servis_id.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_servis_id.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :sevis_id, l10n("insured.consumer_roles.docs_shared.sevis_id") %>
+    <%= label_tag :sevis_id, l10n("insured.consumer_roles.docs_shared.sevis_id"), class: "weight-n" %>
     <%= v.text_field :sevis_id, :placeholder => l10n("insured.consumer_roles.docs_shared.sevis_id"),
                     :pattern => "\\d{10}",
                     :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_visa_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_visa_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :visa_number, l10n("insured.consumer_roles.docs_shared.visa_number") %>
+    <%= label_tag :visa_number, l10n("insured.consumer_roles.docs_shared.visa_number"), class: "weight-n" %>
     <%= v.text_field :visa_number, :placeholder => l10n("insured.consumer_roles.docs_shared.visa_number"),
                     :pattern => "[a-zA-Z0-9]{8,12}",
                     :class => "doc_fields",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/187584366

# A brief description of the changes

Current behavior: Most immigration document fields in Personal Info were bold for BS4.

New behavior: All immigration document fields in Personal Info are now unbold for BS4.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
