### PR TITLE
refactor: Update plan shopping filters and summary display

### DIFF
--- a/app/views/insured/plan_shoppings/show.html.erb
+++ b/app/views/insured/plan_shoppings/show.html.erb
@@ -13,7 +13,9 @@
 
     <div id="all-plans" class="all-filters-row">
       <details id="plan-filter-container" class="my-3">
-        <summary data-open="Hide Filters" data-close="Show Filters"></summary>
+        <summary data-open="Hide Filters" data-close="Show Filters">
+          <span>Filter & Sort</span>
+        </summary>
         <div class="mt-3">
           <%= render partial: './ui-components/v1/filters/plan_filters' %>
         </div>
@@ -77,7 +79,16 @@
       font-size: 18px;
     }
 
-    details#plan-filter-container > summary::-webkit-details-marker, details > summary::marker  {
+    details#plan-filter-container > summary {
+      list-style-type: none;
+      font-weight: bold;
+      font-size: 18px;
+    }
+
+    details#plan-filter-container > summary::-webkit-details-marker,
+    details#plan-filter-container > summary span,
+    details > summary::marker
+    {
       display: none;
     }
 

--- a/app/views/insured/plan_shoppings/show.html.erb
+++ b/app/views/insured/plan_shoppings/show.html.erb
@@ -14,7 +14,7 @@
     <div id="all-plans" class="all-filters-row">
       <details id="plan-filter-container" class="my-3">
         <summary data-open="Hide Filters" data-close="Show Filters">
-          <span>Filter & Sort</span>
+          <span><%= l10n("plans.filter_sort") %></span>
         </summary>
         <div class="mt-3">
           <%= render partial: './ui-components/v1/filters/plan_filters' %>

--- a/db/seedfiles/translations/en/me/plan.rb
+++ b/db/seedfiles/translations/en/me/plan.rb
@@ -1,6 +1,7 @@
 PLAN_TRANSLATIONS = {
   'en.plans.plan_results' => 'Plan Results',
   'en.plans.shop_now' => 'Shop Now',
+  'en.plans.filter_sort' => 'Filter & Sort',
   'en.plans.if_you' => 'If you',
   'en.plans.qualify_for_new_sep' => 'Qualify for New SEP',
   'en.plans.plan_contact_info' => 'Plan Contact Info',


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188071506

# A brief description of the changes

Current behavior:  Show filters/Hide Filters is missing when page is viewed with css turned off

New behavior:  Show filters/Hide Filters is now visible w/ css turned off. However will display "Filter & Sort" since it is not dynamic (without css it doesn't know if it is opened or closed)

