### PR TITLE
bs4 fix applications dropdown clipping

### DIFF
--- a/app/views/datatables/shared/_dropdown.html.erb
+++ b/app/views/datatables/shared/_dropdown.html.erb
@@ -1,7 +1,7 @@
 <% if @bs4 %>
   <% row_actions_id = local_assigns[:row_actions_id].present? ? local_assigns[:row_actions_id] : nil %>
   <div class="dropdown <%= 'pull-right' if !defined? pull_left %>" id="<%= row_actions_id %>">
-    <button class="btn outline p-2 px-3 dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdown_for_<%= row_actions_id %>">
+    <button class="btn outline p-2 px-3 dropdown-toggle" type="button" data-boundary="window" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdown_for_<%= row_actions_id %>">
       <span class="pr-1"><%= l10n("actions") %></span>
     </button>
     <div class="actions-dropdown dropdown-menu <%= local_assigns[:dropdown_class] %> shadow-sm py-0" aria-labelledby="dropdown_for_<%= row_actions_id %>">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188117722

The dropdown was bound by its parent element, the table, which caused clipping when the table's height was less than the boundaries height. Hence, when the admins dropdown was presented with the full suite of five options, and the table itself only had one row, this bug was found. Adding the `data-boundary` attr fixes this.
