### PR TITLE
add optional starting date for employer export report

### DIFF
--- a/lib/tasks/export_employers.rake
+++ b/lib/tasks/export_employers.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 #RAILS_ENV=production bundle exec rake employers:export
+#RAILS_ENV=production bundle exec rake employers:export start_date="11/30/2021"
 
 require 'csv'
 
@@ -160,10 +161,16 @@ namespace :employers do
 
       puts "No general agency profile for CCA Employers" unless general_agency_enabled?
 
+      start_date = Date.strptime(ENV['start_date'], "%m/%d/%Y") if params[:start_date].present?
       organizations.no_timeout.each do |organization|
 
         profile = organization.employer_profile
-        packages = profile.benefit_applications.map(&:benefit_packages).flatten
+        applications = if params[:start_date].present?
+                         profile.benefit_applications.where(:"effective_period.min".gte => start_date)
+                       else
+                         profile.benefit_applications
+                       end
+        packages = applications&.map(&:benefit_packages)&.flatten
 
         if packages.present?
           packages.each do |package|

--- a/lib/tasks/export_employers.rake
+++ b/lib/tasks/export_employers.rake
@@ -166,9 +166,9 @@ namespace :employers do
 
         profile = organization.employer_profile
         applications = if params[:start_date].present?
-                         profile.benefit_applications.where(:"effective_period.min".gte => start_date)
+                         profile&.benefit_applications&.where(:"effective_period.min".gte => start_date)
                        else
-                         profile.benefit_applications
+                         profile&.benefit_applications
                        end
         packages = applications&.map(&:benefit_packages)&.flatten
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
[RM-105476](https://redmine.priv.dchbx.org/issues/105476)

# A brief description of the changes

Current behavior:
Export employers rake outputs every package regardless of start_on date, resulting in unnecessarily long csv reports generated.

New behavior:
An optional start_date parameter limits this by only reporting on packages starting on or after the given date.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
