### PR TITLE
enable continue button if demographic checkboxes checked

### DIFF
--- a/app/assets/javascripts/demographics_fields.js
+++ b/app/assets/javascripts/demographics_fields.js
@@ -53,9 +53,17 @@ function addEventOnSsn(target) {
   });
 }
 
+function enableContinueButton() {
+  var continueButton =  $('.interaction-click-control-continue.hidden');
+  if (continueButton.is(':disabled')) {
+    continueButton.prop('disabled', false);
+  }
+}
+
 function applyListenersFor(target) {
   // target is person or dependent
   $("input[name='" + target + "[us_citizen]']").change(function () {
+    enableContinueButton();
     $('#vlp_documents_container').hide();
     $('#vlp_documents_container .vlp_doc_area').html('');
     $("input[name='" + target + "[naturalized_citizen]']").prop(
@@ -80,6 +88,7 @@ function applyListenersFor(target) {
   });
 
   $("input[name='" + target + "[naturalized_citizen]']").change(function () {
+    enableContinueButton();
     var selected_doc_type = $('#naturalization_doc_type').val();
     if ($(this).val() == 'true') {
       $('#vlp_documents_container').show();
@@ -96,6 +105,7 @@ function applyListenersFor(target) {
 
   $("input[name='" + target + "[eligible_immigration_status]']").change(
     function () {
+      enableContinueButton();
       var selected_doc_type = $('#immigration_doc_type').val();
       if ($(this).val() == 'true' && this.checked) {
         $('#vlp_documents_container').show();
@@ -122,6 +132,7 @@ function applyListenersFor(target) {
 
   // tribal-state change - select from options
   $('select#tribal-state').on("change", function() {
+    enableContinueButton();
     var enroll_state_abbr = $('#enroll_state_abbr').val();
     var is_indian_alaskan_tribe_details_enabled = ($('#is_indian_alaskan_tribe_details_enabled').val() === 'true');
 
@@ -156,6 +167,30 @@ function applyListenersFor(target) {
     }
   });
   //end tribe option controls
+
+  $('input[name="person[is_incarcerated]"]').change(function () {
+    enableContinueButton();
+  })
+
+  $('input[name="person[tribal_id]"]').change(function () {
+    enableContinueButton();
+  })
+
+  $('input[name="person[tribal_name]"]').change(function () {
+    enableContinueButton();
+  })
+
+  $('.mobile-phone-number').change(function() {
+    enableContinueButton();
+  })
+
+  $('.tribe_codes').change(function() {
+    enableContinueButton();
+  })
+
+  $('input[name="person[indian_tribe_member]"]').change(function() {
+    enableContinueButton();
+  })
 }
 
 function showOnly(selected) {

--- a/features/insured/personal_information_page.feature
+++ b/features/insured/personal_information_page.feature
@@ -22,7 +22,9 @@ Feature: Insured Plan Shopping on Individual market
     Then Individual sees form to enter personal information but doesn't check every box
     And Individual clicks on continue
     Then the user will have to accept alert pop up for missing field
-
+    Then Individual sees form to enter personal information
+    Then Individual clicks on continue
+    Then Individual agrees to the privacy agreeement
 
   Scenario: Consumer clicks the personal information page continue button
     Given the Continue button is visible on the Account Setup page


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [ME-187701920](https://www.pivotaltracker.com/n/projects/2640060/stories/187701920)

# A brief description of the changes

Current behavior: If a required checkbox is not checked when the user hits continue, the continue button becomes disabled

New behavior: The continue button is renabled when a user selects the checkbox.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
