### PR TITLE
add response payload to alive status history

### DIFF
--- a/app/domain/operations/fdsh/dmf/pvc/add_family_determination.rb
+++ b/app/domain/operations/fdsh/dmf/pvc/add_family_determination.rb
@@ -163,8 +163,10 @@ module Operations
 
             message = "DMF Determination response for Family with hbx_id #{@family_hbx_id} received successfully"
             alive_status_verification_type.reload
+
+            event_response_record = EventResponse.create({received_at: Time.now, body: {job_id: @job.job_id, family_hbx_id: @family_hbx_id, death_confirmation_code: entity_validation_status, date_of_death: alive_status_entity.date_of_death}.to_json})
             alive_status_verification_type.add_type_history_element(action: "DMF Hub Response", modifier: "System", update_reason: message, from_validation_status: from_validation_status,
-                                                                    to_validation_status: alive_status_verification_type.validation_status)
+                                                                    to_validation_status: alive_status_verification_type.validation_status, event_response_record_id: event_response_record.id)
           end
 
           def update_validation_status(alive_status_verification_type, new_validation_status)

--- a/app/domain/operations/fdsh/dmf/pvc/add_family_determination.rb
+++ b/app/domain/operations/fdsh/dmf/pvc/add_family_determination.rb
@@ -12,6 +12,8 @@ module Operations
           include EventSource::Logging
           include ::Operations::Transmittable::TransmittableUtils
 
+          DEATH_CONFIRMATION_CODE_MAPPING = {"outstanding" => "Confirmed", "attested" => "Unconfirmed"}.freeze
+
           def call(params)
             encrypted_family_payload, job_id, @family_hbx_id = yield validate(params)
             @job = yield find_job(job_id)
@@ -21,6 +23,7 @@ module Operations
             @transaction = yield create_response_transaction(values.merge(transmission: @transmission, subject: @family), {job: @job, transmission: @transmission})
             decrypted_family_payload = yield decrypt_payload(encrypted_family_payload)
             parsed_family_payload = yield parse_json_payload(decrypted_family_payload)
+            yield store_payload_to_transaction(parsed_family_payload)
             @entity_family = yield validate_family(parsed_family_payload)
             yield add_determination
             trigger_family_determination(@family)
@@ -73,6 +76,19 @@ module Operations
             )
 
             Failure("Failed to parse JSON payload for family #{@family_hbx_id}")
+          end
+
+          def store_payload_to_transaction(parsed_family_payload)
+            @transaction.json_payload = parsed_family_payload
+            Success(@transaction.save!)
+          rescue StandardError => e
+            add_errors(
+              :store_payload_to_transaction,
+              "Failed to store family payload due to #{e.inspect}",
+              { transmission: @transmission, transaction: @transaction}
+            )
+
+            Failure("Failed to store payload #{@family_hbx_id}")
           end
 
           def validate_family(parsed_family_payload)
@@ -161,10 +177,13 @@ module Operations
               person.demographics_group.alive_status.update(is_deceased: true, date_of_death: alive_status_entity.date_of_death)
             end
 
-            message = "DMF Determination response for Family with hbx_id #{@family_hbx_id} received successfully"
-            alive_status_verification_type.reload
+            message = "DMF Determination response received successfully"
+            consumer_role = person.consumer_role
+            body = {job_id: @job.job_id, family_hbx_id: @family_hbx_id, death_confirmation_code: DEATH_CONFIRMATION_CODE_MAPPING[entity_validation_status], date_of_death: alive_status_entity.date_of_death}.to_json
+            event_response_record = EventResponse.new({received_at: Time.now, body: body})
+            consumer_role.alive_status_responses << event_response_record
+            consumer_role.save!
 
-            event_response_record = EventResponse.create({received_at: Time.now, body: {job_id: @job.job_id, family_hbx_id: @family_hbx_id, death_confirmation_code: entity_validation_status, date_of_death: alive_status_entity.date_of_death}.to_json})
             alive_status_verification_type.add_type_history_element(action: "DMF Hub Response", modifier: "System", update_reason: message, from_validation_status: from_validation_status,
                                                                     to_validation_status: alive_status_verification_type.validation_status, event_response_record_id: event_response_record.id)
           end

--- a/app/domain/operations/fdsh/dmf/pvc/add_family_determination.rb
+++ b/app/domain/operations/fdsh/dmf/pvc/add_family_determination.rb
@@ -180,9 +180,7 @@ module Operations
             message = "DMF Determination response received successfully"
             consumer_role = person.consumer_role
             body = {job_id: @job.job_id, family_hbx_id: @family_hbx_id, death_confirmation_code: DEATH_CONFIRMATION_CODE_MAPPING[entity_validation_status], date_of_death: alive_status_entity.date_of_death}.to_json
-            event_response_record = EventResponse.new({received_at: Time.now, body: body})
-            consumer_role.alive_status_responses << event_response_record
-            consumer_role.save!
+            consumer_role.alive_status_responses.create({received_at: Time.now, body: body})
 
             alive_status_verification_type.add_type_history_element(action: "DMF Hub Response", modifier: "System", update_reason: message, from_validation_status: from_validation_status,
                                                                     to_validation_status: alive_status_verification_type.validation_status, event_response_record_id: event_response_record.id)

