### PR TITLE
refactor: Add link_class parameter to build_link_for_sep_type method

### DIFF
--- a/app/helpers/insured/families_helper.rb
+++ b/app/helpers/insured/families_helper.rb
@@ -306,7 +306,7 @@ module Insured::FamiliesHelper
     end
   end
 
-  def build_link_for_sep_type(sep, link_title = nil, family_id = nil)
+  def build_link_for_sep_type(sep, link_title = nil, family_id = nil, link_class = nil)
     return if sep.blank?
     qle = QualifyingLifeEventKind.find(sep.qualifying_life_event_kind_id)
     return if qle.blank?
@@ -318,7 +318,7 @@ module Insured::FamiliesHelper
       # Use turbolinks: false, to avoid calling controller action twice.
       # TODO: Refactor Shop For Planss as a translation at some point
       link_path = family_id.present? ? insured_family_members_path(sep_id: sep.id, qle_id: qle.id, family_id: family_id) : insured_family_members_path(sep_id: sep.id, qle_id: qle.id)
-      link_to link_title.presence || l10n("insured.shop_for_plans"), link_path, data: {turbolinks: false}
+      link_to link_title.presence || l10n("insured.shop_for_plans"), link_path, data: {turbolinks: false}, class: link_class
     end
   end
 

--- a/app/views/insured/families/_shop_for_plans_widget.html.erb
+++ b/app/views/insured/families/_shop_for_plans_widget.html.erb
@@ -109,8 +109,7 @@
                 <% if @family.latest_active_sep %>
                   <p><%= l10n('insured.qualify_for_special_enrollment') %> "<%= @family.latest_active_sep.qualifying_life_event_kind.title %>"
                     <br/>
-                    <%#= link_to 'Shop with existing SEP', insured_family_members_path(sep_id: existing_sep.id) %>
-                    <div class="btn btn-default"><%= build_link_for_sep_type(@active_sep, l10n('insured.shop_now'), @family.id.to_s) %></div>
+                    <%= build_link_for_sep_type(@active_sep, l10n('insured.shop_now'), @family.id.to_s, link_class = "btn btn-default") %>
                   </p>
                   <p> <%= l10n('insured.start_your_coverage') %> </p>
                     <br/>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/187995165

# A brief description of the changes

Current behavior: When clicking on `Shop for Health or Dental Plans` from the user homepage, the modal opens and `Shop Now` button appears in the modal. This button, when hovered, does not have acceptable contrast.

New behavior: When clicking on `Shop for Health or Dental Plans` from the user homepage, the modal opens and `Shop Now` button appears in the modal. This button, when hovered, does have acceptable contrast.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
