### PR TITLE
add crm publish env variables

### DIFF
--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -746,10 +746,10 @@ registry:
               ]
       - key: :crm_update_family_save
         item: :crm_update_family_save
-        is_enabled: false
+        is_enabled: <%= ENV['CRM_UPDATE_FAMILY_SAVE_IS_ENABLED'] || false %>
       - key: :crm_publish_primary_subscriber
         item: :crm_publish_primary_subscriber
-        is_enabled: false
+        is_enabled: <%= ENV['CRM_PUBLISH_PRIMARY_SUBSCRIBER_IS_ENABLED'] || false %>
       - key: :pii_match_success_message
         item: :pii_match_success_message
         is_enabled: false

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -750,7 +750,7 @@ registry:
         is_enabled: true
       - key: :crm_publish_primary_subscriber
         item: :crm_publish_primary_subscriber
-        is_enabled: true
+        is_enabled: <%= ENV['CRM_PUBLISH_PRIMARY_SUBSCRIBER_IS_ENABLED'] || false %>
       - key: :pii_match_success_message
         item: :pii_match_success_message
         is_enabled: true

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -746,10 +746,10 @@ registry:
               ]
       - key: :crm_update_family_save
         item: :crm_update_family_save
-        is_enabled: false
+        is_enabled: <%= ENV['CRM_UPDATE_FAMILY_SAVE_IS_ENABLED'] || false %>
       - key: :crm_publish_primary_subscriber
         item: :crm_publish_primary_subscriber
-        is_enabled: false
+        is_enabled: <%= ENV['CRM_PUBLISH_PRIMARY_SUBSCRIBER_IS_ENABLED'] || false %>
       - key: :pii_match_success_message
         item: :pii_match_success_message
         is_enabled: false


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [ME-187604349](https://www.pivotaltracker.com/n/projects/2640060/stories/187604349#)
# A brief description of the changes

Current behavior: 

New behavior: Adding env variables for crm primary person publish and crm family publish

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: CRM_UPDATE_FAMILY_SAVE_IS_ENABLED; CRM_PUBLISH_PRIMARY_SUBSCRIBER_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
