### PR TITLE
Fix broker unable to update employees bug

### DIFF
--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -96,8 +96,16 @@ class PersonPolicy < ApplicationPolicy
 
   private
 
+  # Determines if the current user has permission to show and update family(shop and ivl).
+  # an active associated broker, or an admin in the individual market and shop market,
+  #
+  # @return [Boolean] Returns true if the user has permission to show and update family, false otherwise.
   def allowed_to_modify?
-    allowed_to_access?
+    return true if allowed_to_access?
+    return true if active_associated_shop_market_family_broker?
+    return true if active_associated_shop_market_general_agency?
+
+    false
   end
 
   def allowed_to_download?

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_market.rb"
 require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_application.rb"
 
-RSpec.describe PersonPolicy, type: :policy do
+RSpec.describe PersonPolicy, type: :policy, dbclean: :after_each  do
   include_context "setup benefit market with market catalogs and product packages"
   include_context "setup initial benefit application"
 

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_market.rb"
+require "#{BenefitSponsors::Engine.root}/spec/shared_contexts/benefit_application.rb"
 
 RSpec.describe PersonPolicy, type: :policy do
+  include_context "setup benefit market with market catalogs and product packages"
+  include_context "setup initial benefit application"
+
   context 'with hbx_staff_role' do
     let(:record_person) {FactoryBot.create(:person)}
     let(:admin_person){FactoryBot.create(:person)}
@@ -129,6 +134,69 @@ RSpec.describe PersonPolicy, type: :policy do
       end
 
       context 'unauthorized broker' do
+        it 'broker should not be able to update' do
+          expect(policy.can_update?).to be false
+        end
+      end
+    end
+  end
+
+  context "when shop broker is logged in", :dbclean => :around_each do
+    let(:employee_person) {FactoryBot.create(:person, :with_employee_role, :with_family)}
+    let(:family) {employee_person.primary_family}
+    let(:household) { FactoryBot.create(:household, family: family)}
+    let!(:census_employee) { FactoryBot.create(:census_employee, :with_active_assignment, benefit_sponsorship: benefit_sponsorship, employer_profile: abc_profile, benefit_group: current_benefit_package) }
+    let!(:employee_role) { FactoryBot.create(:employee_role, person: employee_person, employer_profile: abc_profile, census_employee_id: census_employee.id) }
+    let(:broker_agency_profile) { FactoryBot.create(:benefit_sponsors_organizations_broker_agency_profile, market_kind: :shop) }
+    let!(:broker_role) { FactoryBot.create(:broker_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, aasm_state: "active", market_kind: 'both') }
+    let!(:broker_role_user) {FactoryBot.create(:user, :person => broker_role.person, roles: ['broker_role'])}
+    let!(:broker_agency_staff_role) { FactoryBot.create(:broker_agency_staff_role, benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id, aasm_state: 'active')}
+    let!(:broker_agency_staff_user) {FactoryBot.create(:user, :person => broker_agency_staff_role.person, roles: ['broker_agency_staff_role'])}
+
+    context "when broker role person is logged in" do
+      let(:policy) { PersonPolicy.new(broker_role_user, employee_person) }
+
+      context "when broker is hired by an employer for employee" do
+        before do
+          family.primary_person.active_employee_roles.first.employer_profile.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id,
+                                                                                                                                                          writing_agent_id: broker_role.id,
+                                                                                                                                                          start_on: Time.now,
+                                                                                                                                                          is_active: true)
+
+          family.save!
+        end
+
+        it 'broker should be able to update' do
+          expect(policy.can_update?).to be true
+        end
+      end
+
+      context "when broker is not hired by an employer" do
+        it 'broker should not be able to update' do
+          expect(policy.can_update?).to be false
+        end
+      end
+    end
+
+    context "when broker agency staff role is logged in" do
+      let(:policy) { PersonPolicy.new(broker_agency_staff_user, employee_person) }
+
+      context "when broker is hired by an employer for employee" do
+        before do
+          family.primary_person.active_employee_roles.first.employer_profile.broker_agency_accounts << BenefitSponsors::Accounts::BrokerAgencyAccount.new(benefit_sponsors_broker_agency_profile_id: broker_agency_profile.id,
+                                                                                                                                                          writing_agent_id: broker_role.id,
+                                                                                                                                                          start_on: Time.now,
+                                                                                                                                                          is_active: true)
+
+          family.save!
+        end
+
+        it 'broker should be able to update' do
+          expect(policy.can_update?).to be true
+        end
+      end
+
+      context "when broker is not hired by an employer" do
         it 'broker should not be able to update' do
           expect(policy.can_update?).to be false
         end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://redmine.priv.dchbx.org/issues/106122

# A brief description of the changes

Current behavior:
Brokers unable to update employee's details

New behavior:
Brokers and GAs are now able to update employee's details

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [x] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
