### PR TITLE
bs4-fix-non-citizen-date-error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -513,4 +513,9 @@ class ApplicationController < ActionController::Base
   def check_browser_compatibility
     browser.ie? && !support_for_ie_browser?
   end
+
+  def parse_date(string)
+    date_format = string.match(/\d{4}-\d{2}-\d{2}/) ? "%Y-%m-%d" : "%m/%d/%Y"
+    Date.strptime(string, date_format)
+  end
 end

--- a/app/controllers/concerns/vlp_doc.rb
+++ b/app/controllers/concerns/vlp_doc.rb
@@ -52,9 +52,9 @@ module VlpDoc
     end
     if params[source][:consumer_role] && params[source][:consumer_role][:vlp_documents_attributes]
       if params[:dependent].present? && params[:dependent][:consumer_role][:vlp_documents_attributes]["0"].present? && params[:dependent][:consumer_role][:vlp_documents_attributes]["0"][:expiration_date].present?
-        params[:dependent][:consumer_role][:vlp_documents_attributes]["0"][:expiration_date] = DateTime.strptime(params[:dependent][:consumer_role][:vlp_documents_attributes]["0"][:expiration_date], '%m/%d/%Y')
+        params[:dependent][:consumer_role][:vlp_documents_attributes]["0"][:expiration_date] = parse_date(params[:dependent][:consumer_role][:vlp_documents_attributes]["0"][:expiration_date])
       elsif params[:person].present? && params[:person][:consumer_role].present? && params[:person][:consumer_role][:vlp_documents_attributes]["0"].present? && params[:person][:consumer_role][:vlp_documents_attributes]["0"][:expiration_date].present?
-        params[:person][:consumer_role][:vlp_documents_attributes]["0"][:expiration_date] = DateTime.strptime(params[:person][:consumer_role][:vlp_documents_attributes]["0"][:expiration_date], "%m/%d/%Y")
+        params[:person][:consumer_role][:vlp_documents_attributes]["0"][:expiration_date] = parse_date(params[:person][:consumer_role][:vlp_documents_attributes]["0"][:expiration_date])
       end
 
       doc_params = params.require(source).permit(*vlp_doc_params_list)

--- a/components/financial_assistance/app/controllers/financial_assistance/applicants_controller.rb
+++ b/components/financial_assistance/app/controllers/financial_assistance/applicants_controller.rb
@@ -190,20 +190,15 @@ module FinancialAssistance
     end
 
     def format_date_params(model_params)
-      model_params["pregnancy_due_on"] = format_date_string(model_params["pregnancy_due_on"].to_s) if model_params["pregnancy_due_on"].present?
-      model_params["pregnancy_end_on"] = format_date_string(model_params["pregnancy_end_on"].to_s) if model_params["pregnancy_end_on"].present?
-      model_params["student_status_end_on"] = format_date_string(model_params["student_status_end_on"].to_s) if model_params["student_status_end_on"].present?
+      model_params["pregnancy_due_on"] = parse_date(model_params["pregnancy_due_on"].to_s) if model_params["pregnancy_due_on"].present?
+      model_params["pregnancy_end_on"] = parse_date(model_params["pregnancy_end_on"].to_s) if model_params["pregnancy_end_on"].present?
+      model_params["student_status_end_on"] = parse_date(model_params["student_status_end_on"].to_s) if model_params["student_status_end_on"].present?
 
-      model_params["person_coverage_end_on"] = format_date_string(model_params["person_coverage_end_on"].to_s) if model_params["person_coverage_end_on"].present?
-      model_params["medicaid_cubcare_due_on"] = format_date_string(model_params["medicaid_cubcare_due_on"].to_s) if model_params["medicaid_cubcare_due_on"].present?
+      model_params["person_coverage_end_on"] = parse_date(model_params["person_coverage_end_on"].to_s) if model_params["person_coverage_end_on"].present?
+      model_params["medicaid_cubcare_due_on"] = parse_date(model_params["medicaid_cubcare_due_on"].to_s) if model_params["medicaid_cubcare_due_on"].present?
       model_params = format_nil_for_blank_date(model_params)
 
-      model_params["dependent_job_end_on"] = format_date_string(model_params["dependent_job_end_on"].to_s) if model_params["dependent_job_end_on"].present?
-    end
-
-    def format_date_string(string)
-      date_format = string.match(/\d{4}-\d{2}-\d{2}/) ? "%Y-%m-%d" : "%m/%d/%Y"
-      Date.strptime(string, date_format)
+      model_params["dependent_job_end_on"] = parse_date(model_params["dependent_job_end_on"].to_s) if model_params["dependent_job_end_on"].present?
     end
 
     def build_error_messages_for_tax_info(model)

--- a/components/financial_assistance/app/controllers/financial_assistance/application_controller.rb
+++ b/components/financial_assistance/app/controllers/financial_assistance/application_controller.rb
@@ -41,5 +41,10 @@ module FinancialAssistance
         value.gsub! '<application-applicable-year>', @application.assistance_year.to_s if value.include? '<application-applicable-year>'
       end
     end
+
+    def parse_date(string)
+      date_format = string.match(/\d{4}-\d{2}-\d{2}/) ? "%Y-%m-%d" : "%m/%d/%Y"
+      Date.strptime(string, date_format)
+    end
   end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

This ticket fixes an error found by QA when entering VLP doc info in personal step 3. The date field was not being parsed correctly.

I also took this chance to refactor how this works in some other controllers by moving this parsing into the respective base controllers.
