### PR TITLE
remove enrollment already purchased warning message

### DIFF
--- a/app/controllers/insured/plan_shoppings_controller.rb
+++ b/app/controllers/insured/plan_shoppings_controller.rb
@@ -329,7 +329,6 @@ class Insured::PlanShoppingsController < ApplicationController
   def check_enrollment_state
     return if @hbx_enrollment.shopping?
 
-    flash[:notice] = l10n("insured.active_enrollment_warning")
     redirect_to receipt_insured_plan_shopping_path(change_plan: params[:change_plan], enrollment_kind: params[:enrollment_kind])
   end
 

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -573,7 +573,6 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.ssn_configuration_warning' => "This Social Security Number and Date-of-Birth is invalid in our records.  Please verify the entry, and if correct, contact the DC Customer help center at %{site_phone_number}.",
   :'en.insured.match_person.ssn_dob_name_error' => "This Social Security Number, Date-of-Birth and Name are invalid in our records. Please verify the entry, and if correct, contact the %{contact_center_name} at %{contact_center_phone_number}.",
   :'en.insured.out_of_state_error_message' => "Address is out of state or the supported area, please review your application details to update your address",
-    :'en.insured.active_enrollment_warning' => "Your enrollment has been submitted and cannot be changed by clicking the back button. To make any changes, continue to your account.",
   :'en.enrollment.details.header' => 'Enrollment Detail',
   :'en.enrollment.members.header' => 'Enrollment Member Detail',
   :'en.enrollment.effective_on' => 'Effective Date: ',

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -572,7 +572,6 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.ssn_configuration_warning' => "Please check your information and try again. If you’ve already done an application with Healthcare.gov, the Maine Office for Family Independence, or %{site_short_name}, you’ll need to enter your information the same way here. If you have questions, call the %{site_short_name} Consumer Assistance Center at %{site_phone_number} TTY: %{site_tty_number}.",
   :'en.insured.match_person.ssn_dob_name_error' => "Please check your information and try again. If you’ve already done an application with Healthcare.gov, the Maine Office for Family Independence, or %{site_short_name}, you’ll need to enter your information the same way here. If you have questions, call the %{contact_center_name} at %{contact_center_phone_number} TTY: %{contact_center_tty_number}.",
   :'en.insured.out_of_state_error_message' => "Address is out of state or the supported area, please review your application details to update your address",
-  :'en.insured.active_enrollment_warning' => "Your enrollment has been submitted and cannot be changed by clicking the back button. To make any changes, continue to your account.",
   :'en.enrollment.details.header' => 'Enrollment Detail',
   :'en.enrollment.members.header' => 'Enrollment Member Detail',
   :'en.enrollment.effective_on' => 'Effective Date: ',

--- a/features/insured/individual_plan_shopping.feature
+++ b/features/insured/individual_plan_shopping.feature
@@ -14,4 +14,4 @@ Feature: Consumer plan shopping
     And I click on purchase confirm button for matched person
     Then I should see pay now button
     When user clicks browser back button
-    Then user should redirect to receipt page and should see a flash message
+    Then user should redirect to receipt page

--- a/features/insured/step_definitions/individual_steps.rb
+++ b/features/insured/step_definitions/individual_steps.rb
@@ -45,9 +45,8 @@ When(/(.*) clicks browser back button/) do |_name|
   @browser.execute_script('window.history.back()')
 end
 
-Then(/(.*) should redirect to receipt page and should see a flash message/) do |_name|
+Then(/(.*) should redirect to receipt page/) do |_name|
   expect(page).to have_content("Enrollment Submitted")
-  expect(page).to have_content(l10n("insured.active_enrollment_warning"))
 end
 
 Then(/(.*) should see family members page and clicks continue/) do |_name|


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [X] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/187779869

# A brief description of the changes

Current behavior: Displaying a warning message if a user tries to go back from the enrollment submitted page using the browser back button

New behavior: Do not display warning message 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
