### PR TITLE
188137458 extraneous colon on plan contact info popup on health tiles 1

### DIFF
--- a/app/domain/operations/private/families/validate_cv.rb
+++ b/app/domain/operations/private/families/validate_cv.rb
@@ -20,7 +20,7 @@ module Operations
           family_hbx_id             = yield validate_params(params)
           family                    = yield find_family(family_hbx_id)
           family_entity             = yield transform_to_entity(family)
-          cv_validation_job_params  = yield construct_cv_validation_job_params(family_hbx_id, family_entity)
+          cv_validation_job_params  = yield construct_cv_validation_job_params(family, family_hbx_id, family_entity)
           cv_validation_job         = yield create_cv_validation_job(cv_validation_job_params)
 
           Success(cv_validation_job)
@@ -73,16 +73,18 @@ module Operations
         end
 
         # Constructs the CV validation job parameters
+        # @param family [Family] the family object
         # @param family_hbx_id [String] the family HBX ID
         # @param family_entity [Object] the family entity
         # @return [Dry::Monads::Result] the result of the construction
-        def construct_cv_validation_job_params(family_hbx_id, family_entity)
+        def construct_cv_validation_job_params(family, family_hbx_id, family_entity)
           Success(
             {
               cv_payload: family_entity.present? ? family_entity.to_json : nil,
               cv_version: 3,
               aca_version: AcaEntities::VERSION,
               aca_entities_sha: GemUtils.aca_entities_sha,
+              primary_person_hbx_id: family.primary_person&.hbx_id,
               family_hbx_id: family_hbx_id,
               family_updated_at: @family_updated_at,
               job_id: @job_id,

--- a/app/domain/operations/reports/families/cv_validation_jobs/latest_report.rb
+++ b/app/domain/operations/reports/families/cv_validation_jobs/latest_report.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module Operations
+  module Reports
+    module Families
+      module CvValidationJobs
+        # This class generates the latest CV Validation Job report.
+        class LatestReport
+          include Dry::Monads[:do, :result]
+
+          # Generates the latest CV Validation Job report.
+          #
+          # @return [Dry::Monads::Result::Success<String>, Dry::Monads::Result::Failure<String>]
+          def call
+            job_id        = yield fetch_latest_job_id
+            logger_name   = yield fetch_logger_name(job_id)
+            logger        = yield generate_log_file(logger_name)
+            jobs          = yield fetch_cv_validation_jobs(job_id)
+            csv_file_name = yield fetch_csv_file_name(job_id)
+            message       = yield process_jobs(csv_file_name, jobs, logger, logger_name)
+
+            Success(message)
+          end
+
+          private
+
+          # Fetches the latest job ID.
+          #
+          # @return [Dry::Monads::Result::Success<Integer>, Dry::Monads::Result::Failure<String>]
+          def fetch_latest_job_id
+            latest_job_id = CvValidationJob.latest_job_id
+
+            if latest_job_id.present?
+              Success(latest_job_id)
+            else
+              Failure('No CV Validation Job found')
+            end
+          end
+
+          # Fetches the logger name based on the job ID.
+          #
+          # @param job_id [Integer] The job ID.
+          # @return [Dry::Monads::Result::Success<String>, Dry::Monads::Result::Failure<String>]
+          def fetch_logger_name(job_id)
+            Success(
+              "#{Rails.root}/latest_cv_validation_job_logger_#{job_id}_#{DateTime.now.strftime('%Y_%m_%d_%H_%M_%S')}.log"
+            )
+          end
+
+          # Generates the log file for the report.
+          #
+          # @param logger_name [String] The logger file name.
+          # @return [Dry::Monads::Result::Success<Logger>, Dry::Monads::Result::Failure<String>]
+          def generate_log_file(logger_name)
+            Success(Logger.new(logger_name))
+          end
+
+          # Fetches CV validation jobs by job ID.
+          #
+          # @param job_id [Integer] The job ID.
+          # @return [Dry::Monads::Result::Success<Array<CvValidationJob>>, Dry::Monads::Result::Failure<String>]
+          def fetch_cv_validation_jobs(job_id)
+            Success(
+              CvValidationJob.by_job_id(job_id).only(
+                :primary_person_hbx_id,
+                :family_hbx_id,
+                :family_updated_at,
+                :job_id,
+                :result,
+                :cv_errors,
+                :cv_start_time,
+                :cv_end_time
+              )
+            )
+          end
+
+          # Generates the CSV file name for the report.
+          #
+          # @param job_id [Integer] The job ID.
+          # @return [Dry::Monads::Result::Success<String>, Dry::Monads::Result::Failure<String>]
+          def fetch_csv_file_name(job_id)
+            Success(
+              "#{Rails.root}/latest_cv_validation_job_report_#{job_id}_#{DateTime.now.strftime('%Y_%m_%d_%H_%M_%S')}.csv"
+            )
+          end
+
+          # Processes the jobs and generates the CSV report.
+          #
+          # @param csv_file_name [String] The CSV file name.
+          # @param jobs [Array<CvValidationJob>] The CV validation jobs.
+          # @param logger [Logger] The log file.
+          # @param logger_name [String] The logger file name.
+          # @return [Dry::Monads::Result::Success<String>, Dry::Monads::Result::Failure<String>]
+          def process_jobs(csv_file_name, jobs, logger, logger_name)
+            CSV.open(csv_file_name, 'w', force_quotes: true) do |csv|
+              csv << [
+                'Primary Person HBX ID',
+                'Family HBX ID',
+                'Family Updated At',
+                'Job Id',
+                'Result',
+                'CV Errors',
+                'CV Payload Transform Time'
+              ]
+
+              jobs.each do |job|
+                logger.info "Processing job: #{job.job_id}"
+
+                csv << [
+                  job.primary_person_hbx_id,
+                  job.family_hbx_id,
+                  job.family_updated_at,
+                  job.job_id,
+                  job.result,
+                  job.cv_errors,
+                  job.cv_payload_transformation_time
+                ]
+
+                logger.info "Processed job: #{job.job_id}"
+              rescue StandardError => e
+                logger.error "Error processing job: #{job.job_id} - #{e.message}"
+              end
+            end
+
+            Success(
+              "Latest CV Validation Job report generated: #{csv_file_name} and log file: #{logger_name}"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/event_source/subscribers/private/families/validate_cv_requested_subscriber.rb
+++ b/app/event_source/subscribers/private/families/validate_cv_requested_subscriber.rb
@@ -54,7 +54,7 @@ module Subscribers
             payload.slice(:family_hbx_id, :family_updated_at, :job_id)
           )
 
-          message = result.success? ? "----- SUCCESS: #{result.value!}" : "----- FAILURE: #{result.failure}"
+          message = result.success? ? "----- SUCCESS - CvValidationJob ID: #{result.success.id}" : "----- FAILURE: #{result.failure}"
           subscriber_logger.info "ValidateCvRequestedSubscriber, result: #{message}"
         rescue StandardError => e
           subscriber_logger.error "ValidateCvRequestedSubscriber, response: #{response}, error message: #{e.message}, backtrace: #{e.backtrace}"

--- a/app/models/cv_validation_job.rb
+++ b/app/models/cv_validation_job.rb
@@ -21,6 +21,10 @@ class CvValidationJob
   #   @return [String] The SHA of the aca_entities gem that was used to validate the CV.
   field :aca_entities_sha, type: String
 
+  # @!attribute [rw] primary_person_hbx_id
+  #   @return [String] This is the identifier that is used to identify the Primary Person in the Enroll System.
+  field :primary_person_hbx_id, type: String
+
   # @!attribute [rw] family_hbx_id
   #   @return [String] This is the identifier that is used to identify the Family in the Enroll System.
   field :family_hbx_id, type: String
@@ -106,10 +110,10 @@ class CvValidationJob
   # @return [Mongoid::Index] Index on the created_at field.
   index({ created_at: 1 }, { name: 'created_at_index' })
 
-  # Calculates the time taken to create the CV payload.
+  # Calculates the time taken to transform a Family object to a valid CV payload.
   #
   # @return [Integer, nil] The difference in seconds between cv_end_time and cv_start_time, or nil if either is not set.
-  def cv_payload_creation_time
+  def cv_payload_transformation_time
     duration_in_seconds(cv_end_time, cv_start_time)
   end
 

--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -116,6 +116,7 @@
                 data-toggle="modal"
                 data-target="#<%= product.kind.to_s %>-<%= product.id %>-<%= hbx_enrollment.hbx_id%>"
                 tabindex="0"
+                href="#"
                 onkeydown="handleContactInfoKeyDown(event, 'plan_contact_info-<%= hbx_enrollment.hbx_id%>', '#<%= product.kind.to_s %>-<%= product.id %>-<%= hbx_enrollment.hbx_id%>')">
 
                 <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">

--- a/app/views/shared/_me_carrier_contact_information.html.erb
+++ b/app/views/shared/_me_carrier_contact_information.html.erb
@@ -21,34 +21,34 @@
               <div>
                 <p class="bold mb-0"><%=l10n("plans.cho")%></p>
                 <p class="mb-0"><%=l10n("plans.cho_hours")%></p>
-                <p class="mb-0"><%=l10n("plans.call")%>: <a href=<%=l10n("plans.cho_href_phone")%> ><%=l10n("plans.cho_phone")%></a></p>
+                <p class="mb-0"><%=l10n("plans.call")%> <a href=<%=l10n("plans.cho_href_phone")%> ><%=l10n("plans.cho_phone")%></a></p>
                 <p><%=l10n("plans.cho_contact_url")%></p>
               </div>
             <% when "Anthem Blue Cross and Blue Shield" %>
               <div>
                 <p class="bold mb-0"><%=l10n("plans.anthm")%></p>
                 <p class="mb-0"><%=l10n("plans.anthm_hours")%></p>
-                <p class="mb-0"><%=l10n("plans.call")%>: <a href=<%=l10n("plans.anthm_href_phone")%> ><%=l10n("plans.anthm_phone")%></a></p>
+                <p class="mb-0"><%=l10n("plans.call")%> <a href=<%=l10n("plans.anthm_href_phone")%> ><%=l10n("plans.anthm_phone")%></a></p>
                 <p><%=l10n("plans.anthm_contact_url")%></p>
               </div>
             <% when "Taro Health" %>
               <div>
                 <p class="bold mb-0"><%=l10n("plans.taro")%></p>
                 <p class="mb-0"><%=l10n("plans.taro_hours")%></p>
-                <p class="mb-0"><%=l10n("plans.call")%>: <a href=<%=l10n("plans.taro_href_phone_1")%> ><%=l10n("plans.taro_phone_1")%></a></p>
+                <p class="mb-0"><%=l10n("plans.call")%> <a href=<%=l10n("plans.taro_href_phone_1")%> ><%=l10n("plans.taro_phone_1")%></a></p>
                 <p><%=l10n("plans.taro_contact_url")%></p>
               </div>
             <% when "Harvard Pilgrim Health Care" %>
               <div>
                 <p class="bold mb-0"><%=l10n("plans.hphc")%></p>
                 <p class="mb-0"><%=l10n("plans.hphc_hours")%></p>
-                <p><%=l10n("plans.call")%>: <a href=<%=l10n("plans.hphc_href_phone")%> ><%=l10n("plans.hphc_phone")%></a></p>
+                <p><%=l10n("plans.call")%> <a href=<%=l10n("plans.hphc_href_phone")%> ><%=l10n("plans.hphc_phone")%></a></p>
               </div>
             <% when "Northeast Delta Dental" %>
               <div>
                 <p class="bold mb-0"><%=l10n("plans.nedd")%></p>
                 <p class="mb-0"><%=l10n("plans.nedd_hours")%></p>
-                <p class="mb-0"><%=l10n("plans.call")%></>
+                <p class="mb-0"><%=l10n("plans.call")%></p>
                 <a href=<%=l10n("plans.nedd_href_phone_1")%> ><%=l10n("plans.nedd_phone_1")%></a><br>
                 <a href=<%=l10n("plans.nedd_href_phone_2")%> ><%=l10n("plans.nedd_phone_2")%></a>
                 <p><%=l10n("plans.nedd_contact_url")%></p>

--- a/script/bulk_cv_validation/latest_report.rb
+++ b/script/bulk_cv_validation/latest_report.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# This script generates the latest CV Validation Job report for the families.
+
+# Command to trigger the script:
+#   CLIENT=me bundle exec rails runner script/bulk_cv_validation/latest_report.rb
+
+# Checks if the :families_cv_validation_job feature is enabled in the EnrollRegistry.
+# If the feature is not enabled, it prints a message and exits the script.
+#
+# @return [void]
+unless EnrollRegistry.feature_enabled?(:families_cv_validation_job)
+  puts 'The bulk CV Validation Job for all the families feature is not enabled. Please enable the feature :families_cv_validation_job to run this script. EXITING.'
+  exit
+end
+
+# Calls the operation to generate the latest CV Validation Job report and handles the result.
+# If the job is successful, it logs the success message and instructions.
+# If the job fails, it logs the failure message.
+#
+# @return [void]
+result = ::Operations::Reports::Families::CvValidationJobs::LatestReport.new.call
+if result.success?
+  puts result.success
+  puts "2 files (CSV and Log) are created with matching names latest_cv_validation_job_logger_*.log and latest_cv_validation_job_report_*.csv."
+  puts "***** PLEASE RETRIEVE THEM, PASSWORD PROTECT, AND ATTACH TO THE PIVOTAL STORY. *****"
+else
+  puts result.failure
+end

--- a/spec/domain/operations/private/families/validate_cv_spec.rb
+++ b/spec/domain/operations/private/families/validate_cv_spec.rb
@@ -30,8 +30,9 @@ RSpec.describe Operations::Private::Families::ValidateCv do
       it 'returns an instance of CvValidationJob' do
         validation_job = result.success
         expect(validation_job).to be_a(CvValidationJob)
-        expect(validation_job.cv_payload_creation_time).not_to be_nil
+        expect(validation_job.cv_payload_transformation_time).not_to be_nil
         expect(validation_job.cv_validation_job_time).not_to be_nil
+        expect(validation_job.primary_person_hbx_id).to eq(person.hbx_id)
       end
     end
 

--- a/spec/domain/operations/reports/families/cv_validation_jobs/latest_report_spec.rb
+++ b/spec/domain/operations/reports/families/cv_validation_jobs/latest_report_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe Operations::Reports::Families::CvValidationJobs::LatestReport do
+  describe '#call' do
+    let(:result) { subject.call }
+
+    context 'when the jobs do not exist' do
+      it 'returns a failure result' do
+        expect(result).to be_failure
+        expect(result.failure).to eq('No CV Validation Job found')
+      end
+    end
+
+    context 'when the jobs exist' do
+      let(:job_id) { 'aksjh7d7gds7sg00000' }
+      let(:create_jobs) do
+        FactoryBot.create_list(:cv_validation_job, 3, :success, job_id: job_id)
+      end
+
+      let(:csv_file_name) { Dir.glob("#{Rails.root}/latest_cv_validation_job_report_#{job_id}_*.csv").first }
+      let(:primary_person_hbx_ids_from_csv) do
+        primary_person_hbx_ids = []
+
+        CSV.foreach(csv_file_name, headers: true) do |row|
+          primary_person_hbx_ids << row['Primary Person HBX ID']
+        end
+
+        primary_person_hbx_ids
+      end
+
+      it 'returns a success result' do
+        create_jobs
+        expect(result).to be_success
+        expect(primary_person_hbx_ids_from_csv.sort).to eq(
+          CvValidationJob.where(job_id: job_id).pluck(:primary_person_hbx_id).sort
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/cv_validation_jobs.rb
+++ b/spec/factories/cv_validation_jobs.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     cv_version { '3' }
     aca_version { '1.0.0' }
     aca_entities_sha { 'abc123' }
+    primary_person_hbx_id { '98765' }
     family_hbx_id { '12345' }
     family_updated_at { DateTime.now }
     job_id { 'job_123' }

--- a/spec/models/cv_validation_job_spec.rb
+++ b/spec/models/cv_validation_job_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe CvValidationJob, type: :model do
     it { is_expected.to have_field(:cv_version).of_type(String) }
     it { is_expected.to have_field(:aca_version).of_type(String) }
     it { is_expected.to have_field(:aca_entities_sha).of_type(String) }
+    it { is_expected.to have_field(:primary_person_hbx_id).of_type(String) }
     it { is_expected.to have_field(:family_hbx_id).of_type(String) }
     it { is_expected.to have_field(:family_updated_at).of_type(DateTime) }
     it { is_expected.to have_field(:job_id).of_type(String) }
@@ -71,14 +72,14 @@ RSpec.describe CvValidationJob, type: :model do
     it { is_expected.to have_index_for(created_at: 1).with_options(name: 'created_at_index') }
   end
 
-  describe '#cv_payload_creation_time' do
+  describe '#cv_payload_transformation_time' do
     let(:cv_start_time) { DateTime.now - 60.minutes }
     let(:cv_end_time) { DateTime.now - 1.minute }
     let(:cv_validation_job) { FactoryBot.create(:cv_validation_job, cv_start_time: cv_start_time, cv_end_time: cv_end_time) }
 
     context 'when both cv_end_time and cv_start_time are set' do
       it 'returns the difference in seconds between cv_end_time and cv_start_time' do
-        expect(cv_validation_job.cv_payload_creation_time).to eq(3540)
+        expect(cv_validation_job.cv_payload_transformation_time).to eq(3540)
       end
     end
 
@@ -86,7 +87,7 @@ RSpec.describe CvValidationJob, type: :model do
       let(:cv_end_time) { nil }
 
       it 'returns nil' do
-        expect(cv_validation_job.cv_payload_creation_time).to be_nil
+        expect(cv_validation_job.cv_payload_transformation_time).to be_nil
       end
     end
 
@@ -94,7 +95,7 @@ RSpec.describe CvValidationJob, type: :model do
       let(:cv_start_time) { nil }
 
       it 'returns nil' do
-        expect(cv_validation_job.cv_payload_creation_time).to be_nil
+        expect(cv_validation_job.cv_payload_transformation_time).to be_nil
       end
     end
 
@@ -103,7 +104,7 @@ RSpec.describe CvValidationJob, type: :model do
       let(:cv_end_time) { nil }
 
       it 'returns nil' do
-        expect(cv_validation_job.cv_payload_creation_time).to be_nil
+        expect(cv_validation_job.cv_payload_transformation_time).to be_nil
       end
     end
   end


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/188137458

# A brief description of the changes

Current behavior:  When clicking Plan Contact Info on health plan tiles, there are two colons after "Call" before the phone number. 

New behavior: There is only be one colon.
