### PR TITLE
create CHHM when creating an applicant

### DIFF
--- a/app/domain/operations/families/create_member.rb
+++ b/app/domain/operations/families/create_member.rb
@@ -77,8 +77,11 @@ module Operations
         Failure("Relationship creation failed: #{e}")
       end
 
-      def persist_family(family_member, _family)
+      def persist_family(family_member, family)
         family_member.save!
+
+        #ADDED THIS
+        family.active_household.coverage_households.each { |ch| ch.save! if ch.changed? }
         # family.save!
         Success(family_member.id)
       end

--- a/app/domain/operations/families/create_member.rb
+++ b/app/domain/operations/families/create_member.rb
@@ -80,7 +80,6 @@ module Operations
       def persist_family(family_member, family)
         family_member.save!
 
-        #ADDED THIS
         family.active_household.coverage_households.each { |ch| ch.save! if ch.changed? }
         # family.save!
         Success(family_member.id)

--- a/app/models/coverage_household.rb
+++ b/app/models/coverage_household.rb
@@ -72,6 +72,7 @@ class CoverageHousehold
   def add_coverage_household_member(family_member)
     # family.family_members.count
     # family.active_household.coverage_households[0].coverage_household_members
+    binding.irb
     return if coverage_household_members.where(family_member_id: family_member.id).present?
 
     coverage_household_members.build(
@@ -79,7 +80,8 @@ class CoverageHousehold
       is_subscriber: family_member.is_primary_applicant?
     )
 
-    family.active_household.save!
+    # family.active_household.save!
+    household.save!
 
     # chm.save_parent
     # household.save

--- a/app/models/coverage_household.rb
+++ b/app/models/coverage_household.rb
@@ -80,8 +80,8 @@ class CoverageHousehold
       is_subscriber: family_member.is_primary_applicant?
     )
 
-    # family.active_household.save!
-    household.save!
+    family.active_household.save!
+    # household.save!
 
     # chm.save_parent
     # household.save

--- a/app/models/coverage_household.rb
+++ b/app/models/coverage_household.rb
@@ -77,6 +77,7 @@ class CoverageHousehold
       is_subscriber: family_member.is_primary_applicant?
     )
 
+
     # chm.save_parent
     # household.save
   end

--- a/app/models/coverage_household.rb
+++ b/app/models/coverage_household.rb
@@ -70,18 +70,12 @@ class CoverageHousehold
   end
 
   def add_coverage_household_member(family_member)
-    # family.family_members.count
-    # family.active_household.coverage_households[0].coverage_household_members
-    binding.irb
     return if coverage_household_members.where(family_member_id: family_member.id).present?
 
     coverage_household_members.build(
       family_member: family_member,
       is_subscriber: family_member.is_primary_applicant?
     )
-
-    family.active_household.save!
-    # household.save!
 
     # chm.save_parent
     # household.save

--- a/app/models/coverage_household.rb
+++ b/app/models/coverage_household.rb
@@ -70,6 +70,8 @@ class CoverageHousehold
   end
 
   def add_coverage_household_member(family_member)
+    # family.family_members.count
+    # family.active_household.coverage_households[0].coverage_household_members
     return if coverage_household_members.where(family_member_id: family_member.id).present?
 
     coverage_household_members.build(
@@ -77,6 +79,7 @@ class CoverageHousehold
       is_subscriber: family_member.is_primary_applicant?
     )
 
+    family.active_household.save!
 
     # chm.save_parent
     # household.save

--- a/spec/domain/operations/families/create_member_spec.rb
+++ b/spec/domain/operations/families/create_member_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe Operations::Families::CreateMember, type: :model, dbclean: :after
         expect(family.family_members.count).to eq(2)
       end
 
+      it 'creates a new coverage household member associated to new family member' do
+        expect(family.active_household.coverage_households[0].coverage_household_members.count).to eq(2)
+      end
+
       it 'creates a new consumer role' do
         expect(@person.consumer_role.present?).to be_truthy
       end
@@ -90,6 +94,10 @@ RSpec.describe Operations::Families::CreateMember, type: :model, dbclean: :after
 
       it 'should not create family member' do
         expect(family.family_members.count).not_to eq 2
+      end
+
+      it 'should not create coverage household member as family member is not created' do
+        expect(family.active_household.coverage_households[0].coverage_household_members.count).not_to eq 2
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [] Any endpoint modified in the PR only responds to the expected MIME types.
- [] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ x ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/187563748

# A brief description of the changes

Current behavior:
When a member is added as an applicant, coverage household member associated to that member is not created

New behavior:
When a member is added  as an applicant, coverage household member associated to that member will be created

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
