### PR TITLE
chore: fix plan shopping receipt print layout

### DIFF
--- a/app/javascript/css/print.scss
+++ b/app/javascript/css/print.scss
@@ -4,8 +4,9 @@
   }
 }
 @media print {
-  html, body {
-    height:100vh;
+  html,
+  body {
+    height: 100vh;
     margin: 0 !important;
     padding: 0 !important;
     overflow: hidden;
@@ -17,13 +18,14 @@
   body * {
     visibility: hidden;
   }
-  #printSection, #printSection * {
+  #printSection,
+  #printSection * {
     visibility: visible;
   }
   #printSection {
-    position:absolute;
-    left:0;
-    top:0;
+    position: absolute;
+    left: 0;
+    top: 0;
   }
   #printArea {
     display: none !important;
@@ -31,7 +33,15 @@
   #printSection #printArea {
     display: block !important;
   }
-  #btnPrint, nav, header, footer, .progress-nav-container  {
-    display: none  !important;
+  #btnPrint,
+  nav,
+  header,
+  footer,
+  .progress-nav-container {
+    display: none !important;
+  }
+
+  .no-print {
+    display: none !important;
   }
 }

--- a/app/views/insured/plan_shoppings/receipt.en.html.erb
+++ b/app/views/insured/plan_shoppings/receipt.en.html.erb
@@ -20,8 +20,8 @@
       <%= render partial: "insured/plan_shoppings/pay_now", locals: { source: "Plan Shopping", hbx_enrollment: @enrollment }%>
     </div>
     <!-- modal -->
-    <div id="how_to_pay" class="modal" role="dialog" class="hidden" <% if @enrollment.employee_role.present? %>data-employee-role="true"<% else %>data-employee-role="false"<% end %>>
-        <div class="modal-dialog">
+    <div id="how_to_pay" class="modal" role="dialog" <% if @enrollment.employee_role.present? %>data-employee-role="true"<% else %>data-employee-role="false"<% end %>>
+        <div class="modal-dialog no-print">
           <div class="modal-content">
             <div class="d-flex mb-4 align-items-center modal-header">
               <div class="col pl-0">
@@ -159,7 +159,7 @@
     <% end %>
 
     <p><%= l10n("plans.plan_shopping.receipt.when_finished")%></p>
-    <div class="mt-4">
+    <div class="mt-4 no-print">
       <%= h(link_to l10n("plans.plan_shopping.receipt.print"), '#', id: 'btnPrint', class: "btn outline interaction-click-control-print-purchase-confirmation mr-2") %>
       <%= h(link_to l10n("exceptions.go_to_my_account"), main_app.family_account_path, class: "btn secondary text-center", id: 'btn-continue') %>
     </div>


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/188081500

# A brief description of the changes

Current behavior: When print the plan shopping receipt page, the layout included items that should have been hidden

New behavior: The print layout now matches the design
