### PR TITLE
fix incomplete mailing address bug

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -891,6 +891,20 @@ $(document).on('click', '#address_info + span.form-action', function(){
   }
 });
 
+const mailingAddressInputFieldIds = () => {
+  return [
+    '#person_addresses_attributes_1_address_1',
+    '#person_addresses_attributes_1_city',
+    '#person_addresses_attributes_1_zip',
+    '#applicant_addresses_attributes_1_address_1',
+    '#applicant_addresses_attributes_1_city',
+    '#applicant_addresses_attributes_1_zip',
+    '#dependent_addresses_1_address_1',
+    '#dependent_addresses_1_city',
+    '#dependent_addresses_1_zip',
+  ].join(', ');
+};
+
 document.addEventListener('click', function(event) {
   if (event.target.matches('button#add_mailing_address')) {
     event.preventDefault();
@@ -906,7 +920,7 @@ document.addEventListener('click', function(event) {
       el.classList.remove('d-none');
       el.classList.add('d-block');
     });
-    document.querySelectorAll("#person_addresses_attributes_1_zip, #person_addresses_attributes_1_address_1, #person_addresses_attributes_1_city, #dependent_addresses_1_address_1, #dependent_addresses_1_zip, #dependent_addresses_1_city").forEach(function(element) {
+    document.querySelectorAll(mailingAddressInputFieldIds()).forEach(function(element) {
       element.required = true;
     });
   }
@@ -924,7 +938,7 @@ document.addEventListener('click', function(event) {
       el.classList.remove('d-block');
     });
     document.querySelector(".mailing-div #state_id_mailing").value = "";
-    document.querySelectorAll("#person_addresses_attributes_1_zip, #person_addresses_attributes_1_address_1, #person_addresses_attributes_1_city, #dependent_addresses_1_address_1, #dependent_addresses_1_zip, #dependent_addresses_1_city").forEach(function(element) {
+    document.querySelectorAll(mailingAddressInputFieldIds()).forEach(function(element) {
       element.required = false;
     });
     // Mailing address form may appear before or after home address form

--- a/app/views/shared/_consumer_home_address_fields.html.erb
+++ b/app/views/shared/_consumer_home_address_fields.html.erb
@@ -56,7 +56,7 @@
             <div class="d-flex col-sm col-md-6 pr-0">
               <div class="mr-auto col-sm col-md-6 pl-0">
                 <%= address.label :zip, l10n("zip_code"), class: "required" %>
-                <%= address.text_field :zip, class: "w-100 #{required}", required: required.present?, placeholder: l10n("zip_code"), data: { action: true ? 'change->zip-check#zipChange' : '', 'child-index': "#{address.index.to_s}" } %>
+                <%= address.text_field :zip, class: "w-100 #{required}", required: address.object.try(:zip), placeholder: l10n("zip_code"), data: { action: true ? 'change->zip-check#zipChange' : '', 'child-index': "#{address.index.to_s}" } %>
               </div>
               <% if EnrollRegistry.feature_enabled?(:display_county) %>
                 <div id="county-select-<%= f.index %>" class="col-sm col-md-6 pr-0">

--- a/app/views/shared/_consumer_home_address_fields.html.erb
+++ b/app/views/shared/_consumer_home_address_fields.html.erb
@@ -29,6 +29,7 @@
             <div class="col-md-12 pl-0">
               <span><%= address.hidden_field :kind, value: address.object.kind %>
               <%= address.hidden_field :_destroy %></span>
+
               <%= address.label :address_1, "#{l10n("address_1")} #{l10n("address_1_desc")}", class: "required" %>
               <%= address.text_field :address_1, placeholder: l10n("address_1"), class: "#{required} w-100", required: required.present? %>
             </div>

--- a/app/views/shared/_consumer_home_address_fields.html.erb
+++ b/app/views/shared/_consumer_home_address_fields.html.erb
@@ -56,7 +56,7 @@
             <div class="d-flex col-sm col-md-6 pr-0">
               <div class="mr-auto col-sm col-md-6 pl-0">
                 <%= address.label :zip, l10n("zip_code"), class: "required" %>
-                <%= address.text_field :zip, class: "w-100 #{required}", required: address.object.try(:zip), placeholder: l10n("zip_code"), data: { action: true ? 'change->zip-check#zipChange' : '', 'child-index': "#{address.index.to_s}" } %>
+                <%= address.text_field :zip, class: "w-100 #{required}", required: required.present? || address.object.try(:zip), placeholder: l10n("zip_code"), data: { action: true ? 'change->zip-check#zipChange' : '', 'child-index': "#{address.index.to_s}" } %>
               </div>
               <% if EnrollRegistry.feature_enabled?(:display_county) %>
                 <div id="county-select-<%= f.index %>" class="col-sm col-md-6 pr-0">

--- a/app/views/shared/_consumer_home_address_fields.html.erb
+++ b/app/views/shared/_consumer_home_address_fields.html.erb
@@ -29,7 +29,6 @@
             <div class="col-md-12 pl-0">
               <span><%= address.hidden_field :kind, value: address.object.kind %>
               <%= address.hidden_field :_destroy %></span>
-
               <%= address.label :address_1, "#{l10n("address_1")} #{l10n("address_1_desc")}", class: "required" %>
               <%= address.text_field :address_1, placeholder: l10n("address_1"), class: "#{required} w-100", required: required.present? %>
             </div>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -1,4 +1,3 @@
-<% binding.irb %>
 <% if @bs4 %>
   <%= form_for @applicant, url: application_applicant_path(@application, @applicant), method: :patch do |f|%>
     <%= hidden_field_tag :is_dependent, @applicant.is_dependent? %>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -1,3 +1,4 @@
+<% binding.irb %>
 <% if @bs4 %>
   <%= form_for @applicant, url: application_applicant_path(@application, @applicant), method: :patch do |f|%>
     <%= hidden_field_tag :is_dependent, @applicant.is_dependent? %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188039030

# A brief description of the changes

Current behavior: primary user can submit applicants with incomplete mailing addresses

New behavior: primary user can't submit applicants with incomplete mailing addresses, invalid fields pop up in UI

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
