### PR TITLE
display failure message when family determination is not recreated

### DIFF
--- a/app/controllers/exchanges/hbx_profiles_controller.rb
+++ b/app/controllers/exchanges/hbx_profiles_controller.rb
@@ -756,17 +756,17 @@ class Exchanges::HbxProfilesController < ApplicationController
     if EnrollRegistry.feature_enabled?(:temporary_configuration_enable_multi_tax_household_feature)
       @element_to_replace_id = params[:tax_household_group][:family_actions_id]
       family = Person.find(params[:tax_household_group][:person_id]).primary_family
-      result = ::Operations::TaxHouseholdGroups::CreateEligibility.new.call({
-                                                                     family: family,
-                                                                     th_group_info: params.require(:tax_household_group).permit(
-                                                                       :person_id,
-                                                                       :family_actions_id,
-                                                                       :effective_date,
-                                                                       :tax_households => {}
-                                                                     ).to_h
-                                                                   })
+      result = ::Operations::TaxHouseholdGroups::CreateEligibility.new.call(
+        {
+          family: family,
+          th_group_info: params.require(:tax_household_group).permit(
+            :person_id, :family_actions_id, :effective_date, tax_households: {}
+          ).to_h
+        }
+      )
+
       @result = if result.success?
-                  { success: true, message: l10n('eligibility.created') }
+                  { success: true, message: result.success }
                 else
                   { success: false, error: result.failure }
                 end

--- a/app/domain/operations/eligibilities/build_family_determination.rb
+++ b/app/domain/operations/eligibilities/build_family_determination.rb
@@ -3,17 +3,11 @@
 require 'dry/monads'
 require 'dry/monads/do'
 
-# eligibility_items_requested = [
-#   aptc_csr_credit: {
-#     evidence_items: [:esi_evidence]
-#   }
-# ]
-
 module Operations
   module Eligibilities
     # Build determination for subjects passed with effective date
     class BuildFamilyDetermination
-      send(:include, Dry::Monads[:result, :do])
+      include Dry::Monads[:do, :result]
 
       # @param [Hash] opts Options to build determination
       # @option opts [Family] :family required
@@ -46,7 +40,9 @@ module Operations
         if (is_any_member_applying_for_coverage && primary_person.consumer_role.present?) || values[:is_migrating]
           BuildDetermination.new.call(subjects: subjects, effective_date: values[:effective_date], family: family)
         else
-          Failure("The Create Eligibility tool cannot be used because the consumer is not applying for coverage.")
+          Failure(
+            "Determination cannot be built as None of the family members are applying for coverage or Primary person's Consumer Role is missing."
+          )
         end
       end
 

--- a/app/domain/operations/tax_household_groups/create_eligibility.rb
+++ b/app/domain/operations/tax_household_groups/create_eligibility.rb
@@ -5,9 +5,16 @@ require 'dry/monads/do'
 
 module Operations
   module TaxHouseholdGroups
-    # this operation is to create eligibility
+    # Creates a new financial assistance eligibility for a family.
+    #
+    # This operation is specifically used by the Hbx Admin to establish a new eligibility instance for a family.
+    # It is applicable only under the Tax Model 2.0 and when the feature `:temporary_configuration_enable_multi_tax_household_feature` is enabled.
+    # The process involves deactivating the current eligibility, if any, and then creating a new one.
+    #
+    # @note This operation is only applicable for Tax Model 2.0 when the feature `:temporary_configuration_enable_multi_tax_household_feature` is enabled.
     class CreateEligibility
-      send(:include, Dry::Monads[:result, :do])
+      include Dry::Monads[:do, :result]
+      include L10nHelper
 
       def call(params)
         values = yield validate(params)
@@ -16,7 +23,7 @@ module Operations
         yield create_family_determination
         yield create_new_enrollments
 
-        Success()
+        Success(l10n('create_eligibility_tool.success_message'))
       end
 
       private
@@ -24,6 +31,7 @@ module Operations
       def validate(params)
         return Failure('Invalid params. family should be an instance of family') unless params[:family].is_a?(Family)
         return Failure('Missing th_group_info') unless params[:th_group_info]
+        return Failure(l10n('create_eligibility_tool.no_members_applying_coverage')) if params[:family].none_applying_coverage?
 
         Success(params)
       end
@@ -32,11 +40,13 @@ module Operations
         @family = values[:family]
         @effective_date = Date.strptime(values[:th_group_info][:effective_date], '%m/%d/%Y')
 
