### PR TITLE
chore: Update financial assistance translation for Alaska Native income

### DIFF
--- a/components/financial_assistance/db/seedfiles/translations/en/me/financial_assistance.rb
+++ b/components/financial_assistance/db/seedfiles/translations/en/me/financial_assistance.rb
@@ -123,6 +123,7 @@ FINANCIAL_ASSISTANCE_TRANSLATIONS = {
   "en.faa.other_incomes.description" => "Tell us about other income for %{name}, select “Continue to Next Step” when finished.",
   "en.faa.other_incomes.unemployment_question" => "Does %{name} receive unemployment compensation, or have they received it this year?",
   "en.faa.other_incomes.na_question" => "Is any of %{name}'s income from American Indian or Alaska Native tribal sources?",
+  "en.faa.other_incomes.alaska_native" => "Is any of this person's income from American Indian or Alaska Native tribal sources?",
   "en.faa.other_incomes.amount" => "Amount",
   "en.faa.other_incomes.net_amount" => "Net Amount",
   "en.faa.other_incomes.frequency" => "Frequency",


### PR DESCRIPTION

**Ticket:** https://www.pivotaltracker.com/n/projects/2640062/stories/188051053

# A brief description of the changes

**Current behavior:** While on a FAA - review & submit page, under the income section, the "Alaska Native" question is missing a translation and currently shows "Faaother incomeAlaska Native"

**New behavior:** While on a FAA - review & submit page, under the income section, the "Alaska Native" question shows "Is any of this person's income from American Indian or Alaska Native tribal sources?"
