### PR TITLE
bs4 fix benefits saved/edit titles

### DIFF
--- a/components/financial_assistance/app/assets/javascripts/financial_assistance/benefit.js
+++ b/components/financial_assistance/app/assets/javascripts/financial_assistance/benefit.js
@@ -760,12 +760,17 @@ document.addEventListener("turbolinks:load", function() {
     });
   }
 
+  // masks from `application.js.erb` seem to be broken on the cloned forms, redefining the masks on the focus events seems to be the only reliable fix
   $(document).on('focus', '.phone_number', function () {
     $(this).mask('(000) 000-0000');
   });
 
   $(document).on('focus', '.fien_field', function () {
     $(this).mask('99-9999999');
+  });
+
+  $(document).on('focus', '.zip', function () {
+    $(this).mask("99999");
   });
 
   $('body').on('keyup keydown keypress', '#benefit_employer_phone_full_phone_number', function (e) {

--- a/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
+++ b/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
@@ -456,15 +456,16 @@ module FinancialAssistance
       l10n("faa.other_ques.#{key}", subject: use_applicant_name ? @applicant.first_name.capitalize : l10n("faa.this_person"))
     end
 
+    def hr_kind(kind, insurance_kind)
+      eligible_esi = kind == "is_eligible" && insurance_kind == 'employer_sponsored_insurance' && FinancialAssistanceRegistry.feature_enabled?(:minimum_value_standard_question)
+      term = eligible_esi ? "faa.question.#{insurance_kind}_eligible" : "faa.question.#{insurance_kind}"
+      l10n(term, short_name: EnrollRegistry[:enroll_app].setting(:short_name).item)
+    end
+
     def insurance_kind_select_options(kind)
-      insurance_kind_options = []
-      FinancialAssistance::Benefit.valid_insurance_kinds.each do |insurance_kind|
-        eligible_esi = kind == "is_eligible" && insurance_kind == 'employer_sponsored_insurance' && FinancialAssistanceRegistry.feature_enabled?(:minimum_value_standard_question)
-        term = eligible_esi ? "faa.question.#{insurance_kind}_eligible" : "faa.question.#{insurance_kind}"
-        hr_kind = l10n(term, short_name: EnrollRegistry[:enroll_app].setting(:short_name).item)
-        insurance_kind_options << [hr_kind, insurance_kind, {:'data-esi' => display_esi_fields?(insurance_kind, kind), :'data-mvsq' => display_minimum_value_standard_question?(insurance_kind)}]
-      end
-      insurance_kind_options
+      FinancialAssistance::Benefit.valid_insurance_kinds.map { |insurance_kind|
+        [hr_kind(kind, insurance_kind), insurance_kind, {:'data-esi' => display_esi_fields?(insurance_kind, kind), :'data-mvsq' => display_minimum_value_standard_question?(insurance_kind)}]
+      }
     end
   end
 end

--- a/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
+++ b/components/financial_assistance/app/helpers/financial_assistance/application_helper.rb
@@ -463,9 +463,9 @@ module FinancialAssistance
     end
 
     def insurance_kind_select_options(kind)
-      FinancialAssistance::Benefit.valid_insurance_kinds.map { |insurance_kind|
+      FinancialAssistance::Benefit.valid_insurance_kinds.map do |insurance_kind|
         [hr_kind(kind, insurance_kind), insurance_kind, {:'data-esi' => display_esi_fields?(insurance_kind, kind), :'data-mvsq' => display_minimum_value_standard_question?(insurance_kind)}]
-      }
+      end
     end
   end
 end

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit.html.erb
@@ -2,7 +2,7 @@
   <div id="<%= dom_id benefit %>" class="benefit">
     <% is_hra = insurance_kind == "health_reimbursement_arrangement" %>
     <div class="my-4 p-3 border rounded bg-white benefit-show" data-cuke="esi_benefit" data-esi="true" data-hra=<%= is_hra %> data-mvsq=<%= display_minimum_value_standard_question?(insurance_kind) %>>
-      <h2><%= insurance_kind.humanize.titlecase %></h2>
+      <h2><%= hr_kind(kind, insurance_kind) %></h2>
       <h3><%= benefit.employer_name %></h3>
       <dl class="parent mb-4">
         <% if !FinancialAssistanceRegistry.feature_enabled?(:disable_employer_address_fields) %>

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit_form.html.erb
@@ -6,7 +6,7 @@
     <%= f.hidden_field :insurance_kind, value: insurance_kind %>
     <div class="insurance-kind-label-container">
       <% if insurance_kind.present? %>
-        <h2><%= insurance_kind.humanize.titleize %></h2>
+        <h2><%= hr_kind(kind, insurance_kind) %></h2>
       <% end %>
     </div>
     <div class="d-flex flex-column col-6 px-0">

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit_form.html.erb
@@ -39,7 +39,7 @@
             <%= address_fields.select :state, options_for_select(state_options, selected: benefit.employer_address.try(:state)), {prompt: l10n("choose")}, {id: "state|#{form_id}", :required => required} %>
           </div>
           <div class="d-flex flex-column col-3 px-0">
-            <%= address_fields.label :zip, l10n("zip"), for: "zip|#{form_id}", class: "#{"required" if required}" %>
+            <%= address_fields.label :zip, l10n("zip"), for: "zip|#{form_id}", class: "zip #{"required" if required}" %>
             <%= address_fields.text_field :zip, placeholder: l10n('zip'), required: required, value: benefit.employer_address.try(:zip), class: "zip", id: "zip|#{form_id}" %>
           </div>
         </div>

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_esi_benefit_form.html.erb
@@ -5,6 +5,8 @@
     <%= f.hidden_field :kind, value: kind %>
     <%= f.hidden_field :insurance_kind, value: insurance_kind %>
     <div class="insurance-kind-label-container">
+      <%# the dummy forms used for benefit creation do not have a defined insurance_kind, `benefit.js` manages insurance-kind-specifc setup (unhiding the fields and setting this title) %>
+      <%# the forms used for benefit edit will have an insurance_kind %>
       <% if insurance_kind.present? %>
         <h2><%= hr_kind(kind, insurance_kind) %></h2>
       <% end %>

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_non_esi_benefit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_non_esi_benefit.html.erb
@@ -1,7 +1,7 @@
 <% if @bs4 %>
   <div id="<%= dom_id benefit %>" class="benefit">
     <div class="my-4 p-3 border rounded bg-white benefit-show" data-cuke="non_esi_benefit">
-      <h2><%= insurance_kind.humanize.titlecase %></h2>
+      <h2><%= hr_kind(kind, insurance_kind) %></h2>
       <dl class="parent">
         <dt><%= l10n("start_date") %></dt>
         <dd><%= benefit.start_on %>

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_non_esi_benefit_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_non_esi_benefit_form.html.erb
@@ -6,7 +6,7 @@
       <%= f.hidden_field :insurance_kind, value: insurance_kind %>
       <div class="insurance-kind-label-container">
         <% if insurance_kind.present? %>
-          <h2><%= insurance_kind.humanize.titleize %></h2>
+          <h2><%= hr_kind(kind, insurance_kind) %></h2>
         <% end %>
       </div>
       <div class="d-flex flex-column">

--- a/components/financial_assistance/app/views/financial_assistance/benefits/_non_esi_benefit_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/benefits/_non_esi_benefit_form.html.erb
@@ -5,6 +5,8 @@
       <%= f.hidden_field :kind, value: kind %>
       <%= f.hidden_field :insurance_kind, value: insurance_kind %>
       <div class="insurance-kind-label-container">
+        <%# the dummy forms used for benefit creation do not have a defined insurance_kind, `benefit.js` manages setting this title %>
+        <%# the forms used for benefit edit will have an insurance_kind %>
         <% if insurance_kind.present? %>
           <h2><%= hr_kind(kind, insurance_kind) %></h2>
         <% end %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188094045#

This PR updates the benefit partials to use the expected header. Before, the title was set as follows:
1. For create form: `benefit.js` set the benefit partial title using the dropdown content, which was the translated benefit_kind title.
2. For saved benefits and edit form: the markup simply humanized the underlying benefit_kind.

Instead of humanizing the underlying benefit kind, we now grab the same localized benefit kind title used in the dropdown. I broke out the code driving the dropdown title into a helper that can now also be called from the partials. Create forms still rely on the dropdown content through `benefit.js` out of necessity, due to how the benefit forms are setup under the hood for BS4. I'd like to change this wholesale, but that's for another day...
