### PR TITLE
Fix session expiration warning js error

### DIFF
--- a/app/views/devise/sessions/session_expiration_warning.js.erb
+++ b/app/views/devise/sessions/session_expiration_warning.js.erb
@@ -16,7 +16,12 @@ function session_countdown (){
     $('.modal-footer .btn-default').hide();
     $("#stay-logged-in").remove();
     $('.modal-footer .btn-primary').attr('tabindex', '0').text('<%= l10n("faa.login") %>').on('keydown', function(event) { handleButtonKeyDown(event, 'stay-logged-in'); });
-    $('.modal-footer .outline').attr('tabindex', '0').text(<%= l10n("go_to_login") %>).on('keydown', function(event) { handleButtonKeyDown(event, 'stay-logged-in'); });
+    $('.modal-footer .outline')
+      .attr('tabindex', '0')
+      .text("<%= l10n("go_to_login") %>")
+      .on('keydown', function(event) {
+        handleButtonKeyDown(event, 'stay-logged-in')
+      });
     $('.modal-footer .outline').removeClass('outline').addClass('primary');
   }
 }


### PR DESCRIPTION
Ticket: No Ticket

# A brief description of the changes

Current behavior: When session timeout is fired (after waiting 15 min), the screen does not show a modal telling you that the session has timed out. Also, a console error will display with the js error.

New behavior: When session times out, a modal will appear telling you that your session is timed out with a button to log in.



