### PR TITLE
update work phone details on the person when broker agency phone info is updated

### DIFF
--- a/components/benefit_sponsors/spec/models/benefit_sponsors/organizations/factories/profile_factory_spec.rb
+++ b/components/benefit_sponsors/spec/models/benefit_sponsors/organizations/factories/profile_factory_spec.rb
@@ -470,7 +470,7 @@ module BenefitSponsors
                       :_destroy => "false",
                       :phone_attributes =>
                       {
-                        :kind => "phone main",
+                        :kind => "work",
                         :area_code => "879",
                         :number => phone_number,
                         :extension => "",
@@ -531,6 +531,11 @@ module BenefitSponsors
 
         it 'should update address' do
           expect(broker_organization.broker_agency_profile.primary_office_location.address.city).to eq city
+        end
+
+        it 'should update work phone number on the person' do
+          person.reload
+          expect(person.work_phone.number).to eq phone_number
         end
 
         context 'update npn' do
@@ -635,7 +640,7 @@ module BenefitSponsors
                       :_destroy => "false",
                       :phone_attributes =>
                       {
-                        :kind => "phone main",
+                        :kind => "work",
                         :area_code => "786",
                         :number => phone_number,
                         :extension => "",
@@ -677,6 +682,11 @@ module BenefitSponsors
 
         it 'should update address' do
           expect(general_agency.general_agency_profile.primary_office_location.address.city).to eq city
+        end
+
+        it 'should update work phone number on the person' do
+          person.reload
+          expect(person.work_phone.number).to eq phone_number
         end
       end
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [X] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/187764591

# A brief description of the changes

Current behavior:  When the Broker agency updates its phone number, the number associated with the Primary broker is not being updated. This results in an inconsistent phone number being displayed on the Broker agency page under the staff section as well as on the 'Get Help Signing Up' page.

New behavior: Update Primary broker phone number whenever Broker agency updates it's phone number

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
