### PR TITLE
bs4 family info wave error fix

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1124,4 +1124,8 @@ module ApplicationHelper
       :coast_guard => "U.S. Coast Guard Merchant Mariner card"
     }
   end
+
+  def imm_docs_requried_class
+    FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "" : "required"
+  end
 end

--- a/app/views/insured/consumer_roles/_tribe_fields.html.erb
+++ b/app/views/insured/consumer_roles/_tribe_fields.html.erb
@@ -72,7 +72,7 @@
       </div>
     <% else %>
       <div class="mb-4">
-        <label for="tribal_id" class="weight-n"><%= l10n("insured.tribal_name") %> *</label>
+        <label for="tribal-id" class="weight-n"><%= l10n("insured.tribal_name") %> *</label>
         <div id="tribal-id-alert" class="hide">
           <div class="alert alert-warning d-flex" role="alert">
             <div>

--- a/app/views/insured/consumer_roles/docs_shared/_alien_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_alien_number.html.erb
@@ -2,10 +2,10 @@
   <div class="mt-4 mb-4">
     <% cert = (name == 'certificate_citizenship' || name == 'naturalization_certificate') %>
     <% description = cert ? l10n("insured.consumer_roles.docs_shared.certificate_alien_number_req") : l10n("insured.consumer_roles.docs_shared.alien_number_req") %>
-    <%= v.label :alien_number, l10n("insured.consumer_roles.docs_shared.alien_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
+    <%= v.label :alien_number, l10n("insured.consumer_roles.docs_shared.alien_number"), class: "weight-n #{imm_docs_requried_class} doc_fields" %>
     <%= v.text_field :alien_number, :placeholder => l10n("insured.consumer_roles.docs_shared.alien_number"),
                    :pattern => "\\d{9}",
-                   :class => "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" } doc_fields",
+                   :class => "#{imm_docs_requried_class} doc_fields",
                    :title => description.gsub("-li-", ""), id: "alien_number" %>
     <%= render :partial => "insured/consumer_roles/docs_shared/vlp_doc_requirements", locals: {req: description} %>
   </div>

--- a/app/views/insured/consumer_roles/docs_shared/_alien_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_alien_number.html.erb
@@ -2,10 +2,10 @@
   <div class="mt-4 mb-4">
     <% cert = (name == 'certificate_citizenship' || name == 'naturalization_certificate') %>
     <% description = cert ? l10n("insured.consumer_roles.docs_shared.certificate_alien_number_req") : l10n("insured.consumer_roles.docs_shared.alien_number_req") %>
-    <%= label_tag :alien_number, l10n("insured.consumer_roles.docs_shared.alien_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
+    <%= v.label :alien_number, l10n("insured.consumer_roles.docs_shared.alien_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
     <%= v.text_field :alien_number, :placeholder => l10n("insured.consumer_roles.docs_shared.alien_number"),
                    :pattern => "\\d{9}",
-                   :class => "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" }doc_fields",
+                   :class => "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" } doc_fields",
                    :title => description.gsub("-li-", ""), id: "alien_number" %>
     <%= render :partial => "insured/consumer_roles/docs_shared/vlp_doc_requirements", locals: {req: description} %>
   </div>

--- a/app/views/insured/consumer_roles/docs_shared/_card_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_card_number.html.erb
@@ -1,10 +1,10 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
     <% description = name == 'I-766' ? l10n("insured.consumer_roles.docs_shared.i_766_card_number_req") : l10n("insured.consumer_roles.docs_shared.card_number_req") %>
