### PR TITLE
fix employee filters for dc cuke

### DIFF
--- a/app/views/insured/plan_shoppings/show.html.erb
+++ b/app/views/insured/plan_shoppings/show.html.erb
@@ -763,13 +763,13 @@
       var filterType = String;
       // Needs to be used for IVL too
       // var selectedPlans = document.getElementsByClassName("myfilteredPlans");
-      var carrierLogos = JSON.parse('#{raw(digest_logos.to_json)}');
+      var carrierLogos = JSON.parse('<%= raw(digest_logos.to_json) %>');
       // Grabs available products as JSON for filtering onload
       (function () {
         document.getElementById('filteredPlans').classList.add('hidden');
         getEnrollments()
       })();
-      var coverageKind = "#{@hbx_enrollment.coverage_kind}";
+      var coverageKind = "<%= @hbx_enrollment.coverage_kind %>";
       // Allow filtering from high to low
       if (coverageKind == "dental") {
         $(".plan-metal-level-selection-filter").filter(
@@ -1061,14 +1061,14 @@
           }
           var network = "";
           if (result.product.dc_in_network) {
-            network = "#{EnrollRegistry[:enroll_app].setting(:statewide_area).item}";
+            network = "<%= EnrollRegistry[:enroll_app].setting(:statewide_area).item %>";
           }
           if (result.product.nationwide) {
-            network = "#{EnrollRegistry[:enroll_app].setting(:nationwide_area).item}";
+            network = "<%= EnrollRegistry[:enroll_app].setting(:nationwide_area).item %>";
           }
           var standard_plan = "";
           if (result.product.is_standard_plan) {
-            standard_plan = "#{EnrollRegistry[:enroll_app].setting(:standard_plan_label).item}";
+            standard_plan = "<%= EnrollRegistry[:enroll_app].setting(:standard_plan_label).item %>";
           }
           var div = document.createElement('div')
           div.setAttribute('class', 'myfilteredPlans')


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188013743

# A brief description of the changes

Current behavior: Filters for employee shopping for plan was broken

New behavior: Filters now working as expected

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