-        ::Operations::TaxHouseholdGroups::Deactivate.new.call({
-                                                                deactivate_action_type: 'current_only',
-                                                                family: @family,
-                                                                new_effective_date: @effective_date
-                                                              })
+        ::Operations::TaxHouseholdGroups::Deactivate.new.call(
+          {
+            deactivate_action_type: 'current_only',
+            family: @family,
+            new_effective_date: @effective_date
+          }
+        )
       end
 
       def create_taxhousehold_group(th_group_info)
@@ -50,7 +60,7 @@ module Operations
       def create_new_enrollments
         return Success() unless EnrollRegistry.feature_enabled?(:apply_aggregate_to_enrollment)
 
-        ::Operations::Individual::OnNewDetermination.new.call({family: @family.reload, year: @effective_date.year})
+        ::Operations::Individual::OnNewDetermination.new.call({ family: @family.reload, year: @effective_date.year })
         Success()
       end
     end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -1502,7 +1502,18 @@ class Family
     end
   end
 
-private
+  # Checks if none of the active family members are applying for coverage.
+  #
+  # This method iterates through all active family members and returns true if none
+  # of them are applying for coverage, otherwise false.
+  #
+  # @return [Boolean] true if no active family member is applying for coverage, false otherwise.
+  def none_applying_coverage?
+    active_family_members.none?(&:is_applying_coverage)
+  end
+
+  private
+
   def build_household
     if households.size == 0
       irs_group = initialize_irs_group

--- a/db/seedfiles/translations/en/cca/create_eligibility_tool.rb
+++ b/db/seedfiles/translations/en/cca/create_eligibility_tool.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Translations for Create Eligibility Tool
+CREATE_ELIGIBILITY_TOOL_TRANSLATIONS = {
+  :'en.create_eligibility_tool.success_message' => 'THH & Eligibility created successfully',
+  :'en.create_eligibility_tool.no_members_applying_coverage' => 'The Create Eligibility tool cannot be used because the consumer is not applying for coverage.'
+}.freeze

--- a/db/seedfiles/translations/en/dc/create_eligibility_tool.rb
+++ b/db/seedfiles/translations/en/dc/create_eligibility_tool.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Translations for Create Eligibility Tool
+CREATE_ELIGIBILITY_TOOL_TRANSLATIONS = {
+  :'en.create_eligibility_tool.success_message' => 'THH & Eligibility created successfully',
+  :'en.create_eligibility_tool.no_members_applying_coverage' => 'The Create Eligibility tool cannot be used because the consumer is not applying for coverage.'
+}.freeze

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -603,6 +603,5 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.',
   :'en.insured.general_agency_index_disabled_warning' => 'The General Agency Index is Disabled',
   :'en.insured.employer_datatable_disabled_warning' => 'The Employer Data Table is Disabled',
-  :'en.insured.plan_shopping.thankyou.agreement_terms_conditions' => 'You must complete Agreement and Terms and Conditions sections to continue.',
-  :'en.eligibility.created' => 'THH & Eligibility created successfully.'
+  :'en.insured.plan_shopping.thankyou.agreement_terms_conditions' => 'You must complete Agreement and Terms and Conditions sections to continue.'
 }.freeze

--- a/db/seedfiles/translations/en/ic/create_eligibility_tool.rb
+++ b/db/seedfiles/translations/en/ic/create_eligibility_tool.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Translations for Create Eligibility Tool
+CREATE_ELIGIBILITY_TOOL_TRANSLATIONS = {
+  :'en.create_eligibility_tool.success_message' => 'THH & Eligibility created successfully',
+  :'en.create_eligibility_tool.no_members_applying_coverage' => 'The Create Eligibility tool cannot be used because the consumer is not applying for coverage.'
+}.freeze

--- a/db/seedfiles/translations/en/me/create_eligibility_tool.rb
+++ b/db/seedfiles/translations/en/me/create_eligibility_tool.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Translations for Create Eligibility Tool
+CREATE_ELIGIBILITY_TOOL_TRANSLATIONS = {
+  :'en.create_eligibility_tool.success_message' => 'THH & Eligibility created successfully',
+  :'en.create_eligibility_tool.no_members_applying_coverage' => 'The Create Eligibility tool cannot be used because the consumer is not applying for coverage.'
+}.freeze

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -601,6 +601,5 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.existing_person_record_warning_message' => 'Person is already affiliated with another account.',
   :'en.insured.general_agency_index_disabled_warning' => 'The General Agency Index is Disabled',
   :'en.insured.employer_datatable_disabled_warning' => 'The Employer Data Table is Disabled',
-  :'en.insured.plan_shopping.thankyou.agreement_terms_conditions' => 'You must complete Agreement and Terms and Conditions sections to continue.',
-  :'en.eligibility.created' => 'THH & Eligibility created successfully.'
+  :'en.insured.plan_shopping.thankyou.agreement_terms_conditions' => 'You must complete Agreement and Terms and Conditions sections to continue.'
 }.freeze

