### PR TITLE
add data-disable-with attribute

### DIFF
--- a/app/views/shared/_individual_progress.html.haml
+++ b/app/views/shared/_individual_progress.html.haml
@@ -41,7 +41,7 @@
   = link_to "Continue", insured_consumer_role_index_path(person: @person_params), method: :post, class: 'btn btn-lg btn-primary  btn-block'
 - elsif step == 1
   %span{tabindex: '0', onkeydown: "handleButtonKeyDown(event, 'continue_button')", id: 'continue_button', class: 'btn btn-lg btn-primary btn-br btn-block', onkeydown: 'handleButtonKeyDown(event, "continue_button");', onclick: 'PersonValidations.manageRequiredValidations($(this));'} CONTINUE
-  %button.btn.btn-lg.btn-primary.btn-br.btn-block.interaction-click-control-continue.hidden{type: 'submit'}
+  %button.btn.btn-lg.btn-primary.btn-br.btn-block.interaction-click-control-continue.hidden{data: {disable_with: l10n("please_wait")}, type: 'submit'}
     CONTINUE
 - elsif ridp == true && step == 2
   - if next_link.present?  && current_user.has_hbx_staff_role? && (@person.primary_family.application_type == "Phone" || @person.primary_family.application_type == "Paper")

--- a/app/views/shared/_individual_progress.html.haml
+++ b/app/views/shared/_individual_progress.html.haml
@@ -41,7 +41,7 @@
   = link_to "Continue", insured_consumer_role_index_path(person: @person_params), method: :post, class: 'btn btn-lg btn-primary  btn-block'
 - elsif step == 1
   %span{tabindex: '0', onkeydown: "handleButtonKeyDown(event, 'continue_button')", id: 'continue_button', class: 'btn btn-lg btn-primary btn-br btn-block', onkeydown: 'handleButtonKeyDown(event, "continue_button");', onclick: 'PersonValidations.manageRequiredValidations($(this));'} CONTINUE
-  %button.btn.btn-lg.btn-primary.btn-br.btn-block.interaction-click-control-continue.hidden{data: {disable_with: l10n("please_wait")}, type: 'submit'}
+  %button.btn.btn-lg.btn-primary.btn-br.btn-block.interaction-click-control-continue.hidden{type: 'submit', 'data-disable-with': l10n("please_wait")}
     CONTINUE
 - elsif ridp == true && step == 2
   - if next_link.present?  && current_user.has_hbx_staff_role? && (@person.primary_family.application_type == "Phone" || @person.primary_family.application_type == "Paper")

--- a/features/insured/personal_information_page.feature
+++ b/features/insured/personal_information_page.feature
@@ -7,10 +7,10 @@ Feature: Insured Plan Shopping on Individual market
     When Individual creates a new HBX account
     Then Individual should see a successful sign up message
     And Individual sees Your Information page
-    When the user registers as an individual
+    And the user registers as an individual
     
   Scenario: New user creates an account
-    And Individual clicks on the Continue button of the Account Setup page
+    Given Individual clicks on the Continue button of the Account Setup page
     Then Individual sees form to enter personal information but doesn't fill it out completely
     Then Individual clicks on continue
     Then Individual sees form to enter personal information
@@ -18,15 +18,15 @@ Feature: Insured Plan Shopping on Individual market
     Then Individual agrees to the privacy agreeement
 
   Scenario: New user creates an account and forgets to check a box
-    And Individual clicks on the Continue button of the Account Setup page
+    Given Individual clicks on the Continue button of the Account Setup page
     Then Individual sees form to enter personal information but doesn't check every box
-    Then Individual clicks on continue
-    And the user will have to accept alert pop up for missing field
+    And Individual clicks on continue
+    Then the user will have to accept alert pop up for missing field
 
   Scenario: Consumer clicks the personal information page continue button
-    And the Continue button is visible on the Account Setup page
+    Given the Continue button is visible on the Account Setup page
     And Individual clicks on the Continue button of the Account Setup page
-    Then Individual sees form to enter personal information
-    Then the continue button has data disabled attribute
-    Then Individual clicks on continue
+    And Individual sees form to enter personal information
+    And the continue button has data disabled attribute
+    And Individual clicks on continue
     Then Individual agrees to the privacy agreeement

--- a/features/insured/personal_information_page.feature
+++ b/features/insured/personal_information_page.feature
@@ -22,6 +22,9 @@ Feature: Insured Plan Shopping on Individual market
     Then Individual sees form to enter personal information but doesn't check every box
     And Individual clicks on continue
     Then the user will have to accept alert pop up for missing field
