### PR TITLE
Enrollment cucumber

### DIFF
--- a/features/insured/step_definitions/individual_steps.rb
+++ b/features/insured/step_definitions/individual_steps.rb
@@ -41,7 +41,7 @@ Then(/(.*) should land on Home page and should see Shop for Plans Banner$/) do |
 end
 
 When(/(.*) click the "(.*?)" in qle carousel/) do |_name, qle_event|
-  expect(page).to have_content(qle_event, wait: 10)
+  expect(page).to have_content(qle_event, wait: 15)
   click_link qle_event.to_s
 end
 

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -638,8 +638,13 @@ And(/.+ selects a plan on plan shopping page/) do
   screenshot("plan_shopping")
   wait_for_ajax(3, 2)
   expect(page).to have_content "Choose Plan"
-  #find_all(IvlChoosePlan.select_plan_btn, wait: 5)[0].click
-  find_all('div.plan-row')[0].find('.plan-select').click
+  sleep 5
+  plan_rows = find_all('div.plan-row', wait: 5)
+  if plan_rows.any?
+    plan_rows[0].find('.plan-select').click
+  else
+    find_all(IvlChoosePlan.select_plan_btn, wait: 5)[0].click
+  end
 end
 
 When(/^the individual selects a non silver plan on Plan Shopping page$/) do

--- a/features/step_definitions/individual_steps.rb
+++ b/features/step_definitions/individual_steps.rb
@@ -638,7 +638,8 @@ And(/.+ selects a plan on plan shopping page/) do
   screenshot("plan_shopping")
   wait_for_ajax(3, 2)
   expect(page).to have_content "Choose Plan"
-  find_all(IvlChoosePlan.select_plan_btn, wait: 5)[0].click
+  #find_all(IvlChoosePlan.select_plan_btn, wait: 5)[0].click
+  find_all('div.plan-row')[0].find('.plan-select').click
 end
 
 When(/^the individual selects a non silver plan on Plan Shopping page$/) do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