--- a/features/admin/step_definitions/admin_create_eligibility_steps.rb
+++ b/features/admin/step_definitions/admin_create_eligibility_steps.rb
@@ -40,5 +40,3 @@ end
 Then(/^Hbx Admin see error message$/) do
   expect(page).to have_content("Error: The Create Eligibility tool cannot be used because the consumer is not applying for coverage.")
 end
-
-

--- a/spec/domain/operations/eligibilities/build_family_determination_spec.rb
+++ b/spec/domain/operations/eligibilities/build_family_determination_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe ::Operations::Eligibilities::BuildFamilyDetermination,
   let(:required_params) { { family: family, effective_date: effective_date } }
 
   before do
+    allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
     [
       :financial_assistance,
       :'gid://enroll_app/Family',
@@ -151,7 +152,7 @@ RSpec.describe ::Operations::Eligibilities::BuildFamilyDetermination,
       :health_product_enrollment_status,
       :dental_product_enrollment_status
     ].each do |feature_key|
-      EnrollRegistry[feature_key].feature.stub(:is_enabled).and_return(true)
+      allow(EnrollRegistry).to receive(:feature_enabled?).with(feature_key).and_return(true)
     end
   end
 
@@ -197,6 +198,9 @@ RSpec.describe ::Operations::Eligibilities::BuildFamilyDetermination,
       result = subject.call(required_params)
       expect(result.success?).to be_falsey
       expect(result.success).not_to be_a(Eligibilities::Determination)
+      expect(result.failure).to eq(
+        "Determination cannot be built as None of the family members are applying for coverage or Primary person's Consumer Role is missing."
+      )
     end
   end
 

--- a/spec/domain/operations/tax_household_groups/create_eligibility_spec.rb
+++ b/spec/domain/operations/tax_household_groups/create_eligibility_spec.rb
@@ -8,97 +8,131 @@ RSpec.describe ::Operations::TaxHouseholdGroups::CreateEligibility, dbclean: :af
     expect(subject.respond_to?(:call)).to be_truthy
   end
 
-  let(:params) do
-    { family: family, th_group_info: tax_household_group.deep_symbolize_keys! }
-  end
-
-  let(:family) do
-    family = FactoryBot.build(:family, person: primary)
-    family.family_members = [
-      FactoryBot.build(:family_member, is_primary_applicant: true, is_active: true, family: family, person: primary),
-      FactoryBot.build(:family_member, is_primary_applicant: false, is_active: true, family: family, person: dependent1),
-      FactoryBot.build(:family_member, is_primary_applicant: false, is_active: true, family: family, person: dependent2)
-    ]
-
-    family.person.person_relationships.push PersonRelationship.new(relative_id: dependent1.id, kind: 'spouse')
-    family.person.person_relationships.push PersonRelationship.new(relative_id: dependent2.id, kind: 'child')
-    family.save
-    family
-  end
-
-  let(:primary_fm) { family.primary_applicant }
-  let(:dependents) { family.dependents }
-
-  let(:primary) { FactoryBot.create(:person, :with_consumer_role) }
-  let(:dependent1) { FactoryBot.create(:person, :with_consumer_role) }
-  let(:dependent2) { FactoryBot.create(:person, :with_consumer_role) }
-
-  let(:tax_household_group) do
-    {
-      "person_id" => primary.id.to_s,
-      "family_actions_id" => "family_actions_#{family.id}",
-      "effective_date" => TimeKeeper.date_of_record.to_s,
-      "tax_households" => {
-        "0" => {
-          "members" => [
-            {
-              "pdc_type" => "is_ia_eligible",
-              "csr" => "100",
-              "is_filer" => "on",
-              "member_name" => "Ivl ivl",
-              "family_member_id" => primary_fm.id.to_s
-            },
-            {
-              "pdc_type" => "is_ia_eligible",
-              "csr" => "87",
-              "is_filer" => nil,
-              "member_name" => "Spouse spouse",
-              "family_member_id" => dependents[0].id.to_s
-            }
-          ].to_json,
-          "monthly_expected_contribution" => "400"
-        },
-        "1" => {
-          "members" => [
-            {
-              "pdc_type" => "is_ia_eligible",
-              "csr" => "94",
-              "is_filer" => "on",
-              "member_name" => "Child child",
-              "family_member_id" => dependents[1].id.to_s
-            }
-          ].to_json,
-          "monthly_expected_contribution" => "300"
-        }
-      }
-    }
-  end
-
   describe 'invalid params' do
-    it 'should return failure' do
-      params = {}
-      result = subject.call(params)
-      expect(result.failure?).to eq true
+
+    let(:params) do
+      {}
     end
 
