### PR TITLE
adding determination reasons in cv3 payload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 0567ef689cc96c230a4522e22e22118dfe5b41b1
+  revision: 47e3f4c2aae75ae713444e71cc5299f67bb6cb33
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: d3aba9dde2a1efaa66a5aaf8560c64cc4fe0f921
+  revision: 0567ef689cc96c230a4522e22e22118dfe5b41b1
   branch: trunk
   specs:
     aca_entities (0.10.0)
@@ -2141,7 +2141,7 @@ GEM
     jquery-ui-rails (7.0.0)
       railties (>= 3.2.16)
     json (2.5.1)
-    json-schema (4.1.1)
+    json-schema (4.3.1)
       addressable (>= 2.8)
     jsonapi-renderer (0.2.2)
     jwt (2.2.3)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/add_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/add_determination.rb
@@ -86,6 +86,7 @@ module FinancialAssistance
                                               csr_percent_as_integer: get_csr_value(ped_entity),
                                               is_ia_eligible: ped_entity.is_ia_eligible || false,
                                               is_medicaid_chip_eligible: ped_entity.is_medicaid_chip_eligible || ped_entity.is_magi_medicaid,
+                                              is_gap_filling: ped_entity.is_gap_filling,
                                               is_totally_ineligible: ped_entity.is_totally_ineligible,
                                               is_eligible_for_non_magi_reasons: ped_entity.is_eligible_for_non_magi_reasons,
                                               is_non_magi_medicaid_eligible: ped_entity.is_non_magi_medicaid_eligible,

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination.rb
@@ -99,7 +99,7 @@ module FinancialAssistance
                                             csr_percent_as_integer: get_csr_value(ped_entity),
                                             is_ia_eligible: ped_entity.is_ia_eligible,
                                             is_medicaid_chip_eligible: ped_entity.is_medicaid_chip_eligible || ped_entity.is_magi_medicaid,
-                                            is_gap_filling: applicant.is_gap_filling,
+                                            is_gap_filling: ped_entity.is_gap_filling,
                                             is_totally_ineligible: ped_entity.is_totally_ineligible,
                                             is_eligible_for_non_magi_reasons: ped_entity.is_eligible_for_non_magi_reasons,
                                             is_non_magi_medicaid_eligible: ped_entity.is_non_magi_medicaid_eligible})

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination.rb
@@ -99,6 +99,7 @@ module FinancialAssistance
                                             csr_percent_as_integer: get_csr_value(ped_entity),
                                             is_ia_eligible: ped_entity.is_ia_eligible,
                                             is_medicaid_chip_eligible: ped_entity.is_medicaid_chip_eligible || ped_entity.is_magi_medicaid,
+                                            is_gap_filling: ped_entity.is_gap_filling,
                                             is_totally_ineligible: ped_entity.is_totally_ineligible,
                                             is_eligible_for_non_magi_reasons: ped_entity.is_eligible_for_non_magi_reasons,
                                             is_non_magi_medicaid_eligible: ped_entity.is_non_magi_medicaid_eligible})

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination.rb
@@ -99,7 +99,7 @@ module FinancialAssistance
                                             csr_percent_as_integer: get_csr_value(ped_entity),
                                             is_ia_eligible: ped_entity.is_ia_eligible,
                                             is_medicaid_chip_eligible: ped_entity.is_medicaid_chip_eligible || ped_entity.is_magi_medicaid,
-                                            is_gap_filling: ped_entity.is_gap_filling,
+                                            is_gap_filling: applicant.is_gap_filling,
                                             is_totally_ineligible: ped_entity.is_totally_ineligible,
                                             is_eligible_for_non_magi_reasons: ped_entity.is_eligible_for_non_magi_reasons,
                                             is_non_magi_medicaid_eligible: ped_entity.is_non_magi_medicaid_eligible})

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
@@ -157,110 +157,116 @@ module FinancialAssistance
             def applicants(application, benchmark_premiums)
               assistance_year = application.assistance_year
               applicants = application.applicants
-              determination_reasons = fetch_determination_reasons(application)
 
               applicants.inject([]) do |result, applicant|
                 mitc_eligible_incomes = eligible_incomes_for_mitc(applicant)
                 prior_insurance_benefit = prior_insurance(applicant)
                 enrolled_benefits = enrolled_health_coverage?(applicant)
                 eligible_benefits = eligible_health_coverage?(applicant)
