### PR TITLE
improve personal info keyboard nav

### DIFF
--- a/app/javascript/css/forms.scss
+++ b/app/javascript/css/forms.scss
@@ -74,6 +74,22 @@ select,
   }
 }
 
+input[type="checkbox"] {
+  &:active,
+  &:focus {
+  outline: 1px solid var(--grey-150);
+  }
+}
+
+.focus {
+  &:active,
+  &:focus,
+  &:focus-within {
+  outline: -webkit-focus-ring-color auto 1px;
+  outline-offset: 4px;
+  }
+}
+
 input.full-width, select.full-width, .input.full-width {
   width: 100%;
 }

--- a/app/views/shared/_is_applying_for_coverage.html.erb
+++ b/app/views/shared/_is_applying_for_coverage.html.erb
@@ -1,11 +1,11 @@
 <% if @bs4 %>
   <div class="align-items-center mt-2">
-    <div class="col d-flex px-0">
-      <label for="is_applying_coverage_true" tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_applying_coverage_true')" class="radio">
+    <div class="focus col d-flex px-0">
+      <label for="is_applying_coverage_true" class="radio">
         <%= f.radio_button :is_applying_coverage, true, class: "required floatlabel", id: 'is_applying_coverage_true', checked: first_checked%>
         <span class="yes_no_pair"><%= l10n("yes") %></span>
       </label>
-      <label for="is_applying_coverage_false" tabindex="0" onkeydown="handleRadioKeyDown(event, 'is_applying_coverage_false')" class="radio">
+      <label for="is_applying_coverage_false" class="radio">
         <%= f.radio_button :is_applying_coverage, false, class: "required floatlabel", id: 'is_applying_coverage_false', checked: second_checked %>
         <span class="yes_no_pair"><%= l10n("no") %></span>
       </label>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187134301

# A brief description of the changes

Current behavior: Lack of focus on keyboard navigation for checkboxes and radio buttons

New behavior: Improved focus for checkboxes and radio buttons

![Screenshot 2024-05-30 at 10 01 36 AM](https://github.com/ideacrew/enroll/assets/45053146/210b92cd-34b2-492d-af57-eb7dfdb7be2a)
![Screenshot 2024-05-30 at 9 59 32 AM](https://github.com/ideacrew/enroll/assets/45053146/9bc85950-f5fd-4e24-b299-052e823e71c8)



