### PR TITLE
fix cv3 family generation issue

### DIFF
--- a/app/domain/operations/transformers/family_to/cv3_family.rb
+++ b/app/domain/operations/transformers/family_to/cv3_family.rb
@@ -71,8 +71,13 @@ module Operations
           return Success(nil) unless EnrollRegistry.feature_enabled?(:financial_assistance)
           return Success([]) if exclude_applications
 
-          applications = ::FinancialAssistance::Application.only(:aasm_state, :family_id, :effective_date, :assistance_year, :renewal_base_year, :years_to_renew, :is_ridp_verified, :is_renewal_authorized, :us_state, :hbx_id, :submitted_at,
-                                                                 :applicants, :eligibility_determinations,:relationships, :'workflow_state_transitions.from_state', :full_medicaid_determination).where(family_id: family.id).determined
+          applications = ::FinancialAssistance::Application.only(
+            :aasm_state, :family_id, :effective_date, :assistance_year, :renewal_base_year, :years_to_renew,
+            :is_ridp_verified, :is_renewal_authorized, :us_state, :hbx_id, :submitted_at,
+            :applicants, :eligibility_determinations,:relationships, :'workflow_state_transitions.from_state',
+            :'workflow_state_transitions.transition_at', :full_medicaid_determination
+          ).where(family_id: family.id).determined
+
           transformed_applications = applications.collect do |application|
             ::FinancialAssistance::Operations::Applications::Transformers::ApplicationTo::Cv3Application.new.call(application)
           end.compact

--- a/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
+++ b/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
@@ -140,12 +140,33 @@ RSpec.describe ::Operations::Transformers::FamilyTo::Cv3Family, dbclean: :around
       end
     end
 
+    before do
+      FinancialAssistance::Application.all.each do |application|
+        application.workflow_state_transitions.create!(
+          from_state: 'submitted',
+          to_state: 'determined'
+        )
+      end
+    end
+
     it 'performs under 4 seconds' do
       ::BenefitMarkets::Products::ProductRateCache.initialize_rate_cache!
 
       expect do
         ::Operations::Transformers::FamilyTo::Cv3Family.new.call(family)
       end.to perform_under(4).sec
+    end
+
+    it "should not throw missing attribute error" do
+      applications = ::FinancialAssistance::Application.only(
+        :aasm_state, :family_id, :effective_date, :assistance_year, :renewal_base_year, :years_to_renew,
+        :is_ridp_verified, :is_renewal_authorized, :us_state, :hbx_id, :submitted_at,
+        :applicants, :eligibility_determinations,:relationships, :'workflow_state_transitions.from_state',
+        :'workflow_state_transitions.transition_at', :full_medicaid_determination
+      ).where(family_id: family.id).determined
+      
+      state_transition = applications.last.workflow_state_transitions.last
+      expect { state_transition.transition_at }.not_to raise_error(ActiveModel::MissingAttributeError)
     end
   end
 

--- a/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
+++ b/spec/domain/operations/transformers/family_to/cv3_family_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe ::Operations::Transformers::FamilyTo::Cv3Family, dbclean: :around
         :applicants, :eligibility_determinations,:relationships, :'workflow_state_transitions.from_state',
         :'workflow_state_transitions.transition_at', :full_medicaid_determination
       ).where(family_id: family.id).determined
-      
+
       state_transition = applications.last.workflow_state_transitions.last
       expect { state_transition.transition_at }.not_to raise_error(ActiveModel::MissingAttributeError)
     end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187861517

# A brief description of the changes

Current behavior: As part of CV3 performance improvement, we are trying to pull only certain required attributes from FAA application, and as part of it we have missed pulling a workflow state `transition_at` attribute, thus causing `ActiveModel::MissingAttributeError`

New behavior: Pull workflow state `transition_at` attribute when generating a CV3 Application payload and fix `ActiveModel::MissingAttributeError` issue

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