-                result << {name: name(applicant),
-                           identifying_information: identifying_information(applicant),
-                           demographic: demographic(applicant),
-                           attestation: attestation(applicant),
-                           is_primary_applicant: applicant.is_primary_applicant.present?,
-                           native_american_information: native_american_information(applicant),
-                           citizenship_immigration_status_information: { citizen_status: applicant.citizen_status,
-                                                                         is_lawful_presence_self_attested: applicant.eligible_immigration_status.present?,
-                                                                         is_resident_post_092296: applicant.is_resident_post_092296 },
-                           is_consumer_role: applicant.is_consumer_role.present?,
-                           is_resident_role: applicant.is_resident_role.present?,
-                           is_applying_coverage: applicant.is_applying_coverage.present?,
-                           five_year_bar_applies: applicant_five_year_bar_applies(applicant),
-                           five_year_bar_met: applicant_five_year_bar_met(applicant),
-                           qualified_non_citizen: applicant_qnc_code(applicant),
-                           is_consent_applicant: applicant.is_consent_applicant.present?,
-                           vlp_document: vlp_document(applicant),
-                           family_member_reference: {family_member_hbx_id: applicant.person_hbx_id.to_s,
-                                                     first_name: applicant.first_name,
-                                                     last_name: applicant.last_name,
-                                                     person_hbx_id: applicant.person_hbx_id,
-                                                     is_primary_family_member: applicant.is_primary_applicant.present?},
-                           person_hbx_id: applicant.person_hbx_id.to_s,
-                           is_required_to_file_taxes: applicant.is_required_to_file_taxes.present?,
-                           is_filing_as_head_of_household: applicant.is_filing_as_head_of_household.present?,
-                           is_joint_tax_filing: applicant.is_joint_tax_filing.present?,
-                           is_claimed_as_tax_dependent: applicant.is_claimed_as_tax_dependent.present?,
-                           claimed_as_tax_dependent_by: applicant_reference_by_applicant_id(applicants, applicant.claimed_as_tax_dependent_by),
-                           tax_filer_kind: applicant.tax_filer_kind,
-                           student: student_information(applicant),
-                           is_refugee: applicant.is_refugee.present?,
-                           is_trafficking_victim: applicant.is_trafficking_victim.present?,
-                           foster_care: foster(applicant),
-                           pregnancy_information: pregnancy_information(applicant),
-                           is_primary_caregiver: applicant.is_primary_caregiver,
-                           is_subject_to_five_year_bar: applicant.is_subject_to_five_year_bar.present?,
-                           is_five_year_bar_met: applicant.is_five_year_bar_met.present?,
-                           is_forty_quarters: applicant.is_forty_quarters.present?,
-                           is_ssn_applied: applicant.is_ssn_applied.present?,
-                           non_ssn_apply_reason: applicant.non_ssn_apply_reason,
-                           moved_on_or_after_welfare_reformed_law: applicant.moved_on_or_after_welfare_reformed_law.present?,
-                           is_currently_enrolled_in_health_plan: applicant.is_currently_enrolled_in_health_plan.present?,
-                           has_daily_living_help: applicant.has_daily_living_help.present?,
-                           need_help_paying_bills: applicant.need_help_paying_bills.present?,
-                           has_job_income: applicant.has_job_income.present? ? applicant.incomes.present? : false,
-                           has_self_employment_income: applicant.has_self_employment_income.present? ? applicant.incomes.present? : false,
-                           has_unemployment_income: applicant.has_unemployment_income.present? ? applicant.incomes.present? : false,
-                           has_other_income: applicant.has_other_income.present? ? applicant.incomes.present? : false,
-                           has_deductions: applicant.has_deductions.present? ? applicant.deductions.present? : false,
-                           has_enrolled_health_coverage: enrolled_benefits,
-                           has_eligible_health_coverage: eligible_benefits,
-                           job_coverage_ended_in_past_3_months: applicant.has_dependent_with_coverage.present?,
-                           job_coverage_end_date: applicant.dependent_job_end_on,
-                           medicaid_and_chip: medicaid_and_chip(applicant),
-                           other_health_service: {has_received: applicant.health_service_through_referral.present?,
-                                                  is_eligible: applicant.health_service_eligible.present?},
-                           addresses: addresses(applicant),
-                           emails: emails(applicant),
-                           phones: phones(applicant),
-                           incomes: incomes(applicant),
-                           benefits: benefits(applicant, enrolled_benefits, eligible_benefits),
-                           deductions: deductions(applicant),
-                           is_medicare_eligible: applicant.enrolled_or_eligible_in_any_medicare?,
-                           # Does this person need help with daily life activities, such as dressing or bathing?
-                           is_self_attested_long_term_care: applicant.has_daily_living_help.present?,
-                           has_insurance: applicant.is_enrolled_in_insurance?,
-                           has_state_health_benefit: applicant.has_state_health_benefit?,
-                           had_prior_insurance: prior_insurance_benefit.present?,
-                           prior_insurance_end_date: prior_insurance_benefit&.end_on,
-                           age_of_applicant: applicant.age_of_the_applicant,
-                           hours_worked_per_week: applicant.total_hours_worked_per_week,
-                           is_temporarily_out_of_state: applicant.is_temporarily_out_of_state.present?,
-                           is_claimed_as_dependent_by_non_applicant: false, # as per sb notes
-                           benchmark_premium: benchmark_premiums,
-                           is_homeless: applicant.is_homeless.present?,
-                           mitc_income: mitc_income(applicant, mitc_eligible_incomes),
-                           income_evidence: evidence_info(applicant.income_evidence),
-                           esi_evidence: evidence_info(applicant.esi_evidence),
-                           non_esi_evidence: evidence_info(applicant.non_esi_evidence),
-                           local_mec_evidence: evidence_info(applicant.local_mec_evidence),
-                           mitc_relationships: mitc_relationships(applicant),
-                           mitc_is_required_to_file_taxes: applicant_is_required_to_file_taxes(applicant, mitc_eligible_incomes, assistance_year),
-                           determination_reason_codes: determination_reason_codes(applicant, determination_reasons),
-                           mitc_state_resident: mitc_state_resident(applicant, application.us_state)}
+                applicant_hash = {
+                  name: name(applicant),
+                  identifying_information: identifying_information(applicant),
+                  demographic: demographic(applicant),
+                  attestation: attestation(applicant),
+                  is_primary_applicant: applicant.is_primary_applicant.present?,
+                  native_american_information: native_american_information(applicant),
+                  citizenship_immigration_status_information: { citizen_status: applicant.citizen_status,
+                                                                is_lawful_presence_self_attested: applicant.eligible_immigration_status.present?,
+                                                                is_resident_post_092296: applicant.is_resident_post_092296 },
+                  is_consumer_role: applicant.is_consumer_role.present?,
+                  is_resident_role: applicant.is_resident_role.present?,
+                  is_applying_coverage: applicant.is_applying_coverage.present?,
+                  five_year_bar_applies: applicant_five_year_bar_applies(applicant),
+                  five_year_bar_met: applicant_five_year_bar_met(applicant),
+                  qualified_non_citizen: applicant_qnc_code(applicant),
+                  is_consent_applicant: applicant.is_consent_applicant.present?,
+                  vlp_document: vlp_document(applicant),
+                  family_member_reference: {family_member_hbx_id: applicant.person_hbx_id.to_s,
+                                            first_name: applicant.first_name,
+                                            last_name: applicant.last_name,
+                                            person_hbx_id: applicant.person_hbx_id,
+                                            is_primary_family_member: applicant.is_primary_applicant.present?},
+                  person_hbx_id: applicant.person_hbx_id.to_s,
+                  is_required_to_file_taxes: applicant.is_required_to_file_taxes.present?,
+                  is_filing_as_head_of_household: applicant.is_filing_as_head_of_household.present?,
+                  is_joint_tax_filing: applicant.is_joint_tax_filing.present?,
+                  is_claimed_as_tax_dependent: applicant.is_claimed_as_tax_dependent.present?,
+                  claimed_as_tax_dependent_by: applicant_reference_by_applicant_id(applicants, applicant.claimed_as_tax_dependent_by),
+                  tax_filer_kind: applicant.tax_filer_kind,
+                  student: student_information(applicant),
+                  is_refugee: applicant.is_refugee.present?,
+                  is_trafficking_victim: applicant.is_trafficking_victim.present?,
+                  foster_care: foster(applicant),
+                  pregnancy_information: pregnancy_information(applicant),
+                  is_primary_caregiver: applicant.is_primary_caregiver,
+                  is_subject_to_five_year_bar: applicant.is_subject_to_five_year_bar.present?,
+                  is_five_year_bar_met: applicant.is_five_year_bar_met.present?,
+                  is_forty_quarters: applicant.is_forty_quarters.present?,
+                  is_ssn_applied: applicant.is_ssn_applied.present?,
+                  non_ssn_apply_reason: applicant.non_ssn_apply_reason,
+                  moved_on_or_after_welfare_reformed_law: applicant.moved_on_or_after_welfare_reformed_law.present?,
+                  is_currently_enrolled_in_health_plan: applicant.is_currently_enrolled_in_health_plan.present?,
+                  has_daily_living_help: applicant.has_daily_living_help.present?,
+                  need_help_paying_bills: applicant.need_help_paying_bills.present?,
+                  has_job_income: applicant.has_job_income.present? ? applicant.incomes.present? : false,
+                  has_self_employment_income: applicant.has_self_employment_income.present? ? applicant.incomes.present? : false,
+                  has_unemployment_income: applicant.has_unemployment_income.present? ? applicant.incomes.present? : false,
+                  has_other_income: applicant.has_other_income.present? ? applicant.incomes.present? : false,
+                  has_deductions: applicant.has_deductions.present? ? applicant.deductions.present? : false,
+                  has_enrolled_health_coverage: enrolled_benefits,
+                  has_eligible_health_coverage: eligible_benefits,
+                  job_coverage_ended_in_past_3_months: applicant.has_dependent_with_coverage.present?,
+                  job_coverage_end_date: applicant.dependent_job_end_on,
+                  medicaid_and_chip: medicaid_and_chip(applicant),
+                  other_health_service: {
+                    has_received: applicant.health_service_through_referral.present?,
+                    is_eligible: applicant.health_service_eligible.present?
+                  },
+                  addresses: addresses(applicant),
+                  emails: emails(applicant),
+                  phones: phones(applicant),
+                  incomes: incomes(applicant),
+                  benefits: benefits(applicant, enrolled_benefits, eligible_benefits),
+                  deductions: deductions(applicant),
+                  is_medicare_eligible: applicant.enrolled_or_eligible_in_any_medicare?,
+                  # Does this person need help with daily life activities, such as dressing or bathing?
+                  is_self_attested_long_term_care: applicant.has_daily_living_help.present?,
+                  has_insurance: applicant.is_enrolled_in_insurance?,
+                  has_state_health_benefit: applicant.has_state_health_benefit?,
+                  had_prior_insurance: prior_insurance_benefit.present?,
+                  prior_insurance_end_date: prior_insurance_benefit&.end_on,
+                  age_of_applicant: applicant.age_of_the_applicant,
+                  hours_worked_per_week: applicant.total_hours_worked_per_week,
+                  is_temporarily_out_of_state: applicant.is_temporarily_out_of_state.present?,
+                  is_claimed_as_dependent_by_non_applicant: false, # as per sb notes
+                  benchmark_premium: benchmark_premiums,
+                  is_homeless: applicant.is_homeless.present?,
+                  mitc_income: mitc_income(applicant, mitc_eligible_incomes),
+                  income_evidence: evidence_info(applicant.income_evidence),
+                  esi_evidence: evidence_info(applicant.esi_evidence),
+                  non_esi_evidence: evidence_info(applicant.non_esi_evidence),
+                  local_mec_evidence: evidence_info(applicant.local_mec_evidence),
+                  mitc_relationships: mitc_relationships(applicant),
+                  mitc_is_required_to_file_taxes: applicant_is_required_to_file_taxes(applicant, mitc_eligible_incomes, assistance_year),
+                  mitc_state_resident: mitc_state_resident(applicant, application.us_state),
+                  reason_code: fetch_determination_reason(application)
+                }
+                applicant_hash[:additional_reason_codes] = determination_reason_codes(applicant, application) if EnrollRegistry.feature_enabled?(:multiple_determination_submission_reasons)
+                result << applicant_hash
                 result
               end
             end
                         # rubocop:enable Metrics/AbcSize
             # rubocop:enable Metrics/MethodLength
 