-    <%= v.label :card_number, l10n("insured.consumer_roles.docs_shared.card_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
+    <%= v.label :card_number, l10n("insured.consumer_roles.docs_shared.card_number"), class: "weight-n #{imm_docs_requried_class} doc_fields" %>
     <%= v.text_field :card_number, :placeholder => l10n("insured.consumer_roles.docs_shared.card_number"),
                    :pattern => "[a-zA-Z0-9]{13}",
-                   :class => "#{FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "" : "required" } doc_fields",
+                   :class => "#{imm_docs_requried_class} doc_fields",
                    :title => description.gsub("-li-", ""),
                    :id => "card_number" %>
     <%= render :partial => "insured/consumer_roles/docs_shared/vlp_doc_requirements", locals: {req: description} %>

--- a/app/views/insured/consumer_roles/docs_shared/_card_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_card_number.html.erb
@@ -1,7 +1,7 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
     <% description = name == 'I-766' ? l10n("insured.consumer_roles.docs_shared.i_766_card_number_req") : l10n("insured.consumer_roles.docs_shared.card_number_req") %>
-    <%= label_tag :card_number, l10n("insured.consumer_roles.docs_shared.card_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
+    <%= v.label :card_number, l10n("insured.consumer_roles.docs_shared.card_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
     <%= v.text_field :card_number, :placeholder => l10n("insured.consumer_roles.docs_shared.card_number"),
                    :pattern => "[a-zA-Z0-9]{13}",
                    :class => "#{FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "" : "required" } doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_citizenship_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_citizenship_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :citizenship_number, l10n("insured.consumer_roles.docs_shared.citizenship_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
+    <%= v.label :citizenship_number, l10n("insured.consumer_roles.docs_shared.citizenship_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
     <%= v.text_field :citizenship_number, :placeholder => l10n("insured.consumer_roles.docs_shared.citizenship_number"),
                    :pattern => "[a-zA-Z0-9]{6,12}",
                    :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_citizenship_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_citizenship_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= v.label :citizenship_number, l10n("insured.consumer_roles.docs_shared.citizenship_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
+    <%= v.label :citizenship_number, l10n("insured.consumer_roles.docs_shared.citizenship_number"), class: "weight-n doc_fields" %>
     <%= v.text_field :citizenship_number, :placeholder => l10n("insured.consumer_roles.docs_shared.citizenship_number"),
                    :pattern => "[a-zA-Z0-9]{6,12}",
                    :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_country_of_citizenship.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_country_of_citizenship.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
 <div class="mt-4 mb-4">
-  <%= label_tag :country_of_citizenship, l10n("insured.consumer_roles.docs_shared.country_of_citizenship"), class: "weight-n" %>
+  <%= v.label :country_of_citizenship, l10n("insured.consumer_roles.docs_shared.country_of_citizenship"), class: "weight-n" %>
   <%= v.select :country_of_citizenship,
                options_for_select(::VlpDocument::COUNTRIES_LIST, @country ||= l10n("insured.consumer_roles.docs_shared.country_of_citizenship")),
                { prompt: l10n("insured.consumer_roles.docs_shared.country_of_citizenship") },

--- a/app/views/insured/consumer_roles/docs_shared/_document_description.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_document_description.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :description, l10n("insured.consumer_roles.docs_shared.document_description"), class: "weight-n" %>
+    <%= v.label :description, l10n("insured.consumer_roles.docs_shared.document_description"), class: "weight-n" %>
     <%= v.text_field :description, :placeholder => l10n("insured.consumer_roles.docs_shared.document_description"),
                       :pattern => ".{1,35}",
                       :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_expiration_date.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_expiration_date.html.erb
@@ -1,7 +1,7 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= v.label :expiration_date, l10n("insured.consumer_roles.docs_shared.expiration_date", name: name), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
-    <%= v.date_field :expiration_date, {class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" } date-field doc_fields", placeholder: l10n("insured.consumer_roles.docs_shared.expiration_date", name: name)} %>
+    <%= v.label :expiration_date, l10n("insured.consumer_roles.docs_shared.expiration_date", name: name), class: "weight-n #{imm_docs_requried_class} doc_fields" %>
+    <%= v.date_field :expiration_date, {class: "#{imm_docs_requried_class} date-field doc_fields", placeholder: l10n("insured.consumer_roles.docs_shared.expiration_date", name: name)} %>
   </div>
 <% else %>
 <div class="col-md-4 col-sm-4 col-xs-6 form-group form-group-lg no-pd">

--- a/app/views/insured/consumer_roles/docs_shared/_expiration_date.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_expiration_date.html.erb
@@ -1,6 +1,5 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    OOOOF
     <%= v.label :expiration_date, l10n("insured.consumer_roles.docs_shared.expiration_date", name: name), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
     <%= v.date_field :expiration_date, {class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" } date-field doc_fields", placeholder: l10n("insured.consumer_roles.docs_shared.expiration_date", name: name)} %>
   </div>

--- a/app/views/insured/consumer_roles/docs_shared/_expiration_date.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_expiration_date.html.erb
@@ -1,7 +1,8 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :doc_date_field, l10n("insured.consumer_roles.docs_shared.expiration_date", name: name), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
-    <%= v.date_field :expiration_date, {id: "doc_date_field", class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" } date-field doc_fields", placeholder: l10n("insured.consumer_roles.docs_shared.expiration_date", name: name)} %>
+    OOOOF
+    <%= v.label :expiration_date, l10n("insured.consumer_roles.docs_shared.expiration_date", name: name), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
+    <%= v.date_field :expiration_date, {class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" } date-field doc_fields", placeholder: l10n("insured.consumer_roles.docs_shared.expiration_date", name: name)} %>
   </div>
 <% else %>
 <div class="col-md-4 col-sm-4 col-xs-6 form-group form-group-lg no-pd">

--- a/app/views/insured/consumer_roles/docs_shared/_i_94_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_i_94_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :i94_number, l10n("insured.consumer_roles.docs_shared.i94_number"), class: "weight-n" %>
+    <%= v.label :i94_number, l10n("insured.consumer_roles.docs_shared.i94_number"), class: "weight-n" %>
     <%= v.text_field :i94_number, :placeholder => l10n("insured.consumer_roles.docs_shared.i94_number"),
                     :pattern => "[A-Za-z0-9]{11}",
                     :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_naturalization_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_naturalization_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :naturalization_number, l10n("insured.consumer_roles.docs_shared.naturalization_number"), class: "weight-n" %>
+    <%= v.label :naturalization_number, l10n("insured.consumer_roles.docs_shared.naturalization_number"), class: "weight-n" %>
     <%= v.text_field :naturalization_number, :placeholder => l10n("insured.consumer_roles.docs_shared.naturalization_number"),
                     :pattern => "[a-zA-Z0-9]{6,12}",
                     :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_passport_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_passport_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :passport_number, l10n("insured.passport_number"), class: "weight-n" %>
+    <%= v.label :passport_number, l10n("insured.passport_number"), class: "weight-n" %>
     <%= v.text_field :passport_number, :placeholder => l10n("insured.passport_number"),
                     :pattern => "[a-zA-Z0-9]{6,12}",
                     :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_servis_id.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_servis_id.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :sevis_id, l10n("insured.consumer_roles.docs_shared.sevis_id"), class: "weight-n" %>
+    <%= v.label :sevis_id, l10n("insured.consumer_roles.docs_shared.sevis_id"), class: "weight-n" %>
     <%= v.text_field :sevis_id, :placeholder => l10n("insured.consumer_roles.docs_shared.sevis_id"),
                     :pattern => "\\d{10}",
                     :class => "doc_fields",

--- a/app/views/insured/consumer_roles/docs_shared/_visa_number.html.erb
+++ b/app/views/insured/consumer_roles/docs_shared/_visa_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :visa_number, l10n("insured.consumer_roles.docs_shared.visa_number"), class: "weight-n" %>
+    <%= v.label :visa_number, l10n("insured.consumer_roles.docs_shared.visa_number"), class: "weight-n" %>
     <%= v.text_field :visa_number, :placeholder => l10n("insured.consumer_roles.docs_shared.visa_number"),
                     :pattern => "[a-zA-Z0-9]{8,12}",
                     :class => "doc_fields",

--- a/app/views/shared/_consumer_fields.html.erb
+++ b/app/views/shared/_consumer_fields.html.erb
@@ -80,7 +80,7 @@
                   <span class="yes_no_pair">Yes</span>
                 </label>
                 <label for="eligible_immigration_status_false" class="radio">
-                  <%= f.radio_button :eligible_immigration_status, false, class: "required", id: 'naturalized_citizen_false' %>
+                  <%= f.radio_button :eligible_immigration_status, false, class: "required", id: 'eligible_immigration_status_false' %>
                   <span class="yes_no_pair">No</span>
                 </label>
               </div>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_alien_number.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_alien_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :alien_number, l10n("insured.consumer_roles.docs_shared.alien_number"), class: "weight-n doc_fields" %>
+    <%= v.label :alien_number, l10n("insured.consumer_roles.docs_shared.alien_number"), class: "weight-n doc_fields" %>
     <%= v.text_field :alien_number, :placeholder => l10n("insured.consumer_roles.docs_shared.alien_number"),
                    :pattern => "\\d{9}",
                    :class => "doc_fields",

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_card_number.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_card_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= v.label :card_number, l10n("insured.consumer_roles.docs_shared.card_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
+    <%= v.label :card_number, l10n("insured.consumer_roles.docs_shared.card_number"), class: "weight-n doc_fields" %>
     <%= v.text_field :card_number, :placeholder => l10n("insured.consumer_roles.docs_shared.card_number"),
                    :pattern => "[a-zA-Z0-9]{13}",
                    :class => "doc_fields",

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_card_number.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_card_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :card_number, l10n("insured.consumer_roles.docs_shared.card_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
+    <%= v.label :card_number, l10n("insured.consumer_roles.docs_shared.card_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
     <%= v.text_field :card_number, :placeholder => l10n("insured.consumer_roles.docs_shared.card_number"),
                    :pattern => "[a-zA-Z0-9]{13}",
                    :class => "doc_fields",

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_citizenship_number.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_citizenship_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :citizenship_number, l10n("insured.consumer_roles.docs_shared.citizenship_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
+    <%= v.label :citizenship_number, l10n("insured.consumer_roles.docs_shared.citizenship_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
     <%= v.text_field :citizenship_number, :placeholder => l10n("insured.consumer_roles.docs_shared.citizenship_number"),
                    :pattern => "[a-zA-Z0-9]{6,12}",
                    :class => "doc_fields",

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_citizenship_number.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_citizenship_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= v.label :citizenship_number, l10n("insured.consumer_roles.docs_shared.citizenship_number"), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
+    <%= v.label :citizenship_number, l10n("insured.consumer_roles.docs_shared.citizenship_number"), class: "weight-n doc_fields" %>
     <%= v.text_field :citizenship_number, :placeholder => l10n("insured.consumer_roles.docs_shared.citizenship_number"),
                    :pattern => "[a-zA-Z0-9]{6,12}",
                    :class => "doc_fields",

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_country_of_citizenship.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_country_of_citizenship.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
 <div class="mt-4 mb-4">
-  <%= label_tag :country_of_citizenship, l10n("insured.consumer_roles.docs_shared.country_of_citizenship"), class: "weight-n" %>
+  <%= v.label :country_of_citizenship, l10n("insured.consumer_roles.docs_shared.country_of_citizenship"), class: "weight-n" %>
   <%= v.select :country_of_citizenship,
                options_for_select(::VlpDocument::COUNTRIES_LIST, @country ||= l10n("insured.consumer_roles.docs_shared.country_of_citizenship")),
                { prompt: l10n("insured.consumer_roles.docs_shared.country_of_citizenship") },

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_document_description.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_document_description.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :vlp_description, l10n("insured.consumer_roles.docs_shared.document_description"), class: "weight-n" %>
+    <%= v.label :vlp_description, l10n("insured.consumer_roles.docs_shared.document_description"), class: "weight-n" %>
     <%= v.text_field :vlp_description, :placeholder => l10n("insured.consumer_roles.docs_shared.document_description"),
 										:pattern => ".{1,35}",
 										:class => "doc_fields",

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_expiration_date.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_expiration_date.html.erb
@@ -1,7 +1,7 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= v.label :expiration_date, l10n("insured.consumer_roles.docs_shared.expiration_date", name: name), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
-    <%= v.date_field :expiration_date, {class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" } date-field doc_fields", placeholder: l10n("insured.consumer_roles.docs_shared.expiration_date", name: name)} %>
+    <%= v.label :expiration_date, l10n("insured.consumer_roles.docs_shared.expiration_date", name: name), class: "weight-n #{imm_docs_requried_class} doc_fields" %>
+    <%= v.date_field :expiration_date, {class: "#{imm_docs_requried_class} date-field doc_fields", placeholder: l10n("insured.consumer_roles.docs_shared.expiration_date", name: name)} %>
   </div>
 <% else %>
 <div class="col-md-4 col-sm-4 col-xs-6 form-group form-group-lg no-pd">

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_expiration_date.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_expiration_date.html.erb
@@ -1,7 +1,7 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :expiration_date, l10n("insured.consumer_roles.docs_shared.expiration_date", name: name), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""}doc_fields" %>
-    <%= v.date_field :expiration_date, {id: "doc_date_field", class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" } date-field doc_fields", placeholder: l10n("insured.consumer_roles.docs_shared.expiration_date", name: name)} %>
+    <%= v.label :expiration_date, l10n("insured.consumer_roles.docs_shared.expiration_date", name: name), class: "weight-n #{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : ""} doc_fields" %>
+    <%= v.date_field :expiration_date, {class: "#{!FinancialAssistanceRegistry.feature_enabled?(:optional_document_fields) ? "required" : "" } date-field doc_fields", placeholder: l10n("insured.consumer_roles.docs_shared.expiration_date", name: name)} %>
   </div>
 <% else %>
 <div class="col-md-4 col-sm-4 col-xs-6 form-group form-group-lg no-pd">

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_i_94_number.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_i_94_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :i94_number, l10n("insured.consumer_roles.docs_shared.i94_number"), class: "weight-n" %>
+    <%= v.label :i94_number, l10n("insured.consumer_roles.docs_shared.i94_number"), class: "weight-n" %>
     <%= v.text_field :i94_number, :placeholder => l10n("insured.consumer_roles.docs_shared.i94_number"),
                     :pattern => "[A-Za-z0-9]{11}",
                     :class => "doc_fields",

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_naturalization_number.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_naturalization_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :naturalization_number, l10n("insured.consumer_roles.docs_shared.naturalization_number"), class: "weight-n" %>
+    <%= v.label :naturalization_number, l10n("insured.consumer_roles.docs_shared.naturalization_number"), class: "weight-n" %>
     <%= v.text_field :naturalization_number, :placeholder => l10n("insured.consumer_roles.docs_shared.naturalization_number"),
                     :pattern => "[a-zA-Z0-9]{6,12}",
                     :class => "doc_fields",

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_passport_number.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_passport_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :passport_number, l10n("insured.passport_number"), class: "weight-n" %>
+    <%= v.label :passport_number, l10n("insured.passport_number"), class: "weight-n" %>
     <%= v.text_field :passport_number, :placeholder => l10n("insured.passport_number"),
                     :pattern => "[a-zA-Z0-9]{6,12}",
                     :class => "doc_fields",

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_servis_id.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_servis_id.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :sevis_id, l10n("insured.consumer_roles.docs_shared.sevis_id"), class: "weight-n" %>
+    <%= v.label :sevis_id, l10n("insured.consumer_roles.docs_shared.sevis_id"), class: "weight-n" %>
     <%= v.text_field :sevis_id, :placeholder => l10n("insured.consumer_roles.docs_shared.sevis_id"),
                     :pattern => "\\d{10}",
                     :class => "doc_fields",

--- a/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_visa_number.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/docs_shared/_visa_number.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <div class="mt-4 mb-4">
-    <%= label_tag :visa_number, l10n("insured.consumer_roles.docs_shared.visa_number"), class: "weight-n" %>
+    <%= v.label :visa_number, l10n("insured.consumer_roles.docs_shared.visa_number"), class: "weight-n" %>
     <%= v.text_field :visa_number, :placeholder => l10n("insured.consumer_roles.docs_shared.visa_number"),
                     :pattern => "[a-zA-Z0-9]{8,12}",
                     :class => "doc_fields",

--- a/components/financial_assistance/app/views/financial_assistance/shared/_consumer_fields.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/shared/_consumer_fields.html.erb
@@ -78,7 +78,7 @@
               <span class="yes_no_pair"><%= l10n('yes') %></span>
             </label>
             <label for="eligible_immigration_status_false" class="radio">
-              <%= f.radio_button :eligible_immigration_status, false, class: "required", id: 'naturalized_citizen_false' %>
+              <%= f.radio_button :eligible_immigration_status, false, class: "required", id: 'eligible_immigration_status_falsee' %>
               <span class="yes_no_pair"><%= l10n('no') %></span>
             </label>
           </div>

--- a/components/financial_assistance/app/views/financial_assistance/shared/_consumer_fields.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/shared/_consumer_fields.html.erb
@@ -78,7 +78,7 @@
               <span class="yes_no_pair"><%= l10n('yes') %></span>
             </label>
             <label for="eligible_immigration_status_false" class="radio">
-              <%= f.radio_button :eligible_immigration_status, false, class: "required", id: 'eligible_immigration_status_falsee' %>
+              <%= f.radio_button :eligible_immigration_status, false, class: "required", id: 'eligible_immigration_status_false' %>
               <span class="yes_no_pair"><%= l10n('no') %></span>
             </label>
           </div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188094117

This PR fixes some hanging labels on Family Info/My Household. I fixed the immigration labels by updating the (likely typo'd) ids, and I fixed the immigration doc labels by leveraging the rails form helpers.

I also noticed the `required` class was being incorrectly interpolated on all of the immigration doc labels which needed them. I fixed these, and also introduced a simple helper to align the flag-driving required class used on these labels and inputs.
