### PR TITLE
refactor: Update checkbox IDs in shared address fields partials

### DIFF
--- a/app/views/shared/_address_fields_for_dependent.html.erb
+++ b/app/views/shared/_address_fields_for_dependent.html.erb
@@ -71,23 +71,23 @@
             <% if EnrollRegistry.feature_enabled?(:moving_to_state) %>
               <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg">
                 <div class="address_checkbox">
-                  <%= f.check_box :is_moving_to_state %>
-                  <label for="checkbox"><span><strong><%= l10n('insured.dependent_moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
+                  <%= f.check_box :is_moving_to_state, id: "is_moving_to_state" %>
+                  <label for="is_moving_to_state"><span><strong><%= l10n('insured.dependent_moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
                 </div>
               </div>
             <% end %>
             <% if EnrollRegistry.feature_enabled?(:living_outside_state) %>
               <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg">
                 <div class="address_checkbox">
-                  <%= f.check_box :is_temporarily_out_of_state %>
-                  <label for="checkbox"><span><strong><%= l10n('insured.dependent_outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
+                  <%= f.check_box :is_temporarily_out_of_state, id: "is_temporarily_out_of_state" %>
+                  <label for="is_temporarily_out_of_state"><span><strong><%= l10n('insured.dependent_outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
                 </div>
               </div>
             <% end %>
             <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg">
               <div class="address_checkbox">
-                <%= f.check_box :is_homeless %>
-                <label for="checkbox"><span><strong><%= l10n('insured.dependent_dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
+                <%= f.check_box :is_homeless, id: "is_homeless" %>
+                <label for="is_homeless"><span><strong><%= l10n('insured.dependent_dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
               </div>
             </div>
           </div>
@@ -190,23 +190,23 @@ $(document).ready(function () {
             <% if EnrollRegistry.feature_enabled?(:moving_to_state) %>
               <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg">
                 <div class="address_checkbox">
-                  <%= f.check_box :is_moving_to_state %>
-                  <label for="checkbox"><span><strong><%= l10n('insured.dependent_moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
+                  <%= f.check_box :is_moving_to_state, id: "is_moving_to_state" %>
+                  <label for="is_moving_to_state"><span><strong><%= l10n('insured.dependent_moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
                 </div>
               </div>
             <% end %>
             <% if EnrollRegistry.feature_enabled?(:living_outside_state) %>
               <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg">
                 <div class="address_checkbox">
-                  <%= f.check_box :is_temporarily_out_of_state %>
-                  <label for="checkbox"><span><strong><%= l10n('insured.dependent_outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
+                  <%= f.check_box :is_temporarily_out_of_state, id: "is_temporarily_out_of_state" %>
+                  <label for="is_temporarily_out_of_state"><span><strong><%= l10n('insured.dependent_outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
                 </div>
               </div>
             <% end %>
             <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg">
               <div class="address_checkbox">
-                <%= f.check_box :is_homeless %>
-                <label for="checkbox"><span><strong><%= l10n('insured.dependent_dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
+                <%= f.check_box :is_homeless, id: "is_homeless" %>
+                <label for="is_homeless"><span><strong><%= l10n('insured.dependent_dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
               </div>
             </div>
           </div>

--- a/app/views/shared/_consumer_home_address_fields.html.erb
+++ b/app/views/shared/_consumer_home_address_fields.html.erb
@@ -215,23 +215,23 @@
             <% if EnrollRegistry.feature_enabled?(:moving_to_state) %>
               <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg no-pd">
                 <div class="address_checkbox">
-                  <%= f.check_box :is_moving_to_state %>
-                  <label for="checkbox"><span><strong><%= l10n('insured.moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
+                  <%= f.check_box :is_moving_to_state, id: "is_moving_to_state" %>
+                  <label for="is_moving_to_state"><span><strong><%= l10n('insured.moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
                 </div>
               </div>
             <% end %>
             <% if EnrollRegistry.feature_enabled?(:living_outside_state) %>
               <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg no-pd">
                 <div class="address_checkbox">
-                  <%= f.check_box :is_temporarily_out_of_state %>
-                  <label for="checkbox"><span><strong><%= l10n('insured.outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
+                  <%= f.check_box :is_temporarily_out_of_state, id: "is_temporarily_out_of_state" %>
+                  <label for="is_temporarily_out_of_state"><span><strong><%= l10n('insured.outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
                 </div>
               </div>
             <% end %>
             <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg no-pd">
               <div class="address_checkbox">
-                <%= f.check_box :is_homeless %>
-                <label for="checkbox"><span><strong><%= l10n('insured.dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
+                <%= f.check_box :is_homeless, id: "is_homeless" %>
+                <label for="is_homeless"><span><strong><%= l10n('insured.dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
               </div>
             </div>
           </div>

--- a/app/views/shared/_resident_home_address_fields.html.erb
+++ b/app/views/shared/_resident_home_address_fields.html.erb
@@ -97,23 +97,23 @@
         <% if EnrollRegistry.feature_enabled?(:moving_to_state) %>
           <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg no-pd">
             <div class="address_checkbox">
-              <%= f.check_box :is_moving_to_state %>
-              <label for="checkbox"><span><strong><%= l10n('insured.moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
+              <%= f.check_box :is_moving_to_state, id: "is_moving_to_state" %>
+              <label for="is_moving_to_state"><span><strong><%= l10n('insured.moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
             </div>
           </div>
         <% end %>
         <% if EnrollRegistry.feature_enabled?(:living_outside_state) %>
           <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg no-pd">
             <div class="address_checkbox">
-              <%= f.check_box :is_temporarily_out_of_state %>
-              <label for="checkbox"><span><strong><%= l10n('insured.outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
+              <%= f.check_box :is_temporarily_out_of_state, id: "is_temporarily_out_of_state" %>
+              <label for="is_temporarily_out_of_state"><span><strong><%= l10n('insured.outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
             </div>
           </div>
         <% end %>
         <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg no-pd">
           <div class="address_checkbox">
-            <%= f.check_box :is_homeless %>
-            <label for="checkbox"><span><strong><%= l10n('insured.dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
+            <%= f.check_box :is_homeless, id: "is_homeless" %>
+            <label for="is_homeless"><span><strong><%= l10n('insured.dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
           </div>
         </div>
       </div>

--- a/components/financial_assistance/app/views/financial_assistance/shared/_address_fields_for_applicant.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/shared/_address_fields_for_applicant.html.erb
@@ -94,23 +94,23 @@
             <% if EnrollRegistry.feature_enabled?(:moving_to_state) %>
               <div class="col-md-12 col-sm-12 col-xs-12 no-pd form-group form-group-lg">
                 <div class="address_checkbox">
-                  <%= f.check_box :is_temporarily_out_of_state %>
-                  <label for="checkbox"><span><strong><%= l10n('insured.dependent_moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
+                  <%= f.check_box :is_temporarily_out_of_state, id, "is_temporarily_out_of_state" %>
+                  <label for="is_temporarily_out_of_state"><span><strong><%= l10n('insured.dependent_moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
                 </div>
               </div>
             <% end %>
             <% if EnrollRegistry.feature_enabled?(:living_outside_state) %>
               <div class="col-md-12 col-sm-12 col-xs-12 no-pd form-group form-group-lg">
                 <div class="address_checkbox">
-                  <%= f.check_box :is_temporarily_out_of_state %>
-                  <label for="checkbox"><span><strong><%= l10n('insured.dependent_outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
+                  <%= f.check_box :is_temporarily_out_of_state, id, "is_temporarily_out_of_state" %>
+                  <label for="is_temporarily_out_of_state"><span><strong><%= l10n('insured.dependent_outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
                 </div>
               </div>
             <% end %>
             <div class="col-md-12 col-sm-12 col-xs-12 no-pd form-group form-group-lg">
               <div class="address_checkbox">
-                <%= f.check_box :is_homeless %>
-                <label for="checkbox"><span><strong><%= l10n('insured.dependent_dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
+                <%= f.check_box :is_homeless, id, "is_homeless" %>
+                <label for="is_homeless"><span><strong><%= l10n('insured.dependent_dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
               </div>
             </div>
           </div>

--- a/components/financial_assistance/app/views/financial_assistance/shared/_consumer_home_address_fields.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/shared/_consumer_home_address_fields.html.erb
@@ -73,23 +73,23 @@
           <% if EnrollRegistry.feature_enabled?(:moving_to_state) %>
             <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg no-pd">
               <div class="address_checkbox">
-                <%= f.check_box :is_temporarily_out_of_state %>
-                <label for="checkbox"><span><strong><%= l10n('insured.moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
+                <%= f.check_box :is_temporarily_out_of_state, id: "is_temporarily_out_of_state" %>
+                <label for="is_temporarily_out_of_state"><span><strong><%= l10n('insured.moving_to_dc') %></strong></span> <span><%= l10n('insured.moving_to_dc_extension') %></span></label>
               </div>
             </div>
           <% end %>
           <% if EnrollRegistry.feature_enabled?(:living_outside_state) %>
             <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg no-pd">
               <div class="address_checkbox">
-                <%= f.check_box :is_temporarily_out_of_state %>
-                <label for="checkbox"><span><strong><%= l10n('insured.outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
+                <%= f.check_box :is_temporarily_out_of_state, id: "is_temporarily_out_of_state" %>
+                <label for="is_temporarily_out_of_state"><span><strong><%= l10n('insured.outside_dc') %></strong></span> <span><%= l10n('insured.outside_dc_extension') %></span></label>
               </div>
             </div>
           <% end %>
           <div class="col-md-12 col-sm-12 col-xs-12 form-group form-group-lg no-pd">
             <div class="address_checkbox">
-              <%= f.check_box :is_homeless %>
-              <label for="checkbox"><span><strong><%= l10n('insured.dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
+              <%= f.check_box :is_homeless, id: "is_homeless" %>
+              <label for="is_homeless"><span><strong><%= l10n('insured.dc_homeless') %></strong></span><span><%= l10n('insured.dc_homeless_extension') %></span></label>
             </div>
           </div>
         </div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/187995181

# A brief description of the changes

Current behavior: In IVL My Household, while adding a dependant, the checkbox for "This person is ME resident who is experiencing homeless" has a missing label association with the checkbox. A wave error is present.

New behavior: Wave error is not present and checkbox / label are associated.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
