### PR TITLE
adds event, publisher and subscriber for family cv validation job

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: d3aba9dde2a1efaa66a5aaf8560c64cc4fe0f921
+  revision: d277781215e68c15d34d03a71b780c2167ceec35
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/event_source/events/private/families/validate_cv_requested.rb
+++ b/app/event_source/events/private/families/validate_cv_requested.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Events
+  module Private
+    module Families
+      # This class has publisher's path for registering relevant events
+      class ValidateCvRequested < EventSource::Event
+
+        publisher_path 'publishers.private.families.validate_cv_requested_publisher'
+      end
+    end
+  end
+end

--- a/app/event_source/publishers/private/families/validate_cv_requested_publisher.rb
+++ b/app/event_source/publishers/private/families/validate_cv_requested_publisher.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Publishers
+  module Private
+    module Families
+      # This class resisters event 'enroll.private.families.validate_cv_requested'
+      class ValidateCvRequestedPublisher
+        include ::EventSource::Publisher[amqp: 'enroll.private.families']
+
+        register_event 'validate_cv_requested'
+      end
+    end
+  end
+end

--- a/app/event_source/subscribers/private/families/validate_cv_requested_subscriber.rb
+++ b/app/event_source/subscribers/private/families/validate_cv_requested_subscriber.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Subscribers
+  module People
+    module PersonAliveStatus
+      # Subscriber receives events to validate CV for a given family.
+      class ValidateCvRequestedSubscriber
+        include ::EventSource::Subscriber[amqp: 'enroll.private.families']
+
+        # Subscribes to the :on_validate_cv_requested event.
+        #
+        # @param delivery_info [Bunny::DeliveryInfo] Information about the delivery.
+        # @param metadata [Bunny::MessageProperties] Metadata associated with the message.
+        # @param response [String] The message payload.
+        subscribe(:on_validate_cv_requested) do |delivery_info, metadata, response|
+          subscriber_logger = subscriber_logger_for(:on_validate_cv_requested)
+
+          # process_message(subscriber_logger, response, metadata) unless Rails.env.test?
+
+          ack(delivery_info.delivery_tag)
+        rescue StandardError, SystemStackError => e
+          ack(delivery_info.delivery_tag)
+        end
+
+        private
+
+        # Creates a logger for the given event.
+        #
+        # @param event [Symbol] The event name.
+        # @return [Logger] The logger instance.
+        def subscriber_logger_for(event)
+          Logger.new(
+            "#{Rails.root}/log/#{event}_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+          )
+        end
+
+        # Processes the message payload and logs the result.
+        #
+        # @param subscriber_logger [Logger] The logger instance.
+        # @param payload [String] The message payload.
+        # @param metadata [Bunny::MessageProperties] Metadata associated with the message.
+        # @return [void]
+        def process_message(subscriber_logger, payload, metadata)
+          payload = JSON.parse(response, symbolize_names: true)
+
+          result = ::Operations::Private::Families::ValidateCvRequested.new.call(
+            payload: payload,
+            headers: metadata.headers
+          )
+
+          message = result.success? ? "----- SUCCESS: #{result.value!}" : "----- FAILURE: #{result.failure}"
+
+          subscriber_logger.info "ValidateCvRequestedSubscriber, result: #{message}"
+        end
+      end
+    end
+  end
+end

--- a/app/event_source/subscribers/private/families/validate_cv_requested_subscriber.rb
+++ b/app/event_source/subscribers/private/families/validate_cv_requested_subscriber.rb
@@ -19,6 +19,11 @@ module Subscribers
 
           ack(delivery_info.delivery_tag)
         rescue StandardError, SystemStackError => e
+          subscriber_logger.error "ValidateCvRequestedSubscriber, response: #{
+            response}, metadata: #{
+              metadata}, error message: #{
+                e.message}, backtrace: #{
+                  e.backtrace}"
           ack(delivery_info.delivery_tag)
         end
 
@@ -34,13 +39,13 @@ module Subscribers
           )
         end
 
-        # Processes the message payload and logs the result.
+        # Processes the message response and logs the result.
         #
         # @param subscriber_logger [Logger] The logger instance.
-        # @param payload [String] The message payload.
+        # @param response [String] The message response.
         # @param metadata [Bunny::MessageProperties] Metadata associated with the message.
         # @return [void]
-        def process_message(subscriber_logger, payload, metadata)
+        def process_message(subscriber_logger, response, metadata)
           payload = JSON.parse(response, symbolize_names: true)
 
           result = ::Operations::Private::Families::ValidateCvRequested.new.call(


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [Jolly Podgers - 188066931](https://www.pivotaltracker.com/story/show/188066931)

# A brief description of the changes

Current behavior: `N/A`

New behavior: Adds event, publisher, and subscriber for supporting family CV validation job.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
