### PR TITLE
adds alive status check to transform applicant to member class

### DIFF
--- a/app/domain/operations/people/build_demographics_group.rb
+++ b/app/domain/operations/people/build_demographics_group.rb
@@ -26,6 +26,7 @@ module Operations
       end
 
       def build_demographics_group(person)
+        return unless EnrollRegistry.feature_enabled?(:alive_status)
         person.demographics_group = DemographicsGroup.new if person.demographics_group.blank?
         build_alive_status(person.demographics_group)
 

--- a/app/domain/operations/people/transform_applicant_to_member.rb
+++ b/app/domain/operations/people/transform_applicant_to_member.rb
@@ -60,12 +60,15 @@ module Operations
           immigration_documents_attributes: [vlp_document_hash].reject(&:empty?)
         }
         person_hash[:consumer_role][:immigration_documents_attributes] = [] if person_hash[:consumer_role][:citizen_status] == 'us_citizen'
-        person_hash[:demographics_group] = {
-          alive_status: {
-            is_deceased: false,
-            date_of_death: nil
+
+        if EnrollRegistry.feature_enabled?(:alive_status)
+          person_hash[:demographics_group] = {
+            alive_status: {
+              is_deceased: false,
+              date_of_death: nil
+            }
           }
-        }
+        end
 
         Success(person_hash)
       end

--- a/spec/domain/operations/families/create_or_update_member_spec.rb
+++ b/spec/domain/operations/families/create_or_update_member_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe Operations::Families::CreateOrUpdateMember, type: :model, dbclean
   context '#create member' do
     context 'success' do
       before do
+        allow(EnrollRegistry[:alive_status].feature).to receive(:is_enabled).and_return(true)
+
         @result = subject.call(params)
         family.reload
         @person = Person.by_hbx_id(applicant_params[:person_hbx_id]).first

--- a/spec/domain/operations/people/build_demographics_group_spec.rb
+++ b/spec/domain/operations/people/build_demographics_group_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 # spec for testing Operations::People::BuildDemographicsGroup
 describe Operations::People::BuildDemographicsGroup, dbclean: :after_each do
+  before do
+    allow(EnrollRegistry[:alive_status].feature).to receive(:is_enabled).and_return(true)
+  end
+
   context 'a user without a consumer_role' do
     let(:person) { FactoryBot.create(:person, :with_broker_role) }
 

--- a/spec/domain/operations/people/transform_applicant_to_member_spec.rb
+++ b/spec/domain/operations/people/transform_applicant_to_member_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Operations::People::TransformApplicantToMember, dbclean: :after_e
 
     context 'success' do
       before do
+        allow(EnrollRegistry[:alive_status].feature).to receive(:is_enabled).and_return(true)
+
         @result = described_class.new.call(params)
       end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187856469

# A brief description of the changes

Current behavior: No check run for applicants being created as family members

New behavior: Check added for applicants being created as family members

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
