### PR TITLE
fix small logging bug

### DIFF
--- a/app/domain/operations/families/verifications/dmf_determination/dmf_utils.rb
+++ b/app/domain/operations/families/verifications/dmf_determination/dmf_utils.rb
@@ -11,13 +11,10 @@ module Operations
             'dental_product_enrollment_status'
           ].freeze
 
-          def member_dmf_determination_eligible_enrollments(family_member, family)
-            # first check if family has eligibility_determination and subjects
+          def member_dmf_determination_eligible_enrollments(family_member, family) # rubocop:disable Metrics/CyclomaticComplexity
+            # first check if eligibility_determination has family member as a subject
             subjects = family&.eligibility_determination&.subjects
-            return false unless subjects.present?
-
-            # then check if eligibility_determination has family member as a subject
-            subject = subjects.detect { |sub| sub.hbx_id == family_member.hbx_id }
+            subject = subjects&.detect { |sub| sub.hbx_id == family_member.hbx_id }
             return false unless subject.present?
 
             # then check if subject has any of the valid eligibility states

--- a/app/domain/operations/families/verifications/dmf_determination/dmf_utils.rb
+++ b/app/domain/operations/families/verifications/dmf_determination/dmf_utils.rb
@@ -12,8 +12,11 @@ module Operations
           ].freeze
 
           def member_dmf_determination_eligible_enrollments(family_member, family)
-            # first check if eligibility_determination has family member as a subject
-            subjects = family.eligibility_determination.subjects
+            # first check if family has eligibility_determination and subjects
+            subjects = family&.eligibility_determination&.subjects
+            return false unless subjects.present?
+
+            # then check if eligibility_determination has family member as a subject
             subject = subjects.detect { |sub| sub.hbx_id == family_member.hbx_id }
             return false unless subject.present?
 

--- a/script/export_dmf_eligible_consumers.rb
+++ b/script/export_dmf_eligible_consumers.rb
@@ -28,7 +28,7 @@ if EnrollRegistry.feature_enabled?(:alive_status)
     family.family_members.each do |member|
       person = member.person
 
-      next unless member.person.consumer_role.present?
+      next unless person&.consumer_role.present?
 
       eligibility_states = member_dmf_determination_eligible_enrollments(member, family)
       ssn_present = person&.ssn&.present?
@@ -74,7 +74,7 @@ if EnrollRegistry.feature_enabled?(:alive_status)
 
     dmf_eligibile_members.each do |consumer_hash|
       consumers_counter += 1
-      puts "Processing person with hbx_id #{person.hbx_id} and index at #{consumers_counter}" unless Rails.env.test?
+      puts "Processing person with hbx_id #{consumer_hash[:person_hbx_id]} and index at #{consumers_counter}" unless Rails.env.test?
 
       csv << [
         consumer_hash[:family_hbx_id],

--- a/script/generate_post_dmf_call_report.rb
+++ b/script/generate_post_dmf_call_report.rb
@@ -76,7 +76,7 @@ if EnrollRegistry.feature_enabled?(:alive_status)
 
     dmf_call_consumers.each do |consumer_hash|
       consumers_counter += 1
-      puts "Processing person with hbx_id #{person.hbx_id} and index at #{consumers_counter}" unless Rails.env.test?
+      puts "Processing person with hbx_id #{consumer_hash[:person_hbx_id]} and index at #{consumers_counter}" unless Rails.env.test?
 
       csv << [
         consumer_hash[:family_hbx_id],


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187973661

# A brief description of the changes

Current behavior: Small bug when logging which person being moved to CSV file

New behavior: removed bug

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

## NOTE:
Added a # rubocop:disable Metrics/CyclomaticComplexity to a method --> rubocop warning not present previously, but when added safe-navigation operator, rubocop flagged the method. Ignored rubocop rule for better error handling.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
