### PR TITLE
verify identity documents accessibility lift

### DIFF
--- a/app/javascript/css/forms.scss
+++ b/app/javascript/css/forms.scss
@@ -90,6 +90,17 @@ input[type="checkbox"] {
   }
 }
 
+.focus-btn {
+  &:active,
+  &:focus,
+  &:focus-within {
+    border-color: var(--button-primary-hover-color);
+    outline: 2px solid hsl(30, 3%, 12%);
+    outline: 2px solid var(--grey-190);
+    outline-offset: 2px;
+  }
+}
+
 input.full-width, select.full-width, .input.full-width {
   width: 100%;
 }

--- a/app/views/insured/fdsh_ridp_verifications/_insured_ridp_modal.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/_insured_ridp_modal.html.erb
@@ -21,7 +21,7 @@
             <%= form_tag insured_ridp_documents_upload_path, multipart: true do %>
               <fieldset>
                 <legend><%= l10n("insured.consumer_roles.upload_ridp_documents.document_type") %></legend>
-                <span>
+                <span class="focus">
                   <% element_name = "ridp_subject" %>
                   <% ridp_modal_options.each_with_index do |(option, input_value), index| %>
                     <div class="d-inline-flex flex-row-reverse align-items-center mb-2">

--- a/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
@@ -30,14 +30,14 @@
               <% end %>
               <% if ridp_type_unverified?(ridp_type, @person) %>
                 <% if ridp_type == 'Identity' %>
-                  <span class="btn btn-default btn-file" data-toggle="modal" data-target="#insured_ridp_modal" id ="upload_identity">
+                  <span tabindex="0" class="btn btn-default btn-file" data-toggle="modal" data-target="#insured_ridp_modal" id ="upload_identity">
                     <i class="fa fa-upload" aria-hidden="true"></i>
                     <%= l10n("insured.consumer_roles.upload_ridp_documents.upload_documents") %>
                   </span>
                   <%= render partial: 'insured/fdsh_ridp_verifications/insured_ridp_modal', :locals => {:ridp_type => ridp_type} %>
                 <% else %>
                   <%= form_tag insured_ridp_documents_upload_path, multipart: true, method: :post do %>
-                    <span class="btn btn-default btn-file" id ="upload_<%= ridp_type.downcase.gsub(' ', ' _') %>">
+                    <span tabindex="0" class="btn btn-default btn-file" id ="upload_<%= ridp_type.downcase.gsub(' ', ' _') %>">
                       <i class="fa fa-upload" aria-hidden="true"></i>
                       <%= l10n("insured.consumer_roles.upload_ridp_documents.upload_documents") %>
                       <%= file_field_tag "file[]", type: :file, accept: ::FileUploadValidator::VERIFICATION_DOC_TYPES.join(','), class: "doc-upload-file", :multiple => true, value: "Upload Documents" %>
@@ -114,7 +114,7 @@
                         <div class="v-type-upload col-md-4">
                           <% if ridp_type_unverified?(ridp_type, @person) %>
                             <% if ridp_type == 'Identity' %>
-                                <span class="btn btn-default btn-file" data-toggle="modal" data-target="#insured_ridp_modal" id ="upload_identity">
+                                <span tabindex="0" class="btn btn-default btn-file" data-toggle="modal" data-target="#insured_ridp_modal" id ="upload_identity">
                                   <i class="fa fa-upload" aria-hidden="true"></i>
                                   Upload Documents
                                 </span>

--- a/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
@@ -30,14 +30,14 @@
               <% end %>
               <% if ridp_type_unverified?(ridp_type, @person) %>
                 <% if ridp_type == 'Identity' %>
-                  <span tabindex="0" class="btn btn-default btn-file" data-toggle="modal" data-target="#insured_ridp_modal" id ="upload_identity">
+                  <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'upload_identity')" class="btn btn-default btn-file" data-toggle="modal" data-target="#insured_ridp_modal" id ="upload_identity">
                     <i class="fa fa-upload" aria-hidden="true"></i>
                     <%= l10n("insured.consumer_roles.upload_ridp_documents.upload_documents") %>
                   </span>
                   <%= render partial: 'insured/fdsh_ridp_verifications/insured_ridp_modal', :locals => {:ridp_type => ridp_type} %>
                 <% else %>
                   <%= form_tag insured_ridp_documents_upload_path, multipart: true, method: :post do %>
-                    <span tabindex="0" class="btn btn-default btn-file" id ="upload_<%= ridp_type.downcase.gsub(' ', ' _') %>">
+                    <span class="btn btn-default btn-file" id ="upload_<%= ridp_type.downcase.gsub(' ', ' _') %>">
                       <i class="fa fa-upload" aria-hidden="true"></i>
                       <%= l10n("insured.consumer_roles.upload_ridp_documents.upload_documents") %>
                       <%= file_field_tag "file[]", type: :file, accept: ::FileUploadValidator::VERIFICATION_DOC_TYPES.join(','), class: "doc-upload-file", :multiple => true, value: "Upload Documents" %>
@@ -114,7 +114,7 @@
                         <div class="v-type-upload col-md-4">
                           <% if ridp_type_unverified?(ridp_type, @person) %>
                             <% if ridp_type == 'Identity' %>
-                                <span tabindex="0" class="btn btn-default btn-file" data-toggle="modal" data-target="#insured_ridp_modal" id ="upload_identity">
+                                <span class="btn btn-default btn-file" data-toggle="modal" data-target="#insured_ridp_modal" id ="upload_identity">
                                   <i class="fa fa-upload" aria-hidden="true"></i>
                                   Upload Documents
                                 </span>

