### PR TITLE
bs4 fix contact subheader

### DIFF
--- a/app/javascript/css/table.scss
+++ b/app/javascript/css/table.scss
@@ -39,6 +39,10 @@ table {
         font-weight: 400;
       }
     }
+
+    form {
+      font-size: 16px;
+    }
   }
 
   td,

--- a/app/views/insured/consumer_roles/_form.html.erb
+++ b/app/views/insured/consumer_roles/_form.html.erb
@@ -28,6 +28,7 @@
     </section>
     <section class="mb-4">
       <h4 class="gamma mb-0"><%= l10n("insured.consumer_roles.phone_and_email") %></h4>
+      <p><%= l10n("insured.consumer_roles.please_provide") %></p>
       <%= render partial: 'shared/phone_fields', locals: {f: f, bs4: true} %>
       <div id="email_info" class="">
         <div class="email d-flex mb-md-4 row col-sm">

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -100,6 +100,7 @@
         </section>
         <section class="mb-4 hidden">
           <h4 class="gamma mb-0"><%= l10n("insured.consumer_roles.phone_and_email") %></h4>
+          <p><%= l10n("insured.consumer_roles.please_provide") %></p>
           <%= render partial: 'shared/phone_fields', locals: {f: f, bs4: true} %>
           <div id="email_info" class="">
             <div class="email d-flex mb-md-4 row col-sm">

--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -34,6 +34,7 @@ How to find the SEVIS ID: On the DS-2019, the number is on the top right hand si
   :'en.insured.consumer_roles.contact_info_for' => "Contact Information for",
   :'en.insured.consumer_roles.home_address' => "Home Address",
   :'en.insured.consumer_roles.phone_and_email' => "Phone and Email",
+  :'en.insured.consumer_roles.please_provide' => "Please provide as much information as possible",
   :'en.insured.consumer_roles.immigration_field_warning1' => "It's important to enter as many fields from your immigration documents as possible",
   :'en.insured.consumer_roles.immigration_field_warning2' => " even though some fields may be labeled 'optional'. Entering all of your document information makes the application process go smoother and faster, helps make sure your eligibility results are correct, and may prevent you from needing to come back later and provide information.",
   :'en.insured.consumer_roles.dependent_error.header' => "Correct the following to add this family member:",

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -63,6 +63,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :"en.insured.consumer_roles.contact_info_for" => "Contact Information for",
   :"en.insured.consumer_roles.home_address" => "Home Address",
   :"en.insured.consumer_roles.phone_and_email" => "Phone and Email",
+  :'en.insured.consumer_roles.please_provide' => "Please provide as much information as possible",
   :"en.insured.consumer_roles.immigration_field_warning1" => "It's important to enter as many fields from your immigration documents as possible",
   :'en.insured.consumer_roles.immigration_field_warning2' => " even though some fields may be labeled 'optional'. Entering all of your document information makes the application process go smoother and faster, helps make sure your eligibility results are correct, and may prevent you from needing to come back later and provide information.",
   :'en.your_information' => "Privacy & Use of Your Information",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -39,6 +39,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.consumer_roles.contact_info_for' => "Contact Information for",
   :'en.insured.consumer_roles.home_address' => "Home Address",
   :'en.insured.consumer_roles.phone_and_email' => "Phone and Email",
+  :'en.insured.consumer_roles.please_provide' => "Please provide as much information as possible",
   :'en.insured.consumer_roles.immigration_field_warning1' => "It's important to enter as many fields from your immigration documents as possible",
   :'en.insured.consumer_roles.immigration_field_warning2' => " even though some fields may be labeled 'optional'. Entering all of your document information makes the application process go smoother and faster, helps make sure your eligibility results are correct, and may prevent you from needing to come back later and provide information.",
   :'en.insured.consumer_roles.dependent_error.header' => "Correct the following to add this family member:",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
1. https://www.pivotaltracker.com/story/show/188095667
2. https://www.pivotaltracker.com/story/show/188095653

This PR adds a missing translation value for a key used on consumer forms, and also updates the `table` scss to override the font size used in the table, causing the form, which lives in a table row for these pages, to have smaller font than other versions of the form.