### PR TITLE
changes pundit authorization for endpoint and handle no family case

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -112,11 +112,14 @@ class ApplicationPolicy
   # It checks if the user has any active broker agency staff roles and if the user's family has an active broker agency account.
   # If both conditions are met, it checks if any of the user's broker agency staff roles
   # are associated with the broker agency profile of the family's active broker agency account.
+  # Additionally, it checks if the broker staff's benefit sponsors broker agency profile ID matches the broker agency's ID.
   #
   # @return [Boolean] Returns true if the user is an active associated individual market family broker staff, false otherwise.
   def active_associated_individual_market_family_broker_staff?
     broker_staffs = account_holder_person&.broker_agency_staff_roles&.active
     return false if broker_staffs.blank?
+
+    return false if family.blank?
 
     broker_agency_account = family.active_broker_agency_account
     return false if broker_agency_account.blank?

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -30,7 +30,7 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def can_download_document?
-    allowed_to_download?
+    can_download_sbc_documents?
   end
 
   def can_delete_document?

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
+  RSpec.describe ApplicationPolicy, type: :model do
+    subject { described_class }
+
+    permissions :active_associated_individual_market_family_broker_staff? do
+      context 'for case where the logged in user does not have a family' do
+        let(:market_kind) { :both }
+        let(:broker_person) { FactoryBot.create(:person) }
+        let(:broker_role) { FactoryBot.create(:broker_role, person: broker_person) }
+        let(:broker_staff_person) { FactoryBot.create(:person) }
+
+        let(:broker_staff_state) { 'active' }
+
+        let(:broker_staff) do
+          FactoryBot.create(
+            :broker_agency_staff_role,
+            person: broker_staff_person,
+            aasm_state: broker_staff_state,
+            benefit_sponsors_broker_agency_profile_id: broker_agency_id
+          )
+        end
+        let(:broker_staff_user) { FactoryBot.create(:user, person: broker_staff_person) }
+
+        let(:site) do
+          FactoryBot.create(
+            :benefit_sponsors_site,
+            :with_benefit_market,
+            :as_hbx_profile,
+            site_key: ::EnrollRegistry[:enroll_app].settings(:site_key).item
+          )
+        end
+
+        let(:broker_agency_organization) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+        let(:broker_agency_profile) { broker_agency_organization.broker_agency_profile }
+        let(:broker_agency_id) { broker_agency_profile.id }
+
+        before do
+          broker_role.update_attributes!(benefit_sponsors_broker_agency_profile_id: broker_agency_id)
+          broker_person.create_broker_agency_staff_role(
+            benefit_sponsors_broker_agency_profile_id: broker_role.benefit_sponsors_broker_agency_profile_id
+          )
+          broker_agency_profile.update_attributes!(primary_broker_role_id: broker_role.id, market_kind: market_kind)
+          broker_role.approve!
+          broker_staff
+        end
+
+        context 'when the broker agency staff does not belong to any family' do
+          it 'denies access' do
+            expect(subject).not_to permit(broker_staff_user, broker_person)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [Group Production Development - 187734165](https://www.pivotaltracker.com/story/show/187734165)

# A brief description of the changes

Current behavior: Missing family case raises internal server error.

New behavior: Gracefully handles missing family cases. Includes changes to pundit policy authorization for document download endpoint.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
