### PR TITLE
refactor: Update personal.js.erb and _family_members.html.erb for bet…

### DIFF
--- a/app/views/insured/families/personal.js.erb
+++ b/app/views/insured/families/personal.js.erb
@@ -19,6 +19,15 @@
       $("a[id^=edit-member]").attr('disabled', true);
     }
   }
+
+  $('.remove-personal-form').off('click');
+  $('.remove-personal-form').on('click', function (e) {
+    $("#append_consumer_info").empty();
+    $("#person-<%= @person.id %>").addClass('hidden');
+
+    $("#edit-primary-person").show();
+    $("#primary-info-display").removeClass('hidden');
+  });
 <% else %>
   $(".append_consumer_info").html("<%= escape_javascript(render partial: "personal")%>");
   $("#jq_datepicker_ignore_person_dob").closest(".floatlabel-wrapper").hide();

--- a/app/views/insured/family_members/_family_members.html.erb
+++ b/app/views/insured/family_members/_family_members.html.erb
@@ -35,7 +35,7 @@
     </div>
     <%= h(link_to l10n("edit_member"), personal_insured_families_path({bs4: @bs4, person: @person.id}), remote: true, id: 'edit-primary-person', class: 'btn button outline close-2 my-3') %>
 
-    <div class="append_consumer_info"></div>
+    <div id="append_consumer_info"></div>
   </div>
 
   <%# FAA 'info needed' row - add income & coverage info buttons %>


### PR DESCRIPTION
…ter rendering and functionality

# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188015614

# A brief description of the changes

Current behavior: When creating a new user, while viewing the Household Info view, the primary user information has and edit button underneath it. Currently when clicked nothing happens.

New behavior: Clicking the edit button now shows the edit primary member form.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
