### PR TITLE
bs4 fix sep kb nav

### DIFF
--- a/app/assets/javascripts/qle.js.erb
+++ b/app/assets/javascripts/qle.js.erb
@@ -199,12 +199,18 @@ $(function () {
     //$('#qle_flow_info #qle-menu').show();
   });
 
+  // Disable form submit on Enter - the user must manually use the Continue button to submit
   $(document).on('keydown', '#qle_form', function(e) {
+    if (bs4 && e.key == 'Enter') {
+      e.preventDefault();
+      return;
+    }
+  });
+
+  // Override above `#qle_form listener` to allow default Enter behavior for buttons and links within the form
+  $(document).on('keydown', '#qle_form a, #qle_form button', function(e) {
     if (bs4) {
       e.stopImmediatePropagation();
-      if (e.key == 'Enter') {
-        e.preventDefault();
-      }
       return;
     }
   });

--- a/app/assets/javascripts/qle.js.erb
+++ b/app/assets/javascripts/qle.js.erb
@@ -199,16 +199,22 @@ $(function () {
     //$('#qle_flow_info #qle-menu').show();
   });
 
-  // Disable form submit on pressing Enter, instead click Submit link
-  $('#qle_form').on('keydown', function(e) {
-    var code = e.keyCode || e.which;
+  $(document).on('keydown', '#qle_form', function(e) {
     if (bs4) {
-      if (e.key === 'Enter') {
+      e.stopImmediatePropagation();
+      if (e.key == 'Enter') {
         e.preventDefault();
       }
       return;
     }
+  });
 
+  // Disable form submit on pressing Enter, instead click Submit link
+  $('#qle_form').on('keydown', function(e) {
+    if (bs4) {
+      return;
+    }
+    var code = e.keyCode || e.which;
     if (code == 13 && !$("div.n-radio-row").is(":focus") && !$("a.btn-primary").is(":focus")) {
       e.preventDefault();
       $("#qle_submit").click();
@@ -226,7 +232,6 @@ $(function () {
     if(validate_qle_date_input()) {
       $('#qle_date').removeClass('input-error');
 
-      $('#date-nav').addClass('hidden');
       if(QLE.check_qle_reason()){
         check_qle_date();
       }

--- a/app/assets/javascripts/qle.js.erb
+++ b/app/assets/javascripts/qle.js.erb
@@ -207,7 +207,7 @@ $(function () {
     }
   });
 
-  // Override above `#qle_form listener` to allow default Enter behavior for buttons and links within the form
+  // Override above `#qle_form` listener to allow default Enter behavior for buttons and links within the form
   $(document).on('keydown', '#qle_form a, #qle_form button', function(e) {
     if (bs4) {
       e.stopImmediatePropagation();


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188094229

The JS managing this page, `qle.js`, has a listener on form keydown which attempts to prevent allowing Enter form submission. For BS4, this was preventing _all_ Enter keydowns, except for those which explicitly have the `onkeydown=handleButtonKeyDown(...)` attr. Thus, while keyboard navigating on the inputs with that attribute worked as intended (mostly), trying to navigate using the Continue buttons, which do not have that attr, did not.

I say "mostly", because the event listener preventing Enter form submissions on the form keydown seemed a little flaky for BS4 - on page load, it seemed to not properly prevent default and I was able to input a date and hit Enter, and the form would be submitted. Note that this is not the bug logged on the ticket, but I've fixed that issue by adding a new listener using event propagation.

I've fixed the bug logged on the ticket by adding a lower listener under the new listener which will allow button and link keydowns.