--- a/app/views/insured/interactive_identity_verifications/_insured_ridp_modal.html.erb
+++ b/app/views/insured/interactive_identity_verifications/_insured_ridp_modal.html.erb
@@ -21,7 +21,7 @@
             <%= form_tag insured_ridp_documents_upload_path, multipart: true do %>
               <fieldset>
                 <legend><%= l10n("insured.consumer_roles.upload_ridp_documents.document_type") %></legend>
-                <span>
+                <span class="focus">
                   <% element_name = "ridp_subject" %>
                   <% ridp_modal_options.each_with_index do |(option, input_value), index| %>
                     <div class="d-inline-flex flex-row-reverse align-items-center mb-2">
@@ -29,14 +29,14 @@
                       <div class="col-auto px-0"><%= radio_button_tag element_name, option, index == 0, value: input_value %></div>
                     </div>
                   <% end %>
-                </span>
+                </span class="focus">
               </fieldset>
               <div class="d-flex align-items-center mt-4 float-right">
                 <button type="button" class="btn outline mr-2" data-dismiss="modal"> <%= l10n("insured.consumer_roles.upload_ridp_documents.cancel") %> </button>
-                <button type="button" class="btn-default btn-file" id="select_upload_identity">
+                <button tabindex="-1" type="button" class="focus-btn btn-default btn-file" id="select_upload_identity">
                   <i class="fa fa-upload" aria-hidden="true"></i>
                   <%= l10n("insured.consumer_roles.upload_ridp_documents.select_file") %>
-                  <%= file_field_tag "file[]", type: :file, accept: ::FileUploadValidator::VERIFICATION_DOC_TYPES.join(','), class: "doc-upload-file", :multiple => true %>
+                  <%= file_field_tag "file[]", id:"upload_identity", type: :file, accept: ::FileUploadValidator::VERIFICATION_DOC_TYPES.join(','), class: "doc-upload-file",  :multiple => true, onkeydown:"handleButtonKeyDown(event, 'upload_identity')", tabindex:"0" %>
                 </button>
               </div>
               <%= hidden_field_tag 'ridp_verification_type', ridp_type  %>
@@ -57,15 +57,15 @@
           <div>
               <%= form_tag insured_ridp_documents_upload_path, multipart: true, method: :post do %>
                 <div class="text-center">
-                  <span class="btn btn-default btn-file" id="select_upload_identity">
+                  <span tabindex="-1" class="focus-btn btn btn-default btn-file" id="select_upload_identity">
                     <i class="fa fa-upload" aria-hidden="true"></i>
                     <label for="file_"><%= l10n("insured.consumer_roles.upload_ridp_documents.select_file") %></label>
-                    <%= file_field_tag "file[]", type: :file, accept: ::FileUploadValidator::VERIFICATION_DOC_TYPES.join(','), class: "doc-upload-file",  :multiple => true, value: "Upload Documents" %>
+                    <%= file_field_tag "file[]", type: :file, accept: ::FileUploadValidator::VERIFICATION_DOC_TYPES.join(','), class: "doc-upload-file",  :multiple => true, value: "Upload Documents", id:"upload_identity", onkeydown:"handleButtonKeyDown(event, 'upload_identity')", tabindex:"0" %>
                   </span>
                 </div>
                 <fieldset>
                   <legend for="ridp_subject"><%= l10n("insured.consumer_roles.upload_ridp_documents.id_type") %></legend>
-                  <span>
+                  <span class="focus">
                     <label class="mb-4" for="ridp_subject_Driver_s_License_issued_by_state_or_territory"><%= radio_button_tag 'ridp_subject', "Driver's License issued by state or territory", true %><%= l10n("insured.consumer_roles.upload_ridp_documents.driver_license") %></label>
                     <label class="mb-4" for="ridp_subject_School_identification_card"><%= radio_button_tag 'ridp_subject', 'School identification card', false %><%= l10n("insured.consumer_roles.upload_ridp_documents.school_id") %></label>
                     <label class="mb-4" for="ridp_subject_U.S._military_card_or_draft_record"><%= radio_button_tag 'ridp_subject', 'U.S. military card or draft record', false%><%= l10n("insured.consumer_roles.upload_ridp_documents.military_id") %></label>

--- a/app/views/insured/interactive_identity_verifications/_outstanding_ridp_documents.html.erb
+++ b/app/views/insured/interactive_identity_verifications/_outstanding_ridp_documents.html.erb
@@ -30,7 +30,7 @@
               <% end %>
               <% if ridp_type_unverified?(ridp_type, @person) %>
                 <% if ridp_type == 'Identity' %>
-                  <span class="btn btn-default btn-file" data-toggle="modal" data-target="#insured_ridp_modal" id ="upload_identity">
+                  <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'upload_identity')" class="btn btn-default btn-file" data-toggle="modal" data-target="#insured_ridp_modal" id ="upload_identity">
                     <i class="fa fa-upload" aria-hidden="true"></i>
                     <%= l10n("insured.consumer_roles.upload_ridp_documents.upload_documents") %>
                   </span>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187134387

# A brief description of the changes

Current behavior: Radio button has extra focuses in modal, upload documents button needs navigation, submit documents button needs focus and clickability

New behavior: Navigation improved, focus improved, enter button usage approved

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
![Screenshot 2024-06-05 at 9 04 32 AM](https://github.com/ideacrew/enroll/assets/45053146/bcac91c6-997b-45f3-a929-3518793e89e2)
![Screenshot 2024-06-05 at 9 06 48 AM](https://github.com/ideacrew/enroll/assets/45053146/e6746582-079c-4776-b91f-dfce111c6f89)

