### PR TITLE
style fix for plan meta info table

### DIFF
--- a/app/views/ui-components/v1/cards/_summary.html.erb
+++ b/app/views/ui-components/v1/cards/_summary.html.erb
@@ -126,18 +126,19 @@
 
                   <span class="ttu dg fourteen"><%= @plan.product_type ? @plan.product_type.upcase : "" %></span>
                 </td>
-                <td>
-                  <span class="ttu lg twelve" style="margin-left: -10px">Metal Level</span>
 
-                  <span class="ttu dg fourteen" style="margin-left: -10px">
+                <td>
+                  <span class="ttu lg twelve">Metal Level</span>
+
+                  <span class="ttu dg fourteen">
                     <% plan_level = @plan.metal_level.titleize %>
                     <%= plan_level != 'Dental' ? plan_level : display_dental_metal_level(@plan).titleize %>
                   </span>
                 </td>
                 <td>
-                  <span class="ttu lg twelve" style="margin-left: -10px">Network</span>
+                  <span class="ttu lg twelve">Network</span>
 
-                  <span class="ttu dg fourteen" style="margin-left: -10px">
+                  <span class="ttu dg fourteen">
                     <% if offers_nationwide_plans? %>
                       <%= @plan.network %>
                     <% else %>
@@ -149,7 +150,7 @@
                   </span>
                 </td>
                 <td>
-                  <span class="ttu lg twelve" style="margin-left: -10px">
+                  <span class="ttu lg twelve">
                     <% if @hbx_enrollment.hbx_enrollment_members.count > 1 %>
                       Family Deductible
                     <% else %>
@@ -157,7 +158,7 @@
                     <% end %>
                   </span>
 
-                  <span class="ttu dg fourteen" style="margin-left: -10px">
+                  <span class="ttu dg fourteen">
                     <%= deductible_display(@hbx_enrollment, @plan) %>
                   </span>
                 </td>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/187996162

# A brief description of the changes

Current behavior: When shopping for plans and clicking on 'See Details' in the plan card, the plan meta table shown at the top has text that is merged together and unreadable.

New behavior:  When shopping for plans and clicking on 'See Details' in the plan card, the plan meta table shown at the top has text that is not merged together and is readable.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
