### PR TITLE
fix add member validations

### DIFF
--- a/app/views/insured/families/manage_family.html.erb
+++ b/app/views/insured/families/manage_family.html.erb
@@ -40,7 +40,7 @@
       </tbody>
     </table>
 
-    <div class="append_consumer_info"></div>
+    <div id="append_consumer_info"></div>
     <%= h(link_to l10n("add_new_member"), new_insured_family_member_path({family_id: @family.id, bs4: @bs4}), remote: true, id: 'add-new-member', class: 'btn button close-2') %>
   </div>
 <% else %>

--- a/app/views/insured/family_members/_dependent_form.html.erb
+++ b/app/views/insured/family_members/_dependent_form.html.erb
@@ -167,7 +167,7 @@
               <%= l10n("cancel") %>
             <% end %>
           <% end %>
-          <%= f.button(id: 'confirm-member', class: "btn btn-primary", onclick: "$('#btn-continue').removeClass('disabled');") do %>
+          <%= f.button(id: 'confirm-member', class: "btn btn-primary hidden", onclick: "$('#btn-continue').removeClass('disabled');") do %>
             <%= l10n("confirm_member") %>
           <% end %>
 

--- a/app/views/insured/family_members/_family_members.html.erb
+++ b/app/views/insured/family_members/_family_members.html.erb
@@ -34,8 +34,6 @@
       <div class="append_consumer_info"></div>
     </div>
     <%= h(link_to l10n("edit_member"), personal_insured_families_path({bs4: @bs4, person: @person.id}), remote: true, id: 'edit-primary-person', class: 'btn button outline close-2 my-3') %>
-
-    <div class="append_consumer_info"></div>
   </div>
 
   <%# FAA 'info needed' row - add income & coverage info buttons %>
@@ -49,6 +47,8 @@
       </div>
     <% end %>
   </div>
+
+  <div id="append_consumer_info"></div>
 
   <div id="dependent_buttons" class="<%= 'hidden' if @family.active_family_members.empty? %> <%= pundit_class Family, :updateable?%> d-flex flex-column flex-md-row mt-md-5">
       <%= hidden_field_tag 'origin_source', @source %>

--- a/app/views/insured/family_members/new.js.erb
+++ b/app/views/insured/family_members/new.js.erb
@@ -1,6 +1,6 @@
 var bs4 = document.documentElement.dataset.bs4;
 if (bs4 == "true") {
-  if (!$(".my-household-page")) {
+  if ($(".my-household-page").length == 0) {
     $('#dependents_info_wrapper h4:first').text("Please enter the information requested below. When you\'re finished, select \'Confirm Member\' at the bottom of the page.");
     $('#btn-continue').addClass('disabled');
     <% if @dependent.errors.present? || @address_errors.present?  %>
@@ -39,7 +39,7 @@ if (bs4 == "true") {
         $(".dependent_list").find("form").prepend($(dependent_response).find(".alert-error"));
       }
     <% else %>
-      $(".append_consumer_info").replaceWith("<%= escape_javascript(render 'dependent_form', dependent: @dependent, person: @person) %>");
+      $("#append_consumer_info").replaceWith("<%= escape_javascript(render 'dependent_form', dependent: @dependent, person: @person) %>");
     <% end %>
     applyListeners();
     demographicValidations();


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188043114

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
