### PR TITLE
remove default checkbox when applicant has own address

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
@@ -58,7 +58,7 @@
             </div>
             <div class="col-md-6 col-lg-3 p-0">
               <%= f.label :gender, l10n("gender"), class: 'required'  %>
-              <%= f.select :gender, [ [l10n("Male"), 'male'], [l10n("Female"), 'female'] ], {prompt: l10n("select_option")}, autocomplete: :off, required: true%>
+              <%= f.select :gender, [ [l10n("Male"), 'male'], [l10n("Female"), 'female'] ], {prompt: l10n("select_option")}, autocomplete: :off, required: true %>
               <a href="#sex_gender" data-toggle="modal" data-target="#sex_gender" class="d-block"><%= l10n("not_sure") %></a>
               <%= render partial: 'shared/modal_support_text_household', locals: {key: "sex_gender"} %>
             </div>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -86,13 +86,13 @@
 
       <% unless @applicant.is_primary_applicant? %>
         <div class="">
-          <% checked = f.object.same_with_primary.present? ? f.object.same_with_primary : true %>
+          <% checked = f.object.same_with_primary %>
           <label for="applicant_same_with_primary" class="weight-n required">
             <%= f.check_box :same_with_primary, {checked: checked}, "true", "false" %>
             <%=l10n("live_with_primary_subscriber") %>
           </label>
         </div>
-        <div id="applicant-home-address-area" class="<%= 'hidden' unless f.object.same_with_primary.present? && f.object.same_with_primary != true %>">
+        <div id="applicant-home-address-area" class="<%= 'hidden' if f.object.same_with_primary %>">
           <%= render 'shared/consumer_home_address_fields', f: f %><br>
         </div>
       <% else %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188046785

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.
