### PR TITLE
disable call hub for AI/AN status

### DIFF
--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -252,7 +252,8 @@ module VerificationHelper
   end
 
   def build_admin_actions_list(v_type, f_member)
-    if f_member.consumer_role.aasm_state == 'unverified' || ['Alive Status', 'American Indian Status'].include?(v_type.type_name)
+    rejected_list = EnrollRegistry.feature_enabled?(:enable_call_hub_for_ai) ? ['Alive Status', 'American Indian Status'] : ['Alive Status']
+    if f_member.consumer_role.aasm_state == 'unverified' || rejected_list.include?(v_type.type_name)
       ::VlpDocument::ADMIN_VERIFICATION_ACTIONS.reject{ |el| el == 'Call HUB' }
     elsif verification_type_status(v_type, f_member) == 'outstanding'
       ::VlpDocument::ADMIN_VERIFICATION_ACTIONS.reject{|el| el == "Reject" }

--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -252,7 +252,7 @@ module VerificationHelper
   end
 
   def build_admin_actions_list(v_type, f_member)
-    rejected_list = EnrollRegistry.feature_enabled?(:enable_call_hub_for_ai) ? ['Alive Status', 'American Indian Status'] : ['Alive Status']
+    rejected_list = EnrollRegistry.feature_enabled?(:enable_call_hub_for_ai_an) ? ['Alive Status', 'American Indian Status'] : ['Alive Status']
     if f_member.consumer_role.aasm_state == 'unverified' || rejected_list.include?(v_type.type_name)
       ::VlpDocument::ADMIN_VERIFICATION_ACTIONS.reject{ |el| el == 'Call HUB' }
     elsif verification_type_status(v_type, f_member) == 'outstanding'

--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -252,7 +252,7 @@ module VerificationHelper
   end
 
   def build_admin_actions_list(v_type, f_member)
-    if f_member.consumer_role.aasm_state == 'unverified' || !VerificationType::ADMIN_CALL_HUB_VERIFICATION_TYPES.include?(v_type.type_name)
+    if f_member.consumer_role.aasm_state == 'unverified' || ['Alive Status', 'American Indian Status'].include?(v_type.type_name)
       ::VlpDocument::ADMIN_VERIFICATION_ACTIONS.reject{ |el| el == 'Call HUB' }
     elsif verification_type_status(v_type, f_member) == 'outstanding'
       ::VlpDocument::ADMIN_VERIFICATION_ACTIONS.reject{|el| el == "Reject" }

--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -252,7 +252,7 @@ module VerificationHelper
   end
 
   def build_admin_actions_list(v_type, f_member)
-    if f_member.consumer_role.aasm_state == 'unverified' || v_type.type_name == 'Alive Status'
+    if f_member.consumer_role.aasm_state == 'unverified' || !VerificationType::ADMIN_CALL_HUB_VERIFICATION_TYPES.include?(v_type.type_name)
       ::VlpDocument::ADMIN_VERIFICATION_ACTIONS.reject{ |el| el == 'Call HUB' }
     elsif verification_type_status(v_type, f_member) == 'outstanding'
       ::VlpDocument::ADMIN_VERIFICATION_ACTIONS.reject{|el| el == "Reject" }

--- a/app/models/verification_type.rb
+++ b/app/models/verification_type.rb
@@ -28,7 +28,7 @@ class VerificationType
 
   ALIVE_STATUS = 'Alive Status'.freeze
 
-  ADMIN_CALL_HUB_VERIFICATION_TYPES = ALL_VERIFICATION_TYPES - ["Alive Status"].freeze
+  ADMIN_CALL_HUB_VERIFICATION_TYPES = ALL_VERIFICATION_TYPES - ["Alive Status", "American Indian Status"].freeze
 
   NON_CITIZEN_IMMIGRATION_TYPES = [LOCATION_RESIDENCY, "Social Security Number", "American Indian Status"].freeze
   VALIDATION_STATES = %w[na unverified pending review outstanding verified attested expired curam rejected].freeze

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -907,4 +907,7 @@ registry:
       - key: :enable_alive_status
         item: :enable_alive_status
         is_enabled: <%= ENV['ENABLE_ALIVE_STATUS'] || false %>
+      - key: :enable_call_hub_for_ai
+        item: :enable_call_hub_for_ai
+        is_enabled: <%= ENV['ENABLE_CALL_HUB_FOR_AI'] || false %>
 

--- a/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/dc/system/config/templates/features/enroll_app/enroll_app.yml
@@ -907,7 +907,7 @@ registry:
       - key: :enable_alive_status
         item: :enable_alive_status
         is_enabled: <%= ENV['ENABLE_ALIVE_STATUS'] || false %>
-      - key: :enable_call_hub_for_ai
-        item: :enable_call_hub_for_ai
-        is_enabled: <%= ENV['ENABLE_CALL_HUB_FOR_AI'] || false %>
+      - key: :enable_call_hub_for_ai_an
+        item: :enable_call_hub_for_ai_an
+        is_enabled: <%= ENV['ENABLE_CALL_HUB_FOR_AI_AN'] || false %>
 

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -908,4 +908,7 @@ registry:
       - key: :enable_alive_status
         item: :enable_alive_status
         is_enabled: <%= ENV['ENABLE_ALIVE_STATUS'] || false %>
+      - key: :enable_call_hub_for_ai
+        item: :enable_call_hub_for_ai
+        is_enabled: <%= ENV['ENABLE_CALL_HUB_FOR_AI'] || false %>
 

--- a/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/config/client_config/me/system/config/templates/features/enroll_app/enroll_app.yml
@@ -908,7 +908,7 @@ registry:
       - key: :enable_alive_status
         item: :enable_alive_status
         is_enabled: <%= ENV['ENABLE_ALIVE_STATUS'] || false %>
