### PR TITLE
populate additional reason codes only if applicant is gap filling eligible

### DIFF
--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
@@ -249,11 +249,9 @@ module FinancialAssistance
                   mitc_relationships: mitc_relationships(applicant),
                   mitc_is_required_to_file_taxes: applicant_is_required_to_file_taxes(applicant, mitc_eligible_incomes, assistance_year),
                   mitc_state_resident: mitc_state_resident(applicant, application.us_state),
-                  reason_code: 'FullDetermination',
+                  reason_code: 'FullDetermination'
                 }
-                if EnrollRegistry.feature_enabled?(:multiple_determination_submission_reasons) && applicant.is_gap_filling
-                  applicant_hash[:additional_reason_codes] = %w[FullDetermination GapFilling]
-                end
+                applicant_hash[:additional_reason_codes] = %w[FullDetermination GapFilling] if EnrollRegistry.feature_enabled?(:multiple_determination_submission_reasons) && applicant.is_gap_filling
                 result << applicant_hash
                 result
               end

--- a/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
+++ b/components/financial_assistance/app/domain/financial_assistance/operations/applications/transformers/application_to/cv3_application.rb
@@ -249,25 +249,17 @@ module FinancialAssistance
                   mitc_relationships: mitc_relationships(applicant),
                   mitc_is_required_to_file_taxes: applicant_is_required_to_file_taxes(applicant, mitc_eligible_incomes, assistance_year),
                   mitc_state_resident: mitc_state_resident(applicant, application.us_state),
-                  reason_code: fetch_determination_reason(application)
+                  reason_code: 'FullDetermination',
                 }
-                applicant_hash[:additional_reason_codes] = determination_reason_codes(applicant, application) if EnrollRegistry.feature_enabled?(:multiple_determination_submission_reasons)
+                if EnrollRegistry.feature_enabled?(:multiple_determination_submission_reasons) && applicant.is_gap_filling
+                  applicant_hash[:additional_reason_codes] = %w[FullDetermination GapFilling]
+                end
                 result << applicant_hash
                 result
               end
             end
                         # rubocop:enable Metrics/AbcSize
             # rubocop:enable Metrics/MethodLength
-
-            def determination_reason_codes(applicant, application)
-              determination_reasons = [fetch_determination_reason(application)]
-              determination_reasons << 'Gap Filling' if applicant.is_gap_filling
-              determination_reasons
-            end
-
-            def fetch_determination_reason(application)
-              application.previously_renewal_draft? ? 'Renewal' : 'Full Determination'
-            end
 
             def evidence_info(applicant_evidence)
               return if applicant_evidence.nil?


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187862357

# A brief description of the changes

Current behavior: additional reason codes are always being sent in CV3 payload if `multiple_determination_submission_reasons` is enabled, and also incorrect reason codes are being sent

New behavior: Send additional reason codes only if `multiple_determination_submission_reasons` feature is enabled and also if applicant is eligible for gap filling.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
