### PR TITLE
filter verification types to not include alive status type

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -145,6 +145,8 @@ class DocumentsController < ApplicationController
   def fed_hub_request
     authorize HbxProfile, :can_call_hub?
 
+    raise "Call hub feature is not available for #{@verification_type.type_name}" unless VerificationType::ADMIN_CALL_HUB_VERIFICATION_TYPES.include?(@verification_type.type_name)
+
     request_hash = { person_id: @person.id, verification_type: @verification_type.type_name }
     result = ::Operations::CallFedHub.new.call(request_hash)
     key, message = result.failure? ? result.failure : result.success

--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -175,7 +175,7 @@ module VerificationHelper
   def get_person_v_type_status(people)
     v_type_status_list = []
     people.each do |person|
-      person.verification_types.reject { |type| ["Alive Status"].include?(type.type_name) }.each do |v_type|
+      person.filtered_verification_types.each do |v_type|
         v_type_status_list << verification_type_status(v_type, person)
       end
     end

--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -175,7 +175,7 @@ module VerificationHelper
   def get_person_v_type_status(people)
     v_type_status_list = []
     people.each do |person|
-      person.filtered_verification_types.each do |v_type|
+      person.verification_types.without_alive_status_type.each do |v_type|
         v_type_status_list << verification_type_status(v_type, person)
       end
     end

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -1155,7 +1155,7 @@ class ConsumerRole
   def move_types_to_pending(*args)
     types_to_reject = ['American Indian Status', LOCATION_RESIDENCY]
 
-    filtered_verification_types.reject { |type| types_to_reject.include?(type.type_name) }.each(&:pending_type)
+    verification_types.without_alive_status_type.reject { |type| types_to_reject.include?(type.type_name) }.each(&:pending_type)
   end
 
   def pass_lawful_presence(*args)
@@ -1170,7 +1170,7 @@ class ConsumerRole
 
   def fail_lawful_presence(*args)
     lawful_presence_determination.deny!(*args)
-    filtered_verification_types.reject{|type| VerificationType::NON_CITIZEN_IMMIGRATION_TYPES.include? type.type_name }.each{ |type| type.fail_type unless type.validation_status == 'review' }
+    verification_types.without_alive_status_type.reject{|type| VerificationType::NON_CITIZEN_IMMIGRATION_TYPES.include? type.type_name }.each{ |type| type.fail_type unless type.validation_status == 'review' }
   end
 
   def revert_ssn

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -1153,9 +1153,9 @@ class ConsumerRole
   end
 
   def move_types_to_pending(*args)
-    types_to_reject = ['American Indian Status', 'Alive Status', LOCATION_RESIDENCY]
+    types_to_reject = ['American Indian Status', LOCATION_RESIDENCY]
 
-    verification_types.reject { |type| types_to_reject.include?(type.type_name) }.each(&:pending_type)
+    filtered_verification_types.reject { |type| types_to_reject.include?(type.type_name) }.each(&:pending_type)
   end
 
   def pass_lawful_presence(*args)
@@ -1170,7 +1170,7 @@ class ConsumerRole
 
   def fail_lawful_presence(*args)
     lawful_presence_determination.deny!(*args)
-    verification_types.reject{|type| VerificationType::NON_CITIZEN_IMMIGRATION_TYPES.include? type.type_name }.each{ |type| type.fail_type unless type.validation_status == 'review' }
+    filtered_verification_types.reject{|type| VerificationType::NON_CITIZEN_IMMIGRATION_TYPES.include? type.type_name }.each{ |type| type.fail_type unless type.validation_status == 'review' }
   end
 
   def revert_ssn

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -1191,7 +1191,7 @@ class ConsumerRole
 
   def revert_lawful_presence(*args)
     self.lawful_presence_determination.revert!(*args)
-    verification_types.each do |v_type|
+    verification_types.without_alive_status_type.each do |v_type|
       v_type.pending_type unless VerificationType::NON_CITIZEN_IMMIGRATION_TYPES.include? (v_type.type_name)
     end
   end

--- a/app/models/subscribers/ssa_verification.rb
+++ b/app/models/subscribers/ssa_verification.rb
@@ -24,7 +24,7 @@ module Subscribers
         consumer_role = person.consumer_role
         event_response_record = EventResponse.new({received_at: Time.now, body: xml})
         consumer_role.lawful_presence_determination.ssa_responses << event_response_record
