### PR TITLE
move not sure link below radios

### DIFF
--- a/app/views/shared/_is_applying_for_coverage.html.erb
+++ b/app/views/shared/_is_applying_for_coverage.html.erb
@@ -1,21 +1,17 @@
 <% if @bs4 %>
-  <div class="container p-0">
-    <div class="row">
-      <div class="col d-flex align-items-center mt-2">
-        <label for="is_applying_coverage_true" tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_applying_coverage_true')" class="radio">
-          <%= f.radio_button :is_applying_coverage, true, class: "required floatlabel", id: 'is_applying_coverage_true', checked: first_checked%>
-          <span class="yes_no_pair"><%= l10n("yes") %></span>
-        </label>
-        <label for="is_applying_coverage_false" tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_applying_coverage_false')" class="radio">
-          <%= f.radio_button :is_applying_coverage, false, class: "required floatlabel", id: 'is_applying_coverage_false', checked: second_checked %>
-          <span class="yes_no_pair"><%= l10n("no") %></span>
-        </label>
-      </div>
+  <div class="align-items-center mt-2">
+    <div class="col d-flex px-0">
+      <label for="is_applying_coverage_true" tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_applying_coverage_true')" class="radio">
+        <%= f.radio_button :is_applying_coverage, true, class: "required floatlabel", id: 'is_applying_coverage_true', checked: first_checked%>
+        <span class="yes_no_pair"><%= l10n("yes") %></span>
+      </label>
+      <label for="is_applying_coverage_false" tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_applying_coverage_false')" class="radio">
+        <%= f.radio_button :is_applying_coverage, false, class: "required floatlabel", id: 'is_applying_coverage_false', checked: second_checked %>
+        <span class="yes_no_pair"><%= l10n("no") %></span>
+      </label>
     </div>
-    <div class="row">
-      <div class="col">
-        <a href="#is_applying_coverage" data-toggle="modal" data-target="#is_applying_coverage" class="d-block"><%= l10n("not_sure") %></a>
-      </div>
+    <div class="col px-0">
+      <a href="#is_applying_coverage" data-toggle="modal" data-target="#is_applying_coverage" class="d-block"><%= l10n("not_sure") %></a>
     </div>
   </div>
   <%= render partial: 'shared/modal_support_text_household', locals: {key: "is_applying_coverage"} %>

--- a/app/views/shared/_is_applying_for_coverage.html.erb
+++ b/app/views/shared/_is_applying_for_coverage.html.erb
@@ -1,13 +1,23 @@
 <% if @bs4 %>
-  <label for="is_applying_coverage_true" tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_applying_coverage_true')" class="radio">
-    <%= f.radio_button :is_applying_coverage, true, class: "required floatlabel", id: 'is_applying_coverage_true', checked: first_checked%>
-    <span class="yes_no_pair"><%= l10n("yes") %></span>
-  </label>
-  <label for="is_applying_coverage_false" tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_applying_coverage_false')" class="radio">
-    <%= f.radio_button :is_applying_coverage, false, class: "required floatlabel", id: 'is_applying_coverage_false', checked: second_checked %>
-    <span class="yes_no_pair"><%= l10n("no") %></span>
-  </label>
-  <a href="#is_applying_coverage" data-toggle="modal" data-target="#is_applying_coverage" class="d-block"><%= l10n("not_sure") %></a>
+  <div class="container p-0">
+    <div class="row">
+      <div class="col d-flex align-items-center mt-2">
+        <label for="is_applying_coverage_true" tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_applying_coverage_true')" class="radio">
+          <%= f.radio_button :is_applying_coverage, true, class: "required floatlabel", id: 'is_applying_coverage_true', checked: first_checked%>
+          <span class="yes_no_pair"><%= l10n("yes") %></span>
+        </label>
+        <label for="is_applying_coverage_false" tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_applying_coverage_false')" class="radio">
+          <%= f.radio_button :is_applying_coverage, false, class: "required floatlabel", id: 'is_applying_coverage_false', checked: second_checked %>
+          <span class="yes_no_pair"><%= l10n("no") %></span>
+        </label>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <a href="#is_applying_coverage" data-toggle="modal" data-target="#is_applying_coverage" class="d-block"><%= l10n("not_sure") %></a>
+      </div>
+    </div>
+  </div>
   <%= render partial: 'shared/modal_support_text_household', locals: {key: "is_applying_coverage"} %>
 <% else %>
   <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 form-group form-group-lg no-pd">

--- a/app/views/shared/person/_consumer_information.html.erb
+++ b/app/views/shared/person/_consumer_information.html.erb
@@ -58,9 +58,7 @@
     <fieldset class="d-flex row col-sm">
       <legend class="required"><%= l10n("does_person_need_coverage", person: @person.first_name.present? ? @person.first_name : "this person") %></legend>
       <% first_checked, second_checked = is_applying_coverage_value_consumer(@use_person, @person, @consumer_role) %>
-      <div class="d-flex align-items-center mt-2">
-        <%= render 'shared/is_applying_for_coverage', f: f, first_checked: first_checked, second_checked: second_checked %>
-      </div>
+      <%= render 'shared/is_applying_for_coverage', f: f, first_checked: first_checked, second_checked: second_checked %>
     </fieldset>
   </div>
   <%= render 'shared/ssn_coverage_msg' %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187626829

# A brief description of the changes

Current behavior: Not sure link is inline with the radio buttons.

New behavior: The partial is now in its own div with two cols for the radios and not sure link, with the not sure link now below the radios.

<img width="540" alt="Screenshot 2024-05-20 at 11 00 55 PM" src="https://github.com/ideacrew/enroll/assets/167465598/805e45af-5659-4184-a41b-3e946d236bdb">