-            def determination_reason_codes(applicant, determination_reasons)
+            def determination_reason_codes(applicant, application)
+              determination_reasons = [fetch_determination_reason(application)]
               determination_reasons << 'Gap Filling' if applicant.is_gap_filling
               determination_reasons
             end
 
-            def fetch_determination_reasons(application)
-              application.previously_renewal_draft? ? ['Renewal'] : ['Full Determination']
+            def fetch_determination_reason(application)
+              application.previously_renewal_draft? ? 'Renewal' : 'Full Determination'
             end
 
             def evidence_info(applicant_evidence)

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
@@ -157,6 +157,7 @@ module FinancialAssistance
             def applicants(application, benchmark_premiums)
               assistance_year = application.assistance_year
               applicants = application.applicants
+              determination_reasons = fetch_determination_reasons(application)
 
               applicants.inject([]) do |result, applicant|
                 mitc_eligible_incomes = eligible_incomes_for_mitc(applicant)
@@ -245,12 +246,22 @@ module FinancialAssistance
                            local_mec_evidence: evidence_info(applicant.local_mec_evidence),
                            mitc_relationships: mitc_relationships(applicant),
                            mitc_is_required_to_file_taxes: applicant_is_required_to_file_taxes(applicant, mitc_eligible_incomes, assistance_year),
