### PR TITLE
chore: Refactor plan filters UI components

### DIFF
--- a/app/views/ui-components/v1/filters/_plan_filters.html.erb
+++ b/app/views/ui-components/v1/filters/_plan_filters.html.erb
@@ -257,13 +257,20 @@
     <% end %>
     <div class="d-flex mb-md-4 col-sm px-0">
       <div class="mr-auto col-sm col-md-6 col-lg-6 p-0 filter-input-block">
-        <label for="hsa_eligibility"><%= render partial:"shared/glossary", locals: {key: "hc4cc_eligible_title_info", term: l10n("hsa_eligible"), question_mark: true } %></label>
+      <fieldset class="filter-input-block d-block">
+        <legend ><%= render partial:"shared/glossary", locals: {key: "hc4cc_eligible_title_info", term: l10n("hsa_eligible"), question_mark: true } %></legend>
+
         <%= select_tag :hsa_eligibility, options_for_select(["Yes", "No"]), class: "plan-hsa-eligibility-selection-filter w-100", include_blank: "All", onchange:"filterHSAEligibility(this)" %>
+      </fieldset>
+
       </div>
       <div class="mr-auto col-sm col-md-6 col-lg-6 pr-0 filter-input-block">
-        <label for="carrier"><%= render partial:"shared/glossary", locals: {key: "filter_by_carrier", term: l10n("carrier"), question_mark: true } %></label>
-        <% issuer_names = (@market_kind == 'shop' || @market_kind == 'fehb') ? @carrier_names : @carriers %>
-        <%= select_tag :carrier, options_for_select(issuer_names), class: "plan-carrier-selection-filter w-100", include_blank: "All", onchange:"filterPlanCarriers(this)" %>
+        <fieldset>
+          <legend><%= render partial:"shared/glossary", locals: {key: "filter_by_carrier", term: l10n("carrier"), question_mark: true } %></legend>
+
+          <% issuer_names = (@market_kind == 'shop' || @market_kind == 'fehb') ? @carrier_names : @carriers %>
+          <%= select_tag :carrier, options_for_select(issuer_names), class: "plan-carrier-selection-filter w-100", include_blank: "All", onchange:"filterPlanCarriers(this)" %>
+        </fieldset>
       </div>
     </div>
     <div class="d-flex mb-md-4 col-sm px-0">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188021290

# A brief description of the changes

Current behavior: The text isn't staying open for the user to read the content

New behavior: The text stays open for the user to read the content

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
