### PR TITLE
ridp default select agree

### DIFF
--- a/app/views/insured/consumer_roles/ridp_agreement.html.erb
+++ b/app/views/insured/consumer_roles/ridp_agreement.html.erb
@@ -14,7 +14,7 @@
     </legend>
     <div class="d-flex align-items-center">
       <label for="agreement_agree" tabindex="0" class="radio" data-radio-event="agreement_disagree">
-        <%= radio_button_tag :agreement, "agree", class: "required", id: 'agreement_agree' %>
+        <%= radio_button_tag :agreement, "agree", true, class: "required", id: 'agreement_agree' %>
         <%= l10n('faa.i_agree') %>
       </label>
       <%= javascript_tag do %>
@@ -27,7 +27,7 @@
       <% end %>
 
       <label for="agreement_disagree" tabindex="0" class="radio" data-radio-event="agreement_disagree">
-        <%= radio_button_tag :agreement, "disagree", class: "required", id: 'agreement_disagree' %>
+        <%= radio_button_tag :agreement, "disagree", false, class: "required", id: 'agreement_disagree' %>
         <%= l10n('faa.i_disagree') %>
       </label>
     </div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187644123

# A brief description of the changes

Current behavior: I disagree is selected by default.

New behavior: I agree is now selected by default.
