### PR TITLE
refactor subscriber logic and add custom logger to differentiate message

### DIFF
--- a/app/event_source/subscribers/fdsh_gateway/pvc_dmf_family_determination_subscriber.rb
+++ b/app/event_source/subscribers/fdsh_gateway/pvc_dmf_family_determination_subscriber.rb
@@ -8,27 +8,32 @@ module Subscribers
       include ::EventSource::Subscriber[amqp: 'fdsh.pvc.dmf.responses.family']
 
       subscribe(:on_determined) do |delivery_info, metadata, response|
-        logger.info "FdshGateway::PvcDmfFamilyDeterminationSubscriber: invoked on_determined with delivery_info: #{delivery_info.inspect}, response: #{response.inspect}"
+        create_logger
+        info "delivery_info: #{delivery_info.inspect}, response: #{response.inspect}"
+
         payload = JSON.parse(response, :symbolize_names => true)
+        family_hbx_id = payload[:family_hbx_id]
         job_id = payload[:job_id]
         status = metadata[:headers]["status"]
+
         if status == "failure"
           handle_failure_response(job_id, payload[:correlation_id])
-          logger.info "FdshGateway::PvcDmfFamilyDeterminationSubscriber: on_determined acked and processed failure from fdsh_gateway"
+          warn "family_hbx_id: #{payload[:correlation_id]} processed failure from fdsh_gateway"
         else
-          logger.info "FdshGateway::PvcDmfFamilyDeterminationSubscriber: parsed_response: #{payload.inspect}"
-          result = Operations::Dmf::Pvc::AddFamilyDetermination.new.call({encrypted_payload: payload[:encrypted_payload], job_id: job_id, family_hbx_id: payload[:family_hbx_id]})
+          info "parsed_response: #{payload.inspect}"
+          result = Operations::Fdsh::Dmf::Pvc::AddFamilyDetermination.new.call({encrypted_payload: payload[:encrypted_payload], job_id: job_id, family_hbx_id: family_hbx_id})
 
           if result.success?
-            logger.info "FdshGateway::PvcDmfFamilyDeterminationSubscriber: invoked on_determined acked with success: #{result.success}"
+            info "success: #{result.success}"
           else
-            logger.info "FdshGateway::PvcDmfFamilyDeterminationSubscriber: invoked on_determined acked with failure, errors: #{result.failure}"
+            error "errors: #{result.failure}"
           end
         end
+
         ack(delivery_info.delivery_tag)
       rescue StandardError => e
         ack(delivery_info.delivery_tag)
-        logger.error "FdshGateway::PvcDmfFamilyDeterminationSubscriber: invoked on_determined error: #{e.message} // backtrace #{e.backtrace}"
+        fatal "failure: error: #{e.message} // backtrace #{e.backtrace}"
       end
 
       def handle_failure_response(job_id, family_hbx_id)
@@ -39,6 +44,33 @@ module Subscribers
 
         Operations::Transmittable::UpdateProcessStatus.new.call({ transmittable_objects: {transmission: transmission, transaction: transaction }, state: :failed, message: message })
         Operations::Transmittable::AddError.new.call({ transmittable_objects: {transmission: transmission, transaction: transaction }, key: :fdsh_gateway, message: message })
+      end
+
+      def create_logger
+        @dmf_logger = Logger.new("#{Rails.root}/log/fdsh_gateway_pvc_dmf_family_determination_subscriber_#{Date.today.in_time_zone('Eastern Time (US & Canada)').strftime('%Y_%m_%d')}.log")
+        @dmf_logger.formatter = proc do |severity, datetime, _progname, msg|
+          "#{datetime} - #{severity} - #{msg}\n"
+        end
+      end
+
+      def record_log(severity, msg)
+        @dmf_logger.send(severity, "PvcDmfFamilyDeterminationSubscriber: invoked on_determined #{msg}")
+      end
+
+      def info(msg)
+        record_log(:info, msg)
+      end
+
+      def warn(msg)
+        record_log(:warn, msg)
+      end
+
+      def error(msg)
+        record_log(:error, msg)
+      end
+
+      def fatal(msg)
+        record_log(:fatal, msg)
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187973370

# A brief description of the changes

Rename subscriber attribute

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
