### PR TITLE
fix faulty logic in assign_default_general_agency

### DIFF
--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/profiles/employers/broker_agency_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/profiles/employers/broker_agency_controller_spec.rb
@@ -263,7 +263,7 @@ module BenefitSponsors
           broker_agency_profile1.update_attributes!(default_general_agency_profile: general_agency.profiles.first)
           allow_any_instance_of(HbxStaffRole).to receive(:permission).and_return(double(modify_employer: true))
           sign_in(user_with_hbx_staff_role)
-          @request.env['HTTP_REFERER'] = "/benefit_sponsors/profiles/employers/employer_profiles/#{employer_profile.id.to_s}?tab=brokers"
+          @request.env['HTTP_REFERER'] = "/benefit_sponsors/profiles/employers/employer_profiles/#{employer_profile.id}?tab=brokers"
           post :create, params: {employer_profile_id: employer_profile.id, broker_role_id: broker_role1.id, broker_agency_id: broker_agency_profile1.id}
         end
 

--- a/components/benefit_sponsors/spec/controllers/benefit_sponsors/profiles/employers/broker_agency_controller_spec.rb
+++ b/components/benefit_sponsors/spec/controllers/benefit_sponsors/profiles/employers/broker_agency_controller_spec.rb
@@ -25,6 +25,8 @@ module BenefitSponsors
     let!(:person2) { FactoryBot.create(:person) }
     let!(:broker_role2) { FactoryBot.create(:broker_role, aasm_state: 'active', benefit_sponsors_broker_agency_profile_id: broker_agency_profile2.id, person: person2) }
 
+    let!(:general_agency) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_general_agency_profile, site: site) }
+
     let!(:user_with_hbx_staff_role) { FactoryBot.create(:user, :with_hbx_staff_role) }
     let!(:person) { FactoryBot.create(:person, user: user_with_hbx_staff_role )}
     let(:broker_managenement_form_class) { BenefitSponsors::Organizations::OrganizationForms::BrokerManagementForm }
@@ -253,6 +255,24 @@ module BenefitSponsors
 
         it 'should assign broker_agency_profile variable' do
           expect(assigns(:broker_agency_profile)).to eq broker_agency_profile1
+        end
+      end
+
+      context 'broker agency has a default general agency' do
+        before do
+          broker_agency_profile1.update_attributes!(default_general_agency_profile: general_agency.profiles.first)
+          allow_any_instance_of(HbxStaffRole).to receive(:permission).and_return(double(modify_employer: true))
+          sign_in(user_with_hbx_staff_role)
+          @request.env['HTTP_REFERER'] = "/benefit_sponsors/profiles/employers/employer_profiles/#{employer_profile.id.to_s}?tab=brokers"
+          post :create, params: {employer_profile_id: employer_profile.id, broker_role_id: broker_role1.id, broker_agency_id: broker_agency_profile1.id}
+        end
+
+        it 'should assign the default_ga to the employer' do
+          pdo = ::SponsoredBenefits::Organizations::PlanDesignOrganization.where(
+            owner_profile_id: broker_agency_profile1.id,
+            has_active_broker_relationship: true
+          ).first
+          expect(pdo.active_general_agency_account.present?).to eq true
         end
       end
     end

--- a/components/benefit_sponsors/spec/dummy/config/initializers/save_user.rb
+++ b/components/benefit_sponsors/spec/dummy/config/initializers/save_user.rb
@@ -1,0 +1,8 @@
+class SAVEUSER
+  def self.[]=(key, value)
+  end
+
+
+  def self.[](key)
+  end
+end

--- a/components/sponsored_benefits/app/models/sponsored_benefits/services/general_agency_manager.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/services/general_agency_manager.rb
@@ -45,7 +45,7 @@ module SponsoredBenefits
           plan_design_organization(id).general_agency_accounts.active.each do |account|
             account.terminate!
             employer_profile = account.plan_design_organization.employer_profile