+                           determination_reason_codes: determination_reason_codes(applicant, determination_reasons),
                            mitc_state_resident: mitc_state_resident(applicant, application.us_state)}
                 result
               end
             end
                         # rubocop:enable Metrics/AbcSize
             # rubocop:enable Metrics/MethodLength
+
+            def determination_reason_codes(applicant, determination_reasons)
+              determination_reasons << 'Gap Filling' if applicant.is_gap_filling
+              determination_reasons
+            end
+
+            def fetch_determination_reasons(application)
+              application.previously_renewal_draft? ? ['Renewal'] : ['Full Determination']
+            end
 
             def evidence_info(applicant_evidence)
               return if applicant_evidence.nil?

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -194,6 +194,7 @@ module FinancialAssistance
     field :is_physically_disabled, type: Boolean
     field :is_medicaid_chip_eligible, type: Boolean, default: false
     field :is_non_magi_medicaid_eligible, type: Boolean, default: false
+    field :is_gap_filling, type: Boolean
     field :is_totally_ineligible, type: Boolean, default: false
     field :is_without_assistance, type: Boolean, default: false
     field :has_income_verification_response, type: Boolean, default: false

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/add_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/aptc_csr_credit_eligibilities/renewals/add_determination_spec.rb
@@ -156,6 +156,10 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::AptcCsrCreditEli
           expect(@applicant.csr_eligibility_kind).to eq("csr_limited")
         end
 
