### PR TITLE
update info step 1 banner

### DIFF
--- a/app/javascript/css/alerts.scss
+++ b/app/javascript/css/alerts.scss
@@ -46,10 +46,6 @@
   border-radius: 3px;
   border-width: 1px;
   border-style: solid;
-
-  ul {
-    padding: 0em;
-  }
 }
 
 .notice {

--- a/app/javascript/css/alerts.scss
+++ b/app/javascript/css/alerts.scss
@@ -46,6 +46,10 @@
   border-radius: 3px;
   border-width: 1px;
   border-style: solid;
+
+  ul {
+    padding: 0em;
+  }
 }
 
 .notice {

--- a/app/models/forms/consumer_candidate.rb
+++ b/app/models/forms/consumer_candidate.rb
@@ -160,7 +160,7 @@ module Forms
       return unless (self.dob_check == "false" || self.dob_check.blank?) && self.dob.present?
 
       if ::TimeKeeper.date_of_record.year - self.dob.year < 18
-        errors.add(:base, "Please verify your date of birth. If it's correct, please continue.")
+        errors.add(:base, "Please verify your date of birth. If it's correct, please continue.", :level => :warning)
         self.dob_check = true
       else
         self.dob_check = false

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,13 +1,13 @@
 <% if object.errors.any? %>
 	<% if @bs4 %>
-		<% is_only_warning = object.errors.details.values.all? {|error_type| error_type.all? { |details| details[:level] == :warning}} %>
+		<% is_only_warning = object.errors.details.values.all? {|error_type| error_type.all? {|details| details[:level] == :warning}} %>
 		<% type = is_only_warning ? "warning" : "severe" %>
-		<div class="container mt-2 mb-0 px-0">
+		<div class="mt-2 mb-0 px-0">
    			<div class="alert alert-<%= type %> d-flex flash" role="alert">
       			<div class="pl-1">
         			<div class="<%= type %>-icon icon" alt=<%= type %>>&nbsp;</div>
       			</div>
-				<div class="col mt-2 mr-auto p-0 align-self-center">
+				<div class="mt-2 p-0 align-self-center">
 					<h4>You need to correct the following errors:</h4>
 					<ul>
 						<% object.errors.each do |attr, msg| %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -8,8 +8,8 @@
         			<div class="<%= type %>-icon icon" alt=<%= type %>>&nbsp;</div>
       			</div>
 				<div class="mt-2 p-0 align-self-center">
-					<h4>You need to correct the following errors:</h4>
-					<ul>
+					<label class="weight-n">You need to correct the following errors:</label>
+					<ul class="list-unstyled">
 						<% object.errors.each do |attr, msg| %>
 							<% if attr == :base %>
 								<li><%= "#{msg}" %></li>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,15 +1,40 @@
 <% if object.errors.any? %>
-	<div class="alert alert-danger">
-		<h4>You need to correct the following errors:</h4>
-		<ul>
-			<% object.errors.each do |attr, msg| %>
-				<% if attr == :base %>
-					<li><%= "#{msg}" %></li>
-				<% else %>
-          <% attr = (attr == :gender && EnrollRegistry.feature_enabled?(:gender_to_sex)) ? "sex" : attr %>
-					<li><%= attr.to_s.titleize %>: <%= raw(msg) %></li>
+	<% if @bs4 %>
+		<% is_only_warning = object.errors.details.values.all? {|error_type| error_type.all? { |details| details[:level] == :warning}} %>
+		<% type = is_only_warning ? "warning" : "severe" %>
+		<div class="container mt-2 mb-0 px-0">
+   			<div class="alert alert-<%= type %> d-flex flash" role="alert">
+      			<div class="pl-1">
+        			<div class="<%= type %>-icon icon" alt=<%= type %>>&nbsp;</div>
+      			</div>
+				<div class="col mt-2 mr-auto p-0 align-self-center">
+					<h4>You need to correct the following errors:</h4>
+					<ul>
+						<% object.errors.each do |attr, msg| %>
+							<% if attr == :base %>
+								<li><%= "#{msg}" %></li>
+							<% else %>
+								<% attr = (attr == :gender && EnrollRegistry.feature_enabled?(:gender_to_sex)) ? "sex" : attr %>
+								<li><%= attr.to_s.titleize %>: <%= raw(msg) %></li>
+							<% end %>
+						<% end %>
+					</ul>
+				</div>
+    		</div>
+  		</div>
+	<% else %>
+		<div class="alert alert-danger">
+			<h4>You need to correct the following errors:</h4>
+			<ul>
+				<% object.errors.each do |attr, msg| %>
+					<% if attr == :base %>
+						<li><%= "#{msg}" %></li>
+					<% else %>
+						<% attr = (attr == :gender && EnrollRegistry.feature_enabled?(:gender_to_sex)) ? "sex" : attr %>
+						<li><%= attr.to_s.titleize %>: <%= raw(msg) %></li>
+					<% end %>
 				<% end %>
-			<% end %>
-		</ul>
-	</div>
+			</ul>
+		</div>
+	<% end %>
 <% end %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187605025

# A brief description of the changes

Current behavior: The error banner on Personal Info step 1 follows legacy UI.

New behavior: The error banner on Personal Info step 1 follows the new UI and supports warning/severe cases.

I added a new argument to the `errors.add` call in `ConsumerCandidate`, which seems a little hacky to me. We need a way to drive the two kinds of banners we have now, where before it was only ever the red version, so this is what I landed on.

In terms of the view logic, we'll use the new red banner in most cases, and only use the yellow banner when only "warning"-level severity errors exist on the model. Currently, only this DOB error falls in this category.

<img width="520" alt="Screenshot 2024-05-19 at 11 13 18 PM" src="https://github.com/ideacrew/enroll/assets/167465598/380fbd8a-9385-41d2-9223-2ca62bd2d6cb">

<img width="520" alt="Screenshot 2024-05-19 at 11 12 51 PM" src="https://github.com/ideacrew/enroll/assets/167465598/6ee8e0f9-0213-44d4-b670-c265495b708d">

