### PR TITLE
update cucumber default config

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,4 +1,4 @@
-default: --format pretty --strict --tags 'not @wip and not @broken and not @flaky and not @ma_only and not @aca_shop_market_disabled' -r features --profile semaphoreci
+default: --format pretty --strict --tags 'not @wip and not @broken and not @flaky and not @ma_only and not @aca_shop_market_disabled and @accessibility' -r features --profile semaphoreci
 everything: --format pretty --strict -r features
 nightly: --format pretty --strict --tags 'not @wip and not @broken and not @flaky and not @ma_only and not @aca_shop_market_disabled' -r features --profile semaphoreci
 semaphoreci: -q


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/186923328

# A brief description of the changes

Current behavior: All cucumber contrast tests are listed with the tag "accessibility". Since they have that tag, they will not be included in the default cucumber test workflow and will not run on builds/PRs.

New behavior: The tag is added to the default test plan and will begin to run with every build.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
