### PR TITLE
fix eligibility error for "family_relationships"

### DIFF
--- a/app/models/insured_eligible_for_benefit_rule.rb
+++ b/app/models/insured_eligible_for_benefit_rule.rb
@@ -57,6 +57,8 @@ class InsuredEligibleForBenefitRule
             @errors << ["eligibility failed on market kind"]
           elsif FinancialAssistanceRegistry[:consumer_validations].enabled?
             @errors << [eligibility_errors(element)]
+          elsif "#{element}" == "family_relationships"
+            @errors << ["Ineligible due to family relationships"]
           else
             @errors << ["eligibility failed on #{element}"]
           end

--- a/app/models/insured_eligible_for_benefit_rule.rb
+++ b/app/models/insured_eligible_for_benefit_rule.rb
@@ -57,7 +57,7 @@ class InsuredEligibleForBenefitRule
             @errors << ["eligibility failed on market kind"]
           elsif FinancialAssistanceRegistry[:consumer_validations].enabled?
             @errors << [eligibility_errors(element)]
-          elsif "#{element}" == "family_relationships"
+          elsif element == "family_relationships"
             @errors << ["Ineligible due to family relationships"]
           else
             @errors << ["eligibility failed on #{element}"]
@@ -85,6 +85,8 @@ class InsuredEligibleForBenefitRule
       "Since #{name} is not currently a state resident,#{pronoun} is not eligible to purchase a plan on #{short_name}.<br/> Other family members may still be eligible to enroll."
     when "incarceration_status"
       "Since #{name} is currently incarcerated, #{pronoun} is not eligible to purchase a plan on #{short_name}.<br/> Other family members may still be eligible to enroll."
+    when "family_relationships"
+      "Ineligible due to family relationships"
     else
       "eligibility failed on #{element}"
     end

--- a/features/step_definitions/group_selection_steps.rb
+++ b/features/step_definitions/group_selection_steps.rb
@@ -313,7 +313,7 @@ And(/(.*) should also see the reason for ineligibility/) do |named_person|
   if person&.active_employee_roles.present?
     expect(page).to have_content "Employer sponsored coverage is not available"
   else
-    expect(page).to have_content "eligibility failed on family_relationships"
+    expect(page).to have_content "Ineligible due to family relationships"
   end
 end
 


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/188064067

# A brief description of the changes

Current behavior: Applying for SEP, if family member is over age 26, the error message is vague.

New behavior: "Ineligible due to family relationships" should be displayed