--- a/app/domain/operations/fdsh/dmf/pvc/add_family_determination.rb
+++ b/app/domain/operations/fdsh/dmf/pvc/add_family_determination.rb
@@ -180,8 +180,7 @@ module Operations
             message = "DMF Determination response received successfully"
             consumer_role = person.consumer_role
             body = {job_id: @job.job_id, family_hbx_id: @family_hbx_id, death_confirmation_code: DEATH_CONFIRMATION_CODE_MAPPING[entity_validation_status], date_of_death: alive_status_entity.date_of_death}.to_json
-            consumer_role.alive_status_responses.create({received_at: Time.now, body: body})
-
+            event_response_record = consumer_role.alive_status_responses.create({received_at: Time.now, body: body})
             alive_status_verification_type.add_type_history_element(action: "DMF Hub Response", modifier: "System", update_reason: message, from_validation_status: from_validation_status,
                                                                     to_validation_status: alive_status_verification_type.validation_status, event_response_record_id: event_response_record.id)
           end

--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -306,10 +306,10 @@ module VerificationHelper
   end
 
   def show_deceased_verification_response(person, history)
-    if history.event_response_record_id
-      event_response = EventResponse.where(id: history.event_response_record_id).first
-      event_response.present? ? JSON.parse(event_response) : "no response record"
-    end
+    return unless history.event_response_record_id
+
+    event_response = person.consumer_role.alive_status_responses.select{ |response| response.id == BSON::ObjectId.from_string(history.event_response_record_id) }.first
+    event_response.present? ? JSON.parse(event_response.body) : "no response record"
   end
 
   def show_ssa_dhs_request(person, record)

--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -288,6 +288,8 @@ module VerificationHelper
   end
 
   def request_response_details(person, record, v_type)
+    return show_deceased_verification_response(person, record) if v_type == "Alive Status"
+
     local_residency = EnrollRegistry[:enroll_app].setting(:state_residency).item
     if record.event_request_record_id
       v_type == local_residency ? show_residency_request(person, record) : show_ssa_dhs_request(person, record)
@@ -301,6 +303,13 @@ module VerificationHelper
         |request| request.id == BSON::ObjectId.from_string(record.event_request_record_id)
     }
     raw_request.any? ? Nokogiri::XML(raw_request.first.body) : "no request record"
+  end
+
+  def show_deceased_verification_response(person, history)
+    if history.event_response_record_id
+      event_response = EventResponse.where(id: history.event_response_record_id).first
+      event_response.present? ? JSON.parse(event_response) : "no response record"
+    end
   end
 
   def show_ssa_dhs_request(person, record)

--- a/app/helpers/verification_helper.rb
+++ b/app/helpers/verification_helper.rb
@@ -288,7 +288,7 @@ module VerificationHelper
   end
 
   def request_response_details(person, record, v_type)
-    return show_deceased_verification_response(person, record) if v_type == "Alive Status"
+    return show_deceased_verification_response(person, record) if v_type == VerificationType::ALIVE_STATUS
 
     local_residency = EnrollRegistry[:enroll_app].setting(:state_residency).item
     if record.event_request_record_id

--- a/app/helpers/verifications/alive_status_helper.rb
+++ b/app/helpers/verifications/alive_status_helper.rb
@@ -15,7 +15,7 @@ module Verifications
     end
 
     def alive_status_type?(verif_type)
-      verif_type&.type_name == 'Alive Status'
+      verif_type&.type_name == VerificationType::ALIVE_STATUS
     end
 
     def outstanding_status?(verif_type)

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -235,7 +235,7 @@ class ConsumerRole
   embeds_many :local_residency_responses, class_name:"EventResponse"
   embeds_many :local_residency_requests, class_name:"EventRequest"
 
-  embeds_many :alive_status_responses, class_name:"EventResponse"
+  embeds_many :alive_status_responses, class_name: "EventResponse"
 
   after_initialize :setup_lawful_determination_instance
   after_create :create_initial_market_transition, :publish_created_event

--- a/app/models/consumer_role.rb
+++ b/app/models/consumer_role.rb
@@ -235,6 +235,8 @@ class ConsumerRole
   embeds_many :local_residency_responses, class_name:"EventResponse"
   embeds_many :local_residency_requests, class_name:"EventRequest"
 
+  embeds_many :alive_status_responses, class_name:"EventResponse"
+
   after_initialize :setup_lawful_determination_instance
   after_create :create_initial_market_transition, :publish_created_event
   after_update :publish_updated_event

--- a/app/views/insured/families/verification/_admin_verification_actions.html.erb
+++ b/app/views/insured/families/verification/_admin_verification_actions.html.erb
@@ -112,7 +112,7 @@
               <td><%= record.modifier %></td>
               <td><%= record.update_reason %></td>
               <td>
-                <% if request_response_details(person, record, v_type) %>
+                <% if record.event_request_record_id || record.event_response_record_id %>
                     <button type="button" data-toggle="modal" data-target=<%="#record_details_#{record.id}" %>>Payload</button>
                 <% end %>
               </td>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188008994

# A brief description of the changes

New behavior: Store response payload to verification history

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
