### PR TITLE
188007369 fix invalid address error when address valid

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
@@ -108,9 +108,11 @@
 
           <div id="dependent-address" class="my-3">
             <div class="">
+              <% binding.irb %>
               <% checked = (f.object.same_with_primary.present? && f.object.same_with_primary == false) ? "false" : "checked" %>
               <label for="applicant_same_with_primary" class="weight-n required">
                 <%= f.check_box :same_with_primary, {checked: checked, class: 'checked', id: 'applicant_same_with_primary'}, "true", "false" %>
+                <!-- f.check_box :same_with_primary, {}, "true", "false" -->
                 <%= l10n("live_with_primary_subscriber") %>
               </label>
             </div>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -86,8 +86,9 @@
 
       <% unless @applicant.is_primary_applicant? %>
         <div class="">
-          <% checked = f.object.same_with_primary.present? ? f.object.same_with_primary : true %>
+          <% checked = f.object.same_with_primary ? _ : true %>
           <label for="applicant_same_with_primary" class="weight-n required">
+            <% binding.irb %>
             <%= f.check_box :same_with_primary, {checked: checked}, "true", "false" %>
             <%=l10n("live_with_primary_subscriber") %>
           </label>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -86,7 +86,8 @@
 
       <% unless @applicant.is_primary_applicant? %>
         <div class="">
-          <% checked = f.object.same_with_primary ? _ : true %>
+          <!-- <% checked = f.object.same_with_primary.present? ? f.object.same_with_primary : true %> -->
+          <% checked = false %>
           <label for="applicant_same_with_primary" class="weight-n required">
             <% binding.irb %>
             <%= f.check_box :same_with_primary, {checked: checked}, "true", "false" %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
