### PR TITLE
improve tab focus verify identity

### DIFF
--- a/app/javascript/css/main.scss
+++ b/app/javascript/css/main.scss
@@ -110,6 +110,7 @@ nav .login-options li {
 
 .hide, .hidden {
   @extend .sr-only;
+  visibility: hidden;
 }
 
 .hidden_field {

--- a/app/views/insured/fdsh_ridp_verifications/new.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/new.html.erb
@@ -14,15 +14,17 @@
       <% end %>
       <fieldset class="mt-4 mb-4 d-block">
         <legend class="required"><%= qf.object.question_text %></legend>
-        <% qf.object.responses.each do |r| %>
-          <div class="radio" tabindex="0" onkeydown="handleRadioKeyDown(event, 'interactive_verification_questions_attributes_#{qf.index}_response_id_#{r.response_id.downcase}')">
-            <%= qf.label "response_id_#{r.response_id.downcase}", class: "mb-4 weight-n" do %>
-              <%= qf.radio_button :response_id, r.response_id, class: 'weight-n' %>
-              <span></span>
-              <%= r.response_text %>
-            <% end %>
-          </div>
-        <% end %>
+        <div class="focus">
+          <% qf.object.responses.each do |r| %>
+            <div class="radio">
+              <%= qf.label "response_id_#{r.response_id.downcase}", class: "mb-4 weight-n" do %>
+                <%= qf.radio_button :response_id, r.response_id, class: 'weight-n' %>
+                <span></span>
+                <%= r.response_text %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
       </fieldset>
     <% end %>
     <%= f.submit l10n("submit"), class: 'btn' + pundit_class(Family, :updateable?) %>
@@ -52,14 +54,16 @@
               <% end %>
               <div class="form-group">
                 <p><%= qf.object.question_text %></p>
-                <% qf.object.responses.each do |r| %>
-                  <div class="row row-form-wrapper no-buffer">
-                    <div class="radio skinned-form-controls skinned-form-controls-mac" style="height: auto;" tabindex="0" onkeydown="handleRadioKeyDown(event, 'interactive_verification_questions_attributes_#{qf.index}_response_id_#{r.response_id.downcase}')">
-                      <%= qf.radio_button :response_id, r.response_id, class: 'required floatlabel' %>
-                      <%= qf.label "response_id_#{r.response_id.downcase}" do %>
-                        <span></span>
-                        <%= r.response_text %>
-                      <% end %>
+                <div class="focus">
+                  <% qf.object.responses.each do |r| %>
+                    <div class="row row-form-wrapper no-buffer">
+                      <div class="focus radio skinned-form-controls skinned-form-controls-mac" style="height: auto;">
+                        <%= qf.radio_button :response_id, r.response_id, class: 'required floatlabel' %>
+                        <%= qf.label "response_id_#{r.response_id.downcase}" do %>
+                          <span></span>
+                          <%= r.response_text %>
+                        <% end %>
+                      </div>
                     </div>
                   </div>
                 <% end %>

--- a/app/views/insured/fdsh_ridp_verifications/primary_response.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/primary_response.html.erb
@@ -14,15 +14,17 @@
       <% end %>
       <fieldset class="mt-4 mb-4 d-block">
         <legend class="required"><%= qf.object.question_text %></legend>
-        <% qf.object.responses.each do |r| %>
-          <div class="radio" tabindex="0" onkeydown="handleRadioKeyDown(event, 'interactive_verification_questions_attributes_#{qf.index}_response_id_#{r.response_id.downcase}')">
-            <%= qf.label "response_id_#{r.response_id.downcase}", class: "mb-4 weight-n" do %>
-              <%= qf.radio_button :response_id, r.response_id, class: 'weight-n' %>
-              <span></span>
-              <%= r.response_text %>
-            <% end %>
-          </div>
-        <% end %>
+        <div class="focus">
+          <% qf.object.responses.each do |r| %>
+            <div class="radio">
+              <%= qf.label "response_id_#{r.response_id.downcase}", class: "mb-4 weight-n" do %>
+                <%= qf.radio_button :response_id, r.response_id, class: 'weight-n' %>
+                <span></span>
+                <%= r.response_text %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
       </fieldset>
     <% end %>
     <%= f.submit l10n("submit"), class: 'btn' + pundit_class(Family, :updateable?) %>

--- a/app/views/insured/interactive_identity_verifications/new.html.erb
+++ b/app/views/insured/interactive_identity_verifications/new.html.erb
@@ -14,15 +14,17 @@
       <% end %>
       <fieldset class="mt-4 mb-4 d-block">
         <legend class="weight-n required"><%= qf.object.question_text %></legend>
-        <% qf.object.responses.each do |r| %>
-          <div class="radio" tabindex="0" onkeydown="handleRadioKeyDown(event, 'interactive_verification_questions_attributes_#{qf.index}_response_id_#{r.response_id.downcase}')">
-            <%= qf.label "response_id_#{r.response_id.downcase}", class: "mb-4 weight-n" do %>
-              <%= qf.radio_button :response_id, r.response_id, class: 'required' %>
-              <span></span>
-              <%= r.response_text %>
-            <% end %>
-          </div>
-        <% end %>
+        <div class="focus">
+          <% qf.object.responses.each do |r| %>
+            <div class="radio">
+              <%= qf.label "response_id_#{r.response_id.downcase}", class: "mb-4 weight-n" do %>
+                <%= qf.radio_button :response_id, r.response_id, class: 'required' %>
+                <span></span>
+                <%= r.response_text %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
       </fieldset>
     <% end %>
     <%= f.submit l10n("submit"), class: 'btn' + pundit_class(Family, :updateable?) %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187134369

# A brief description of the changes

Current behavior: Radio button has extra focuses

New behavior: focus on each set of questions instead of each radio button

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
![Screenshot 2024-06-03 at 4 56 02 PM](https://github.com/ideacrew/enroll/assets/45053146/e1a76cd9-426a-4235-aafc-d4e7f15cba83)
![Screenshot 2024-06-03 at 5 00 39 PM](https://github.com/ideacrew/enroll/assets/45053146/3e3d1db1-8205-4b4c-9718-48971531cddc)


