### PR TITLE
bs4 benefits fix edit esi

### DIFF
--- a/components/financial_assistance/app/assets/javascripts/financial_assistance/benefit.js
+++ b/components/financial_assistance/app/assets/javascripts/financial_assistance/benefit.js
@@ -389,8 +389,7 @@ document.addEventListener("turbolinks:load", function() {
       e.preventDefault();
       var benefitEl = $(this).parents('.benefit');
       benefitEl.find('.benefit-show').addClass('hidden');
-      var form = benefitEl.find('.edit-benefit-form')
-      form.removeClass('hidden');
+      benefitEl.find('.edit-benefit-form').removeClass('hidden');
       benefitEl.find('select').selectric();
       $(benefitEl).find(".datepicker-js").datepicker({ dateFormat: 'mm/dd/yy', changeMonth: true, changeYear: true, yearRange: "-110:+110"});
       startEditingBenefit($(this).parents('.benefit-kind').attr('id'));

--- a/components/financial_assistance/app/assets/javascripts/financial_assistance/benefit.js
+++ b/components/financial_assistance/app/assets/javascripts/financial_assistance/benefit.js
@@ -48,6 +48,51 @@ function stopEditing() {
   $('.driver-question, .instruction-row, .disabled a, .benefits-list, #nav-buttons a, .benefit, .add_new_benefit_kind').removeClass('disabled');
 };
 
+function handleEsiFields(form, isEsi, isHra, isMvsq) {
+  // do all the esi specific hiding and showing
+  if (isEsi == "true") {
+    // show non-hra questions if non-hra is the selected insurance kind
+    // show hra questions if hra is the selected insurance kind
+    // make the inputs of the non-selected kind non-reqquired
+    // make the inputs of the selected kind required
+    if (isHra == "true") {
+      form.querySelector('.non-hra-questions').classList.remove('hidden');
+      form.querySelectorAll('.non-hra-questions input, non-hra-questions select').forEach(function(input) {
+        var label = form.querySelector("label[for='" + input.id + "']")
+        if ((label && label.classList.contains('required')) || input.classList.contains('required')) {
+          input.setAttribute('required', true);
+        }
+      });
+      $(form).find('.hra-questions').remove();
+    } else {
+      form.querySelector('.hra-questions').classList.remove('hidden');
+      form.querySelectorAll('.hra-questions input, hra-questions select').forEach(function(input) {
+        var label = form.querySelector("label[for='" + input.id + "']")
+        if ((label && label.classList.contains('required')) || input.classList.contains('required')) {
+          input.setAttribute('required', true);
+        }
+      });
+      $(form).find('.non-hra-questions').remove();
+    }
+
+    // show mvsq if msqv is true
+    if (isMvsq == "true") {
+      form.querySelector('.mvsq-questions').classList.remove('hidden');
+      form.querySelectorAll('.mvsq-questions input, mvsq-questions select').forEach(function(input) {
+        var label = form.querySelector("label[for='" + input.id + "']")
+        if ((label && label.classList.contains('required')) || input.classList.contains('required')) {
+          input.setAttribute('required', true);
+        }
+      });
+    } else {
+      form.querySelector('.mvsq-questions').classList.add('hidden');
+      form.querySelectorAll('.mvsq-questions input, mvsq-questions select').forEach(function(input) {
+        input.removeAttribute('required');
+      });
+    }
+  }
+}
+
 // in order to make sure the input ids/labels are unique, we need to add a random string to the end
 // so we don't get WAVE errors
 function makeInputIdsUnique(formId, clonedForm) {
@@ -120,49 +165,7 @@ document.addEventListener("turbolinks:load", function() {
     $(clonedForm).find('input').removeAttr('disabled');
     let formId = clonedForm.querySelector('.benefit-form-container').id
     makeInputIdsUnique(formId, clonedForm)
-
-    // do all the esi specific hiding and showing
-    if (esi == "true") {
-      // show non-hra questions if non-hra is the selected insurance kind
-      // show hra questions if hra is the selected insurance kind
-      // make the inputs of the non-selected kind non-reqquired
-      // make the inputs of the selected kind required
-      if (selected.value !== "health_reimbursement_arrangement") {
-        clonedForm.querySelector('.non-hra-questions').classList.remove('hidden');
-        clonedForm.querySelectorAll('.non-hra-questions input, non-hra-questions select').forEach(function(input) {
-          var label = clonedForm.querySelector("label[for='" + input.id + "']")
-          if ((label && label.classList.contains('required')) || input.classList.contains('required')) {
-            input.setAttribute('required', true);
-          }
-        });
-        $(clonedForm).find('.hra-questions').remove();
-      } else {
-        clonedForm.querySelector('.hra-questions').classList.remove('hidden');
-        clonedForm.querySelectorAll('.hra-questions input, hra-questions select').forEach(function(input) {
-          var label = clonedForm.querySelector("label[for='" + input.id + "']")
-          if ((label && label.classList.contains('required')) || input.classList.contains('required')) {
-            input.setAttribute('required', true);
-          }
-        });
-        $(clonedForm).find('.non-hra-questions').remove();
-      }
-
-      // show mvsq if msqv is true
-      if (mvsq === "true") {
-        clonedForm.querySelector('.mvsq-questions').classList.remove('hidden');
-        clonedForm.querySelectorAll('.mvsq-questions input, mvsq-questions select').forEach(function(input) {
-          var label = clonedForm.querySelector("label[for='" + input.id + "']")
-          if ((label && label.classList.contains('required')) || input.classList.contains('required')) {
-            input.setAttribute('required', true);
-          }
-        });
-      } else {
-        clonedForm.querySelector('.mvsq-questions').classList.add('hidden');
-        clonedForm.querySelectorAll('.mvsq-questions input, mvsq-questions select').forEach(function(input) {
-          input.removeAttribute('required');
-        });
-      }
-    }
+    handleEsiFields(clonedForm, esi, kind, mvsq);
 
     select.closest(".new-benefit-form").classList.add('hidden');
     benefitList.appendChild(clonedForm);
@@ -262,8 +265,9 @@ document.addEventListener("turbolinks:load", function() {
     var container = button.closest('.benefit');
     var benefitList = container.closest('.benefits-list');
     var show = container.querySelector('.benefit-show');
-    var form = container.querySelector('.edit-benefit-form');
     show.classList.add('hidden');
+    var form = container.querySelector('.edit-benefit-form');
+    handleEsiFields(form, show.dataset.esi, show.dataset.hra, show.dataset.mvsq);
     form.classList.remove('hidden');
     document.getElementById('new-benefit-form-' + kind).classList.add('hidden');
     document.getElementById('add_new_benefit_kind_' + kind).classList.add('hidden');
@@ -385,7 +389,8 @@ document.addEventListener("turbolinks:load", function() {
       e.preventDefault();
       var benefitEl = $(this).parents('.benefit');
       benefitEl.find('.benefit-show').addClass('hidden');
-      benefitEl.find('.edit-benefit-form').removeClass('hidden');
+      var form = benefitEl.find('.edit-benefit-form')
+      form.removeClass('hidden');
       benefitEl.find('select').selectric();
       $(benefitEl).find(".datepicker-js").datepicker({ dateFormat: 'mm/dd/yy', changeMonth: true, changeYear: true, yearRange: "-110:+110"});
       startEditingBenefit($(this).parents('.benefit-kind').attr('id'));

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit.html.erb
@@ -1,6 +1,7 @@
 <% if @bs4 %>
   <div id="<%= dom_id benefit %>" class="benefit">
-    <div class="my-4 p-3 border rounded bg-white benefit-show" data-cuke="esi_benefit">
+    <% is_hra = insurance_kind == "health_reimbursement_arrangement" %>
+    <div class="my-4 p-3 border rounded bg-white benefit-show" data-cuke="esi_benefit" data-esi="true" data-hra=<%= display_esi_fields?(insurance_kind, kind) %> data-mvsq=<%= display_minimum_value_standard_question?(insurance_kind) %>>
       <h2><%= insurance_kind.humanize.titlecase %></h2>
       <h3><%= benefit.employer_name %></h3>
       <dl class="parent mb-4">
@@ -22,17 +23,17 @@
         <dd><%= benefit.employer_id %>
       </dl>
       <dl class="parent">
-        <% unless insurance_kind == 'health_reimbursement_arrangement' %>
+        <% unless is_hra %>
           <dt><%= l10n("faa.health_coverage.esi.waiting_label") %></dt>
           <dd><%= benefit.is_esi_waiting_period ? l10n("yes") : l10n("no") %>
           <dt><%= l10n("faa.health_coverage.esi.waiting_label") %></dt>
           <dd><%= benefit.is_esi_mec_met ? l10n("yes") : l10n("no") %>
           <dt><%= l10n("faa.health_coverage.esi.covered") %></dt>
           <dd><%= benefit.esi_covered&.titleize %></dd>
-          <dt><%= l10n("start_on") %></dt>
+          <dt><%= l10n("start_date") %></dt>
           <dd><%= benefit.start_on %>
           <% if benefit.end_on %>
-            <dt><%= l10n("end_on") %></dt>
+            <dt><%= l10n("end_date") %></dt>
             <dd><%= benefit.end_on %>
           <% end %>
           <dt><%= l10n("faa.health_coverage.esi.mvs_amount_question") %></dt>

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit_form.html.erb
@@ -3,7 +3,7 @@
   <% form_id = SecureRandom.random_number(10000000) %>
   <section class="my-4 p-3 border rounded bg-white benefit-form-container" id="<%= form_id %>">
     <%= f.hidden_field :kind, value: kind %>
-    <%= f.hidden_field :insurance_kind, value: kind %>
+    <%= f.hidden_field :insurance_kind, value: insurance_kind %>
     <div class="insurance-kind-label-container">
       <% if insurance_kind.present? %>
         <h2><%= insurance_kind.humanize.titleize %></h2>
@@ -79,7 +79,7 @@
         <div class="d-flex mt-2 col-6 px-0">
           <div class="col px-0 mr-3">
             <%= f.label :employee_cost, l10n("faa.health_coverage.esi.amount"), class: "required", for: "employee_cost|#{form_id}" %>
-            <%= f.text_field :employee_cost, placeholder: '0.00', value: "", id: "employee_cost|#{form_id}" %>
+            <%= f.text_field :employee_cost, placeholder: '0.00', value: benefit.employee_cost, id: "employee_cost|#{form_id}" %>
           </div>
           <div class="col px-0">
             <%= f.label :employee_cost_frequency, l10n("frequency"), class:"required", for: "employee_cost_frequency|#{form_id}" %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188038141#

The esi benefit form partials has several different divs containing kind-specific inputs which are shown/hidden based on the kind. The dynamic showing and hiding was accounted for in add new, but not for edit. I've updated the view to show and hide these divs for edit, and also fixed two bugs that were previously untestable due to this one.