+    Then Individual sees form to enter personal information
+    Then Individual clicks on continue
+    Then Individual agrees to the privacy agreeement
 
   Scenario: Consumer clicks the personal information page continue button
     Given the Continue button is visible on the Account Setup page

--- a/features/insured/personal_information_page.feature
+++ b/features/insured/personal_information_page.feature
@@ -30,3 +30,14 @@ Feature: Insured Plan Shopping on Individual market
     Then Individual clicks on continue
     Then Individual agrees to the privacy agreeement
 
+  Scenario: Consumer clicks the continue button twice
+    When Individual creates a new HBX account
+    Then Individual should see a successful sign up message
+    And Individual sees Your Information page
+    When the user registers as an individual
+    And the Continue button is visible on the Account Setup page
+    And Individual clicks on the Continue button of the Account Setup page
+    Then Individual sees form to enter personal information
+    Then the continue button has data disabled attribute
+
+

--- a/features/insured/personal_information_page.feature
+++ b/features/insured/personal_information_page.feature
@@ -22,10 +22,6 @@ Feature: Insured Plan Shopping on Individual market
     Then Individual sees form to enter personal information but doesn't check every box
     Then Individual clicks on continue
     And the user will have to accept alert pop up for missing field
-    Then Individual fills in missing fields
-    Then Individual sees the continue button is enabled
-    Then Individual clicks on continue
-    Then Individual agrees to the privacy agreeement
 
   Scenario: Consumer clicks the personal information page continue button
     And the Continue button is visible on the Account Setup page

--- a/features/insured/personal_information_page.feature
+++ b/features/insured/personal_information_page.feature
@@ -26,11 +26,11 @@ Feature: Insured Plan Shopping on Individual market
     Then Individual sees form to enter personal information but doesn't check every box
     Then Individual clicks on continue
     And the user will have to accept alert pop up for missing field
-    Then Individual sees form to enter personal information
+    Then Individual fills in missing fields
     Then Individual clicks on continue
     Then Individual agrees to the privacy agreeement
 
-  Scenario: Consumer clicks the continue button twice
+  Scenario: Consumer clicks the personal information page continue button
     When Individual creates a new HBX account
     Then Individual should see a successful sign up message
     And Individual sees Your Information page

--- a/features/insured/personal_information_page.feature
+++ b/features/insured/personal_information_page.feature
@@ -4,12 +4,12 @@ Feature: Insured Plan Shopping on Individual market
     Given FAA no_coverage_tribe_details feature is enabled
     Given Individual has not signed up as an HBX user
     And Individual visits the Consumer portal during open enrollment
-    
-  Scenario: New user creates an account
     When Individual creates a new HBX account
     Then Individual should see a successful sign up message
     And Individual sees Your Information page
     When the user registers as an individual
+    
+  Scenario: New user creates an account
     And Individual clicks on the Continue button of the Account Setup page
     Then Individual sees form to enter personal information but doesn't fill it out completely
     Then Individual clicks on continue
@@ -18,26 +18,19 @@ Feature: Insured Plan Shopping on Individual market
     Then Individual agrees to the privacy agreeement
 
   Scenario: New user creates an account and forgets to check a box
-    When Individual creates a new HBX account
-    Then Individual should see a successful sign up message
-    And Individual sees Your Information page
-    When the user registers as an individual
     And Individual clicks on the Continue button of the Account Setup page
     Then Individual sees form to enter personal information but doesn't check every box
     Then Individual clicks on continue
     And the user will have to accept alert pop up for missing field
     Then Individual fills in missing fields
+    Then Individual sees the continue button is enabled
     Then Individual clicks on continue
     Then Individual agrees to the privacy agreeement
 
   Scenario: Consumer clicks the personal information page continue button
-    When Individual creates a new HBX account
-    Then Individual should see a successful sign up message
-    And Individual sees Your Information page
-    When the user registers as an individual
     And the Continue button is visible on the Account Setup page
     And Individual clicks on the Continue button of the Account Setup page
     Then Individual sees form to enter personal information
     Then the continue button has data disabled attribute
-
-
+    Then Individual clicks on continue
+    Then Individual agrees to the privacy agreeement

--- a/features/insured/personal_information_page.feature
+++ b/features/insured/personal_information_page.feature
@@ -22,9 +22,7 @@ Feature: Insured Plan Shopping on Individual market
     Then Individual sees form to enter personal information but doesn't check every box
     And Individual clicks on continue
     Then the user will have to accept alert pop up for missing field
-    Then Individual sees form to enter personal information
-    Then Individual clicks on continue
-    Then Individual agrees to the privacy agreeement
+
 
   Scenario: Consumer clicks the personal information page continue button
     Given the Continue button is visible on the Account Setup page

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -152,6 +152,11 @@ Then(/^.+ sees form to enter personal information$/) do
   sleep 30
 end
 
