### PR TITLE
update call BuildFamilyDetermination for non primary family members too

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -158,7 +158,13 @@ class DocumentsController < ApplicationController
       @verification_type.add_type_history_element(action: "Hub Request Failed",
                                                   modifier: "System",
                                                   update_reason: "#{@verification_type.type_name} Request Failed due to #{message}")
-      ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: @person.primary_family, effective_date: TimeKeeper.date_of_record)
+      if @person.primary_family
+        ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: @person.primary_family, effective_date: TimeKeeper.date_of_record)
+      else
+        @person.families.each do |family|
+          ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: family, effective_date: TimeKeeper.date_of_record)
+        end
+      end
     end
 
     respond_to do |format|

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -158,12 +158,8 @@ class DocumentsController < ApplicationController
       @verification_type.add_type_history_element(action: "Hub Request Failed",
                                                   modifier: "System",
                                                   update_reason: "#{@verification_type.type_name} Request Failed due to #{message}")
-      if @person.primary_family
-        ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: @person.primary_family, effective_date: TimeKeeper.date_of_record)
-      else
-        @person.families.each do |family|
-          ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: family, effective_date: TimeKeeper.date_of_record)
-        end
+      @person.families.each do |family|
+        ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: family, effective_date: TimeKeeper.date_of_record)
       end
     end
 

--- a/app/models/lawful_presence_determination.rb
+++ b/app/models/lawful_presence_determination.rb
@@ -84,12 +84,8 @@ class LawfulPresenceDetermination
 
       if result.failure? && EnrollRegistry.feature_enabled?(:validate_and_record_publish_errors)
         process_ssa_request_failure(result, ssa_verification_type)
-        if self.ivl_role.person.primary_family
-          ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: self.ivl_role.person.primary_family, effective_date: TimeKeeper.date_of_record)
-        else
-          self.ivl_role.person.families.each do |family|
-            ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: family, effective_date: TimeKeeper.date_of_record)
-          end
+        self.ivl_role.person.families.each do |family|
+          ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: family, effective_date: TimeKeeper.date_of_record)
         end
       else
         ssa_verification_type&.pending_type
@@ -114,12 +110,8 @@ class LawfulPresenceDetermination
           ivl_role.fail_lawful_presence(args)
         end
 
-        if self.ivl_role.person.primary_family
-          ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: self.ivl_role.person.primary_family, effective_date: TimeKeeper.date_of_record)
-        else
-          self.ivl_role.person.families.each do |family|
-            ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: family, effective_date: TimeKeeper.date_of_record)
-          end
+        self.ivl_role.person.families.each do |family|
+          ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: family, effective_date: TimeKeeper.date_of_record)
         end
       else
         verification_type.pending_type

--- a/app/models/lawful_presence_determination.rb
+++ b/app/models/lawful_presence_determination.rb
@@ -84,7 +84,13 @@ class LawfulPresenceDetermination
 
       if result.failure? && EnrollRegistry.feature_enabled?(:validate_and_record_publish_errors)
         process_ssa_request_failure(result, ssa_verification_type)
-        ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: self.ivl_role.person.primary_family, effective_date: TimeKeeper.date_of_record)
+        if self.ivl_role.person.primary_family
+          ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: self.ivl_role.person.primary_family, effective_date: TimeKeeper.date_of_record)
+        else
+          self.ivl_role.person.families.each do |family|
+            ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: family, effective_date: TimeKeeper.date_of_record)
+          end
+        end
       else
         ssa_verification_type&.pending_type
       end
@@ -107,7 +113,14 @@ class LawfulPresenceDetermination
         else
           ivl_role.fail_lawful_presence(args)
         end
-        ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: self.ivl_role.person.primary_family, effective_date: TimeKeeper.date_of_record)
+
+        if self.ivl_role.person.primary_family
+          ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: self.ivl_role.person.primary_family, effective_date: TimeKeeper.date_of_record)
+        else
+          self.ivl_role.person.families.each do |family|
+            ::Operations::Eligibilities::BuildFamilyDetermination.new.call(family: family, effective_date: TimeKeeper.date_of_record)
+          end
+        end
       else
         verification_type.pending_type
       end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/187984534


# A brief description of the changes

https://www.pivotaltracker.com/story/show/187944169/comments/241903738

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
