### PR TITLE
ridp fixes for previous and log out links

### DIFF
--- a/app/javascript/css/_buttons.scss
+++ b/app/javascript/css/_buttons.scss
@@ -88,6 +88,6 @@ button.error, .button.error, .btn.error, .btn-error {
 }
 
 a.button:hover {
-  text-decoration: underline;
+  text-decoration: none;
   cursor: pointer;
 }

--- a/app/views/shared/_progress_navigation_buttons.html.erb
+++ b/app/views/shared/_progress_navigation_buttons.html.erb
@@ -13,7 +13,7 @@
 
 <div class="d-flex flex-column flex-sm-row align-items-center">
   <% unless dont_show_prev_button || @no_previous_button %>
-    <button class="back button mr-2 <%= previous_style %>" href="#"><%= l10n("previous_step") %></button>
+    <a class="back button mr-2 <%= previous_style %>" href="#"><%= l10n("previous_step") %></a>
   <% end %>
 
   <% unless dont_show_next_button %>

--- a/app/views/shared/_shopping_nav_panel.html.erb
+++ b/app/views/shared/_shopping_nav_panel.html.erb
@@ -4,6 +4,7 @@
   <% show_previous_button = local_assigned_boolean(local_assigns[:show_previous_button], true) %>
   <% show_account_button = local_assigned_boolean(local_assigns[:show_account_button], back_to_account_flag) %>
   <% show_help_button = local_assigned_boolean(local_assigns[:show_help_button], !is_complete) %>
+  <% show_exit_button = local_assigned_boolean(local_assigns[:show_exit_button], !is_complete) %>
 
   <% continue_to_account_text ||= l10n("insured.plan_shoppings.receipt.go_to_my_account") %>
   <% to_account_text = is_complete ? continue_to_account_text : l10n("back_to_my_account") %>
@@ -35,7 +36,7 @@
             <%= l10n("save_and_exit") %>
           </a>
         </li>
-        <% unless back_to_account_flag %>
+        <% unless back_to_account_flag || @bs4 %>
           <br>
           <br>
           <li>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
https://www.pivotaltracker.com/story/show/187620749
https://www.pivotaltracker.com/story/show/187645989
https://www.pivotaltracker.com/story/show/187646843
https://www.pivotaltracker.com/story/show/187646847


# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
