### PR TITLE
add disabled class to continue link

### DIFF
--- a/app/views/shared/_progress_navigation_buttons.html.erb
+++ b/app/views/shared/_progress_navigation_buttons.html.erb
@@ -20,7 +20,7 @@
     <% if confirmation_link %>
       <%= h(link_to l10n("confirm"), checkout_insured_plan_shopping_path(@enrollment.id, plan_id: @plan.id, market_kind: @market_kind, coverage_kind: @coverage_kind), class: "btn btn-primary btn-block disabled", id: 'btn-continue', method: :post, disabled: !@enrollable) %>
     <% elsif !button_type.nil? %>
-      <button id="btn-continue" <%= "disabled=#{disable_link}" if disable_link == true %> type="<%= button_type %>" method="<%= link_method %>">
+      <button id="btn-continue" <%= "disabled=#{disable_link}" %> type="<%= button_type %>" method="<%= link_method %>">
         <%= l10n("continue_next") %>
       </button>
     <% else %>
@@ -32,7 +32,7 @@
           <%= l10n("continue_next") %>
         </button>
       <% else %>
-        <%= h(link_to l10n("continue_next"), next_link, method: link_method, class: 'btn', disabled: disable_link, id: "btn-continue") %>
+        <%= h(link_to l10n("continue_next"), next_link, method: link_method, class: "btn #{'disabled' if disable_link}", id: "btn-continue") %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/shared/_progress_navigation_buttons.html.erb
+++ b/app/views/shared/_progress_navigation_buttons.html.erb
@@ -20,7 +20,7 @@
     <% if confirmation_link %>
       <%= h(link_to l10n("confirm"), checkout_insured_plan_shopping_path(@enrollment.id, plan_id: @plan.id, market_kind: @market_kind, coverage_kind: @coverage_kind), class: "btn btn-primary btn-block disabled", id: 'btn-continue', method: :post, disabled: !@enrollable) %>
     <% elsif !button_type.nil? %>
-      <button id="btn-continue" <%= "disabled=#{disable_link}" %> type="<%= button_type %>" method="<%= link_method %>">
+      <button id="btn-continue" <%= "disabled=#{disable_link}" if disable_link == true %> type="<%= button_type %>" method="<%= link_method %>">
         <%= l10n("continue_next") %>
       </button>
     <% else %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187637649

# A brief description of the changes

Current behavior: Continue button is enabled for un-verified statuses in RIDP.

New behavior: Continue button is disabled for un-verified statuses in RIDP, and the new partial will now properly handle `disable_link` for continue cases.