### PR TITLE
fix label for verified state

### DIFF
--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -68,7 +68,7 @@ module VerificationHelper
     when 'in review'
       l10n("ridp_status.in_review")
     when 'valid'
-      l10n("ridp_status.valid")
+      l10n("ridp_status.verified")
     when 'rejected'
       l10n('verification_type.validation_status')
     else

--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -103,7 +103,7 @@ How to find the SEVIS ID: On the DS-2019, the number is on the top right hand si
   :'en.application_type' => "Application Type",
   :'en.confirm_selection' => "Confirm",
   :'en.ridp_status.in_review' => "In Review",
-  :'en.ridp_status.valid' => "Valid",
+  :'en.ridp_status.verified' => "Verified",
   :'en.ridp_status.outstanding' => "Outstanding",
   :'en.suffix' => "Suffix",
   :'en.insured.families.get_help_sign_up' => "Get Help Signing Up",

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -116,7 +116,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.application_type' => "Application Type",
   :'en.confirm_selection' => "Confirm",
   :'en.ridp_status.in_review' => "In Review",
-  :'en.ridp_status.valid' => "Valid",
+  :'en.ridp_status.verified' => "Verified",
   :'en.ridp_status.outstanding' => "Outstanding",
   :'en.suffix' => "Suffix",
   :'en.insured.families.get_help_sign_up' => "Get Help Signing Up",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -126,7 +126,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.application_type' => "Application Type",
   :'en.confirm_selection' => "Confirm",
   :'en.ridp_status.in_review' => "In Review",
-  :'en.ridp_status.valid' => "Valid",
+  :'en.ridp_status.verified' => "Verified",
   :'en.ridp_status.outstanding' => "Outstanding",
   :'en.insured.employee_roles.enroll_as_an_employee' => "Enroll as an employee of %{employer_name}",
   :'en.new_message' => "New Message",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187636874

# A brief description of the changes

Current behavior: When verified status is Valid, label displays Valid

New behavior: When verified status is Valid, label displays Verified
