### PR TITLE
fix edit button on my household

### DIFF
--- a/app/views/insured/families/manage_family.html.erb
+++ b/app/views/insured/families/manage_family.html.erb
@@ -18,20 +18,22 @@
       </thead>
       <tbody>
         <% @family.active_family_members.each do |member| %>
-          <tr class="member-<%= member.id%>-row">
+          <% person_id = member.person.id %>
+          <tr class="member-<%= person_id %>-row">
             <td><%= member.full_name.titleize %></td>
-            <td><%= member.hbx_id[0,10] %></td>
+            <td><%= member.person.hbx_id %></td>
             <td><%= member.age_on(TimeKeeper.date_of_record) %></td>
             <td><%= member.gender.humanize %></td>
             <td><%= member.relationship.try(:humanize) %></td>
             <td class="p-2 <%= pundit_class Family, :updateable? %>">
               <% edit_url = member.is_primary_applicant ? personal_insured_families_path({bs4: @bs4}) : main_app.edit_insured_family_member_path(member, {bs4: @bs4}) %>
               <span class="d-flex">
-                <%= h(link_to l10n("edit_member"), edit_url, remote: true, id: "edit-member-#{member.id}", class: 'btn button outline close-2') %>
-                <%= h(link_to l10n("cancel_edit"), insured_family_member_path(member, {bs4: @bs4}), remote: true, id: "cancel-edit-#{member.id}", class: 'hidden btn button outline close-2 text-nowrap') %>
-                <%# defers click to in-form submit button via JS, note primary & dependents have different forms %>
-                <%= h(link_to l10n("save_changes"), "", remote: true, id: "save-member-#{member.id}", class: 'hidden btn button close-2 ml-3 my-hh-save-member text-nowrap') %>
+                <%= h(link_to l10n("edit_member"), edit_url, remote: true, id: "edit-member-#{person_id}", class: 'btn button outline close-2') %>
               </span>
+            </td>
+          </tr>
+          <tr id="person-<%= person_id %>" class="hidden">
+            <td colspan="6" class="append_consumer_info">
             </td>
           </tr>
         <% end %>

--- a/app/views/insured/families/personal.js.erb
+++ b/app/views/insured/families/personal.js.erb
@@ -11,12 +11,11 @@
 
   } else {
     //manage family/ my household page
-    $("#primary-person .append_consumer_info").html("<%= escape_javascript(render partial: "personal")%>");
+    var personContainer = $("#person-<%= @person.id %>")
+    $("#person-<%= @person.id %> .append_consumer_info").html("<%= escape_javascript(render partial: "personal")%>");
+    personContainer.removeClass('hidden');
     $("a[id^=edit-member]").addClass('disabled');
-    $("#add-new-member").addClass("hidden");
-    $("#edit-member-<%= @family_members.first.id %>").addClass("hidden");
-    $("#cancel-edit-<%= @family_members.first.id %>").removeClass("hidden");
-    $("#save-member-<%= @family_members.first.id %>").removeClass("hidden");
+    $("a[id^=edit-member]").atrr('disabled', true);
   }
 <% else %>
   $(".append_consumer_info").html("<%= escape_javascript(render partial: "personal")%>");

--- a/app/views/people/landing_pages/_personal.html.erb
+++ b/app/views/people/landing_pages/_personal.html.erb
@@ -118,7 +118,8 @@
   <script>
     $('.remove-personal-form').off('click');
     $('.remove-personal-form').on('click', function (e) {
-      $(".append_consumer_info").empty()
+      $(".append_consumer_info").empty();
+      $("#person-<%= @person.id %>").addClass('hidden');
     });
   </script>
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188008893

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
