### PR TITLE
fetches user active roles from person instead of legacy user roles

### DIFF
--- a/app/models/effective/datatables/user_account_datatable.rb
+++ b/app/models/effective/datatables/user_account_datatable.rb
@@ -10,7 +10,7 @@ module Effective
         table_column :hbx_id, :label => 'HBX ID', :proc => Proc.new { |row| row.person.hbx_id if row.person.present?}, :filter => false, :sortable => false
         table_column :email, :label => 'USER EMAIL', :proc => Proc.new { |row| row.email }, :filter => false, :sortable => false
         table_column :status, :label => 'Status', :proc => Proc.new { |row| status(row) }, :filter => false, :sortable => false
-        table_column :role_type, :label => 'Role Type', :proc => Proc.new { |row| row.roles.join(', ') }, :filter => false, :sortable => false
+        table_column :role_type, :label => 'Role Type', :proc => proc { |row| all_roles(row) }, :filter => false, :sortable => false
         table_column :permission, :label => 'Permission level', :proc => Proc.new { |row| permission_type(row) }, :filter => false, :sortable => false
         table_column :actions, :width => '50px', :proc => Proc.new { |row|
                                dropdown = []
@@ -73,6 +73,14 @@ module Effective
       def authorized?(current_user, _controller, _action, _resource)
         return nil unless current_user
         HbxProfilePolicy.new(current_user, nil).can_access_user_account_tab?
+      end
+
+      # Concatenates all active role names of a given user into a single comma-separated string.
+      #
+      # @param user [User] The user whose active roles are to be concatenated.
+      # @return [String] A comma-separated string of all active role names for the user.
+      def all_roles(user)
+        user.all_active_role_names.join(', ')
       end
     end
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1387,7 +1387,58 @@ class Person
     Operations::People::BuildDemographicsGroup.new.call(self)
   end
 
+  # Returns a list of all active role names for the person.
+  # This method caches the result to avoid recalculating the active roles on subsequent calls.
+  #
+  # @return [Array<String>] An array of strings representing the active roles.
+  def all_active_role_names
+    return @all_active_role_names if defined?(@all_active_role_names)
+
+    @all_active_role_names = role_names_based_on_status_of_roles
+  end
+
   private
+
+  # Determines the active roles based on specific conditions for each role.
+  # It utilizes a hash where each key is a role (localized string) and its value is a boolean
+  # indicating whether the role is active or not. Only roles with true conditions are kept.
+  #
+  # @return [Array<String>] An array of strings representing the active roles.
+  def role_names_based_on_status_of_roles
+    {
+      l10n('user_roles.assister') => assister_role.present?,
+      l10n('user_roles.broker') => active_broker_role?,
+      l10n('user_roles.broker_agency_staff') => has_active_broker_staff_role?,
+      l10n('user_roles.consumer') => active_consumer_role?,
+      l10n('user_roles.csr') => csr_role.present?,
+      l10n('user_roles.employee') => has_active_employee_role?,
+      l10n('user_roles.employer_staff') => has_active_employer_staff_role?,
+      l10n('user_roles.general_agency_staff') => has_active_general_agency_staff_role?,
+      l10n('user_roles.hbx_staff') => hbx_staff_role.present?,
+      l10n('user_roles.resident') => active_resident_role?
+    }.select { |_role, condition| condition }.keys
+  end
+
+  # Checks if the resident role is active.
+  #
+  # @return [Boolean] True if the resident role is present and active, false otherwise.
+  def active_resident_role?
+    resident_role.present? && is_resident_role_active?
+  end
+
+  # Checks if the consumer role is active.
+  #
+  # @return [Boolean] True if the consumer role is present and active, false otherwise.
+  def active_consumer_role?
+    consumer_role.present? && is_consumer_role_active?
+  end
+
+  # Checks if the broker role is active.
+  #
+  # @return [Boolean] True if the broker role is present and active, false otherwise.
+  def active_broker_role?
+    broker_role&.active?
+  end
 
   def assign(collection, association)
     collection.each do |attributes|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -294,6 +294,17 @@ class User
     end
   end
 
+  # Retrieves all active role names for the associated person.
+  # This method caches the result to minimize database queries on subsequent calls.
+  # If the person is nil, it returns an empty array.
+  #
+  # @return [Array<String>] An array of strings representing the names of all active roles.
+  def all_active_role_names
+    return @all_active_role_names if defined?(@all_active_role_names)
+
+    @all_active_role_names = person&.all_active_role_names || []
+  end
+
   private
   # Remove indexed, unique, empty attributes from document
   def strip_empty_fields

--- a/db/seedfiles/translations/en/cca/user_roles.rb
+++ b/db/seedfiles/translations/en/cca/user_roles.rb
@@ -1,0 +1,21 @@
+# This hash maps user role identifiers to their human-readable translations.
+# It is used throughout the application to display user roles in a more understandable format.
+# Each key follows the pattern 'en.user_roles.<role_identifier>' to denote that these are English translations
+# for user roles. The value associated with each key is the translated string that represents the user role in English.
+#
+# @example How to access a translation by using the L10nHelper module:
+#   include L10nHelper
+#   # This will return 'Assister'
+#   l10n('user_roles.assister') # => 'Assister'
+USER_ROLES_TRANSLATIONS = {
+  'en.user_roles.assister' => 'Assister',
+  'en.user_roles.broker' => 'Broker',
+  'en.user_roles.broker_agency_staff' => 'Broker Agency Staff',
+  'en.user_roles.consumer' => 'Consumer',
+  'en.user_roles.csr' => 'CSR',
+  'en.user_roles.employee' => 'Employee',
+  'en.user_roles.employer_staff' => 'Employer Staff',
+  'en.user_roles.general_agency_staff' => 'General Agency Staff',
+  'en.user_roles.hbx_staff' => 'HBX Staff',
+  'en.user_roles.resident' => 'Resident'
+}

--- a/db/seedfiles/translations/en/dc/user_roles.rb
+++ b/db/seedfiles/translations/en/dc/user_roles.rb
@@ -1,0 +1,21 @@
+# This hash maps user role identifiers to their human-readable translations.
+# It is used throughout the application to display user roles in a more understandable format.
+# Each key follows the pattern 'en.user_roles.<role_identifier>' to denote that these are English translations
+# for user roles. The value associated with each key is the translated string that represents the user role in English.
+#
+# @example How to access a translation by using the L10nHelper module:
+#   include L10nHelper
+#   # This will return 'Assister'
+#   l10n('user_roles.assister') # => 'Assister'
+USER_ROLES_TRANSLATIONS = {
+  'en.user_roles.assister' => 'Assister',
+  'en.user_roles.broker' => 'Broker',
+  'en.user_roles.broker_agency_staff' => 'Broker Agency Staff',
+  'en.user_roles.consumer' => 'Consumer',
+  'en.user_roles.csr' => 'CSR',
+  'en.user_roles.employee' => 'Employee',
+  'en.user_roles.employer_staff' => 'Employer Staff',
+  'en.user_roles.general_agency_staff' => 'General Agency Staff',
+  'en.user_roles.hbx_staff' => 'HBX Staff',
+  'en.user_roles.resident' => 'Resident'
+}

--- a/db/seedfiles/translations/en/ic/user_roles.rb
+++ b/db/seedfiles/translations/en/ic/user_roles.rb
@@ -1,0 +1,21 @@
+# This hash maps user role identifiers to their human-readable translations.
+# It is used throughout the application to display user roles in a more understandable format.
+# Each key follows the pattern 'en.user_roles.<role_identifier>' to denote that these are English translations
+# for user roles. The value associated with each key is the translated string that represents the user role in English.
+#
+# @example How to access a translation by using the L10nHelper module:
+#   include L10nHelper
+#   # This will return 'Assister'
+#   l10n('user_roles.assister') # => 'Assister'
+USER_ROLES_TRANSLATIONS = {
+  'en.user_roles.assister' => 'Assister',
+  'en.user_roles.broker' => 'Broker',
+  'en.user_roles.broker_agency_staff' => 'Broker Agency Staff',
+  'en.user_roles.consumer' => 'Consumer',
+  'en.user_roles.csr' => 'CSR',
+  'en.user_roles.employee' => 'Employee',
+  'en.user_roles.employer_staff' => 'Employer Staff',
+  'en.user_roles.general_agency_staff' => 'General Agency Staff',
+  'en.user_roles.hbx_staff' => 'HBX Staff',
+  'en.user_roles.resident' => 'Resident'
+}

--- a/db/seedfiles/translations/en/me/user_roles.rb
+++ b/db/seedfiles/translations/en/me/user_roles.rb
@@ -1,0 +1,21 @@
+# This hash maps user role identifiers to their human-readable translations.
+# It is used throughout the application to display user roles in a more understandable format.
+# Each key follows the pattern 'en.user_roles.<role_identifier>' to denote that these are English translations
+# for user roles. The value associated with each key is the translated string that represents the user role in English.
+#
+# @example How to access a translation by using the L10nHelper module:
+#   include L10nHelper
+#   # This will return 'Assister'
+#   l10n('user_roles.assister') # => 'Assister'
+USER_ROLES_TRANSLATIONS = {
+  'en.user_roles.assister' => 'Assister',
+  'en.user_roles.broker' => 'Broker',
+  'en.user_roles.broker_agency_staff' => 'Broker Agency Staff',
+  'en.user_roles.consumer' => 'Consumer',
+  'en.user_roles.csr' => 'CSR',
+  'en.user_roles.employee' => 'Employee',
+  'en.user_roles.employer_staff' => 'Employer Staff',
+  'en.user_roles.general_agency_staff' => 'General Agency Staff',
+  'en.user_roles.hbx_staff' => 'HBX Staff',
+  'en.user_roles.resident' => 'Resident'
+}

--- a/spec/models/effective/datatable/user_account_datatable_spec.rb
+++ b/spec/models/effective/datatable/user_account_datatable_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Effective::Datatables::UserAccountDatatable do
+  describe '#all_roles' do
+    let(:user) { FactoryBot.create(:user) }
+
+    context 'when the user has active roles' do
+      before do
+        allow(user).to receive(:all_active_role_names).and_return(['admin', 'editor'])
+      end
+
+      it 'returns a comma-separated string of active roles' do
+        expect(subject.all_roles(user)).to eq('admin, editor')
+      end
+    end
+
+    context 'when the user has no active roles' do
+      before do
+        allow(user).to receive(:all_active_role_names).and_return([])
+      end
+
+      it 'returns an empty string' do
+        expect(subject.all_roles(user)).to eq('')
+      end
+    end
+  end
+end

--- a/spec/models/person_roles_spec.rb
+++ b/spec/models/person_roles_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Person, type: :model do
+  describe '#all_active_role_names' do
+    let(:person) { FactoryBot.create(:person) }
+
+    before do
+      allow(person).to receive(:assister_role).and_return(double('AssisterRole', present?: true))
+      allow(person).to receive(:active_broker_role?).and_return(true)
+      allow(person).to receive(:has_active_broker_staff_role?).and_return(false)
+      allow(person).to receive(:active_consumer_role?).and_return(true)
+      allow(person).to receive(:csr_role).and_return(double('CsrRole', present?: false))
+      allow(person).to receive(:has_active_employee_role?).and_return(true)
+      allow(person).to receive(:has_active_employer_staff_role?).and_return(false)
+      allow(person).to receive(:has_active_general_agency_staff_role?).and_return(true)
+      allow(person).to receive(:hbx_staff_role).and_return(double('HbxStaffRole', present?: true))
+      allow(person).to receive(:active_resident_role?).and_return(false)
+    end
+
+    it 'returns an array of all active roles' do
+      expect(person.all_active_role_names).to match_array(
+        [
+          l10n('user_roles.assister'),
+          l10n('user_roles.broker'),
+          l10n('user_roles.consumer'),
+          l10n('user_roles.employee'),
+          l10n('user_roles.general_agency_staff'),
+          l10n('user_roles.hbx_staff')
+        ]
+      )
+    end
+
+    it 'caches the result to avoid recalculating' do
+      expect(person).to receive(:role_names_based_on_status_of_roles).once.and_call_original
+      2.times { person.all_active_role_names }
+    end
+  end
+end

--- a/spec/models/user_roles_spec.rb
+++ b/spec/models/user_roles_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe '#all_active_role_names' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:person) { double('Person') }
+
+    context 'when person is present' do
+      before do
+        allow(user).to receive(:person).and_return(person)
+        allow(person).to receive(:all_active_role_names).and_return(['Broker', 'Consumer'])
+      end
+
+      it 'returns all active roles from the person' do
+        expect(user.all_active_role_names).to eq(['Broker', 'Consumer'])
+      end
+
+      it 'caches the result to avoid recalculating' do
+        expect(person).to receive(:all_active_role_names).once.and_return(['Broker', 'Consumer'])
+        2.times { user.all_active_role_names }
+      end
+    end
+
+    context 'when person is not present' do
+      before do
+        allow(user).to receive(:person).and_return(nil)
+      end
+
+      it 'returns an empty array' do
+        expect(user.all_active_role_names).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [Pod of War - 187811366](https://www.pivotaltracker.com/story/show/187811366)

# A brief description of the changes

Current behavior: Roles displayed for the `Role Type` table column in the User Account Data Table are fetched from legacy User role types.

New behavior: Roles displayed for the `Role Type` table column in the User Account Data Table are fetched from the Person object that matches our roles and usage across the Enroll Application.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