-      - key: :enable_call_hub_for_ai
-        item: :enable_call_hub_for_ai
-        is_enabled: <%= ENV['ENABLE_CALL_HUB_FOR_AI'] || false %>
+      - key: :enable_call_hub_for_ai_an
+        item: :enable_call_hub_for_ai_an
+        is_enabled: <%= ENV['ENABLE_CALL_HUB_FOR_AI_AN'] || false %>
 

--- a/spec/helpers/verification_helper_spec.rb
+++ b/spec/helpers/verification_helper_spec.rb
@@ -600,7 +600,7 @@ RSpec.describe VerificationHelper, :type => :helper do
         allow(EnrollRegistry[:enroll_app].setting(:state_abbreviation)).to receive(:item).and_return('ME')
         person.update_attributes!(tribal_state: "ME", tribe_codes: ["", "PE"])
         person.save!
-        allow(EnrollRegistry[:enable_call_hub_for_ai].feature).to receive(:is_enabled).and_return(true)
+        allow(EnrollRegistry[:enable_call_hub_for_ai_an].feature).to receive(:is_enabled).and_return(true)
 
         allow(helper).to receive(:verification_type_status).and_return status
         allow(EnrollRegistry[:enable_alive_status].feature).to receive(:is_enabled).and_return(true)

--- a/spec/helpers/verification_helper_spec.rb
+++ b/spec/helpers/verification_helper_spec.rb
@@ -600,6 +600,7 @@ RSpec.describe VerificationHelper, :type => :helper do
         allow(EnrollRegistry[:enroll_app].setting(:state_abbreviation)).to receive(:item).and_return('ME')
         person.update_attributes!(tribal_state: "ME", tribe_codes: ["", "PE"])
         person.save!
+        allow(EnrollRegistry[:enable_call_hub_for_ai].feature).to receive(:is_enabled).and_return(true)
 
         allow(helper).to receive(:verification_type_status).and_return status
         allow(EnrollRegistry[:enable_alive_status].feature).to receive(:is_enabled).and_return(true)

--- a/spec/helpers/verification_helper_spec.rb
+++ b/spec/helpers/verification_helper_spec.rb
@@ -595,6 +595,12 @@ RSpec.describe VerificationHelper, :type => :helper do
   describe "#build_admin_actions_list" do
     shared_examples_for "admin actions dropdown list" do |type, status, state, actions|
       before do
+        allow(EnrollRegistry[:indian_alaskan_tribe_details].feature).to receive(:is_enabled).and_return(true)
+        allow(EnrollRegistry[:indian_alaskan_tribe_codes].feature).to receive(:is_enabled).and_return(true)
+        allow(EnrollRegistry[:enroll_app].setting(:state_abbreviation)).to receive(:item).and_return('ME')
+        person.update_attributes!(tribal_state: "ME", tribe_codes: ["", "PE"])
+        person.save!
+
         allow(helper).to receive(:verification_type_status).and_return status
         allow(EnrollRegistry[:enable_alive_status].feature).to receive(:is_enabled).and_return(true)
       end
@@ -614,6 +620,7 @@ RSpec.describe VerificationHelper, :type => :helper do
     it_behaves_like "admin actions dropdown list", EnrollRegistry[:enroll_app].setting(:state_residency).item, "outstanding", "verification_outstanding",["Verify", "View History", "Call HUB", "Extend"]
     it_behaves_like "admin actions dropdown list", EnrollRegistry[:enroll_app].setting(:state_residency).item, "in review","verification_outstanding", ["Verify", "Reject", "View History", "Call HUB", "Extend"]
     it_behaves_like "admin actions dropdown list", "Alive Status", "unverified", "verification_outstanding", ["Verify", "Reject", "View History", "Extend"]
+    it_behaves_like "admin actions dropdown list", "American Indian Status", "unverified", "verification_outstanding", ["Verify", "Reject", "View History", "Extend"]
   end
 
   describe "#request response details" do

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -907,4 +907,7 @@ registry:
       - key: :enable_alive_status
         item: :enable_alive_status
         is_enabled: <%= ENV['ENABLE_ALIVE_STATUS'] || false %>
+      - key: :enable_call_hub_for_ai
+        item: :enable_call_hub_for_ai
+        is_enabled: <%= ENV['ENABLE_CALL_HUB_FOR_AI'] || false %>
 

--- a/system/config/templates/features/enroll_app/enroll_app.yml
+++ b/system/config/templates/features/enroll_app/enroll_app.yml
@@ -907,7 +907,7 @@ registry:
       - key: :enable_alive_status
         item: :enable_alive_status
         is_enabled: <%= ENV['ENABLE_ALIVE_STATUS'] || false %>
-      - key: :enable_call_hub_for_ai
-        item: :enable_call_hub_for_ai
-        is_enabled: <%= ENV['ENABLE_CALL_HUB_FOR_AI'] || false %>
+      - key: :enable_call_hub_for_ai_an
+        item: :enable_call_hub_for_ai_an
+        is_enabled: <%= ENV['ENABLE_CALL_HUB_FOR_AI_AN'] || false %>
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/n/projects/2640060/stories/187652913

# A brief description of the changes

Current behavior:
Call HUB button is enabled from admin actions for AI/AN verification type.

New behavior:
Call HUB button is disabled from admin actions for AI/AN verification type.
added spec changes


# Feature Flag

Added new feature flag `enable_call_hub_for_ai_an`

`ENABLE_CALL_HUB_FOR_AI_AN` - should be enaled for ME
`ENABLE_CALL_HUB_FOR_AI_AN` - should be disabled for DC


For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