+Then(/the continue button has data disabled attribute$/) do
+  continue_button = find('button.interaction-click-control-continue', visible: false)['data-disable-with']
+  expect(continue_button).to eql(l10n("please_wait"))
+end
+
 Then(/^.+ sees form to enter personal information but doesn't fill it out completely$/) do
   find(IvlPersonalInformation.us_citizen_or_national_yes_radiobtn).click
   find(IvlPersonalInformation.naturalized_citizen_no_radiobtn).click
@@ -750,8 +755,14 @@ Then(/Individual asks for help$/) do
   find(".interaction-click-control-×").click
 end
 
+And(/^the Continue button is visible on the Account Setup page/i) do
+  continue_button = find(IvlPersonalInformation.continue_btn)
+  expect(continue_button).to be_visible
+end
+
 And(/^.+ clicks? on the Continue button of the Account Setup page$/i) do
-  find(IvlPersonalInformation.continue_btn).click
+  wait_for_ajax
+  find(IvlPersonalInformation.continue_btn, wait: 5).click
 end
 
 Then(/^.+ sees the Verify Identity Consent page/)  do

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -157,6 +157,10 @@ Then(/the continue button has data disabled attribute$/) do
   expect(continue_button).to eql(l10n("please_wait"))
 end
 
+Then(/^.+ sees the continue button is enabled$/) do
+  find(IvlChooseCoverage.continue_btn)
+end
+
 Then(/^.+ sees form to enter personal information but doesn't fill it out completely$/) do
   find(IvlPersonalInformation.us_citizen_or_national_yes_radiobtn).click
   find(IvlPersonalInformation.naturalized_citizen_no_radiobtn).click

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -761,7 +761,6 @@ And(/^the Continue button is visible on the Account Setup page/i) do
 end
 
 And(/^.+ clicks? on the Continue button of the Account Setup page$/i) do
-  find("#personal_info").click
   wait_for_ajax
   find(IvlPersonalInformation.continue_btn, wait: 5).click
 end

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -761,6 +761,7 @@ And(/^the Continue button is visible on the Account Setup page/i) do
 end
 
 And(/^.+ clicks? on the Continue button of the Account Setup page$/i) do
+  find("#personal_info").click
   wait_for_ajax
   find(IvlPersonalInformation.continue_btn, wait: 5).click
 end

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -157,10 +157,6 @@ Then(/the continue button has data disabled attribute$/) do
   expect(continue_button).to eql(l10n("please_wait"))
 end
 
-Then(/^.+ sees the continue button is enabled$/) do
-  find(IvlChooseCoverage.continue_btn, visible: false)
-end
-
 Then(/^.+ sees form to enter personal information but doesn't fill it out completely$/) do
   find(IvlPersonalInformation.us_citizen_or_national_yes_radiobtn).click
   find(IvlPersonalInformation.naturalized_citizen_no_radiobtn).click
@@ -191,10 +187,6 @@ Then(/^.+ sees form to enter personal information but doesn't check every box$/)
   fill_in IvlPersonalInformation.zip, :with => EnrollRegistry[:enroll_app].setting(:contact_center_zip_code).item
   fill_in IvlPersonalInformation.home_phone, :with => "22075555555"
   sleep 2
-end
-
-Then(/^.+ fills in missing fields$/) do
-  find(IvlPersonalInformation.american_or_alaskan_native_no_radiobtn).click
 end
 
 And(/the individual enters address information$/) do

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -189,6 +189,10 @@ Then(/^.+ sees form to enter personal information but doesn't check every box$/)
   sleep 2
 end
 
+Then(/^.+ fills in missing fields$/) do
+  find(IvlPersonalInformation.american_or_alaskan_native_no_radiobtn).click
+end
+
 And(/the individual enters address information$/) do
   fill_in IvlPersonalInformation.address_line_one, :with => "4900 USAA BLVD NE"
   fill_in IvlPersonalInformation.address_line_two, :with => "212"

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -158,7 +158,7 @@ Then(/the continue button has data disabled attribute$/) do
 end
 
 Then(/^.+ sees the continue button is enabled$/) do
-  find(IvlChooseCoverage.continue_btn)
+  find(IvlChooseCoverage.continue_btn, visible: false)
 end
 
 Then(/^.+ sees form to enter personal information but doesn't fill it out completely$/) do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [ME-187565853](https://www.pivotaltracker.com/n/projects/2640060/stories/187565853)

# A brief description of the changes

Current behavior: Clicking continue on the personal information page multiple times results in duplicate DMIs being created

New behavior: Clicking continue will not result in multiple DMIs being created

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
