### PR TITLE
bs4 fix sep tooltips

### DIFF
--- a/app/assets/javascripts/qle.js.erb
+++ b/app/assets/javascripts/qle.js.erb
@@ -154,6 +154,7 @@ $(function () {
     if (bs4) {
       $('#qle_submit').attr('disabled', 'disabled');
       $("#qle-details").get(0).scrollIntoView({behavior: 'smooth'});
+      $('.tooltip').remove();
     }
   });
 

--- a/app/helpers/insured/families_helper.rb
+++ b/app/helpers/insured/families_helper.rb
@@ -117,7 +117,7 @@ module Insured::FamiliesHelper
   end
 
   def qle_link_generator(qle, index)
-    options = {class: 'qle-menu-item'}
+    options = {class: "qle-menu-item #{'pr-3' if @bs4}"}
     data = {
       title: qle.title, id: qle.id.to_s, label: qle.event_kind_label,
       is_self_attested: qle.is_self_attested,
@@ -127,7 +127,8 @@ module Insured::FamiliesHelper
     }
 
     if qle.tool_tip.present?
-      data.merge!(toggle: 'tooltip', placement: index > 2 ? 'top' : 'bottom')
+      legacy_placement = index > 2 ? 'top' : 'bottom'
+      data.merge!(toggle: 'tooltip', placement: @bs4 ? 'right' : legacy_placement, trigger: 'hover')
       options.merge!(data: data, title: qle.tool_tip)
     else
       options.merge!(data: data)

--- a/app/javascript/css/main.scss
+++ b/app/javascript/css/main.scss
@@ -676,8 +676,3 @@ a.disabled {
     color: var(--grey-100);
   }
 }
-
-.tooltip.fade.in {
-  opacity: 1;
-  filter: alpha(opacity=100);
-}

--- a/app/javascript/css/main.scss
+++ b/app/javascript/css/main.scss
@@ -676,3 +676,8 @@ a.disabled {
     color: var(--grey-100);
   }
 }
+
+.tooltip.fade.in {
+  opacity: 1;
+  filter: alpha(opacity=100);
+}

--- a/app/views/insured/families/find_sep.html.erb
+++ b/app/views/insured/families/find_sep.html.erb
@@ -59,6 +59,12 @@
       </div>
     </div>
   </div>
+  <script>
+    $(".qle-menu-item ").tooltip({
+      // need to define template to add 'show' class to override the tooltip's default 'fade' class which sets opacity: 0
+      template: '<div class="tooltip show" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
+    });
+  </script>
 <% else %>
   <div class="container">
     <div class="row">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188059541

The crux of the fix has to do with the `fade` class on tooltips causing opacity to be 0 on hover. There is a similar issue with popovers that we account for by setting `data-animation` on the popover's owning element to false, but that trick doesn't work for some reason for tooltips. So, I added a new selector on tooltips which forces the opacity.

