### PR TITLE
display alive status if consumer has atleast one outstanding status

### DIFF
--- a/app/helpers/verifications/alive_status_helper.rb
+++ b/app/helpers/verifications/alive_status_helper.rb
@@ -7,15 +7,20 @@ module Verifications
     # this verification type should always be visible to admin
     # but should only display for consumers/brokers/broker agency staff if the validation_status is 'outstanding'
     def can_display_or_modify_type?(verif_type)
-      return true unless verif_type&.type_name == 'Alive Status'
+      return true unless alive_status_type?(verif_type)
       return false unless EnrollRegistry.feature_enabled?(:alive_status)
-      return true if current_user.has_hbx_staff_role?
-
-      previous_states = verif_type&.type_history_elements&.pluck(:from_validation_status)&.compact
-      return true if previous_states&.include?('outstanding')
-      return true if verif_type&.validation_status == 'outstanding'
+      return true if current_user.has_hbx_staff_role? || outstanding_status?(verif_type)
 
       false
+    end
+
+    def alive_status_type?(verif_type)
+      verif_type&.type_name == 'Alive Status'
+    end
+
+    def outstanding_status?(verif_type)
+      previous_states = verif_type&.type_history_elements&.pluck(:from_validation_status, :to_validation_status)&.flatten&.compact
+      previous_states&.include?('outstanding') || verif_type&.validation_status == 'outstanding'
     end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
