### PR TITLE
skip members without alive status verification type

### DIFF
--- a/app/domain/operations/families/verifications/dmf_determination/request_dmf_determination.rb
+++ b/app/domain/operations/families/verifications/dmf_determination/request_dmf_determination.rb
@@ -99,10 +99,13 @@ module Operations
           end
 
           def record_verification_history
-            @family.family_members.each do |member|
-              message = "DMF Determination request for Family with hbx_id #{@family.hbx_assigned_id} is submitted"
+            active_family_members = @family.family_members.active
+            active_family_members.each do |member|
+              message = "DMF Determination submitted"
               person = member.person
               alive_status_type = person.verification_types.alive_status_type.first
+              next unless alive_status_type
+
               alive_status_type.add_type_history_element(action: "DMF_Request_Submitted", modifier: "System", update_reason: message)
             end
 

--- a/spec/domain/operations/families/verifications/dmf_determination/request_dmf_determination_spec.rb
+++ b/spec/domain/operations/families/verifications/dmf_determination/request_dmf_determination_spec.rb
@@ -255,4 +255,21 @@ RSpec.describe Operations::Families::Verifications::DmfDetermination::RequestDmf
       expect(family.transactions.count).to eq 1
     end
   end
+
+  context 'person without alive status' do
+    before do
+      family
+      person.verification_types.delete_all
+      job.create_process_status
+      Operations::Eligibilities::BuildFamilyDetermination.new.call({effective_date: Date.today, family: family})
+      family.eligibility_determination.subjects[0].eligibility_states.last.update(is_eligible: true)
+      @result = described_class.new.call(payload)
+    end
+
+    it "should not create a verification type history element for primary" do
+      person.reload
+      expect(person.verification_types.count).to eq 0
+      expect(@result.success?).to eq true
+    end
+  end
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2648255/stories/188045005

# A brief description of the changes

New behavior: skip members without alive status verification type

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