-        person.filtered_verification_types.active.reject{|type| [VerificationType::LOCATION_RESIDENCY, "American Indian Status", "Immigration status"].include? type.type_name}.each do |type|
+        person.verification_types.without_alive_status_type.active.reject{|type| [VerificationType::LOCATION_RESIDENCY, "American Indian Status", "Immigration status"].include? type.type_name}.each do |type|
           type.add_type_history_element(action: "SSA Hub Response",
                                         modifier: "external Hub",
                                         update_reason: "Hub response",

--- a/app/models/subscribers/ssa_verification.rb
+++ b/app/models/subscribers/ssa_verification.rb
@@ -24,7 +24,7 @@ module Subscribers
         consumer_role = person.consumer_role
         event_response_record = EventResponse.new({received_at: Time.now, body: xml})
         consumer_role.lawful_presence_determination.ssa_responses << event_response_record
-        person.verification_types.active.reject{|type| [VerificationType::LOCATION_RESIDENCY, "American Indian Status", "Immigration status", "Alive Status"].include? type.type_name}.each do |type|
+        person.filtered_verification_types.active.reject{|type| [VerificationType::LOCATION_RESIDENCY, "American Indian Status", "Immigration status"].include? type.type_name}.each do |type|
           type.add_type_history_element(action: "SSA Hub Response",
                                         modifier: "external Hub",
                                         update_reason: "Hub response",

--- a/app/models/verification_type.rb
+++ b/app/models/verification_type.rb
@@ -28,6 +28,8 @@ class VerificationType
 
   ALIVE_STATUS = 'Alive Status'.freeze
 
+  ADMIN_CALL_HUB_VERIFICATION_TYPES = ALL_VERIFICATION_TYPES - ["Alive Status"].freeze
+
   NON_CITIZEN_IMMIGRATION_TYPES = [LOCATION_RESIDENCY, "Social Security Number", "American Indian Status"].freeze
   VALIDATION_STATES = %w[na unverified pending review outstanding verified attested expired curam rejected].freeze
   OUTSTANDING_STATES = %w[outstanding rejected].freeze
@@ -71,6 +73,10 @@ class VerificationType
     def uploaded
       @target.select{|document| document.identifier }
     end
+  end
+
+  def filtered_verification_types
+    verification_types.reject { |type| type == 'Alive Status' }
   end
 
   def accept(visitor)

--- a/app/models/verification_type.rb
+++ b/app/models/verification_type.rb
@@ -64,6 +64,8 @@ class VerificationType
   scope :citizenship_type, -> { by_name("Citizenship").active }
   scope :alive_status_type, -> { by_name("Alive Status").active }
 
+  scope :without_alive_status_type, -> { where(:type_name.ne => ALIVE_STATUS) }
+
   # embeds_many :external_service_responses  -> needs datamigration
   embeds_many :type_history_elements
 
@@ -73,10 +75,6 @@ class VerificationType
     def uploaded
       @target.select{|document| document.identifier }
     end
-  end
-
-  def filtered_verification_types
-    verification_types.reject { |type| type == 'Alive Status' }
   end
 
   def accept(visitor)

--- a/spec/models/consumer_role_spec.rb
+++ b/spec/models/consumer_role_spec.rb
@@ -1099,6 +1099,10 @@ RSpec.describe ConsumerRole, dbclean: :after_each, type: :model do
     let(:verification_types) { consumer.verification_types }
     let(:verification_attr) { OpenStruct.new({ :determined_at => Time.zone.now, :vlp_authority => "hbx" })}
 
+    before do
+      allow(EnrollRegistry[:enable_alive_status].feature).to receive(:is_enabled).and_return(true)
+    end
+
     it "should move Citizenship verification type to pending state" do
       consumer.lawful_presence_determination.authorize!(verification_attr)
       consumer.revert_lawful_presence(verification_attr)
@@ -1106,6 +1110,7 @@ RSpec.describe ConsumerRole, dbclean: :after_each, type: :model do
       expect(consumer.verification_types.by_name(VerificationType::LOCATION_RESIDENCY).first.validation_status).to eq "unverified"
       expect(consumer.verification_types.by_name("Social Security Number").first.validation_status).to eq "unverified"
       expect(consumer.verification_types.by_name("Citizenship").first.validation_status).to eq "pending"
+      expect(consumer.verification_types.by_name("Alive Status").first.validation_status).to eq "unverified"
     end
   end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2648255/stories/187614136

# A brief description of the changes

New behavior: Skip callbacks for alive status verification types


# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
