### PR TITLE
Map incarceration status of applicant in ATP inbound process

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 81da83a2f709502104875e282bab6f238b25e6a4
+  revision: 76f664dce913d31767227aa39221aaa0ebee31a2
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 11a86c60092ba59f512cf117dc330614e66f8815
+  revision: 81da83a2f709502104875e282bab6f238b25e6a4
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/domain/operations/people/create_or_update.rb
+++ b/app/domain/operations/people/create_or_update.rb
@@ -44,20 +44,38 @@ module Operations
       def match_or_update_or_create_person(person_entity)
         person = find_existing_person(person_entity.to_h)
         #create new person
-        if person.blank?
-          person = Person.new(person_entity.to_h) #if person_valid_params.success?
-          person.save!
-        else
-          return Success(person) if no_infomation_changed?(params: { attributes_hash: person_entity, person: person })
-          person.assign_attributes(person_entity.except(:addresses, :phones, :emails, :hbx_id))
-          person.save!
-          create_or_update_associations(person, person_entity.to_h, :addresses)
-          create_or_update_associations(person, person_entity.to_h, :emails)
-          create_or_update_associations(person, person_entity.to_h, :phones)
-        end
-        Success(person)
+        person_record =  if person.blank?
+                           create_new_person(person_entity)
+                         else
+                           return Success(person) if no_infomation_changed?(params: { attributes_hash: person_entity, person: person })
+                           update_existing_person(person, person_entity)
+                         end
+        Success(person_record)
       rescue StandardError => e
         Failure(person.errors.messages)
+      end
+
+      def create_new_person(person_entity)
+        person_params = person_entity.to_h
+        person_params[:is_incarcerated] = person_params[:is_incarcerated].nil? ? false : person_params[:is_incarcerated]
+
+        person = Person.new(person_params)
+        person.save!
+
+        person
+      end
+
+      def update_existing_person(person, person_entity)
+        attributes_to_exclude = %i[addresses phones emails hbx_id]
+        attributes_to_exclude << :is_incarcerated if person_entity.to_h[:is_incarcerated].nil?
+        person.assign_attributes(person_entity.except(*attributes_to_exclude))
+        person.save!
+
+        %i[addresses emails phones].each do |association|
+          create_or_update_associations(person, person_entity.to_h, association)
+        end
+
+        person
       end
 
       def create_or_update_associations(person, applicant_params, assoc)

--- a/app/domain/operations/people/create_or_update.rb
+++ b/app/domain/operations/people/create_or_update.rb
@@ -44,12 +44,12 @@ module Operations
       def match_or_update_or_create_person(person_entity)
         person = find_existing_person(person_entity.to_h)
         #create new person
-        person_record =  if person.blank?
-                           create_new_person(person_entity)
-                         else
-                           return Success(person) if no_infomation_changed?(params: { attributes_hash: person_entity, person: person })
-                           update_existing_person(person, person_entity)
-                         end
+        person_record = if person.blank?
+                          create_new_person(person_entity)
+                        else
+                          return Success(person) if no_infomation_changed?(params: { attributes_hash: person_entity, person: person })
+                          update_existing_person(person, person_entity)
+                        end
         Success(person_record)
       rescue StandardError => e
         Failure(person.errors.messages)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in.rb
@@ -344,7 +344,7 @@ module FinancialAssistance
                 is_veteran_or_active_military: applicant_hash['demographic']['is_veteran_or_active_military'],
                 is_vets_spouse_or_child: applicant_hash['demographic']['is_vets_spouse_or_child'],
                 same_with_primary: address_result.value!,
-                is_incarcerated: applicant_hash["is_incarcerated"],
+                is_incarcerated: family_member.person.is_incarcerated,
                 is_physically_disabled: applicant_hash['attestation']['is_self_attested_disabled'],
                 is_self_attested_disabled: applicant_hash['attestation']['is_self_attested_disabled'],
                 is_self_attested_blind: applicant_hash['attestation']['is_self_attested_blind'],

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
     context "when person records exits and the payload has incarceration set to nil in the payload" do
       let!(:person) do
         FactoryBot.create(:person, first_name: "Junior", last_name: "Banfield",
-                          dob: Date.new(2014,1,1), is_incarcerated: true)
+                                   dob: Date.new(2014,1,1), is_incarcerated: true)
       end
 
       let(:document) do
@@ -283,12 +283,12 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
         record = serializer.parse(document.root.canonicalize, :single => true)
         @transformed = transformer.transform(record.to_hash(identifier: true))
         @result = subject.call(@transformed)
-        family_member =  @transformed["family"]["family_members"].detect do |member|
+        family_member = @transformed["family"]["family_members"].detect do |member|
           member if member["person"]["person_name"]["first_name"] == person.first_name
         end
         matching_person = Person.all.where(first_name: "Junior").first
