### PR TITLE
fix missing document faq button

### DIFF
--- a/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
@@ -2,7 +2,6 @@
 <% if @bs4 %>
   <% show_faq_button = (defined? show_faq_button) ? show_faq_button : true %>
   <div class="mt-4 mb-4">
-    <%= show_faq_button %>
   <% if show_faq_button %>
     <%= sanitize(link_to l10n("insured.consumer_roles.upload_ridp_documents.documents_faq"), ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, class: "button outline", target: '_blank', rel: 'noopener noreferrer') %>
   <% end %>

--- a/app/views/insured/fdsh_ridp_verifications/service_unavailable.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/service_unavailable.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: 'insured/fdsh_ridp_verifications/options_to_verify_identity' %>
     <%= render partial: 'shared/application_types_list' %>
     <div class="outstanding-ridp-documents">
-      <%= render partial: 'insured/fdsh_ridp_verifications/outstanding_ridp_documents' %>
+      <%= render partial: 'insured/fdsh_ridp_verifications/outstanding_ridp_documents', locals: { show_faq_button: @verification_transaction_id.blank? } %>
     </div>
   </div>
   <% redirect_path = EnrollRegistry.feature_enabled?(:financial_assistance) ? help_paying_coverage_insured_consumer_role_index_path : insured_family_members_path(consumer_role_id: @person.consumer_role.id) %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187637672

# A brief description of the changes

Current behavior: Documents FAQ button not available on the fdsh service unavailable page

New behavior: button is now available

<img width="1282" alt="Screenshot 2024-05-21 at 1 50 45 PM" src="https://github.com/ideacrew/enroll/assets/45053146/c44cccde-3f38-4bc4-856e-5cfc5b6a2be5">

