### PR TITLE
Fix/188020439 choose plan your current 2024 plan text is misplaced

### DIFF
--- a/app/views/insured/families/_enrollment_status_label.html.erb
+++ b/app/views/insured/families/_enrollment_status_label.html.erb
@@ -1,3 +1,3 @@
 <div class="text-right">
-   <%= enrollment_state_label(hbx_enrollment, @bs4 == true) %>
+   <%= render partial: "shared/plan_shoppings/select_plan_button", locals: { plan: @plan } %>
 </div>

--- a/app/views/shared/plan_shoppings/_select_plan_button.html.erb
+++ b/app/views/shared/plan_shoppings/_select_plan_button.html.erb
@@ -1,5 +1,5 @@
 <% if @person.primary_family.enrolled_hbx_enrollments.map(&:product).map(&:id).include?(plan.id) %>
-  <h5 class="col-md-12 current bg-title"><i class="fa fa-star fa-lg enrolling"></i>YOUR CURRENT <%= plan.try(:active_year) %> PLAN </h5>
+  <h5 class="col-md-12 current bg-title"><i class="fa fa-star fa-lg enrolling"></i><%= l10n("your_current_plan", year: plan.try(:active_year)).to_s.upcase %></h5>
 <% else %>
   <%= link_to("Select Plan",
       thankyou_insured_plan_shopping_path(@hbx_enrollment,

--- a/app/views/shared/plan_shoppings/_select_plan_button.html.erb
+++ b/app/views/shared/plan_shoppings/_select_plan_button.html.erb
@@ -1,5 +1,5 @@
 <% if @person.primary_family.enrolled_hbx_enrollments.map(&:product).map(&:id).include?(plan.id) %>
-  <h5 class="col-md-12 current bg-title"><i class="fa fa-star fa-lg enrolling"></i>YOUR CURRENT <%= plan.try(:active_year) %>PLAN </h5>
+  <h5 class="col-md-12 current bg-title"><i class="fa fa-star fa-lg enrolling"></i>YOUR CURRENT <%= plan.try(:active_year) %> PLAN </h5>
 <% else %>
   <%= link_to("Select Plan",
       thankyou_insured_plan_shopping_path(@hbx_enrollment,

--- a/app/views/ui-components/v1/cards/_summary.html.erb
+++ b/app/views/ui-components/v1/cards/_summary.html.erb
@@ -5,7 +5,10 @@
   <% @plan = @member_group %>
 <% end %>
 
-<% back_btn_text = request.referrer&.include?('enrollment_history') ? l10n("back_to_enrollments") : l10n("back_to_my_account") %>
+<% unless @hbx_enrollment.shopping? %>
+  <% back_btn_text = request.referrer&.include?('enrollment_history') ? l10n("back_to_enrollments") : l10n("back_to_my_account") %>
+  <%= h(link_to back_btn_text.to_s, request.referrer, class: 'btn btn-default all-plans mb-2') %>
+<% end %>
 
 <% if @bs4 %>
   <div class="enrollment-details">
@@ -64,12 +67,12 @@
         </tbody>
       </table>
 
-      <% if @hbx_enrollment.shopping? %>
-        <%= render partial: "shared/plan_shoppings/select_plan_button", locals: { plan: @plan } %>
-      <% else %>
+
+
+
         <% back_btn_text = request.referrer&.include?('enrollment_history') ? l10n("back_to_enrollments") : l10n("back_to_my_account") %>
         <%= h(link_to back_btn_text.to_s, request.referrer, class: 'btn btn-default all-plans mb-2') %>
-      <% end %>
+
 
     <% else %>
       <%= l10n("enrollment.no_plans") %>
@@ -128,19 +131,18 @@
 
                   <span class="ttu dg fourteen"><%= @plan.product_type ? @plan.product_type.upcase : "" %></span>
                 </td>
-
                 <td>
-                  <span class="ttu lg twelve">Metal Level</span>
+                  <span class="ttu lg twelve" style="margin-left: -10px">Metal Level</span>
 
-                  <span class="ttu dg fourteen">
+                  <span class="ttu dg fourteen" style="margin-left: -10px">
                     <% plan_level = @plan.metal_level.titleize %>
                     <%= plan_level != 'Dental' ? plan_level : display_dental_metal_level(@plan).titleize %>
                   </span>
                 </td>
                 <td>
-                  <span class="ttu lg twelve">Network</span>
+                  <span class="ttu lg twelve" style="margin-left: -10px">Network</span>
 
-                  <span class="ttu dg fourteen">
+                  <span class="ttu dg fourteen" style="margin-left: -10px">
                     <% if offers_nationwide_plans? %>
                       <%= @plan.network %>
                     <% else %>
@@ -152,7 +154,7 @@
                   </span>
                 </td>
                 <td>
-                  <span class="ttu lg twelve">
+                  <span class="ttu lg twelve" style="margin-left: -10px">
                     <% if @hbx_enrollment.hbx_enrollment_members.count > 1 %>
                       Family Deductible
                     <% else %>
@@ -160,7 +162,7 @@
                     <% end %>
                   </span>
 
-                  <span class="ttu dg fourteen">
+                  <span class="ttu dg fourteen" style="margin-left: -10px">
                     <%= deductible_display(@hbx_enrollment, @plan) %>
                   </span>
                 </td>

--- a/app/views/ui-components/v1/cards/_summary.html.erb
+++ b/app/views/ui-components/v1/cards/_summary.html.erb
@@ -10,7 +10,7 @@
   <%= h(link_to back_btn_text.to_s, request.referrer, class: 'btn btn-default all-plans mb-2') %>
 <% end %>
 
-<% if !@bs4 %>
+<% if @bs4 %>
   <div class="enrollment-details">
     <% if qhp.present? %>
       <h1><%= @hbx_enrollment.coverage_year %> <%= @hbx_enrollment&.product&.kind.to_s.titleize %> <%= l10n('coverage').titleize %></h1>

--- a/app/views/ui-components/v1/cards/_summary.html.erb
+++ b/app/views/ui-components/v1/cards/_summary.html.erb
@@ -10,7 +10,7 @@
   <%= h(link_to back_btn_text.to_s, request.referrer, class: 'btn btn-default all-plans mb-2') %>
 <% end %>
 
-<% if @bs4 %>
+<% if !@bs4 %>
   <div class="enrollment-details">
     <% if qhp.present? %>
       <h1><%= @hbx_enrollment.coverage_year %> <%= @hbx_enrollment&.product&.kind.to_s.titleize %> <%= l10n('coverage').titleize %></h1>
@@ -132,17 +132,17 @@
                   <span class="ttu dg fourteen"><%= @plan.product_type ? @plan.product_type.upcase : "" %></span>
                 </td>
                 <td>
-                  <span class="ttu lg twelve" style="margin-left: -10px">Metal Level</span>
+                  <span class="ttu lg twelve">Metal Level</span>
 
-                  <span class="ttu dg fourteen" style="margin-left: -10px">
+                  <span class="ttu dg fourteen">
                     <% plan_level = @plan.metal_level.titleize %>
                     <%= plan_level != 'Dental' ? plan_level : display_dental_metal_level(@plan).titleize %>
                   </span>
                 </td>
                 <td>
-                  <span class="ttu lg twelve" style="margin-left: -10px">Network</span>
+                  <span class="ttu lg twelve">Network</span>
 
-                  <span class="ttu dg fourteen" style="margin-left: -10px">
+                  <span class="ttu dg fourteen">
                     <% if offers_nationwide_plans? %>
                       <%= @plan.network %>
                     <% else %>
@@ -154,7 +154,7 @@
                   </span>
                 </td>
                 <td>
-                  <span class="ttu lg twelve" style="margin-left: -10px">
+                  <span class="ttu lg twelve">
                     <% if @hbx_enrollment.hbx_enrollment_members.count > 1 %>
                       Family Deductible
                     <% else %>
@@ -162,7 +162,7 @@
                     <% end %>
                   </span>
 
-                  <span class="ttu dg fourteen" style="margin-left: -10px">
+                  <span class="ttu dg fourteen">
                     <%= deductible_display(@hbx_enrollment, @plan) %>
                   </span>
                 </td>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188020439

# A brief description of the changes

Current behavior: "YOUR CURRENT %YEAR% PLAN" callout is at the bottom of the plan summary view

New behavior: "YOUR CURRENT %YEAR% PLAN" callout is at the top of the plan summary view

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
