### PR TITLE
187579400 update flash

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -379,6 +379,8 @@ module ApplicationHelper
       "info"
     when "message" 
       "warning"
+    when "success"
+      "success"
     else 
       "error"
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -365,7 +365,7 @@ module ApplicationHelper
   end
 
   def get_flash(use_bs4, type, msg)
-    type = use_bs4 ? get_bs4_flash_type(type) : type
+    type = use_bs4 ? get_flash_type(type) : type
     if is_announcement?(msg)
       render(:partial => 'layouts/announcement_flash', :locals => {:type => type, :message => msg[:announcement]})
     else
@@ -373,7 +373,7 @@ module ApplicationHelper
     end
   end
 
-  def get_bs4_flash_type(type)
+  def get_flash_type(type)
     case type
     when "notice"
       "info"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -348,27 +348,39 @@ module ApplicationHelper
             '#', class: "add_fields #{classes}", data: {id: id, fields: fields.gsub("\n", "")})
   end
 
-  def render_flash
+  def render_flash(use_bs4 = false)
     rendered = []
     flash.each do |type, messages|
       next if messages.blank? || (messages.respond_to?(:include?) && messages.include?("nil is not a symbol nor a string"))
 
       if messages.respond_to?(:each)
         messages.each do |m|
-          rendered << get_flash(type, m) if m.present?
+          rendered << get_flash(use_bs4, type, m) if m.present?
         end
       else
-        rendered << get_flash(type, messages)
+        rendered << get_flash(use_bs4, type, messages)
       end
     end
     sanitize_html(rendered.join)
   end
 
-  def get_flash(type, msg)
+  def get_flash(use_bs4, type, msg)
+    type = use_bs4 ? get_bs4_flash_type(type) : type
     if is_announcement?(msg)
       render(:partial => 'layouts/announcement_flash', :locals => {:type => type, :message => msg[:announcement]})
     else
       render(:partial => 'layouts/flash', :locals => {:type => type, :message => msg})
+    end
+  end
+
+  def get_bs4_flash_type(type)
+    case type
+    when "notice"
+      "info"
+    when "message" 
+      "warning"
+    else 
+      "error"
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -377,12 +377,12 @@ module ApplicationHelper
     case type
     when "notice"
       "info"
-    when "message" 
+    when "warning", "message" 
       "warning"
     when "success"
       "success"
     else 
-      "error"
+      "severe"
     end
   end
 

