### PR TITLE
bs4 fix address titles

### DIFF
--- a/app/views/insured/consumer_roles/_form.html.erb
+++ b/app/views/insured/consumer_roles/_form.html.erb
@@ -23,7 +23,6 @@
     </div>
     <h3 class="beta mt-4"><%= l10n("insured.consumer_roles.contact_info_for") %> <%= @person.full_name %></h3>
     <section class="mb-4">
-      <h4 class="gamma"><%= l10n("insured.consumer_roles.home_address") %></h4>
       <%= render partial: 'shared/consumer_home_address_fields', locals: {f: f, bs4: true} %>
     </section>
     <section class="mb-4">

--- a/app/views/insured/families/_family_member_row.html.erb
+++ b/app/views/insured/families/_family_member_row.html.erb
@@ -1,26 +1,26 @@
-  <% person_id = member.person.id %>
-  <tr class="member-<%= person_id %>-row">
-    <td><%= member.full_name.titleize %></td>
-    <td><%= member.person.hbx_id %></td>
-    <td><%= member.age_on(TimeKeeper.date_of_record) %></td>
-    <td><%= member.gender.humanize %></td>
-    <td><%= member.relationship.try(:humanize) %></td>
-    <td class="p-2">
-      <% edit_url = member.is_primary_applicant ? personal_insured_families_path({bs4: @bs4}) : main_app.edit_insured_family_member_path({id: member.id, bs4: @bs4}) %>
-      <span class="d-flex">
-        <%= h(link_to l10n("edit_member"), edit_url, remote: true, class: 'edit-member btn button outline close-2') %>
-        <span class="d-flex hidden edit-buttons">
-            <%= link_to('#', class: 'btn outline mr-2 text-nowrap') do %>
-              <%= l10n("cancel_edit") %>
-            <% end %>
-            <% confirm_id = "member-#{person_id}-confirm" %>
-            <span tabindex="0", onkeydown="handleButtonKeyDown(event, '<%= confirm_id %>')", id=<%= confirm_id %> class="confirm-member btn btn-primary text-nowrap">
-              <%= l10n("save_changes") %>
-            </span>
-        </span>
+<% person_id = member.person.id %>
+<tr class="member-<%= person_id %>-row">
+  <td><%= member.full_name.titleize %></td>
+  <td><%= member.person.hbx_id %></td>
+  <td><%= member.age_on(TimeKeeper.date_of_record) %></td>
+  <td><%= member.gender.humanize %></td>
+  <td><%= member.relationship.try(:humanize) %></td>
+  <td class="p-2">
+    <% edit_url = member.is_primary_applicant ? personal_insured_families_path({bs4: @bs4}) : main_app.edit_insured_family_member_path({id: member.id, bs4: @bs4}) %>
+    <span class="d-flex">
+      <%= h(link_to l10n("edit_member"), edit_url, remote: true, class: 'edit-member btn button outline close-2') %>
+      <span class="d-flex hidden edit-buttons">
+          <%= link_to('#', class: 'btn outline mr-2 text-nowrap') do %>
+            <%= l10n("cancel_edit") %>
+          <% end %>
+          <% confirm_id = "member-#{person_id}-confirm" %>
+          <span tabindex="0", onkeydown="handleButtonKeyDown(event, '<%= confirm_id %>')", id=<%= confirm_id %> class="confirm-member btn btn-primary text-nowrap">
+            <%= l10n("save_changes") %>
+          </span>
       </span>
-    </td>
-  </tr>
+    </span>
+  </td>
+</tr>
 <tr id="person-<%= person_id %>" class="hidden">
   <td colspan="6" class="append_consumer_info"></td>
 </tr>

--- a/app/views/insured/family_members/_dependent_form.html.erb
+++ b/app/views/insured/family_members/_dependent_form.html.erb
@@ -119,12 +119,6 @@
               </div>
             </div>
 
-            <div class="row row-form-wrapper no-buffer" id="home-info" style="display: <%= f.object.same_with_primary.present? and f.object.same_with_primary == 'true' ? 'none' : 'block' %>">
-              <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 form-group form-group-lg">
-              <h4 class="gamma"><%= l10n("insured.consumer_roles.home_address")%></h4>
-                <i class="fa fa-info-circle"></i> <%= l10n('insured.dependent_home_address_info') %>
-              </div>
-            </div>
             <div id="dependent-home-address-area" style="display: <%= f.object.same_with_primary.present? and f.object.same_with_primary == 'true' ? 'none' : 'block' %>">
               <% if has_active_consumer_dependent?(@person, @dependent) %>
                 <%= render 'shared/address_fields_for_dependent', f: f, show_no_dc_address: true %>

