### PR TITLE
separate out glossary file

### DIFF
--- a/app/controllers/exchanges/hbx_profiles_controller.rb
+++ b/app/controllers/exchanges/hbx_profiles_controller.rb
@@ -355,9 +355,7 @@ class Exchanges::HbxProfilesController < ApplicationController
     else
       status_text = call_customer_service params[:firstname].strip, params[:lastname].strip
     end
-    if params[:broker].present?
-      status_text = l10n("broker_agencies.successfully_assigned")
-    end
+    status_text = l10n("broker_agencies.successfully_assigned") if params[:broker].present?
     @person = Person.find(params[:person])
     broker_view = render_to_string 'insured/families/_consumer_brokers_widget', :layout => false
     render :plain => {broker: broker_view, status: status_text, broker_id: broker_role_id}.to_json, layout: false

--- a/app/views/shared/_glossary.html.erb
+++ b/app/views/shared/_glossary.html.erb
@@ -6,23 +6,34 @@
 <% show_question_mark = local_assigns[:question_mark].present? %>
 
 <span tabindex="0"
-      class='<%= "glossary" %>'
-      data-toggle="popover"
-      data-animation="false"
-      data-placement="auto top"
-      data-trigger="click focus"
-      data-html="true"
-      data-content="<%= t('glossary.' + key) %>"
-      data-title="<%= term_display %>">
-      <% if show_question_mark %>
-        <span><%= term_display %></span>
-        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none">
-          <title>?</title>
-          <path d="M6 0C9.31371 0 12 2.68629 12 6C12 9.31371 9.31371 12 6 12C2.68629 12 0 9.31371 0 6C0 2.68629 2.68629 0 6 0ZM6 1C3.23858 1 1 3.23858 1 6C1 8.76142 3.23858 11 6 11C8.76142 11 11 8.76142 11 6C11 3.23858 8.76142 1 6 1ZM6 8.5C6.41421 8.5 6.75 8.83579 6.75 9.25C6.75 9.66421 6.41421 10 6 10C5.58579 10 5.25 9.66421 5.25 9.25C5.25 8.83579 5.58579 8.5 6 8.5ZM6 2.5C7.10457 2.5 8 3.39543 8 4.5C8 5.23053 7.78822 5.63969 7.24605 6.20791L6.98196 6.47745C6.60451 6.87102 6.5 7.0831 6.5 7.5C6.5 7.77614 6.27614 8 6 8C5.72386 8 5.5 7.77614 5.5 7.5C5.5 6.76947 5.71178 6.36031 6.25395 5.79209L6.51804 5.52255C6.89549 5.12898 7 4.9169 7 4.5C7 3.94772 6.55228 3.5 6 3.5C5.44772 3.5 5 3.94772 5 4.5C5 4.77614 4.77614 5 4.5 5C4.22386 5 4 4.77614 4 4.5C4 3.39543 4.89543 2.5 6 2.5Z" fill="currentColor"/>
-        </svg>
-      <% else %>
-        <span class='<%= "glossary" if @bs4 %>'><%= term_display %></span>
-      <% end %>
+  class='<%= "glossary" %>'
+  data-toggle="popover"
+  data-animation="false"
+  data-placement="auto top"
+  data-trigger="click focus"
+  data-html="true"
+  data-content="<%= t('glossary.' + key) %>"
+  data-title="<%= term_display %>">
+
+  <% if @bs4 %>
+    <% if show_question_mark %>
+      <span><%= term_display %></span>
+      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none">
+        <title>?</title>
+        <path d="M6 0C9.31371 0 12 2.68629 12 6C12 9.31371 9.31371 12 6 12C2.68629 12 0 9.31371 0 6C0 2.68629 2.68629 0 6 0ZM6 1C3.23858 1 1 3.23858 1 6C1 8.76142 3.23858 11 6 11C8.76142 11 11 8.76142 11 6C11 3.23858 8.76142 1 6 1ZM6 8.5C6.41421 8.5 6.75 8.83579 6.75 9.25C6.75 9.66421 6.41421 10 6 10C5.58579 10 5.25 9.66421 5.25 9.25C5.25 8.83579 5.58579 8.5 6 8.5ZM6 2.5C7.10457 2.5 8 3.39543 8 4.5C8 5.23053 7.78822 5.63969 7.24605 6.20791L6.98196 6.47745C6.60451 6.87102 6.5 7.0831 6.5 7.5C6.5 7.77614 6.27614 8 6 8C5.72386 8 5.5 7.77614 5.5 7.5C5.5 6.76947 5.71178 6.36031 6.25395 5.79209L6.51804 5.52255C6.89549 5.12898 7 4.9169 7 4.5C7 3.94772 6.55228 3.5 6 3.5C5.44772 3.5 5 3.94772 5 4.5C5 4.77614 4.77614 5 4.5 5C4.22386 5 4 4.77614 4 4.5C4 3.39543 4.89543 2.5 6 2.5Z" fill="currentColor"/>
+      </svg>
+    <% else %>
+      <span class='<%= "glossary"%>'><%= term_display %></span>
+    <% end %>
+  <% else %>
+    <button data-dismiss='modal'
+      type='button'
+      class='close'
+      aria-label='Close'
+      onclick="$('.glossary').popover('hide');">
+    </button>
+    <%= term_display %>
+  <% end %>
 </span>
 
 <script>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/187888232#

# A brief description of the changes

Current behavior: Glossary closes out much too quickly on non-bootstrap DC enroll

New behavior: Separated the glossary file a bit more. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
![Screenshot 2024-07-27 at 4 30 03 PM](https://github.com/user-attachments/assets/045ce18f-88bb-4147-bd06-86646aa06d39)

**Open to cleaning this up and putting two separate spans in each of the if-else cases to make it more readable.**

**Also, small bug found for bootstrap on bs4 branch: html tags are not working in some of the glossary sections**
![Screenshot 2024-07-27 at 4 28 14 PM](https://github.com/user-attachments/assets/8ad80a79-99eb-4f69-b7eb-dfbfd7a3e69c)