-        expect(matching_person). to be_present
-        expect(matching_person.is_incarcerated). to eq true
+        expect(matching_person).to be_present
+        expect(matching_person.is_incarcerated).to eq true
         expect(family_member["person"]["person_demographics"]["is_incarcerated"]).not_to eq matching_person.is_incarcerated
       end
     end

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/transfers/medicaid_gateway/account_transfer_in_spec.rb
@@ -230,6 +230,70 @@ RSpec.describe ::FinancialAssistance::Operations::Transfers::MedicaidGateway::Ac
     end
   end
 
+  context 'Incarceration status' do
+    context "when incarceration indicator does not exists for any applicant" do
+      let(:document) do
+        document = Nokogiri::XML(xml)
+        document.xpath('//hix-ee:InsuranceApplicantIncarceration', 'hix-ee' => "http://hix.cms.gov/0.1/hix-ee").each(&:remove)
+        document
+      end
+
+      it "should default the person/applicant incarceration status to false" do
+        record = serializer.parse(document.root.canonicalize, :single => true)
+        @transformed = transformer.transform(record.to_hash(identifier: true))
+        @result = subject.call(@transformed)
+        app = FinancialAssistance::Application.find(@result.value!)
+        expect(app.applicants.first.is_incarcerated).to eq false
+        expect(Person.all.first.is_incarcerated).to eq false
+      end
+    end
+
+    context "when incarceration indicator is set to true for all applicants" do
+      let(:document) do
+        document = Nokogiri::XML(xml)
+        document.xpath('//ns4:IncarcerationIndicator', 'ns4' => "http://hix.cms.gov/0.1/hix-core").each do |node|
+          node.content = 'true'
+        end
+        document
+      end
+
+      it "should default the person/applicant incarceration status to false" do
+        record = serializer.parse(document.root.canonicalize, :single => true)
+        @transformed = transformer.transform(record.to_hash(identifier: true))
+        @result = subject.call(@transformed)
+        app = FinancialAssistance::Application.find(@result.value!)
+        expect(app.applicants.first.is_incarcerated).to eq true
+        expect(Person.all.first.is_incarcerated).to eq true
+      end
+    end
+
+    context "when person records exits and the payload has incarceration set to nil in the payload" do
+      let!(:person) do
+        FactoryBot.create(:person, first_name: "Junior", last_name: "Banfield",
+                          dob: Date.new(2014,1,1), is_incarcerated: true)
+      end
+
+      let(:document) do
+        document = Nokogiri::XML(xml)
+        document.xpath('//ns4:IncarcerationIndicator', 'ns4' => "http://hix.cms.gov/0.1/hix-core")[1].remove
+        document
+      end
+
+      it "should default the incarceration status to existing person value" do
+        record = serializer.parse(document.root.canonicalize, :single => true)
+        @transformed = transformer.transform(record.to_hash(identifier: true))
+        @result = subject.call(@transformed)
+        family_member =  @transformed["family"]["family_members"].detect do |member|
+          member if member["person"]["person_name"]["first_name"] == person.first_name
+        end
+        matching_person = Person.all.where(first_name: "Junior").first
+        expect(matching_person). to be_present
+        expect(matching_person.is_incarcerated). to eq true
+        expect(family_member["person"]["person_demographics"]["is_incarcerated"]).not_to eq matching_person.is_incarcerated
+      end
+    end
+  end
+
   context 'failure' do
     context 'load_county_on_inbound_transfer feature is enabled' do
       context 'with no counties loaded in database' do

--- a/spec/domain/operations/people/create_or_update_spec.rb
+++ b/spec/domain/operations/people/create_or_update_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe Operations::People::CreateOrUpdate, type: :model, dbclean: :after
           expect(@result).to be_a(Dry::Monads::Result::Success)
         end
       end
+
+      context 'nil incarceration status' do
+        before do
+          person_params.merge!({is_incarcerated: nil})
+          @result = subject.call(params: person_params)
+        end
+
+        it 'should return success' do
+          expect(@result).to be_a(Dry::Monads::Result::Success)
+          expect(@result.value!.is_incarcerated).to eq false
+        end
+      end
     end
 
     context 'for failed case' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [X] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/story/show/187854929

# A brief description of the changes

Current behavior: The Incarceration Indicator value is not being populated correctly on the Person/Applicant during the ATP inbound process. Additionally, we are overwriting the incarceration status of a person if it already exists in the exchange when the ATP incoming payload has a nil value set for the incarceration status indicator.

New behavior: Populate incarceration indicator properly on Person/Applicant, and also not overriding incarceration status indicator if the ATP inbound payload has nil value for a matching person record.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
