### PR TITLE
align new button on left when present, submit button on right

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/applications/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/index.html.erb
@@ -13,12 +13,10 @@
     <% end %>
   <% end %>
 
-  <div class="d-flex justify-content-end">
-    <%= form_tag(main_app.help_paying_coverage_response_insured_consumer_role_index_path, method: :get, id: 'start-new-app-form') do %>
-      <%= hidden_field_tag :is_applying_for_assistance, 'true' %>
-      <%= submit_tag l10n('faa.start_new_application'), id: "start-new-app", class: "btn btn-primary" %>
-    <% end %>
-  </div>
+  <%= form_tag(main_app.help_paying_coverage_response_insured_consumer_role_index_path, method: :get, id: 'start-new-app-form') do %>
+    <%= hidden_field_tag :is_applying_for_assistance, 'true' %>
+    <%= submit_tag l10n('faa.start_new_application'), id: "start-new-app", class: "btn btn-primary" %>
+  <% end %>
 
   <% if @applications.present? %>
     <div class="table-responsive">

--- a/components/financial_assistance/app/views/financial_assistance/applications/index_with_filter.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/index_with_filter.html.erb
@@ -13,19 +13,20 @@
       <% end %>
     <% end %>
 
-    <% if @applications.present? %>
-      <%= form_with url: nil, :method => :get do %>
-        <label>
-          <div class="mb-1"><%= l10n('faa.applications.application_year') %></div>
-          <%= select("filter", "year", @applications.distinct(:assistance_year)&.compact&.sort&.reverse&.each, {include_blank: l10n('faa.applications.all_years'), :selected => params.dig(:filter, :year)}, {:onchange => "this.form.submit();", class: "col-3 col-md-2"})%>
-        </label>
+    <div class="d-flex align-items-center">
+      <% if @applications.present? %>
+        <%= form_with url: nil, :method => :get, class: "col-2 mr-auto px-0" do %>
+          <label class="">
+            <div class="mb-1"><%= l10n('faa.applications.application_year') %></div>
+            <%= select("filter", "year", @applications.distinct(:assistance_year)&.compact&.sort&.reverse&.each, {include_blank: l10n('faa.applications.all_years'), :selected => params.dig(:filter, :year)}, {:onchange => "this.form.submit();", class: "col"})%>
+          </label>
+        <% end %>
       <% end %>
-    <% else %>
       <%= form_tag(main_app.help_paying_coverage_response_insured_consumer_role_index_path, method: :get, id: 'start-new-app-form') do %>
         <%= hidden_field_tag :is_applying_for_assistance, 'true' %>
         <%= submit_tag l10n('faa.start_new_application'), id: "start-new-app", class: "btn btn-primary" %>
       <% end %>
-    <% end %>
+    </div>
 
     <% if @filtered_applications.present? %>
       <div class="table-responsive">
@@ -69,12 +70,6 @@
             <% end %>
           </tbody>
         </table>
-      </div>
-      <div>
-        <%= form_tag(main_app.help_paying_coverage_response_insured_consumer_role_index_path, method: :get, id: 'start-new-app-form') do %>
-          <%= hidden_field_tag :is_applying_for_assistance, 'true' %>
-          <%= submit_tag l10n('faa.start_new_application'), id: "start-new-app", class: "btn btn-primary" %>
-        <% end %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188051831

# A brief description of the changes

Current behavior:

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.

# AppScan CodeSweep Failure
In the event of a failed check on the AppScan CodeSweep step of our GitHub Actions workflow, please review the False Positive protocol outlined here: appscan_codesweep/CODESWEEP_FALSE_POSITIVES_README.MD

Add all required notes to this section if the failure is a suspected false positive.](https://www.pivotaltracker.com/story/show/188051831)