+        it 'should update is_gap_filling' do
+          expect(@applicant.is_gap_filling).to eq(true)
+        end
+
         context 'member_determinations' do
           before do
             ped = response_payload[:tax_households].first[:tax_household_members].first[:product_eligibility_determination]

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/medicaid_gateway/add_eligibility_determination_spec.rb
@@ -138,6 +138,10 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::MedicaidGateway:
           expect(@applicant.csr_eligibility_kind).to eq("csr_limited")
         end
 
+        it 'should update is_gap_filling' do
+          expect(@applicant.is_gap_filling).to eq(true)
+        end
+
         context 'member_determinations' do
           before do
             ped = response_payload[:tax_households].first[:tax_household_members].first[:product_eligibility_determination]

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Transformers::Ap
                                   is_incarcerated: false,
                                   net_annual_income: 10_078.90,
                                   is_post_partum_period: false,
+                                  is_gap_filling: true,
                                   is_veteran_or_active_military: true)
     applicant
   end
@@ -150,6 +151,10 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Transformers::Ap
 
     it 'should have applicant with person hbx_id' do
       expect(result.value![:applicants].first[:person_hbx_id]).to eq person.hbx_id
+    end
+
+    it 'should add determination_reason_codes' do
+      expect(result.value!.dig(:applicants, 0, :determination_reason_codes)).to eq ["Full Determination", "Gap Filling"]
     end
 
     context 'application' do

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
@@ -97,6 +97,8 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Transformers::Ap
   let(:benefit_coverage_period) { hbx_profile.benefit_sponsorship.benefit_coverage_periods.first }
 
   before do