--- a/app/javascript/css/alerts.scss
+++ b/app/javascript/css/alerts.scss
@@ -36,9 +36,9 @@
 }
 
 .alert-error {
-  color: var(--error-shade);
   background-color: var(--error-tint);
-  border-color: var(--error-tint);
+  border-color: var(--error-color);
+  color: var(--error-shade);
 }
 
 .alert {
@@ -74,6 +74,14 @@
 .icon {
   width: 1em;
   margin-right: .25em;
+}
+
+.error-icon {
+  background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23A21E1F'/%3E%3Cline x1='8.46451' y1='8.46448' x2='15.5356' y2='15.5355' stroke='white' stroke-width='2' stroke-linecap='round'/%3E%3Cline x1='15.5356' y1='8.46451' x2='8.46458' y2='15.5356' stroke='white' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  color: transparent !important;
+  font-size: 27px !important;
 }
 
 .warning-icon {

--- a/app/javascript/css/alerts.scss
+++ b/app/javascript/css/alerts.scss
@@ -91,3 +91,11 @@
   color: transparent !important;
   font-size: 27px !important;
 }
+
+.close-icon {
+  background-image: url("data:image/svg+xml, %3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z' fill='gray' /%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  color: transparent !important;
+  font-size: 27px !important;
+}

--- a/app/javascript/css/alerts.scss
+++ b/app/javascript/css/alerts.scss
@@ -36,9 +36,9 @@
 }
 
 .alert-error {
-  background-color: var(--error-tint);
-  border-color: var(--error-color);
   color: var(--error-shade);
+  background-color: var(--error-tint);
+  border-color: var(--error-tint);
 }
 
 .alert {
@@ -51,6 +51,12 @@
 .notice {
   padding: .25em;
   border-radius: 6px;
+}
+
+.alert-severe {
+  background-color: var(--error-tint);
+  border-color: var(--error-color);
+  color: var(--error-shade);
 }
 
 .alert-warning, .notice-warning {
@@ -76,7 +82,7 @@
   margin-right: .25em;
 }
 
-.error-icon {
+.severe-icon {
   background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='12' cy='12' r='10' fill='%23A21E1F'/%3E%3Cline x1='8.46451' y1='8.46448' x2='15.5356' y2='15.5355' stroke='white' stroke-width='2' stroke-linecap='round'/%3E%3Cline x1='15.5356' y1='8.46451' x2='8.46458' y2='15.5356' stroke='white' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: center;

--- a/app/models/forms/consumer_candidate.rb
+++ b/app/models/forms/consumer_candidate.rb
@@ -160,7 +160,7 @@ module Forms
       return unless (self.dob_check == "false" || self.dob_check.blank?) && self.dob.present?
 
       if ::TimeKeeper.date_of_record.year - self.dob.year < 18
-        errors.add(:base, "Please verify your date of birth. If it's correct, please continue.")
+        errors.add(:base, "Please verify your date of birth. If it's correct, please continue.", :level => :warning)
         self.dob_check = true
       else
         self.dob_check = false

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,13 +1,13 @@
 <% if @bs4 %>
-  <div class="container mt-3 px-0">
+  <div class="container mt-3 mb-0 px-0">
     <div class="alert alert-<%= type %> d-flex flash" role="alert">
-      <div class="p-0">
+      <div class="pl-1">
         <div class="<%= type %>-icon icon" alt=<%= type %>>&nbsp;</div>
       </div>
       <div class="col my-1 mr-auto p-0 align-self-center">
         <%= raw message %>
       </div>
-      <a class="close-icon icon align-self-start" alt="Close" href="#">&nbsp;</a>
+      <a class="close-icon icon pr-1 align-self-start" alt="Close" href="#">&nbsp;</a>
     </div>
   </div>
 <% else %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,5 +1,5 @@
 <% if @bs4 %>
-  <div class="container mt-4 mb-0 px-0">
+  <div class="container mb-0 px-0">
     <div class="alert alert-<%= type %> d-flex flash" role="alert">
       <div class="pl-1">
         <div class="<%= type %>-icon icon" alt=<%= type %>>&nbsp;</div>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,10 +1,24 @@
-<div class="row flash module">
-  <div class="alert alert-<%= type %>" style="width: 100%; margin-top: 0px !important;">
-    <div class="container">
-      <div class="col-xs-12" style="width: 100%; max-width: 1170px; margin: auto;">
-        <a class="close" data-dismiss="alert" href="#">×</a>
-        <%= raw message %>
+<% if @bs4 %>
+  <div class="alert alert-info d-flex" role="alert">
+    <div class="col-auto p-0">
+      <div class="info-icon icon" alt="info" aria-hidden="true">&nbsp;</div>
+    </div>
+    <div class="col mt-1 mb-1 p-0 align-self-center">
+      <%= raw message %>
+    </div>
+    <div class="col-auto">
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+    </div>
+  </div>
+<% else %>
+  <div class="row flash module">
+    <div class="alert alert-<%= type %>" style="width: 100%; margin-top: 0px !important;">
+      <div class="container">
+        <div class="col-xs-12" style="width: 100%; max-width: 1170px; margin: auto;">
+          <a class="close" data-dismiss="alert" href="#">×</a>
+          <%= raw message %>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -6,8 +6,8 @@
     <div class="col mt-1 mb-1 p-0 align-self-center">
       <%= raw message %>
     </div>
-    <div class="col-auto">
-      <button type="button" class="close" data-dismiss="alert">&times;</button>
+    <div class="col-auto flash">
+      <a class="close" data-dismiss="alert" href="#">×</a>
     </div>
   </div>
 <% else %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,12 +1,14 @@
 <% if @bs4 %>
-  <div class="alert alert-<%= type %> d-flex flash" role="alert">
-    <div class="p-0">
-      <div class="<%= type %>-icon icon" alt=<%= type %>>&nbsp;</div>
+  <div class="container mt-3 px-0">
+    <div class="alert alert-<%= type %> d-flex flash" role="alert">
+      <div class="p-0">
+        <div class="<%= type %>-icon icon" alt=<%= type %>>&nbsp;</div>
+      </div>
+      <div class="col my-1 mr-auto p-0 align-self-center">
+        <%= raw message %>
+      </div>
+      <a class="close-icon icon align-self-start" alt="Close" href="#">&nbsp;</a>
     </div>
-    <div class="col my-1 mr-auto p-0 align-self-center">
-      <%= raw message %>
-    </div>
-    <a class="close-icon icon align-self-start" alt="Close" href="#">&nbsp;</a>
   </div>
 <% else %>
   <div class="row flash module">

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,5 +1,5 @@
 <% if @bs4 %>
-  <div class="container mt-3 mb-0 px-0">
+  <div class="container mt-4 mb-0 px-0">
     <div class="alert alert-<%= type %> d-flex flash" role="alert">
       <div class="pl-1">
         <div class="<%= type %>-icon icon" alt=<%= type %>>&nbsp;</div>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,14 +1,12 @@
 <% if @bs4 %>
-  <div class="alert alert-info d-flex" role="alert">
-    <div class="col-auto p-0">
+  <div class="alert alert-info d-flex flash" role="alert">
+    <div class="p-0">
       <div class="info-icon icon" alt="info" aria-hidden="true">&nbsp;</div>
     </div>
-    <div class="col mt-1 mb-1 p-0 align-self-center">
+    <div class="my-1 mr-auto p-0 align-self-center">
       <%= raw message %>
     </div>
-    <div class="col-auto flash">
-      <a class="close" data-dismiss="alert" href="#">×</a>
-    </div>
+    <a class="close-icon icon align-self-start" alt="info" aria-hidden="true" href="#">&nbsp;</a>
   </div>
 <% else %>
   <div class="row flash module">

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,12 +1,12 @@
 <% if @bs4 %>
-  <div class="alert alert-info d-flex flash" role="alert">
+  <div class="alert alert-<%= type %> d-flex flash" role="alert">
     <div class="p-0">
-      <div class="info-icon icon" alt="info" aria-hidden="true">&nbsp;</div>
+      <div class="<%= type %>-icon icon" alt=<%= type %>>&nbsp;</div>
     </div>
-    <div class="my-1 mr-auto p-0 align-self-center">
+    <div class="col my-1 mr-auto p-0 align-self-center">
       <%= raw message %>
     </div>
-    <a class="close-icon icon align-self-start" alt="info" aria-hidden="true" href="#">&nbsp;</a>
+    <a class="close-icon icon align-self-start" alt="Close" href="#">&nbsp;</a>
   </div>
 <% else %>
   <div class="row flash module">

--- a/app/views/layouts/bootstrap_4.html.erb
+++ b/app/views/layouts/bootstrap_4.html.erb
@@ -47,7 +47,7 @@
         <%= render 'users/security_question_responses/modal' %>
       <% end %>
 
-      <%= render_flash(use_bs4: true) %>
+      <%= render_flash(use_bs4: @bs4) %>
 
       <% if content_for? :content %>
         <%= yield :content %>

--- a/app/views/layouts/bootstrap_4.html.erb
+++ b/app/views/layouts/bootstrap_4.html.erb
@@ -47,7 +47,11 @@
         <%= render 'users/security_question_responses/modal' %>
       <% end %>
 
-      <%= render_flash(use_bs4: @bs4) %>
+      <%= render_flash use_bs4: @bs4 %>
+
+      <aside class="container">
+        <%= yield :horizontal_status %>
+      </aside>
 
       <% if content_for? :content %>
         <%= yield :content %>

--- a/app/views/layouts/bootstrap_4.html.erb
+++ b/app/views/layouts/bootstrap_4.html.erb
@@ -61,7 +61,6 @@
         </div>
       <% else %> 
        <%= render_flash %>
-
         <aside class="container">
           <%= yield :horizontal_status %>
         </aside>

--- a/app/views/layouts/bootstrap_4.html.erb
+++ b/app/views/layouts/bootstrap_4.html.erb
@@ -47,16 +47,29 @@
         <%= render 'users/security_question_responses/modal' %>
       <% end %>
 
-      <%= render_flash %>
 
-      <aside class="container">
-        <%= yield :horizontal_status %>
-      </aside>
+      <% if @bs4 %>
+        <div class="container">
+          <div class="mt-3 px-0">
+              <%= render_flash %>
+          </div>
+          <% if content_for? :content %>
+              <%= yield :content %>
+          <% else %>
+            <%= yield %>
+          <% end %>
+        </div>
+      <% else %> 
+       <%= render_flash %>
 
-      <% if content_for? :content %>
-        <%= yield :content %>
-      <% else %>
-        <%= yield %>
+        <aside class="container">
+          <%= yield :horizontal_status %>
+        </aside>
+        <% if content_for? :content %>
+            <%= yield :content %>
+        <% else %>
+          <%= yield %>
+        <% end %>
       <% end %>
     </main>
 

--- a/app/views/layouts/bootstrap_4.html.erb
+++ b/app/views/layouts/bootstrap_4.html.erb
@@ -47,7 +47,9 @@
         <%= render 'users/security_question_responses/modal' %>
       <% end %>
 
-      <%= render_flash use_bs4: @bs4 %>
+      <div class=<%= "mt-4" if @bs4 %>>
+       <%= render_flash use_bs4: @bs4 %>
+      </div>
 
       <aside class="container">
         <%= yield :horizontal_status %>

--- a/app/views/layouts/bootstrap_4.html.erb
+++ b/app/views/layouts/bootstrap_4.html.erb
@@ -47,28 +47,12 @@
         <%= render 'users/security_question_responses/modal' %>
       <% end %>
 
+      <%= render_flash(use_bs4: true) %>
 
-      <% if @bs4 %>
-        <div class="container">
-          <div class="mt-3 px-0">
-            <%= render_flash(use_bs4: true) %>
-          </div>
-          <% if content_for? :content %>
-            <%= yield :content %>
-          <% else %>
-            <%= yield %>
-          <% end %>
-        </div>
-      <% else %> 
-        <%= render_flash %>
-        <aside class="container">
-          <%= yield :horizontal_status %>
-        </aside>
-        <% if content_for? :content %>
-          <%= yield :content %>
-        <% else %>
-          <%= yield %>
-        <% end %>
+      <% if content_for? :content %>
+        <%= yield :content %>
+      <% else %>
+        <%= yield %>
       <% end %>
     </main>
 

--- a/app/views/layouts/bootstrap_4.html.erb
+++ b/app/views/layouts/bootstrap_4.html.erb
@@ -60,12 +60,12 @@
           <% end %>
         </div>
       <% else %> 
-       <%= render_flash %>
+        <%= render_flash %>
         <aside class="container">
           <%= yield :horizontal_status %>
         </aside>
         <% if content_for? :content %>
-            <%= yield :content %>
+          <%= yield :content %>
         <% else %>
           <%= yield %>
         <% end %>

--- a/app/views/layouts/bootstrap_4.html.erb
+++ b/app/views/layouts/bootstrap_4.html.erb
@@ -51,10 +51,10 @@
       <% if @bs4 %>
         <div class="container">
           <div class="mt-3 px-0">
-              <%= render_flash %>
+            <%= render_flash(use_bs4: true) %>
           </div>
           <% if content_for? :content %>
-              <%= yield :content %>
+            <%= yield :content %>
           <% else %>
             <%= yield %>
           <% end %>

--- a/app/views/layouts/bootstrap_4_two_column.html.erb
+++ b/app/views/layouts/bootstrap_4_two_column.html.erb
@@ -40,7 +40,7 @@
         </div>
         <div class="col-md-10">
           <div class="col-xs-12 notice">
-            <%= render_flash %>
+            <%= render_flash use_bs4: @bs4 %>
           </div>
           <%= yield %>
         </div>

--- a/app/views/layouts/progress.html.erb
+++ b/app/views/layouts/progress.html.erb
@@ -45,7 +45,7 @@
       <% end %>
 
       <div class="mt-4 mb-4">
-        <%= render_flash(use_bs4: true) %>
+        <%= render_flash use_bs4: @bs4 %>
         <div class="container mt-4">
           <div class="row">
             <div class="col-sm-12 col-md-12 col-lg-3 mr-auto p-0">

--- a/app/views/layouts/progress.html.erb
+++ b/app/views/layouts/progress.html.erb
@@ -45,7 +45,6 @@
       <% end %>
 
       <div class="mt-4 mb-4">
-        <%= render_flash use_bs4: @bs4 %>
         <div class="container mt-4">
           <div class="row">
             <div class="col-sm-12 col-md-12 col-lg-3 mr-auto p-0">
@@ -66,6 +65,7 @@
                             back_to_account_flag: content_for?(:back_to_account_flag) ? yield(:back_to_account_flag) : EnrollRegistry.feature_enabled?(:back_to_account_all_shop) } %>
             </div>
             <div class="col-sm-12 col-md-12 col-lg-9 pl-4">
+              <%= render_flash use_bs4: @bs4 %>
               <% if content_for? :content %>
                 <%= yield :content %>
               <% else %>

--- a/app/views/layouts/progress.html.erb
+++ b/app/views/layouts/progress.html.erb
@@ -45,13 +45,9 @@
       <% end %>
 
       <div class="mt-4 mb-4">
-        <div class="container">
+        <%= render_flash(use_bs4: true) %>
+        <div class="container mt-4">
           <div class="row">
-            <div class="col mr-auto p-0">
-              <%= render_flash %>
-            </div>
-          </div>
-          <div class="row mt-4">
             <div class="col-sm-12 col-md-12 col-lg-3 mr-auto p-0">
               <% step = content_for?(:step) ? yield(:step).to_i : 1 %>
               <% title = content_for?(:title) ? yield(:title) : "" %>

--- a/app/views/layouts/progress.html.erb
+++ b/app/views/layouts/progress.html.erb
@@ -44,11 +44,14 @@
         <%= render 'users/security_question_responses/modal' %>
       <% end %>
 
-      <%= render_flash %>
-
       <div class="mt-4 mb-4">
-        <div class="container mt-4">
+        <div class="container">
           <div class="row">
+            <div class="col mr-auto p-0">
+              <%= render_flash %>
+            </div>
+          </div>
+          <div class="row mt-4">
             <div class="col-sm-12 col-md-12 col-lg-3 mr-auto p-0">
               <% step = content_for?(:step) ? yield(:step).to_i : 1 %>
               <% title = content_for?(:title) ? yield(:title) : "" %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,15 +1,40 @@
 <% if object.errors.any? %>
-	<div class="alert alert-danger">
-		<h4>You need to correct the following errors:</h4>
-		<ul>
-			<% object.errors.each do |attr, msg| %>
-				<% if attr == :base %>
-					<li><%= "#{msg}" %></li>
-				<% else %>
-          <% attr = (attr == :gender && EnrollRegistry.feature_enabled?(:gender_to_sex)) ? "sex" : attr %>
-					<li><%= attr.to_s.titleize %>: <%= raw(msg) %></li>
+	<% if @bs4 %>
+		<% is_only_warning = object.errors.details.values.all? {|error_type| error_type.all? {|details| details[:level] == :warning}} %>
+		<% type = is_only_warning ? "warning" : "severe" %>
+		<div class="mt-2 mb-0 px-0">
+   			<div class="alert alert-<%= type %> d-flex flash" role="alert">
+      			<div class="pl-1">
+        			<div class="<%= type %>-icon icon" alt=<%= type %>>&nbsp;</div>
+      			</div>
+				<div class="mt-2 p-0 align-self-center">
+					<label class="weight-n">You need to correct the following errors:</label>
+					<ul class="list-unstyled">
+						<% object.errors.each do |attr, msg| %>
+							<% if attr == :base %>
+								<li><%= "#{msg}" %></li>
+							<% else %>
+								<% attr = (attr == :gender && EnrollRegistry.feature_enabled?(:gender_to_sex)) ? "sex" : attr %>
+								<li><%= attr.to_s.titleize %>: <%= raw(msg) %></li>
+							<% end %>
+						<% end %>
+					</ul>
+				</div>
+    		</div>
+  		</div>
+	<% else %>
+		<div class="alert alert-danger">
+			<h4>You need to correct the following errors:</h4>
+			<ul>
+				<% object.errors.each do |attr, msg| %>
+					<% if attr == :base %>
+						<li><%= "#{msg}" %></li>
+					<% else %>
+						<% attr = (attr == :gender && EnrollRegistry.feature_enabled?(:gender_to_sex)) ? "sex" : attr %>
+						<li><%= attr.to_s.titleize %>: <%= raw(msg) %></li>
+					<% end %>
 				<% end %>
-			<% end %>
-		</ul>
-	</div>
+			</ul>
+		</div>
+	<% end %>
 <% end %>

--- a/app/views/ui-components/bs4/v1/navs/_header.html.erb
+++ b/app/views/ui-components/bs4/v1/navs/_header.html.erb
@@ -1,7 +1,7 @@
 <hidden id='dchbx_enroll_date_of_record' class='d-none'><%= TimeKeeper.date_of_record.iso8601 %></hidden>
 <header class="bg-white navbar-primary py-2 <%= 'pre_prod_nav_color' if ENV['ENROLL_REVIEW_ENVIRONMENT'] == true %>">
 
-  <nav class="navbar navbar-default navbar-expand-lg container py-1">
+  <nav class="navbar navbar-default navbar-expand-lg container py-1 px-0">
     <a class="navbar-brand mr-0" href="#">
       <%= image_pack_tag "logo_bs4_#{ENV['CLIENT'] || 'ic'}.svg", alt: "#{ENV['CLIENT']} logo"%>
     </a>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187579400

# A brief description of the changes

Current behavior: The flash message as described in the ticket was using the old flash banner UI.

New behavior: The flash across all BS4 experiences now uses the new flash banner UI, and a new Severe banner was added.

Updated info banner for ticket:
<img width="520" alt="Screenshot 2024-05-17 at 10 32 15 AM" src="https://github.com/ideacrew/enroll/assets/167465598/2a248019-58c2-4e18-8995-21d9b0b716b0">

Longer text:
<img width="520" alt="Screenshot 2024-05-17 at 10 32 42 AM" src="https://github.com/ideacrew/enroll/assets/167465598/2fd74a0e-193a-4fe0-a669-30c05c155da1">

New severe banner:
<img width="520" alt="Screenshot 2024-05-17 at 12 04 38 PM" src="https://github.com/ideacrew/enroll/assets/167465598/74cea036-4bdc-4663-b13c-caf561a9d2f6">

Flash in progress layout:
<img width="520" alt="Screenshot 2024-05-21 at 1 55 09 PM" src="https://github.com/ideacrew/enroll/assets/167465598/66bf30ea-dc70-4566-b762-5af0aa1269fa">


