### PR TITLE
add text for missing immigrant status labels

### DIFF
--- a/app/views/insured/consumer_roles/_immigration_statuses.html.erb
+++ b/app/views/insured/consumer_roles/_immigration_statuses.html.erb
@@ -1,12 +1,12 @@
 <% if @bs4 %>
   <fieldset id="immigration_doc_statuses" class="mt-4">
-    <legend><%= l10n("insured.consumer_roles.docs_shared.other_status_question") %></legend>
+    <legend>Does this person also have any of these document types or statuses?</legend>
     <div>
       <% ::ConsumerRole::IMMIGRATION_DOCUMENT_STATUSES.each_with_index do |status, index| %>
         <label for="<%= status.gsub(/[^\w\s_-]+/, '').gsub(/\s+/, '_') %>" class="mb-3">
           <%= c.check_box :immigration_doc_statuses, { multiple: true, id: status.gsub(/[^\w\s_-]+/, '').gsub(/\s+/, '_') }, status, false %>
           <span class="weight-n"><%= status %></span>
-          <% if index == ::ConsumerRole::IMMIGRATION_DOCUMENT_STATUSES.length - 1 %><small class="muted-text"><%= l10n("insured.consumer_roles.docs_shared.none_of_above_note") %></small><% end %>
+          <% if index == ::ConsumerRole::IMMIGRATION_DOCUMENT_STATUSES.length - 1 %><small class="muted-text">(Select this if this person doesn't have a listed document. You can continue the application without selecting a document or status type)</small><% end %>
         </label>
       <% end %>
     </div>

--- a/app/views/insured/consumer_roles/_immigration_statuses.html.erb
+++ b/app/views/insured/consumer_roles/_immigration_statuses.html.erb
@@ -1,12 +1,12 @@
 <% if @bs4 %>
   <fieldset id="immigration_doc_statuses" class="mt-4">
-    <legend>Does this person also have any of these document types or statuses?</legend>
+    <legend><%= l10n("insured.consumer_roles.docs_shared.other_status_question") %></legend>
     <div>
       <% ::ConsumerRole::IMMIGRATION_DOCUMENT_STATUSES.each_with_index do |status, index| %>
         <label for="<%= status.gsub(/[^\w\s_-]+/, '').gsub(/\s+/, '_') %>" class="mb-3">
           <%= c.check_box :immigration_doc_statuses, { multiple: true, id: status.gsub(/[^\w\s_-]+/, '').gsub(/\s+/, '_') }, status, false %>
           <span class="weight-n"><%= status %></span>
-          <% if index == ::ConsumerRole::IMMIGRATION_DOCUMENT_STATUSES.length - 1 %><small class="muted-text">(Select this if this person doesn't have a listed document. You can continue the application without selecting a document or status type)</small><% end %>
+          <% if index == ::ConsumerRole::IMMIGRATION_DOCUMENT_STATUSES.length - 1 %><small class="muted-text"><%= l10n("insured.consumer_roles.docs_shared.none_of_above_note") %></small><% end %>
         </label>
       <% end %>
     </div>

--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -24,6 +24,8 @@ The I-94 Number is also called an admission number. It is an 11 digit number fou
 How to find the SEVIS ID: On the DS-2019, the number is on the top right hand side of the page in the box above the barcode.",
   :'en.insured.consumer_roles.docs_shared.visa_number' => "Visa number",
   :'en.insured.consumer_roles.docs_shared.visa_number_title' => "Please enter the Visa Number exactly as it appears on the document. You must enter exactly eight letters and numbers. You may not enter any special characters.",
+  :'en.insured.consumer_roles.docs_shared.other_status_question' => "Does this person also have any of these document types or statuses?",
+  :'en.insured.consumer_roles.docs_shared.none_of_above_note' => "(Select this if this person doesn't have a listed document. You can continue the application without selecting a document or status type)",
   :'en.personal_information' => "Personal Information",
   :'en.personal_info' => "Personal Info",
   :"en.tell_us_about_yourself" => "Tell Us About Yourself",

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -29,6 +29,8 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
 -li- How to find the SEVIS ID: On the DS-2019, the number is on the top right hand side of the page in the box above the barcode.",
   :'en.insured.consumer_roles.docs_shared.visa_number' => "Visa Number",
   :'en.insured.consumer_roles.docs_shared.visa_number_req' => "Enter 8-12 numbers. -li- Do not enter any other characters or spaces.",
+  :'en.insured.consumer_roles.docs_shared.other_status_question' => "Does this person also have any of these document types or statuses?",
+  :'en.insured.consumer_roles.docs_shared.none_of_above_note' => "(Select this if this person doesn't have a listed document. You can continue the application without selecting a document or status type)",
   :'en.personal_information' => "Personal Information",
   :'en.personal_info' => "Personal Info",
   :'en.insured.consumer_roles.help_question_info' => "Enter your personal information and answer the following questions. When you're finished, select CONTINUE.",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -29,6 +29,8 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
 -li- How to find the SEVIS ID: On the DS-2019, the number is on the top right hand side of the page in the box above the barcode.",
   :'en.insured.consumer_roles.docs_shared.visa_number' => "Visa Number",
   :'en.insured.consumer_roles.docs_shared.visa_number_req' => "Enter 8-12 numbers. -li- Do not enter any other characters or spaces.",
+  :'en.insured.consumer_roles.docs_shared.other_status_question' => "Does this person also have any of these document types or statuses?",
+  :'en.insured.consumer_roles.docs_shared.none_of_above_note' => "(Select this if this person doesn't have a listed document. You can continue the application without selecting a document or status type)",
   :'en.personal_information' => "Personal Information",
   :'en.personal_info' => "Personal Info",
   :"en.tell_us_about_yourself" => "Tell Us About Yourself",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187627477 & https://www.pivotaltracker.com/story/show/187627465

# A brief description of the changes

Current behavior: Two labels were referring to undeclared translation keys.

New behavior: The two labels now use hardcoded text - localizing is now out of scope for this project. 