-            if employer_profile
+            if employer_profile && account&.general_agency_profile
               send_message({
                 employer_profile: employer_profile,
                 general_agency_profile: account.general_agency_profile,

--- a/components/sponsored_benefits/app/models/sponsored_benefits/services/general_agency_manager.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/services/general_agency_manager.rb
@@ -45,15 +45,12 @@ module SponsoredBenefits
           plan_design_organization(id).general_agency_accounts.active.each do |account|
             account.terminate!
             employer_profile = account.plan_design_organization.employer_profile
-            if employer_profile && account&.general_agency_profile
-              send_message({
-                employer_profile: employer_profile,
-                general_agency_profile: account.general_agency_profile,
-                broker_agency_profile: account.broker_agency_profile,
-                status: 'Terminate'
-              })
-              notify("acapi.info.events.employer.general_agent_terminated", {timestamp: Time.now.to_i, employer_id: employer_profile.hbx_id, event_name: "general_agent_terminated"})
-            end
+            next unless employer_profile && account&.general_agency_profile
+            send_message({ employer_profile: employer_profile,
+                           general_agency_profile: account.general_agency_profile,
+                           broker_agency_profile: account.broker_agency_profile,
+                           status: 'Terminate' })
+            notify("acapi.info.events.employer.general_agent_terminated", {timestamp: Time.now.to_i, employer_id: employer_profile.hbx_id, event_name: "general_agent_terminated"})
           end
         end
       end

--- a/components/sponsored_benefits/app/models/sponsored_benefits/services/general_agency_manager.rb
+++ b/components/sponsored_benefits/app/models/sponsored_benefits/services/general_agency_manager.rb
@@ -35,7 +35,8 @@ module SponsoredBenefits
         return true if broker_agency_profile.default_general_agency_profile_id.blank?
         broker_role_id = broker_agency_profile.primary_broker_role.id
         ids.each do |id|
-          create_general_agency_account(id, broker_role_id, start_on, broker_agency_profile.default_general_agency_profile_id, broker_agency_profile.id) if plan_design_organization(id).active_general_agency_account.present?
+          next if plan_design_organization(id).active_general_agency_account.present?
+          create_general_agency_account(id, broker_role_id, start_on, broker_agency_profile.default_general_agency_profile_id, broker_agency_profile.id)
         end
       end
 

--- a/spec/models/subscribers/default_ga_changed_spec.rb
+++ b/spec/models/subscribers/default_ga_changed_spec.rb
@@ -46,10 +46,10 @@ describe Subscribers::DefaultGaChanged do
         pdo.update(has_active_broker_relationship: true)
         pdo.general_agency_accounts.delete_all
         expect(pdo.active_general_agency_account).to eq nil
-        expect(subject.service).not_to receive(:send_message)
+        expect(subject.service).to receive(:send_message)
         subject.call(nil, nil, nil, nil, message)
         pdo.reload
-        expect(pdo.active_general_agency_account).to eq nil
+        expect(pdo.active_general_agency_account.general_agency_profile).to eq new_ga
       end
 
       it "should do not change when employer_profile have active general_agency_profile" do
@@ -57,7 +57,7 @@ describe Subscribers::DefaultGaChanged do
         expect(subject.service).not_to receive(:send_message)
         subject.call(nil, nil, nil, nil, message)
         pdo_with_ga.reload
-        expect(pdo_with_ga.active_general_agency_account).not_to eq new_ga
+        expect(pdo_with_ga.active_general_agency_account.general_agency_profile).not_to eq new_ga
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
[101340](https://redmine.priv.dchbx.org/issues/101340)

# A brief description of the changes

Current behavior:
When an employer hires a broker agency, the default general agency is only assigned if an existing PDO with that employer, broker, and GA exists.

New behavior:
When an employer hires a broker agency, the default general agency is assigned and the PDO is created if one does not already exist.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
