### PR TITLE
bs4 add qle scroll

### DIFF
--- a/app/assets/javascripts/qle.js.erb
+++ b/app/assets/javascripts/qle.js.erb
@@ -1,4 +1,4 @@
-var bs4 = document.documentElement.dataset.bs4;
+var bs4 = document.documentElement.dataset.bs4 == "true";
 
 var QLE = ( function( window, undefined ) {
   function initialize() {
@@ -93,7 +93,7 @@ $(function () {
       defaultDate: cdate
 		});
 
-    if (bs4 == 'true') {
+    if (bs4) {
       $("#qle_date").on("change", function(){
         if ($("#qle_date").val()) {
           $('#qle_submit').removeAttr('disabled');

--- a/app/assets/javascripts/qle.js.erb
+++ b/app/assets/javascripts/qle.js.erb
@@ -117,7 +117,8 @@ $(function () {
     }
   };
 
-  $(document).on('click', 'a.qle-menu-item', function() {
+  $(document).on('click', 'a.qle-menu-item', function(e) {
+    e.preventDefault();
     init_qle_message();
     $('#qle_flow_info #qle-menu').hide();
 

--- a/app/assets/javascripts/qle.js.erb
+++ b/app/assets/javascripts/qle.js.erb
@@ -1,3 +1,5 @@
+var bs4 = document.documentElement.dataset.bs4;
+
 var QLE = ( function( window, undefined ) {
   function initialize() {
     $(document).on('change', 'input[type=radio][name=reason]', function() {
@@ -91,13 +93,15 @@ $(function () {
       defaultDate: cdate
 		});
 
-    $(".sep-date #qle_date").on("change", function(){
-      if ($(".sep-date #qle_date").val()) {
-        $('#qle_submit').removeAttr('disabled');
-      } else {
-        $('#qle_submit').attr('disabled', 'disabled');
-      }
-    });
+    if (bs4 == 'true') {
+      $("#qle_date").on("change", function(){
+        if ($("#qle_date").val()) {
+          $('#qle_submit').removeAttr('disabled');
+        } else {
+          $('#qle_submit').attr('disabled', 'disabled');
+        }
+      });
+    }
   }
 
   function set_details_title(event_element) {
@@ -124,7 +128,6 @@ $(function () {
     $('#qle_id').val($(this).data('id'));
     $('#qle_reason > *').addClass('hidden');
     $('#qle-date-chose').show();
-    $('.sep-date #qle_submit').attr('disabled', 'disabled');
     $('#qle-nav').addClass('hidden');
     var is_self_attested = $(this).data('is-self-attested');
     if (!is_self_attested) {
@@ -147,6 +150,10 @@ $(function () {
 
     $('#qle-details').removeClass('hidden');
     $('#qle-details-for-existing-sep').addClass('hidden');
+    if (bs4) {
+      $('#qle_submit').attr('disabled', 'disabled');
+      $("#qle-details").get(0).scrollIntoView({behavior: 'smooth'});
+    }
   });
 
 
@@ -193,7 +200,7 @@ $(function () {
   // Disable form submit on pressing Enter, instead click Submit link
   $('#qle_form').on('keydown', function(e) {
     var code = e.keyCode || e.which;
-    if ($("#qle-nav").length > 0) {
+    if (bs4) {
       return;
     }
 

--- a/app/helpers/insured/families_helper.rb
+++ b/app/helpers/insured/families_helper.rb
@@ -135,7 +135,7 @@ module Insured::FamiliesHelper
 
     qle_title_html = sanitize_html("<u>#{qle.title}</u>") if qle.reason == 'covid-19'
 
-    link_to qle_title_html || qle.title, "javascript:void(0)", options
+    link_to qle_title_html || qle.title, @bs4 ? "#" : "javascript:void(0)", options
   end
 
   def qle_link_generator_for_an_existing_qle(qle, link_title=nil)

--- a/app/views/insured/families/_qle_detail.html.erb
+++ b/app/views/insured/families/_qle_detail.html.erb
@@ -5,7 +5,7 @@
     <div class="hidden qle-label"></div>
     <div>
       <div class="col px-0">
-        <div id='qle-date-chose' class="sep-date">
+        <div id='qle-date-chose'>
           <div class="mb-2" onkeydown="handleButtonKeyDown(event, 'qle_submit')">
             <label class="weight-n" for="qle_date"><%= l10n("insured.qle_detail.event_date") %></label>
             <%= date_field_tag "qle_date", nil, placeholder: "MM/DD/YYYY", required: true %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:
1. https://www.pivotaltracker.com/story/show/188036742
2. https://www.pivotaltracker.com/story/show/187996079

This PR adds focus to the SEP inputs on QLE selection. It also fixes the QLE links to prevent the redundant link wave alert.
Additionally, it cleans up the JS and HTML by removing a redundant class that was used to isolate BS4 behavior in favor of the bs4 data attribute. 