### PR TITLE
bs4 eligiblity results back fix

### DIFF
--- a/app/views/shared/_progress_navigation_buttons.html.erb
+++ b/app/views/shared/_progress_navigation_buttons.html.erb
@@ -1,6 +1,5 @@
 <%# previous button params %>
 <% dont_show_prev_button = local_assigns[:dont_show_prev_button] ? dont_show_prev_button : false %>
-<% previous_class = local_assigns[:previous_link].present? ? '' : "back" %>
 <% previous_style = local_assigns[:previous_style] ? previous_style : "outline" %>
 
 <%# continue button params %>
@@ -15,7 +14,7 @@
 
 <div class="d-flex flex-column flex-sm-row align-items-center">
   <% unless dont_show_prev_button || @no_previous_button %>
-    <a id="previous_button" class="button mr-2 <%= "#{previous_class} #{previous_style}" %>" href="#"><%= l10n("previous_step") %></a>
+    <a id="previous_button" class="back button mr-2 <%= previous_style %>" href="#"><%= l10n("previous_step") %></a>
   <% end %>
 
   <% unless dont_show_next_button %>

--- a/app/views/shared/_progress_navigation_buttons.html.erb
+++ b/app/views/shared/_progress_navigation_buttons.html.erb
@@ -1,5 +1,6 @@
 <%# previous button params %>
 <% dont_show_prev_button = local_assigns[:dont_show_prev_button] ? dont_show_prev_button : false %>
+<% previous_class = local_assigns[:previous_link].present? ? '' : "back" %>
 <% previous_style = local_assigns[:previous_style] ? previous_style : "outline" %>
 
 <%# continue button params %>
@@ -14,7 +15,7 @@
 
 <div class="d-flex flex-column flex-sm-row align-items-center">
   <% unless dont_show_prev_button || @no_previous_button %>
-    <a id="previous_button" class="back button mr-2 <%= previous_style %>" href="#"><%= l10n("previous_step") %></a>
+    <a id="previous_button" class="back button mr-2 <%= "#{previous_class} #{previous_style}" %>" href="#"><%= l10n("previous_step") %></a>
   <% end %>
 
   <% unless dont_show_next_button %>

--- a/app/views/shared/_progress_navigation_buttons.html.erb
+++ b/app/views/shared/_progress_navigation_buttons.html.erb
@@ -15,7 +15,7 @@
 
 <div class="d-flex flex-column flex-sm-row align-items-center">
   <% unless dont_show_prev_button || @no_previous_button %>
-    <a id="previous_button" class="back button mr-2 <%= "#{previous_class} #{previous_style}" %>" href="#"><%= l10n("previous_step") %></a>
+    <a id="previous_button" class="button mr-2 <%= "#{previous_class} #{previous_style}" %>" href="#"><%= l10n("previous_step") %></a>
   <% end %>
 
   <% unless dont_show_next_button %>

--- a/components/financial_assistance/app/views/financial_assistance/shared/_progress_navigation_buttons.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/shared/_progress_navigation_buttons.html.erb
@@ -3,9 +3,9 @@
 
 <%# previous button params %>
 <% dont_show_prev_button = local_assigns[:dont_show_prev_button] ? dont_show_prev_button : false %>
-<% previous_class = local_assigns[:previous_link].present? ? '' : "back" %>
-<% previous_link = local_assigns[:previous_link] ? previous_link : '#' %>
 <% previous_style = local_assigns[:previous_style] ? previous_style : "outline" %>
+<% previous_class = "#{previous_style} #{'back' unless local_assigns[:previous_link].present?}" %>
+<% previous_link = local_assigns[:previous_link] ? previous_link : '#' %>
 
 <%# continue button params %>
 <% dont_show_next_button = local_assigns[:dont_show_next_button] ? dont_show_next_button : false %>
@@ -19,7 +19,7 @@
   <% end %>
 
   <% unless dont_show_prev_button || @no_previous_button %>
-    <a class="button <%= "#{previous_class} #{previous_style}" %> mr-2" href=<%= previous_link %>><%= l10n("previous_step") %></a>
+    <a class="button <%= previous_class %> mr-2" href=<%= previous_link %>><%= l10n("previous_step") %></a>
   <% end %>
 
   <% unless dont_show_next_button %>

--- a/components/financial_assistance/app/views/financial_assistance/shared/_progress_navigation_buttons.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/shared/_progress_navigation_buttons.html.erb
@@ -3,6 +3,7 @@
 
 <%# previous button params %>
 <% dont_show_prev_button = local_assigns[:dont_show_prev_button] ? dont_show_prev_button : false %>
+<% previous_class = local_assigns[:previous_link].present? ? '' : "back" %>
 <% previous_link = local_assigns[:previous_link] ? previous_link : '#' %>
 <% previous_style = local_assigns[:previous_style] ? previous_style : "outline" %>
 
@@ -18,7 +19,7 @@
   <% end %>
 
   <% unless dont_show_prev_button || @no_previous_button %>
-    <a class="back button <%= previous_style %> mr-2" href=<%= previous_link %>><%= l10n("previous_step") %></a>
+    <a class="button <%= "#{previous_class} #{previous_style}" %> mr-2" href=<%= previous_link %>><%= l10n("previous_step") %></a>
   <% end %>
 
   <% unless dont_show_next_button %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188117640

This PR fixes another issue with the Previous Step button, which applied the `back` class to the button regardless of there being an explicit href. This is problematic as the `back` class should really only ever be used as a default case for when there is no href, as this class has a JS listener which hits the browser's Back action.
