### PR TITLE
bs4 fix vlp primary fields

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -12,7 +12,7 @@ class PeopleController < ApplicationController
     @family = @person.primary_family
 
     @person.updated_by = current_user.oim_id unless current_user.nil?
-    if @person.is_consumer_role_active? && request.referer.include?("insured/families/personal")
+    if @person.is_consumer_role_active? && (request.referer.include?("insured/families/personal") || request.referer.include?("insured/families/manage_family"))
       @valid_vlp = update_vlp_documents(@person.consumer_role, 'person')
       redirect_path = personal_insured_families_path
     else

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -12,7 +12,8 @@ class PeopleController < ApplicationController
     @family = @person.primary_family
 
     @person.updated_by = current_user.oim_id unless current_user.nil?
-    if @person.is_consumer_role_active? && (request.referer.include?("insured/families/personal") || request.referer.include?("insured/families/manage_family"))
+    valid_referer_component = "insured/families/#{params[:bs4] == 'true' ? 'manage_family' : 'personal'}"
+    if @person.is_consumer_role_active? && request.referer.include?(valid_referer_component)
       @valid_vlp = update_vlp_documents(@person.consumer_role, 'person')
       redirect_path = personal_insured_families_path
     else

--- a/app/views/people/landing_pages/_personal.html.erb
+++ b/app/views/people/landing_pages/_personal.html.erb
@@ -1,5 +1,6 @@
 <% if @bs4 %>
   <%= form_for @person do |f| %>
+    <%= hidden_field_tag :bs4, true %>
     <div id="personal_info" class="module new_person_wrapper">
       <div class="d-flex mb-md-4 row col-sm">
         <div class="mr-auto col-sm col-md-6 col-lg-3 p-0">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188080458

The `update_vlp_documents` helper called from `people/update` for the primary POST was conditionally called only when the requester had the "personal" component. While I'm not sure why this check is needed at all, it did work as intended on legacy given that this post would only be made from that path. Now that primaries can be edited/updated from inside "manage_family", the vlp docs were not being saved.