--- a/app/views/people/landing_pages/_personal.html.erb
+++ b/app/views/people/landing_pages/_personal.html.erb
@@ -66,13 +66,13 @@
     <% if current_user.does_not_have_any_staff_role? && !current_user.has_insured_role? %>
       <%= render 'shared/age_off_excluded', f: f %>
     <% end %>
-
+    
     <section class="mb-4">
       <% if @person.is_consumer_role_active? %>
         <div id="consumer_fields_sets ">
           <%= render 'shared/consumer_fields', f: f %>
         </div>
-        <%= render partial: 'shared/consumer_home_address_fields', locals: {f: f, bs4: true} %>
+        <%= render partial: 'shared/consumer_home_address_fields', locals: {f: f} %>
       <% else %>
         <%= render 'shared/home_address_fields', f: f %>
       <% end %>
@@ -81,11 +81,11 @@
     <section class="mb-4">
       <h4 class="gamma mb-0"><%= l10n("insured.consumer_roles.phone_and_email") %></h4>
       <p><%= l10n("insured.consumer_roles.please_provide") %></p>
-      <%= render partial: 'shared/phone_fields', locals: {f: f, bs4: true} %>
+      <%= render partial: 'shared/phone_fields', locals: {f: f} %>
       <div id="email_info" class="">
         <div class="email d-flex mb-md-4 row col-sm">
           <%= f.fields_for :emails, errors: {}, fieldset: true do |email|  %>
-            <%= render partial: 'shared/email_fields', locals: {f: email, bs4: true} %>
+            <%= render partial: 'shared/email_fields', locals: {f: email} %>
           <% end %>
         </div>
       </div>

--- a/app/views/shared/_address_fields_for_dependent.html.erb
+++ b/app/views/shared/_address_fields_for_dependent.html.erb
@@ -15,8 +15,18 @@
           <% display_class="d-none" %>
         <% end %>
       <% end %>
-      <% required = kind =='home' ? "address_required" : '' %>
 
+      <div class="address-row <%= div_class %> <%= display_class %>">
+        <% if kind == 'home' %>
+          <h4 class="gamma"><%= l10n("insured.consumer_roles.home_address") %></h4>
+          <i class="fa fa-info-circle"></i> <%= l10n("insured.primary_home_address_info") %>
+        <% elsif kind == 'mailing' %>
+          <h4 class="gamma"><%= l10n("insured.mailing_address") %></h4>
+          <i class="fa fa-info-circle"></i> <%=l10n("insured.primary_mailing_address_info")%>
+        <% end %>
+      </div>
+
+      <% required = kind =='home' ? "address_required" : '' %>
       <div class="address-row <%= div_class %> <%= display_class %>">
       <%# mailing-div inputs should default to unrequired because the mailing-div is hidden by default; required attrs on the fields are added in application.js on show %>
         <div class="d-flex mb-md-2 row col-sm">

--- a/app/views/shared/_consumer_home_address_fields.html.erb
+++ b/app/views/shared/_consumer_home_address_fields.html.erb
@@ -16,6 +16,7 @@
       <% required = kind =='home' ? "address_required" : '' %>
       <div class="address-row <%= div_class %> <%= display_class %>">
         <% if kind == 'home' %>
+          <h4 class="gamma"><%= l10n("insured.consumer_roles.home_address") %></h4>
           <i class="fa fa-info-circle"></i> <%= l10n("insured.primary_home_address_info") %>
         <% elsif kind == 'mailing' %>
           <h4 class="gamma"><%= l10n("insured.mailing_address") %></h4>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -2,7 +2,7 @@
   <%= form_for @applicant, url: application_applicant_path(@application, @applicant), method: :patch do |f|%>
     <%= hidden_field_tag :is_dependent, @applicant.is_dependent? %>
     <% readonly_status = @applicant.is_primary_applicant? %>
-
+    
     <div id="personal_info" class="house">
       <div class="@applicant_notice_div_<%= @applicant.id%>"></div>
 
@@ -95,7 +95,6 @@
         </div>
       <% else %>
         <section class="mb-4">
-          <h4 class="gamma"><%= l10n("insured.consumer_roles.home_address") %></h4>
           <%= render partial: 'shared/consumer_home_address_fields', locals: {f: f, bs4: true} %>
         </section>
         <section class="mb-4 hidden">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
1. https://www.pivotaltracker.com/n/projects/2640062/stories/188093682#
2. https://www.pivotaltracker.com/n/projects/2640062/stories/188093670#

This PR cleans up the headers used with the address partials in the app. At some call sites, the parent view defined its own address header. I've updated the address partials to own their own home/mailing headers, and removed the instances where some parent view defined their own headers. I also cleaned up some indentation and removed some unneeded arguments.