+    allow(EnrollRegistry).to receive(:feature_enabled?).with(:multiple_determination_submission_reasons).and_return(false)
+    allow(EnrollRegistry).to receive(:feature_enabled?).and_call_original
     allow(HbxProfile).to receive(:current_hbx).and_return hbx_profile
     allow(hbx_profile).to receive(:benefit_sponsorship).and_return benefit_sponsorship
     allow(benefit_sponsorship).to receive(:current_benefit_period).and_return(benefit_coverage_period)

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application_spec.rb
@@ -155,8 +155,14 @@ RSpec.describe ::FinancialAssistance::Operations::Applications::Transformers::Ap
       expect(result.value![:applicants].first[:person_hbx_id]).to eq person.hbx_id
     end
 
-    it 'should add determination_reason_codes' do
-      expect(result.value!.dig(:applicants, 0, :determination_reason_codes)).to eq ["Full Determination", "Gap Filling"]
+    context "when multiple determination reasons is enabled" do
+      before :each do
+        allow(EnrollRegistry).to receive(:feature_enabled?).with(:multiple_determination_submission_reasons).and_return(true)
+      end
+
+      it 'should add additional_reason_codes' do
+        expect(result.value!.dig(:applicants, 0, :additional_reason_codes)).to eq ["Full Determination", "Gap Filling"]
+      end
     end
 
     context 'application' do

--- a/components/financial_assistance/spec/shared_examples/medicaid_gateway/test_case_d_response.rb
+++ b/components/financial_assistance/spec/shared_examples/medicaid_gateway/test_case_d_response.rb
@@ -116,6 +116,7 @@ RSpec.shared_context 'cms ME simple_scenarios test_case_d', :shared_context => :
                                                                       :is_uqhp_eligible => nil,
                                                                       :is_csr_eligible => true,
                                                                       is_eligible_for_non_magi_reasons: true,
+                                                                      :is_gap_filling => true,
                                                                       :csr => "limited",
                                                                       :is_non_magi_medicaid_eligible => false,
                                                                       :is_without_assistance => false,

--- a/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/dc/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -176,6 +176,8 @@ registry:
       is_enabled: <%= ENV['AUTOMATIC_SUBMISSION_IS_ENABLED'] || false %>
     - key: :optimistic_upstream_coverage_attestation
       is_enabled: <%= ENV['OPTIMISTIC_UPSTREAM_COVERAGE_ATTESTATION_IS_ENABLED'] || false %>
+    - key: :multiple_determination_submission_reasons
+      is_enabled: <%= ENV['MULTIPLE_DETERMINATION_SUBMISSION_REASONS_IS_ENABLED'] || false %>
   - namespace:
     - :documents
     features:

--- a/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/config/client_config/me/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -176,6 +176,8 @@ registry:
       is_enabled: <%= ENV['AUTOMATIC_SUBMISSION_IS_ENABLED'] || false %>
     - key: :optimistic_upstream_coverage_attestation
       is_enabled: <%= ENV['OPTIMISTIC_UPSTREAM_COVERAGE_ATTESTATION_IS_ENABLED'] || false %>
+    - key: :multiple_determination_submission_reasons
+      is_enabled: <%= ENV['MULTIPLE_DETERMINATION_SUBMISSION_REASONS_IS_ENABLED'] || false %>
   - namespace:
     - :documents
     features:

--- a/system/config/templates/features/aca_individual_market/financial_assistance.yml
+++ b/system/config/templates/features/aca_individual_market/financial_assistance.yml
@@ -176,6 +176,8 @@ registry:
       is_enabled: <%= ENV['AUTOMATIC_SUBMISSION_IS_ENABLED'] || false %>
     - key: :optimistic_upstream_coverage_attestation
       is_enabled: <%= ENV['OPTIMISTIC_UPSTREAM_COVERAGE_ATTESTATION_IS_ENABLED'] || false %>
+    - key: :multiple_determination_submission_reasons
+      is_enabled: <%= ENV['MULTIPLE_DETERMINATION_SUBMISSION_REASONS_IS_ENABLED'] || false %>
   - namespace:
     - :documents
     features:


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?
Adding determination reasons to cv3 payload
- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187862378

# A brief description of the changes

Current behavior:

New behavior: Adding determination reasons to cv3 payload

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
