### PR TITLE
bs4 remove button missing in mh

### DIFF
--- a/app/controllers/insured/family_members_controller.rb
+++ b/app/controllers/insured/family_members_controller.rb
@@ -6,7 +6,7 @@ class Insured::FamilyMembersController < ApplicationController
   include ::L10nHelper
 
   layout 'progress', only: [:index] if EnrollRegistry.feature_enabled?(:bs4_consumer_flow)
-  before_action :enable_bs4_layout, only: [:index] if EnrollRegistry.feature_enabled?(:bs4_consumer_flow)
+  before_action :enable_bs4_layout, only: [:index, :destroy] if EnrollRegistry.feature_enabled?(:bs4_consumer_flow)
 
   before_action :dependent_person_params, only: [:create, :update]
   before_action :set_current_person

--- a/app/views/insured/families/_family_member_row.html.erb
+++ b/app/views/insured/families/_family_member_row.html.erb
@@ -1,0 +1,17 @@
+  <% person_id = member.person.id %>
+  <tr class="member-<%= person_id %>-row">
+    <td><%= member.full_name.titleize %></td>
+    <td><%= member.person.hbx_id %></td>
+    <td><%= member.age_on(TimeKeeper.date_of_record) %></td>
+    <td><%= member.gender.humanize %></td>
+    <td><%= member.relationship.try(:humanize) %></td>
+    <td class="p-2 <%= pundit_class Family, :updateable? %>">
+      <% edit_url = member.is_primary_applicant ? personal_insured_families_path({bs4: @bs4}) : main_app.edit_insured_family_member_path(member, {bs4: @bs4}) %>
+      <span class="d-flex">
+        <%= h(link_to l10n("edit_member"), edit_url, remote: true, id: "edit-member-#{person_id}", class: 'btn button outline close-2') %>
+      </span>
+    </td>
+  </tr>
+  <tr id="person-<%= person_id %>" class="hidden">
+    <td colspan="6" class="append_consumer_info"></td>
+  </tr>

--- a/app/views/insured/families/_manage_family_table.html.erb
+++ b/app/views/insured/families/_manage_family_table.html.erb
@@ -1,20 +1,4 @@
 <% members.each do |member| %>
-  <% person_id = member.person.id %>
-  <tr class="member-<%= person_id %>-row">
-    <td><%= member.full_name.titleize %></td>
-    <td><%= member.person.hbx_id %></td>
-    <td><%= member.age_on(TimeKeeper.date_of_record) %></td>
-    <td><%= member.gender.humanize %></td>
-    <td><%= member.relationship.try(:humanize) %></td>
-    <td class="p-2 <%= pundit_class Family, :updateable? %>">
-      <% edit_url = member.is_primary_applicant ? personal_insured_families_path({bs4: @bs4}) : main_app.edit_insured_family_member_path(member, {bs4: @bs4}) %>
-      <span class="d-flex">
-        <%= h(link_to l10n("edit_member"), edit_url, remote: true, id: "edit-member-#{person_id}", class: 'btn button outline close-2') %>
-      </span>
-    </td>
-  </tr>
-  <tr id="person-<%= person_id %>" class="hidden">
-    <td colspan="6" class="append_consumer_info"></td>
-  </tr>
+  <%= render partial: 'insured/families/family_member_row', locals: {member: member} %>
 <% end %>
 

--- a/app/views/insured/family_members/_dependent_form.html.erb
+++ b/app/views/insured/family_members/_dependent_form.html.erb
@@ -147,6 +147,7 @@
             <%= link_to('#', class: 'btn outline mr-2') do %>
               <%= l10n("cancel") %>
             <% end %>
+            <%= h(link_to l10n('remove_member'), insured_family_member_path(dependent, {bs4: @bs4}), class: 'btn button-error outline mr-2', :method => :delete, :remote => true, data: {confirm: l10n("confirm_remove_dependent"), ok: l10n("yes"), cancel: l10n("no")}) %>
           <% end %>
           <%= f.button(id: 'confirm-member', class: "btn btn-primary hidden", onclick: "$('#btn-continue').removeClass('disabled');") do %>
             <%= l10n("confirm_member") %>

--- a/app/views/insured/family_members/destroyed.js.erb
+++ b/app/views/insured/family_members/destroyed.js.erb
@@ -6,6 +6,12 @@ $('#family_error_messages').append("<%= escape_javascript render partial: 'destr
   $('#qle_flow_info').removeClass('hidden');
 <% end %>
 
+<% person_id = @dependent.family_member.person.id %>
+$("#person-<%= person_id %>").remove();
+$(".member-<%= person_id %>-row").remove();
+$("a[id^=edit-member]").removeClass('disabled').removeClass('hidden');
+$("#add-new-member").removeClass("hidden");
+
 <% if ::EnrollRegistry.feature_enabled?(:financial_assistance) &&  (['destroy'].include? controller.action_name) && (@person.consumer_role.present?)  %>
   $('#faa_flow_info').html("<%= escape_javascript(render partial: 'insured/families/faa_popup') %>");
 <% end %>

--- a/app/views/insured/family_members/show.js.erb
+++ b/app/views/insured/family_members/show.js.erb
@@ -10,7 +10,15 @@ if (!$(".my-household-page").length) {
   $("a[id^=edit-member]").removeClass('disabled').removeClass('hidden');
   $("#add-new-member").removeClass("hidden");
   $("#new_employee_dependent_form").html($(document.createElement("div")).attr("id", "append_consumer_info"));
-  $('#manage_family_content').html("<%= escape_javascript(render partial: 'insured/families/manage_family_table', locals: {members: @family.active_family_members}) %>")
+  <% member = @dependent.family_member %>
+  <% person_id = member.person.id %>
+  member_row = $(".member-<%= person_id %>-row");
+  if (member_row.length) {
+    $("#person-<%= person_id %>").remove();
+    $(member_row).replaceWith("<%= escape_javascript(render partial: 'insured/families/family_member_row', locals: {member: member}) %>");
+  } else {
+    $('#manage_family_content tr:last').after("<%= escape_javascript(render partial: 'insured/families/family_member_row', locals: {member: member}) %>");
+  }
 }
 
 <% if ::EnrollRegistry.feature_enabled?(:financial_assistance) &&  (['create', 'update', 'destroy'].include? controller.action_name) && (@person.consumer_role.present?) %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188013956

I've re-added the delete button which was removed in a recent PR. I also had to adjust the JS managing this page so that:
1. After deleting a dependent, the table is updated in AJAX
2. Creating a new dependent works correctly

(2) Is mostly unrelated to this ticket, but undoubtedly a bug. My recent PR which updated the `show` JS to update the table in AJAX for `edit` actions broke the `create` action. Seemingly, newly-created dependents don't fully propagate to the family model within `create`, so re-rendering the whole manage family table using `@family` doesn't work for the create action. I've fixed this by updating the `show` action to not rely on `@family`, but instead, just render a new row and append it to the table using the `@dependent` on the action. For consistency, I also updated `show` to re-render some row for the `edit` action as well.