### PR TITLE
bs4 session ended pop up

### DIFF
--- a/app/views/devise/sessions/session_expiration_warning.js.erb
+++ b/app/views/devise/sessions/session_expiration_warning.js.erb
@@ -9,12 +9,15 @@ function session_countdown (){
   new_time = time - 1;
   $('#sessionExpirationWarningModal p strong').text(new_time)
 
-  if ( parseInt(new_time) <= 0 ) {
+  if ( parseInt(new_time) <= 80000 ) {
     clearInterval(countdown_timer);
     $('#sessionExpirationWarningModal p').text("Your session has timed out due to inactivity. Please log back in.");
     $('h4.modal-title').text("Session Ended");
     $('.modal-footer .btn-default').hide();
+    $("#stay-logged-in").remove();
     $('.modal-footer .btn-primary').attr('tabindex', '0').text('<%= l10n("faa.login") %>').on('keydown', function(event) { handleButtonKeyDown(event, 'stay-logged-in'); });
+    $('.modal-footer .outline').attr('tabindex', '0').text(<%= l10n("go_to_login") %>).on('keydown', function(event) { handleButtonKeyDown(event, 'stay-logged-in'); });
+    $('.modal-footer .outline').removeClass('outline').addClass('primary');
   }
 }
 

--- a/app/views/devise/sessions/session_expiration_warning.js.erb
+++ b/app/views/devise/sessions/session_expiration_warning.js.erb
@@ -9,7 +9,7 @@ function session_countdown (){
   new_time = time - 1;
   $('#sessionExpirationWarningModal p strong').text(new_time)
 
-  if ( parseInt(new_time) <= 80000 ) {
+  if ( parseInt(new_time) <= 0 ) {
     clearInterval(countdown_timer);
     $('#sessionExpirationWarningModal p').text("Your session has timed out due to inactivity. Please log back in.");
     $('h4.modal-title').text("Session Ended");

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -695,6 +695,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.plan_shoppings.show.can_not_select_more_than_n_plans_to_compare' => "Can not select more than %{number} plans to compare.",
   :'en.insured.plan_shoppings.thankyou.confirm_your_plan_selection.content' => "Please review your current plan selection. Select Previous Step if you want to change your plan selection. When you're satisfied with your plan, carefully review and acknowledge the Agreement below along with the Terms and Conditions. You must also provide an electronic signature at the bottom of the page. When you're finished, select CONFIRM to submit your enrollment to your insurance company. You don't have to pay today.",
   :'en.important' => "Important",
+  :'en.go_to_login' => "Go To Login",
   :'en.insured.plan_shoppings.thankyou.heading' => "Review & Submit",
   :'en.insured.plan_shoppings.thankyou.selected_enrollment' => "Selected Enrollment",
   :'en.insured.plan_shoppings.thankyou.applied_credits' => "Applied Credits",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188014293

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
