### PR TITLE
accessibility error on flash, remove mailing button color, mailing address title added 

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -879,13 +879,11 @@ document.addEventListener('click', function(event) {
     const addButton = event.target;
     addButton.classList.add('d-none');
     const removeButton = addButton.cloneNode(true);
-    console.log(removeButton);
     removeButton.textContent = 'Remove Mailing Address';
     removeButton.id = 'remove_mailing_address';
-    removeButton.classList.add('interaction-click-control-remove-mailing-address');
-    removeButton.classList.remove("d-none", "interaction-click-control-add-mailing-address");
+    removeButton.classList.add('interaction-click-control-remove-mailing-address', 'error');
+    removeButton.classList.remove("d-none", "btn-secondary", "interaction-click-control-add-mailing-address");
     addButton.parentNode.insertBefore(removeButton, addButton);
-    console.log(removeButton);
     document.querySelectorAll(".mailing-div").forEach(el => {
       el.classList.remove('d-none');
       el.classList.add('d-block');

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -7,7 +7,7 @@
       <div class="col my-1 mr-auto p-0 align-self-center">
         <%= raw message %>
       </div>
-      <a class="close-icon icon pr-1 align-self-start" alt="Close" href="#">&nbsp;</a>
+      <a class="close-icon icon pr-1 align-self-start" alt="Close" href="#">&nbsp;<span class="sr-only">Close</span></a>
     </div>
   </div>
 <% else %>

--- a/app/views/shared/_consumer_home_address_fields.html.erb
+++ b/app/views/shared/_consumer_home_address_fields.html.erb
@@ -16,9 +16,9 @@
       <% required = kind =='home' ? "address_required" : '' %>
       <div class="address-row <%= div_class %> <%= display_class %>">
         <% if kind == 'home' %>
-          <i class="fa fa-info-circle"></i> <%=l10n("insured.primary_home_address_info")%>
+          <i class="fa fa-info-circle"></i> <%= l10n("insured.primary_home_address_info") %>
         <% elsif kind == 'mailing' %>
-          <div><strong class="mt-4"><%=l10n("insured.enter_mailing_address")%></strong></div>
+          <h4 class="gamma"><%= l10n("insured.consumer_roles.mailing_address") %></h4>
           <i class="fa fa-info-circle"></i> <%=l10n("insured.primary_mailing_address_info")%>
         <% end %>
       </div>
@@ -104,10 +104,10 @@
     <% end %>
   </div>
   <% if f.object.addresses[1].present? %>
-  <button class="form-action btn-secondary <%= pundit_class Family, :updateable?%>" id="remove_mailing_address" data-cuke="remove_mailing_address">Remove Mailing Address</button>
-  <button id="add_mailing_address" class="form-action btn-secondary <%= pundit_class Family, :updateable?%> mb-4 d-none">Add Mailing Address</button>
+    <button class="form-action btn-error <%= pundit_class Family, :updateable?%>" id="remove_mailing_address" data-cuke="remove_mailing_address">Remove Mailing Address</button>
+    <button id="add_mailing_address" class="form-action btn-secondary <%= pundit_class Family, :updateable?%> mb-4 d-none">Add Mailing Address</button>
   <% else %>
-  <button id="add_mailing_address" class="form-action btn-secondary <%= pundit_class Family, :updateable?%> mb-4">Add Mailing Address</button>
+    <button id="add_mailing_address" class="form-action btn-secondary <%= pundit_class Family, :updateable?%> mb-4">Add Mailing Address</button>
   <% end %>
   <div class="mt-2">&nbsp;</div>
 <% else %>

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -635,6 +635,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.dependent_home_address_info' => "<strong>The home address is where this person legally resides.</strong> If they want to receive mail at another address such as an office or a PO Box, Select 'Add Mailing Address'",
   :'en.insured.dependent_mailing_address_info' => "This is the <strong>address where this person wants to have their mail delivered.</strong> It may be the same or different from their home address.",
   :'en.insured.enter_home_address' => "Enter your home address",
+  :'en.insured.mailing_address' => "Mailing Address",
   :'en.insured.enter_mailing_address' => "Enter a mailing address",
   :'en.insured.review_information' => "I have reviewed the information in this application and I attest, under penalty of perjury, that it is accurate and complete to the best of my knowledge. I understand that if I’m not truthful, there may be a penalty, including retroactive termination of my coverage and an obligation to repay all medical claims previous covered by the health insurance.",
   :'en.insured.us_citizen' => "Is this person a US citizen or US national?",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -639,6 +639,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.dependent_home_address_info' => "<strong>The home address is where this person legally resides.</strong> If they want to receive mail at another address such as an office or a PO Box, Select 'Add Mailing Address'",
   :'en.insured.dependent_mailing_address_info' => "This is the <strong>address where this person wants to have their mail delivered.</strong> It may be the same or different from their home address.",
   :'en.insured.enter_home_address' => "Enter your home address",
+  :'en.insured.mailing_address' => "Mailing Address",
   :'en.insured.enter_mailing_address' => "Enter a mailing address",
   :'en.insured.review_information' => "I have reviewed the information in this application and I attest, under penalty of perjury, that it is accurate and complete to the best of my knowledge. I understand that if I’m not truthful, there may be a penalty.",
   :'en.insured.us_citizen' => "Is this person a US citizen or US national?",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
* https://www.pivotaltracker.com/story/show/187750374
* https://www.pivotaltracker.com/story/show/187736298
* https://www.pivotaltracker.com/story/show/187736325

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
