### PR TITLE
bs4 fix benefits household income input

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/benefits/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/index.html.erb
@@ -169,12 +169,12 @@
             <fieldset>
               <legend class="weight-n instruction-row"><%=l10n("faa.household_income_changed")%></legend>
               <div class="focus d-flex mt-3">
-                <label class="radio mr-3" for="has_household_income_changed_yes">
-                  <input id="has_household_income_changed_yes" type="radio" value="true" name="has_household_income_changed" <%='checked' if @applicant.has_household_income_changed? %>>
+                <label class="radio mr-3">
+                  <input id="has_household_income_changed_true" type="radio" value="true" name="has_household_income_changed" <%='checked' if @applicant.has_household_income_changed? %>>
                   <span><%= l10n("yes") %></span>
                 </label>
-                <label class="radio mr-3" for="has_household_income_changed_no">
-                  <input id="has_household_income_changed_no" type="radio" value="false" name="has_household_income_changed" <%='checked'if @applicant.has_household_income_changed == false %>>
+                <label class="radio mr-3">
+                  <input id="has_household_income_changed_false" type="radio" value="false" name="has_household_income_changed" <%='checked'if @applicant.has_household_income_changed == false %>>
                   <span><%= l10n("no") %></span>
                 </label>
               </div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188078696

There is an event listener in `benefit.js` which listens to the radios on this page, and the ids for the radios for this field was incorrect.
