### PR TITLE
refactor: Update link target for "Documents FAQ" on Verify Identity page

### DIFF
--- a/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
@@ -184,8 +184,7 @@
 
 <div class="row">
   <div class="col-xs-12">
-    <%= h(link_to 'Documents FAQ', ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, class: "btn btn-default btn-small pull-right", target: '_blank', rel: "noopener noreferrer") %>
-    <%= h(link_to 'Documents FAQ', ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, class: "btn btn-default btn-small pull-right", target: '_blank', rel: "noopener noreferrer") %>
+    <%= h(link_to 'Documents FAQ', ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, target: '_blank', class: "btn btn-default btn-small pull-right", rel: "noopener noreferrer") %>
   </div>
 
   <div class="collapse" id="docs-verification-faq">

--- a/app/views/insured/interactive_identity_verifications/_outstanding_ridp_documents.html.erb
+++ b/app/views/insured/interactive_identity_verifications/_outstanding_ridp_documents.html.erb
@@ -185,7 +185,7 @@
 <% if ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item.present? %>
   <div class="row">
     <div class="col-xs-12">
-      <%= h(link_to 'Documents FAQ', ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, class: "btn btn-default btn-small pull-right", target: '_blank', rel: 'noopener noreferrer') %>
+      <%= h(link_to 'Documents FAQ', ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, target: '_blank', class: "btn btn-default btn-small pull-right", rel: 'noopener noreferrer') %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/188116863

# A brief description of the changes

Current behavior: Documents FAQ button not opening in a new window

New behavior: Documents FAQ button opens a new window
