### PR TITLE
update "show all enrollments" button

### DIFF
--- a/app/javascript/css/_buttons.scss
+++ b/app/javascript/css/_buttons.scss
@@ -204,3 +204,8 @@ button.accordion-action {
     background: inherit;
   }
 }
+
+.all-enroll-button {
+  margin-top: 1rem;
+  translate: 0.25rem 0;
+}

--- a/app/javascript/src/enrollment.js
+++ b/app/javascript/src/enrollment.js
@@ -1,33 +1,45 @@
 // For when families home page is refreshed when user on it
-document.addEventListener("DOMContentLoaded", function () {
-  const initiallyHiddenEnrollmentPanels = document.getElementsByClassName("initially_hidden_enrollment");
-  const enrollmentToggleCheckbox = document.getElementById("display_all_enrollments");
-  const enrollmentToggleButton = document.getElementById("display_all_enrollments_btn");
+document.addEventListener('DOMContentLoaded', function () {
+  const initiallyHiddenEnrollmentPanels = document.getElementsByClassName(
+    'initially_hidden_enrollment'
+  );
+  const enrollmentToggleCheckbox = document.getElementById(
+    'display_all_enrollments'
+  );
+  const enrollmentToggleButton = document.getElementById(
+    'display_all_enrollments_btn'
+  );
 
   enrollmentToggleButton.addEventListener('click', toggleDisplayEnrollments);
   enrollmentToggleCheckbox.addEventListener('click', toggleDisplayEnrollments);
 
   function toggleDisplayEnrollments(event) {
-    if (event.target.type == "submit") {
+    if (event.target.type == 'submit') {
       enrollmentToggleCheckbox.checked = !enrollmentToggleCheckbox.checked;
     }
 
     if (enrollmentToggleCheckbox.checked) {
       for (let i = 0; i < initiallyHiddenEnrollmentPanels.length; i++) {
-        initiallyHiddenEnrollmentPanels[i].classList.remove("hidden");
-        enrollmentToggleButton.innerText = l10n("");
+        initiallyHiddenEnrollmentPanels[i].classList.remove('hidden');
+        enrollmentToggleButton.innerText = l10n('');
       }
     } else {
       for (let i = 0; i < initiallyHiddenEnrollmentPanels.length; i++) {
-        initiallyHiddenEnrollmentPanels[i].classList.add("hidden");
-        enrollmentToggleButton.innerText = "Show All Enrollments";
+        initiallyHiddenEnrollmentPanels[i].classList.add('hidden');
+        enrollmentToggleButton.innerText = 'Show All Enrollments';
       }
     }
-  };
+  }
 
   // For when family home page loaded through clicking off of the families index page
-  if (enrollmentToggleCheckbox != null || enrollmentToggleCheckbox != undefined) {
-    enrollmentToggleCheckbox.addEventListener('click', toggleDisplayEnrollments);
+  if (
+    enrollmentToggleCheckbox != null ||
+    enrollmentToggleCheckbox != undefined
+  ) {
+    enrollmentToggleCheckbox.addEventListener(
+      'click',
+      toggleDisplayEnrollments
+    );
     enrollmentToggleButton.addEventListener('click', toggleDisplayEnrollments);
-  };
-})
+  }
+});

--- a/app/javascript/src/enrollment.js
+++ b/app/javascript/src/enrollment.js
@@ -14,21 +14,11 @@ document.addEventListener('DOMContentLoaded', function () {
   enrollmentToggleCheckbox.addEventListener('click', toggleDisplayEnrollments);
 
   function toggleDisplayEnrollments(event) {
-    if (event.target.type == 'submit') {
-      enrollmentToggleCheckbox.checked = !enrollmentToggleCheckbox.checked;
+    for (const panel of initiallyHiddenEnrollmentPanels) {
+      panel.classList.remove('hidden');
     }
 
-    if (enrollmentToggleCheckbox.checked) {
-      for (let i = 0; i < initiallyHiddenEnrollmentPanels.length; i++) {
-        initiallyHiddenEnrollmentPanels[i].classList.remove('hidden');
-        enrollmentToggleButton.innerText = l10n('');
-      }
-    } else {
-      for (let i = 0; i < initiallyHiddenEnrollmentPanels.length; i++) {
-        initiallyHiddenEnrollmentPanels[i].classList.add('hidden');
-        enrollmentToggleButton.innerText = 'Show All Enrollments';
-      }
-    }
+    enrollmentToggleButton.remove();
   }
 
   // For when family home page loaded through clicking off of the families index page

--- a/app/views/insured/families/enrollment_history.html.erb
+++ b/app/views/insured/families/enrollment_history.html.erb
@@ -30,9 +30,7 @@
     <% end %>
 
     <% if pundit_allow(Family, :can_view_entire_family_enrollment_history?) && enrollments&.any? %>
-      <button id="display_all_enrollments_btn" class="button button-primary"><%= l10n("enrollment_history.show_all") %></button>
-      <label for="display_all_enrollments" class="ml-half hidden"><%= l10n("enrollment_history.show_all") %></label>
-      <input id="display_all_enrollments" class="ml-half hidden" type="checkbox" >
+      <button id="display_all_enrollments_btn" class="button button-primary all-enroll-button"><%= l10n("enrollment_history.show_all") %></button>
     <% end %>
   </div>
 


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/188126668

# A brief description of the changes

Current behavior: Button is a toggle button that when clicked will show all enrollment history tiles. When clicked again, will hide history past 2 years from current.

New behavior: Button no longer toggles, will show all history tiles when clicked and then the button is removed. 
