### PR TITLE
fix radio buttons for dc

### DIFF
--- a/app/views/insured/group_selection/new.html.erb
+++ b/app/views/insured/group_selection/new.html.erb
@@ -67,7 +67,7 @@
               <label class="n-radio weight-n" for="market_kind_<%= kind %>">
                 <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'market_kind_<%= kind %>')">
                   <%= radio_button_tag 'market_kind', kind, index == 0, id: "market_kind_#{kind}", required: true, class: "n-radio", checked: is_market_kind_checked?(kind, @person), disabled: is_market_kind_disabled?(kind, @person) %>
-                  <% if kind=="individual"  %>
+                  <% if kind=="individual" %>
                     <%= l10n("insured.group_selection.new.individual_benefits") %>
                   <% end %>
                 </div>
@@ -101,14 +101,14 @@
         <div class="n-radio-group d-flex align-items-center my-2">
           <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'coverage_kind_health')" class="n-radio-row mr-3">
             <label class="n-radio weight-n" for="coverage_kind_health">
-              <%= radio_button_tag 'coverage_kind', 'health', is_coverage_kind_checked?("health"), disabled: is_coverage_kind_disabled?("health"), id: 'coverage_kind_health', class: 'n-radio' %>
+              <%= radio_button_tag 'coverage_kind', 'health', is_coverage_kind_checked?("health"), disabled: is_coverage_kind_disabled?("health"), id: 'coverage_kind_health', required: true, class: "n-radio" %>
               <%= l10n("health") %>
             </label>
           </div>
 
           <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'coverage_kind_dental')" id="dental-radio-button" class=" mr-3 n-radio-row <%= 'dn' if @adapter.can_shop_shop?(@person) && !@adapter.is_eligible_for_dental?(@employee_role, @change_plan, @hbx_enrollment, effective_date_for_display) %>">
             <label class="n-radio weight-n" for="coverage_kind_dental">
-              <%= radio_button_tag 'coverage_kind', 'dental', is_coverage_kind_checked?("dental"), disabled: is_coverage_kind_disabled?("dental"), id: 'coverage_kind_dental', class: 'n-radio' %>
+              <%= radio_button_tag 'coverage_kind', 'dental', is_coverage_kind_checked?("dental"), disabled: is_coverage_kind_disabled?("dental"), id: 'coverage_kind_dental', required: true, class: 'n-radio' %>
               <%= l10n("dental") %>
             </label>
           </div>
@@ -236,14 +236,16 @@
             <div class="n-radio-group">
               <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'coverage_kind_health')" class="n-radio-row">
                 <label class="n-radio" for="coverage_kind_health">
-                  <%= radio_button_tag 'coverage_kind', 'health', is_coverage_kind_checked?("health"), disabled: is_coverage_kind_disabled?("health"), id: 'coverage_kind_health', class: 'n-radio' %>
+                  <%= radio_button_tag 'coverage_kind', 'health', is_coverage_kind_checked?("health"), disabled: is_coverage_kind_disabled?("health"), id: 'coverage_kind_health', required: true, class: "n-radio" %>
+                  <span class="n-radio"></span>
                   <%= l10n(".health") %>
                 </label>
               </div>
 
               <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'coverage_kind_dental')" id="dental-radio-button" class="n-radio-row <%= 'dn' if @adapter.can_shop_shop?(@person) && !@adapter.is_eligible_for_dental?(@employee_role, @change_plan, @hbx_enrollment, effective_date_for_display) %>">
                 <label class="n-radio" for="coverage_kind_dental">
-                  <%= radio_button_tag 'coverage_kind', 'dental', is_coverage_kind_checked?("dental"), disabled: is_coverage_kind_disabled?("dental"), id: 'coverage_kind_dental', class: 'n-radio' %>
+                  <%= radio_button_tag 'coverage_kind', 'dental', is_coverage_kind_checked?("dental"), disabled: is_coverage_kind_disabled?("dental"), id: 'coverage_kind_dental', required: true, class: 'n-radio' %>
+                  <span class="n-radio"></span>
                   <%= l10n("dental") %>
                 </label>
               </div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187792223

# A brief description of the changes

Current behavior: No radio buttons with expected styling showing up for DC

New behavior: Radio buttons, with expected styling, returned

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
