### PR TITLE
remove personal info step in consumer signup

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -36,9 +36,8 @@ module NavigationHelper
 
   def sign_up_nav_options
     [
-      {step: 1, label: l10n('personal_information')},
-      {step: 2, label: l10n('tell_us_about_yourself')},
-      {step: 3, label: l10n('family_info')}
+      {step: 1, label: l10n('tell_us_about_yourself')},
+      {step: 2, label: l10n('family_info')}
     ]
   end
 end

--- a/app/views/insured/consumer_roles/ridp_agreement.html.erb
+++ b/app/views/insured/consumer_roles/ridp_agreement.html.erb
@@ -1,5 +1,5 @@
 <% if @bs4 %>
-  <%= render partial: 'shared/consumer_signup', locals: {step: 2, show_help_button: true} %>
+  <%= render partial: 'shared/consumer_signup', locals: {step: 1, show_help_button: true} %>
   <h1><%= l10n("insured.consumer_roles.ridp_agreement.heading") %></h1>
   <p><%= l10n("insured.consumer_roles.ridp_agreement.instruction1") %></p>
   <p><%= l10n("insured.consumer_roles.ridp_agreement.instruction2") %></p>

--- a/app/views/insured/fdsh_ridp_verifications/new.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/new.html.erb
@@ -1,5 +1,5 @@
 <% if @bs4 %>
-  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 2} %>
+  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 1} %>
   <h1><%= l10n("verify_identity") %></h1>
   <p><%= l10n(".answer_the_following_questions_when_you_finish") %></p>
   <%= form_for(@interactive_verification, as: :interactive_verification, url: insured_interactive_identity_verifications_path, method: :post) do |f| %>

--- a/app/views/insured/fdsh_ridp_verifications/primary_response.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/primary_response.html.erb
@@ -1,5 +1,5 @@
 <% if @bs4 %>
-  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 2} %>
+  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 1} %>
   <h1><%= l10n("verify_identity") %></h1>
   <p><%= l10n(".answer_the_following_questions_when_you_finish") %></p>
   <%= form_for(@interactive_verification, as: :interactive_verification, url: insured_interactive_identity_verifications_path, method: :post) do |f| %>

--- a/app/views/insured/fdsh_ridp_verifications/service_unavailable.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/service_unavailable.html.erb
@@ -1,5 +1,5 @@
 <% if @bs4 %>
-  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 2} %>
+  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 1} %>
   <h1><%= l10n('insured.interactive_identity_verifications.service_unavailable.try_again_later') %></h1>
   <div class="mt-4 mb-4">
     <%= render partial: 'insured/fdsh_ridp_verifications/options_to_verify_identity' %>

--- a/app/views/insured/fdsh_ridp_verifications/wait_for_primary_response.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/wait_for_primary_response.html.erb
@@ -1,5 +1,5 @@
 <% if @bs4 %>
-  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 2} %>
+  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 1} %>
   <div class="<%=pundit_class Family, :updateable?%>">
     <div class="d-flex full-height justify-content-center align-items-center">
       <div>

--- a/app/views/insured/fdsh_ridp_verifications/wait_for_secondary_response.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/wait_for_secondary_response.html.erb
@@ -1,5 +1,5 @@
 <% if @bs4 %>
-  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 2} %>
+  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 1} %>
   <div class="d-flex full-height justify-content-center align-items-center">
     <div>
       <h1><%= l10n("getting_response") %></h1>

--- a/app/views/insured/interactive_identity_verifications/failed_validation.html.erb
+++ b/app/views/insured/interactive_identity_verifications/failed_validation.html.erb
@@ -1,5 +1,5 @@
 <% if @bs4 %>
-  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 2} %>
+  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 1} %>
   <h1><%= l10n("verify_identity") %></h1>
   <% if @step == 'start' %>
     <h4>

--- a/app/views/insured/interactive_identity_verifications/new.html.erb
+++ b/app/views/insured/interactive_identity_verifications/new.html.erb
@@ -1,5 +1,5 @@
 <% if @bs4 %>
-  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 2} %>
+  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 1} %>
   <h1><%= l10n("verify_identity") %></h1>
   <p><%= l10n(".answer_the_following_questions_when_you_finish") %></p>
   <%= form_for(@interactive_verification, as: :interactive_verification, url: insured_interactive_identity_verifications_path, method: :post) do |f| %>

--- a/app/views/insured/interactive_identity_verifications/service_unavailable.html.erb
+++ b/app/views/insured/interactive_identity_verifications/service_unavailable.html.erb
@@ -1,5 +1,5 @@
 <% if @bs4 %>
-  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 2} %>
+  <%= render partial: 'shared/consumer_signup.html.erb', locals: {step: 1} %>
   <h1><%= l10n('insured.interactive_identity_verifications.service_unavailable.try_again_later') %></h1>
   <div class="mt-4 mb-4">
     <%= render partial: 'insured/interactive_identity_verifications/options_to_verify_identity' %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187579623

# A brief description of the changes

Current behavior: The personal info step is used in the consumer signup flow.

New behavior: The personal info step is removed from the consumer signup flow, and pages that used to use it now use the tell us about yourself step.
