### PR TITLE
Adds optimistic coverage attestation for applicants.

### DIFF
--- a/app/domain/operations/people/create_or_update_consumer_role.rb
+++ b/app/domain/operations/people/create_or_update_consumer_role.rb
@@ -11,7 +11,7 @@ module Operations
       def call(params:)
         values = yield validate(params[:applicant_params])
         entity = yield create_entity(values)
-        result = yield create_consumer_role(entity, params[:family_member])
+        result = yield create_consumer_role(entity, params[:family_member], optimistic_upstream_interpretation: params[:optimistic_upstream_coverage_attestation_interpretation])
 
         Success(result)
       end
@@ -34,13 +34,18 @@ module Operations
         Success(result)
       end
 
-      def create_consumer_role(entity, family_member)
+      def create_consumer_role(entity, family_member, optimistic_upstream_interpretation: false)
         person = family_member.person
         if person.consumer_role.present?
           consumer_role_params = entity.to_h
           consumer_role = person.consumer_role
           return Success(consumer_role) if consumer_role.citizen_status == consumer_role_params[:citizen_status] && consumer_role.is_applying_coverage == consumer_role_params[:is_applying_coverage]
-          person.consumer_role.assign_attributes(consumer_role_params)
+          if optimistic_upstream_interpretation && !entity.is_applying_coverage
+            updated_params = entity.to_h.except(:is_applying_coverage)
+            person.consumer_role.assign_attributes(updated_params)
+          else
+            person.consumer_role.assign_attributes(consumer_role_params)
+          end
         else
           person.build_consumer_role({:is_applicant => false}.merge(entity.to_h))
         end

--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -228,7 +228,13 @@ module FinancialAssistance
             # assign_citizen_status
             params = applicant_params.except("lawful_presence_determination")
             merge_params = params.merge(citizen_status: applicant_params["lawful_presence_determination"]["citizen_status"])
-            ::Operations::People::CreateOrUpdateConsumerRole.new.call(params: { applicant_params: merge_params, family_member: family_member })
+            ::Operations::People::CreateOrUpdateConsumerRole.new.call(
+              params: {
+                applicant_params: merge_params,
+                family_member: family_member,
+                optimistic_upstream_coverage_attestation_interpretation: EnrollRegistry.feature_enabled?(:optimistic_upstream_coverage_attestation)
+              }
+            )
           rescue StandardError => e
             Failure("create_or_update_consumer_role: #{e}")
           end

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -174,6 +174,8 @@ registry:
       is_enabled: <%= ENV['LOAD_COUNTY_ON_INBOUND_TRANSFER_IS_ENABLED'] || false %>
     - key: :automatic_submission
       is_enabled: <%= ENV['AUTOMATIC_SUBMISSION_IS_ENABLED'] || false %>
+    - key: :optimistic_upstream_coverage_attestation
+      is_enabled: <%= ENV['OPTIMISTIC_UPSTREAM_COVERAGE_ATTESTATION_IS_ENABLED'] || false %>
   - namespace:
     - :documents
     features:

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -174,6 +174,8 @@ registry:
       is_enabled: <%= ENV['LOAD_COUNTY_ON_INBOUND_TRANSFER_IS_ENABLED'] || true %>
     - key: :automatic_submission
       is_enabled: <%= ENV['AUTOMATIC_SUBMISSION_IS_ENABLED'] || false %>
+    - key: :optimistic_upstream_coverage_attestation
+      is_enabled: <%= ENV['OPTIMISTIC_UPSTREAM_COVERAGE_ATTESTATION_IS_ENABLED'] || false %>
   - namespace:
     - :documents
     features:

--- a/spec/domain/operations/people/create_or_update_consumer_role_spec.rb
+++ b/spec/domain/operations/people/create_or_update_consumer_role_spec.rb
@@ -65,3 +65,63 @@ RSpec.describe ::Operations::People::CreateOrUpdateConsumerRole, dbclean: :after
     end
   end
 end
+
+RSpec.describe ::Operations::People::CreateOrUpdateConsumerRole, "given:
+  - an existing person
+  - an existing consumer role
+  - the existing consumer role has 'Y' for is applying coverage
+  - the incoming application value is 'N' for applying coverage
+  - optimistic_upstream_coverage_attestation_interpretation is true
+", dbclean: :after_each do
+
+  let(:person) { FactoryBot.create(:person, :with_consumer_role, :male, first_name: 'john', last_name: 'adams', dob: 40.years.ago, ssn: '472743442') }
+  let(:family) { FactoryBot.create(:family, :with_primary_family_member, person: person)}
+  let!(:application) { FactoryBot.create(:financial_assistance_application, :with_applicants, family_id: family.id) }
+  let(:applicant) { application.active_applicants.last }
+  let(:applicant_person) do
+    FactoryBot.create(
+      :person,
+      :with_consumer_role,
+      first_name: applicant.first_name,
+      last_name: applicant.last_name,
+      dob: applicant.dob,
+      ssn: applicant.ssn,
+      gender: applicant.gender
+    )
+  end
+  let(:applicant_family_member) do
+    family_member = family.relate_new_member(applicant_person, 'child')
+    family.save!
+    family_member
+  end
+  let(:vlp_doc_params) do
+    {
+      vlp_subject: 'I-551 (Permanent Resident Card)',
+      alien_number: "974312399",
+      card_number: "7478823423442",
+      expiration_date: Date.new(2020,10,31)
+    }
+  end
+  let(:applicant_params) do
+    {
+      is_applying_coverage: false
+    }.merge(vlp_doc_params)
+  end
+  let(:params) do
+    {
+      applicant_params: applicant_params,
+      family_member: applicant_family_member,
+      optimistic_upstream_coverage_attestation_interpretation: true
+    }
+  end
+
+  before do
+    applicant_family_member
+  end
+
+  it "leaves the is_applying_coverage value as 'Y'" do
+    described_class.new.call(params: params)
+    applicant_person.reload
+    expect(applicant_person.consumer_role.is_applying_coverage).to be_truthy
+  end
+end

--- a/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -174,6 +174,8 @@ registry:
       is_enabled: <%= ENV['LOAD_COUNTY_ON_INBOUND_TRANSFER_IS_ENABLED'] || false %>
     - key: :automatic_submission
       is_enabled: <%= ENV['AUTOMATIC_SUBMISSION_IS_ENABLED'] || false %>
+    - key: :optimistic_upstream_coverage_attestation
+      is_enabled: <%= ENV['OPTIMISTIC_UPSTREAM_COVERAGE_ATTESTATION_IS_ENABLED'] || false %>
   - namespace:
     - :documents
     features:


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [X] For all UI changes, there is cucumber coverage
- [X] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [X] Any endpoint modified in the PR only responds to the expected MIME types.
- [X] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [X] There are no inline styles added
- [X] There are no inline javascript added
- [X] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [X] Code does not use .html_safe
- [X] All images added/updated have alt text
- [X] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187780132

# A brief description of the changes

Current behavior:  Transmission of who did and did not attest as applying for coverage from upstream systems could be spotty and would result in multiple cases of individuals being marked as 'not applying for coverage', at the consumer role, when this was not the case.

New behavior:  When the feature is enabled a more optimistic view of the applying for coverage attestation will be taken, keeping the current view instead of marking it as 'no' - in the specific case that we already have attestation data and the upstream system does not provide an attestation section.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

`OPTIMISTIC_UPSTREAM_COVERAGE_ATTESTATION_IS_ENABLED` - defaults to false unless explicitly enabled.

- [X] DC
- [X] ME