### PR TITLE
change condition for CreateEligibility

### DIFF
--- a/app/domain/operations/eligibilities/build_family_determination.rb
+++ b/app/domain/operations/eligibilities/build_family_determination.rb
@@ -46,7 +46,7 @@ module Operations
         if (is_any_member_applying_for_coverage && primary_person.consumer_role.present?) || values[:is_migrating]
           BuildDetermination.new.call(subjects: subjects, effective_date: values[:effective_date], family: family)
         else
-          Failure("Person don't have consumer role or is not applying for coverage")
+          Failure("The Create Eligibility tool cannot be used because the consumer is not applying for coverage.")
         end
       end
 

--- a/app/domain/operations/tax_household_groups/create_eligibility.rb
+++ b/app/domain/operations/tax_household_groups/create_eligibility.rb
@@ -24,7 +24,6 @@ module Operations
       def validate(params)
         return Failure('Invalid params. family should be an instance of family') unless params[:family].is_a?(Family)
         return Failure('Missing th_group_info') unless params[:th_group_info]
-        return Failure('The Create Eligibility tool cannot be used because the consumer is not applying for coverage.') unless params[:family].family_members.find(&:is_primary_applicant).is_applying_coverage
 
         Success(params)
       end

--- a/app/domain/operations/tax_household_groups/create_eligibility.rb
+++ b/app/domain/operations/tax_household_groups/create_eligibility.rb
@@ -24,8 +24,7 @@ module Operations
       def validate(params)
         return Failure('Invalid params. family should be an instance of family') unless params[:family].is_a?(Family)
         return Failure('Missing th_group_info') unless params[:th_group_info]
-        return Failure('The Create Eligibility tool cannot be used because the consumer is not applying for coverage.') unless params[:family].family_members.find(&:is_primary_applicant).is_coverage_applicant
-
+        return Failure('The Create Eligibility tool cannot be used because the consumer is not applying for coverage.') unless params[:family].family_members.find(&:is_primary_applicant).is_applying_coverage
 
         Success(params)
       end

--- a/features/admin/step_definitions/admin_create_eligibility_steps.rb
+++ b/features/admin/step_definitions/admin_create_eligibility_steps.rb
@@ -2,7 +2,7 @@
 
 Given(/^a consumer exists without coverage$/) do
   user :with_consumer_role
-  user.primary_family.family_members.find(&:is_primary_applicant).update_attributes!(is_coverage_applicant: false)
+  # user.primary_family.family_members.find(&:is_primary_applicant).update_attributes!(is_applying_coverage: false)
 end
 
 When(/^Hbx Admin clicks on Create Eligibility$/) do

--- a/features/admin/step_definitions/admin_create_eligibility_steps.rb
+++ b/features/admin/step_definitions/admin_create_eligibility_steps.rb
@@ -2,7 +2,7 @@
 
 Given(/^a consumer exists without coverage$/) do
   user :with_consumer_role
-  # user.primary_family.family_members.find(&:is_primary_applicant).update_attributes!(is_applying_coverage: false)
+  user.primary_family.family_members.find(&:is_primary_applicant).person.consumer_role.update_attributes!(is_applying_coverage: false)
 end
 
 When(/^Hbx Admin clicks on Create Eligibility$/) do

--- a/spec/domain/operations/tax_household_groups/create_eligibility_spec.rb
+++ b/spec/domain/operations/tax_household_groups/create_eligibility_spec.rb
@@ -82,7 +82,9 @@ RSpec.describe ::Operations::TaxHouseholdGroups::CreateEligibility, dbclean: :af
     end
 
     it 'should return error message' do
-      primary_fm.update_attributes(is_coverage_applicant: false)
+      family.family_members.each do |fm|
+        fm.person.consumer_role.update_attributes!(is_applying_coverage: false)
+      end
       result = subject.call(params)
       expect(result.failure?).to eq true
       expect(result.failure).to eq "The Create Eligibility tool cannot be used because the consumer is not applying for coverage."


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:  updates for ticket https://www.pivotaltracker.com/n/projects/2640060/stories/187796392

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
