### PR TITLE
keyboard navigation auth and consent

### DIFF
--- a/app/javascript/css/main.scss
+++ b/app/javascript/css/main.scss
@@ -110,6 +110,7 @@ nav .login-options li {
 
 .hide, .hidden {
   @extend .sr-only;
+  visibility: hidden;
 }
 
 .hidden_field {

--- a/app/views/insured/consumer_roles/ridp_agreement.html.erb
+++ b/app/views/insured/consumer_roles/ridp_agreement.html.erb
@@ -12,21 +12,12 @@
     <legend class="weight-n">
       <%= l10n("insured.consumer_roles.ridp_agreement.ridp_agreement_label") %>
     </legend>
-    <div class="d-flex align-items-center">
-      <label for="agreement_agree" tabindex="0" class="radio" data-radio-event="agreement_disagree">
+    <div class="focus d-flex align-items-center">
+      <label for="agreement_agree" class="radio" data-radio-event="agreement_disagree">
         <%= radio_button_tag :agreement, "agree", true, class: "required", id: 'agreement_agree' %>
         <%= l10n('faa.i_agree') %>
       </label>
-      <%= javascript_tag do %>
-        window.addEventListener('DOMContentLoaded', (event) => {
-          const agreementDisagree = document.querySelector("[for='agreement_disagree']");
-          agreementDisagree.addEventListener("keydown", (event) => {
-            handleRadioKeyDown(event, 'agreement_disagree');
-          });
-        });
-      <% end %>
-
-      <label for="agreement_disagree" tabindex="0" class="radio" data-radio-event="agreement_disagree">
+      <label for="agreement_disagree" class="radio" data-radio-event="agreement_disagree">
         <%= radio_button_tag :agreement, "disagree", false, class: "required", id: 'agreement_disagree' %>
         <%= l10n('faa.i_disagree') %>
       </label>
@@ -58,16 +49,18 @@
             <%= "Please contact #{EnrollRegistry[:enroll_app].setting(:contact_center_name).item}: #{Settings.contact_center.phone_number} for more information" %>
           </div>
         </div>
-        <div class="row row-form-wrapper no-buffer" style="border-top: solid 1px #b7b7b7;">
-          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'agreement_agree')" class="col-lg-2 radio skinned-form-controls skinned-form-controls-mac">
-            <%= radio_button_tag :agreement, "agree", true, class: "required floatlabel"  %>
-            <label for="agreement_agree"><span style="white-space: nowrap;"><%= l10n('faa.i_agree') %></span></label>
+        <div class="focus">
+          <div class="row row-form-wrapper no-buffer" style="border-top: solid 1px #b7b7b7;">
+            <div class="col-lg-2 radio skinned-form-controls skinned-form-controls-mac">
+              <%= radio_button_tag :agreement, "agree", true, class: "required floatlabel"  %>
+              <label for="agreement_agree"><span style="white-space: nowrap;"><%= l10n('faa.i_agree') %></span></label>
+            </div>
           </div>
-        </div>
-        <div class="row row-form-wrapper no-buffer">
-          <div tabindex="0" onkeydown="handleRadioKeyDown(event, 'agreement_disagree')" class="col-lg-10 radio skinned-form-controls skinned-form-controls-mac">
-            <%= radio_button_tag :agreement, "disagree", false, class: "required floatlabel"  %>
-            <label for="agreement_disagree"><span style="white-space: nowrap;"><%= l10n('faa.i_disagree') %></span></label>
+          <div class="row row-form-wrapper no-buffer">
+            <div class="col-lg-10 radio skinned-form-controls skinned-form-controls-mac">
+              <%= radio_button_tag :agreement, "disagree", false, class: "required floatlabel"  %>
+              <label for="agreement_disagree"><span style="white-space: nowrap;"><%= l10n('faa.i_disagree') %></span></label>
+            </div>
           </div>
         </div>
         <br />


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187134363

# A brief description of the changes

Current behavior: Radio button has extra focuses, coverme external link is navigable even when not shown

New behavior: Navigation improved, radio focus improved

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
![Screenshot 2024-06-03 at 4 44 56 PM](https://github.com/ideacrew/enroll/assets/45053146/d696ab28-b170-4159-ac7a-14609a193175)
![Screenshot 2024-06-03 at 4 45 10 PM](https://github.com/ideacrew/enroll/assets/45053146/902dfa62-e128-4237-9ad5-53281841d881)
