### PR TITLE
build family determination to include alive status verification

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -140,6 +140,7 @@ class Family
           'eligibility_determination.subjects.eligibility_states.evidence_states.due_on': 1},
         { name: 'subjects_evidence_states_status_due_on'})
 
+  index({ "verification_types.type_name" => 1 })
 
   validates :renewal_consent_through_year,
             numericality: {only_integer: true, inclusion: 2014..2025},
@@ -244,6 +245,12 @@ class Family
   scope :vlp_fully_uploaded,                    ->{ where(vlp_documents_status: "Fully Uploaded")}
   scope :vlp_partially_uploaded,                ->{ where(vlp_documents_status: "Partially Uploaded")}
   scope :vlp_none_uploaded,                     ->{ where(:vlp_documents_status.in => ["None",nil])}
+  scope :enrolled_members_with_ssn, lambda {
+                                      where(:'eligibility_determination.subjects' =>
+                                      { :$elemMatch => { :encrypted_ssn.exists => true, :eligibility_states =>
+                                      { :$elemMatch => { :eligibility_item_key.in => ['health_product_enrollment_status', 'dental_product_enrollment_status'],
+                                                         :is_eligible => true } } } })
+                                    }
 
   scope :outstanding_verification,   ->{ where(
     :"_id".in => HbxEnrollment.individual_market.verification_outstanding.distinct(:family_id))

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -55,6 +55,7 @@ registry:
               - :american_indian_status
               - :social_security_number
               - :residency
+              - :alive_status
       - key: :health_product_enrollment_status
         is_enabled: true
         settings:
@@ -125,6 +126,13 @@ registry:
             item: 'gid://enroll_app/Person'
       - key: :social_security_number
         is_enabled: true
+        settings:
+          - key: :subject_ref
+            item: 'gid://enroll_app/Family::FamilyMember'
+          - key: :evidence_ref
+            item: 'gid://enroll_app/Person'
+      - key: :alive_status
+        is_enabled: false
         settings:
           - key: :subject_ref
             item: 'gid://enroll_app/Family::FamilyMember'

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -55,6 +55,7 @@ registry:
               - :american_indian_status
               - :social_security_number
               - :residency
+              - :alive_status
       - key: :health_product_enrollment_status
         is_enabled: true
         settings:
@@ -124,6 +125,13 @@ registry:
           - key: :evidence_ref
             item: 'gid://enroll_app/Person'
       - key: :social_security_number
+        is_enabled: true
+        settings:
+          - key: :subject_ref
+            item: 'gid://enroll_app/Family::FamilyMember'
+          - key: :evidence_ref
+            item: 'gid://enroll_app/Person'
+      - key: :alive_status
         is_enabled: true
         settings:
           - key: :subject_ref

--- a/system/config/templates/features/aca_individual_market/eligibilities.yml
+++ b/system/config/templates/features/aca_individual_market/eligibilities.yml
@@ -55,6 +55,7 @@ registry:
               - :american_indian_status
               - :social_security_number
               - :residency
+              - :alive_status
       - key: :health_product_enrollment_status
         is_enabled: true
         settings:
@@ -125,6 +126,13 @@ registry:
             item: 'gid://enroll_app/Person'
       - key: :social_security_number
         is_enabled: true
+        settings:
+          - key: :subject_ref
+            item: 'gid://enroll_app/Family::FamilyMember'
+          - key: :evidence_ref
+            item: 'gid://enroll_app/Person'
+      - key: :alive_status
+        is_enabled: false
         settings:
           - key: :subject_ref
             item: 'gid://enroll_app/Family::FamilyMember'


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187563454

# A brief description of the changes

Current behavior: Build family determination does not include alive status verification type.

New behavior: Build family determination will include alive status verification type.

# Feature Flag alive_status

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