-    it 'should return error message' do
-      family.family_members.each do |fm|
-        fm.person.consumer_role.update_attributes!(is_applying_coverage: false)
-      end
+    it 'should return failure' do
       result = subject.call(params)
       expect(result.failure?).to eq true
-      expect(result.failure).to eq "The Create Eligibility tool cannot be used because the consumer is not applying for coverage."
     end
   end
 
   describe 'valid params' do
+    let(:params) do
+      { family: family, th_group_info: tax_household_group.deep_symbolize_keys! }
+    end
 
+    let(:family) do
+      family = FactoryBot.build(:family, person: primary)
+      family.family_members = [
+        FactoryBot.build(:family_member, is_primary_applicant: true, is_active: true, family: family, person: primary),
+        FactoryBot.build(:family_member, is_primary_applicant: false, is_active: true, family: family, person: dependent1),
+        FactoryBot.build(:family_member, is_primary_applicant: false, is_active: true, family: family, person: dependent2)
+      ]
+
+      family.person.person_relationships.push PersonRelationship.new(relative_id: dependent1.id, kind: 'spouse')
+      family.person.person_relationships.push PersonRelationship.new(relative_id: dependent2.id, kind: 'child')
+      family.save
+      family
+    end
+
+    let(:primary_fm) { family.primary_applicant }
+    let(:dependents) { family.dependents }
+
+    let(:primary) { FactoryBot.create(:person, :with_consumer_role) }
+    let(:dependent1) { FactoryBot.create(:person, :with_consumer_role) }
+    let(:dependent2) { FactoryBot.create(:person, :with_consumer_role) }
+
+    let(:tax_household_group) do
+      {
+        "person_id" => primary.id.to_s,
+        "family_actions_id" => "family_actions_#{family.id}",
+        "effective_date" => TimeKeeper.date_of_record.to_s,
+        "tax_households" => {
+          "0" => {
+            "members" => [
+              {
+                "pdc_type" => "is_ia_eligible",
+                "csr" => "100",
+                "is_filer" => "on",
+                "member_name" => "Ivl ivl",
+                "family_member_id" => primary_fm.id.to_s
+              },
+              {
+                "pdc_type" => "is_ia_eligible",
+                "csr" => "87",
+                "is_filer" => nil,
+                "member_name" => "Spouse spouse",
+                "family_member_id" => dependents[0].id.to_s
+              }
+            ].to_json,
+            "monthly_expected_contribution" => "400"
+          },
+          "1" => {
+            "members" => [
+              {
+                "pdc_type" => "is_ia_eligible",
+                "csr" => "94",
+                "is_filer" => "on",
+                "member_name" => "Child child",
+                "family_member_id" => dependents[1].id.to_s
+              }
+            ].to_json,
+            "monthly_expected_contribution" => "300"
+          }
+        }
+      }
+    end
 
     it 'should create grants' do
       subject.call(params)
       eligibility_determination = family.reload.eligibility_determination
 
       expect(eligibility_determination.grants.size).to eq 2
+    end
+  end
+
+  describe '#call' do
+    let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+
+    let(:spouse_person) do
+      per = FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role)
+      person.ensure_relationship_with(per, 'spouse')
+      per
+    end
+
+    let(:child_person) do
+      per = FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role)
+      person.ensure_relationship_with(per, 'child')
+      per
+    end
+
+    let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person) }
+    let(:spouse_member) { FactoryBot.create(:family_member, family: family, person: spouse_person, is_active: spouse_member_active) }
+    let(:child_member) { FactoryBot.create(:family_member, family: family, person: child_person) }
+
+    let(:params) do
+      { family: spouse_member.family, th_group_info: {} }
+    end
+
+    context 'with:
+      - none of the active family members are applying for coverage
+      - spouse_member is applying for coverage but is a destroyed member(not an active family member)
+    ' do
+
+      let(:spouse_member_active) { false }
+
+      before do
+        child_member.person.consumer_role.update_attributes(is_applying_coverage: false)
+        person.consumer_role.update_attributes(is_applying_coverage: false)
+      end
+
+      it 'returns a failure monad' do
+        expect(subject.call(params).failure).to eq(l10n('create_eligibility_tool.no_members_applying_coverage'))
+      end
     end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, the reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard-coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [Pod of War - 187796392](https://www.pivotaltracker.com/story/show/187796392)

# A brief description of the changes

Current behavior: The Create Eligibility tool always displays a success message, regardless of whether the eligibility is created or not.

New behavior: The Create Eligibility tool displays a success message only when the financial assistance determination is created and all the subsequent steps are successful. This tool now displays a failure message if there is a failure. Also, as per the ticket's request, a specific failure is displayed when none of the active family members are applying for coverage.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
