### PR TITLE
update organization factory staff by default do not have ssn

### DIFF
--- a/components/benefit_sponsors/app/models/benefit_sponsors/organizations/factories/profile_factory.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/organizations/factories/profile_factory.rb
@@ -188,9 +188,10 @@ module BenefitSponsors
 
         def build_person
           Person.new({
-                       :first_name => first_name.strip,
-                       :last_name => last_name.strip,
-                       :dob => dob
+                       first_name: first_name.strip,
+                       last_name: last_name.strip,
+                       dob: dob,
+                       no_ssn: 1
                      })
         end
 

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/profiles/registrations_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/profiles/registrations_controller_spec.rb
@@ -346,7 +346,7 @@ module BenefitSponsors # rubocop:disable Metrics/ModuleLength
               expect(response.location.include?("new?profile_type=general_agency")).to eq true if profile_type == "general_agency"
             end
 
-            it "should create stuff person with no ssn" do
+            it "should create staff person with no ssn" do
               person = Person.where(
                 first_name: staff_roles_attributes[0][:first_name],
                 last_name: staff_roles_attributes[0][:last_name],

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/profiles/registrations_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/profiles/registrations_controller_spec.rb
@@ -345,6 +345,15 @@ module BenefitSponsors # rubocop:disable Metrics/ModuleLength
             it "should redirect to new for general agency" do
               expect(response.location.include?("new?profile_type=general_agency")).to eq true if profile_type == "general_agency"
             end
+
+            it "should create stuff person with no ssn" do
+              person = Person.where(
+                first_name: staff_roles_attributes[0][:first_name],
+                last_name: staff_roles_attributes[0][:last_name],
+                dob: staff_roles_attributes[0][:dob]
+              ).first
+              expect("1").to eq person.no_ssn
+            end
           end
 
           it_behaves_like "store profile for create", "benefit_sponsor"


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [*] There are no inline styles added
- [*] There are no inline javascript added
- [*] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [*] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/187565852

Added for organization stuff person by default do not have SSN. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
