### PR TITLE
use erb tag on plan shopping page

### DIFF
--- a/app/views/insured/plan_shoppings/show.html.erb
+++ b/app/views/insured/plan_shoppings/show.html.erb
@@ -725,7 +725,7 @@
 
   <%= render partial: "ui-components/v1/modals/help_with_plan", locals: { enrollment: @hbx_enrollment } %>
   <script>
-    var marketKind = "#{@hbx_enrollment.is_shop? ? 'shop' : @hbx_enrollment.kind}";
+    var marketKind = "<%= @hbx_enrollment.is_shop? ? 'shop' : @hbx_enrollment.kind %>";
     // Needs to be defined outside of conditional for marketKind
     // because will try to render on plan_filters.html.slim even on individual market
     var selectedPlans = document.getElementsByClassName("myfilteredPlans");
@@ -1150,9 +1150,8 @@
     }
     if (marketKind === 'individual' || marketKind === 'coverall') {
       $(document).ready(function () {
-        var coverageKind = "#{@hbx_enrollment.coverage_kind}";
         $.ajax({
-          url: "#{plans_insured_plan_shopping_path(id: @hbx_enrollment.id, change_plan: @change_plan, market_kind: @market_kind, coverage_kind: @coverage_kind, enrollment_kind: @enrollment_kind) if @hbx_enrollment.present?}",
+          url: "<%= plans_insured_plan_shopping_path(id: @hbx_enrollment.id, change_plan: @change_plan, market_kind: @market_kind, coverage_kind: @coverage_kind, enrollment_kind: @enrollment_kind) if @hbx_enrollment.present? %>",
           type: "GET"
         });
       });


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187891838

# A brief description of the changes

Current behavior: DC non-bootstrap plan shopping page will not load plans correctly

New behavior: Plans are loading correctly on tests now that erb tag is being used

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.

BS4 side should be all good thanks to @bbodine1's changes in https://github.com/ideacrew/enroll/pull/4035