### PR TITLE
fix product plans path dc

### DIFF
--- a/app/views/insured/families/_enrollment_actions.html.erb
+++ b/app/views/insured/families/_enrollment_actions.html.erb
@@ -68,7 +68,7 @@
       <div class="dropdown-menu dropdown-glossary run-glossary" role="menu" aria-labelledby="dropdownmenuButton">
         <%# coverage details %>
         <div class="dropdown-divider" style="border-top: 1px solid #e9ecef"></div>
-        <a onfocus="handleGlossaryFocus('view_coverage_details')" onblur="handleGlossaryBlur('view_coverage_details')" href="<%= summary_products_plans_path({plan_id: product.id, :standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, market_kind: hbx_enrollment.market_name&.downcase, coverage_kind: hbx_enrollment.coverage_kind, active_year: product.active_year, bs4: @bs4}) %>" class='btn-link btn-block dropdown-item' id='view-details-btn' style='padding: 6px 12px; margin: 4px 0;' data-remote='true'>
+        <a onfocus="handleGlossaryFocus('view_coverage_details')" onblur="handleGlossaryBlur('view_coverage_details')" href="<%= summary_products_plans_path({plan_id: hbx_enrollment.product.id, :standard_component_id => hbx_enrollment.product.hios_id, hbx_enrollment_id: hbx_enrollment.id, market_kind: hbx_enrollment.market_name&.downcase, coverage_kind: hbx_enrollment.coverage_kind, active_year: hbx_enrollment.product.active_year, bs4: @bs4}) %>" class='btn-link btn-block dropdown-item' id='view-details-btn' style='padding: 6px 12px; margin: 4px 0;' data-remote='true'>
           <%= render partial:"shared/glossary_hover", locals: {key: "view_coverage_details", title: "View my coverage details", term: sanitize(l10n("view_details")) } %>
         </a>
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188019815

# A brief description of the changes

Current behavior: Broken home page due to product not existing without callout to hbx_enrollments

New behavior: Home page is now working for dc enroll

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
