### PR TITLE
fix popover / tooltips not showing

### DIFF
--- a/app/views/shared/_glossary.html.erb
+++ b/app/views/shared/_glossary.html.erb
@@ -7,30 +7,19 @@
 <span class="glossary"
       tabindex="0"
       data-toggle="popover"
+      data-animation="false"
       data-placement="auto top"
       data-trigger="click focus"
-      data-boundary="window"
-      data-fallbackPlacement="flip"
-      data-html="true"
       data-content="<%= t('glossary.' + key) %>"
       data-title="<%= term_display %>">
-  <button data-dismiss='modal'
-    type='button'
-    class='close'
-    aria-label='Close'
-    onclick="$('.glossary').popover('hide');">
-  </button>
   <%= term_display %>
 </span>
 
 <script>
-$(document).click(function(e){
-  if (e.target.className == 'glossary') {
-    e.preventDefault();
-    $('.glossary').not($(e.target)).popover('hide');
-  }
-  else if (!$(e.target).parents('.popover').length) {
-    $('.glossary').popover('hide');
-  }
-});
+$(function () {
+  $('[data-toggle="popover"]').popover()
+})
+$('[data-toggle="popover"]').popover({
+  trigger: 'focus'
+})
 </script>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 187807869

# A brief description of the changes

Current behavior: popovers are not showing

New behavior: popovers now show

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
