### PR TITLE
using valid cv3 family

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: fc3e633fd733c0bc97b74f208d548e165bcdff33
+  revision: c47cda5288f4d47f5f728c879821982b1757d80a
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/domain/operations/families/verifications/dmf_determination/build_cv3_family_payload_for_dmf.rb
+++ b/app/domain/operations/families/verifications/dmf_determination/build_cv3_family_payload_for_dmf.rb
@@ -28,7 +28,7 @@ module Operations
             valid_cv3_family = yield validate_cv3_family(cv3_family)
 
             yield validate_all_family_members(valid_cv3_family)
-            result = yield confirm_transmittable_payload(cv3_family)
+            result = yield confirm_transmittable_payload(valid_cv3_family)
 
             Success(result)
           end
@@ -93,8 +93,8 @@ module Operations
             states.any?(&:is_eligible?)
           end
 
-          def confirm_transmittable_payload(cv3_family)
-            payload = { family_hash: cv3_family.to_h, job_id: @job.job_id }
+          def confirm_transmittable_payload(valid_cv3_family)
+            payload = { family_hash: valid_cv3_family.to_h, job_id: @job.job_id }
 
             @transaction.json_payload = payload
             @transaction.save


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187810670

# A brief description of the changes

Current behavior: using cv3_hash to be saved on transaction.

New behavior: Uses validated Family CV Payload to persist on the Transaction and use the same payload for publishing the event.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
