### PR TITLE
Refactor the faa eligibility results accordion UI navigation.

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/applications/_eligibility_results_per_tax_household.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/_eligibility_results_per_tax_household.html.erb
@@ -161,27 +161,33 @@
 
     <p data-cuke='your_application_reference_2' class="mt-4"><%= l10n("faa.results.your_application_reference_2", application_hbx_id: @application.hbx_id)%></p>
 
-    <div class="mt-4 accordion card" data-cuke='other_actions'>
+    <div id="other-accordion" data-cuke='other_actions'>
+      <div class="card">
+        <div class="card-header" id="otherActionsHeading">
+          <h5 class="mb-0">
+            <button class="btn btn-link" data-toggle="collapse" data-target="#otherActions" aria-expanded="true" aria-controls="otherActions">
+              <%= l10n("other_actions") %>
+            </button>
+          </h5>
+        </div>
 
-      <h3 class="accordion-header collapsed" data-toggle="collapse" data-target="#fa_other_actions" aria-expanded="true" aria-controls="fa_other_actions" href="#fa_other_actions">
-        <%= l10n("other_actions") %>
-      </h3>
+        <div id="otherActions" class="collapse show" aria-labelledby="otherActionsHeading" data-parent="#other-accordion">
+          <div class="card-body">
+            <% if FinancialAssistanceRegistry.feature_enabled?(:fa_send_to_external_verification) && !@application.is_transferrable? %>
+              <div class="w-100 pb-4">
+                <p><%= l10n("faa.full_long_name_determination",
+                    program_long_name: FinancialAssistanceRegistry[:medicaid_or_chip_agency_long_name].setting(:name).item,
+                    program_short_name: FinancialAssistanceRegistry[:medicaid_or_chip_program_short_name].setting(:name).item) %></p>
+                <%= h(link_to l10n("faa.send_to_external_verification"), update_transfer_requested_application_url, method: :put, class: "button secondary", id: "btn-request-transfer", remote: true) %>
+              </div>
+            <% end %>
 
-      <div id="fa_other_actions" class="collapse">
-        <div class="panel-group" id="accordion">
-          <% if FinancialAssistanceRegistry.feature_enabled?(:fa_send_to_external_verification) && !@application.is_transferrable? %>
-            <div class="w-100 pb-4">
-              <p><%= l10n("faa.full_long_name_determination",
-                  program_long_name: FinancialAssistanceRegistry[:medicaid_or_chip_agency_long_name].setting(:name).item,
-                  program_short_name: FinancialAssistanceRegistry[:medicaid_or_chip_program_short_name].setting(:name).item) %></p>
-              <%= h(link_to l10n("faa.send_to_external_verification"), update_transfer_requested_application_url, method: :put, class: "button secondary", id: "btn-request-transfer", remote: true) %>
+            <div class="w-100 pb-2">
+              <p><%= l10n("faa.do_not_agree",
+                appeal_link: EnrollRegistry[:enroll_app].setting(:appeal_link).item,
+                find_expert_link: EnrollRegistry[:enroll_app].setting(:find_expert_link).item) %></p>
+              <%= h(link_to l10n("faa.results.view_my_applications"), applications_path, class: "button secondary") %>
             </div>
-          <% end %>
-          <div class="w-100 pb-2">
-            <p><%= l10n("faa.do_not_agree",
-              appeal_link: EnrollRegistry[:enroll_app].setting(:appeal_link).item,
-              find_expert_link: EnrollRegistry[:enroll_app].setting(:find_expert_link).item) %></p>
-            <%= h(link_to l10n("faa.results.view_my_applications"), applications_path, class: "button secondary") %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188057094

# A brief description of the changes

Current behavior: After completing a FAA and submitting, the results page has an accordion at the bottom for "Other Actions". The accordion is not keyboard accessible.

New behavior: The accordion IS keyboard accessible. Styles will be done in another ticket.

