### PR TITLE
chore: Fix UI issues and improve form submission on plan details page

### DIFF
--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -116,6 +116,7 @@
                 data-toggle="modal"
                 data-target="#<%= product.kind.to_s %>-<%= product.id %>-<%= hbx_enrollment.hbx_id%>"
                 tabindex="0"
+                href="#"
                 onkeydown="handleContactInfoKeyDown(event, 'plan_contact_info-<%= hbx_enrollment.hbx_id%>', '#<%= product.kind.to_s %>-<%= product.id %>-<%= hbx_enrollment.hbx_id%>')">
 
                 <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">

--- a/app/views/shared/_me_carrier_contact_information.html.erb
+++ b/app/views/shared/_me_carrier_contact_information.html.erb
@@ -21,34 +21,34 @@
               <div>
                 <p class="bold mb-0"><%=l10n("plans.cho")%></p>
                 <p class="mb-0"><%=l10n("plans.cho_hours")%></p>
-                <p class="mb-0"><%=l10n("plans.call")%>: <a href=<%=l10n("plans.cho_href_phone")%> ><%=l10n("plans.cho_phone")%></a></p>
+                <p class="mb-0"><%=l10n("plans.call")%> <a href=<%=l10n("plans.cho_href_phone")%> ><%=l10n("plans.cho_phone")%></a></p>
                 <p><%=l10n("plans.cho_contact_url")%></p>
               </div>
             <% when "Anthem Blue Cross and Blue Shield" %>
               <div>
                 <p class="bold mb-0"><%=l10n("plans.anthm")%></p>
                 <p class="mb-0"><%=l10n("plans.anthm_hours")%></p>
-                <p class="mb-0"><%=l10n("plans.call")%>: <a href=<%=l10n("plans.anthm_href_phone")%> ><%=l10n("plans.anthm_phone")%></a></p>
+                <p class="mb-0"><%=l10n("plans.call")%> <a href=<%=l10n("plans.anthm_href_phone")%> ><%=l10n("plans.anthm_phone")%></a></p>
                 <p><%=l10n("plans.anthm_contact_url")%></p>
               </div>
             <% when "Taro Health" %>
               <div>
                 <p class="bold mb-0"><%=l10n("plans.taro")%></p>
                 <p class="mb-0"><%=l10n("plans.taro_hours")%></p>
-                <p class="mb-0"><%=l10n("plans.call")%>: <a href=<%=l10n("plans.taro_href_phone_1")%> ><%=l10n("plans.taro_phone_1")%></a></p>
+                <p class="mb-0"><%=l10n("plans.call")%> <a href=<%=l10n("plans.taro_href_phone_1")%> ><%=l10n("plans.taro_phone_1")%></a></p>
                 <p><%=l10n("plans.taro_contact_url")%></p>
               </div>
             <% when "Harvard Pilgrim Health Care" %>
               <div>
                 <p class="bold mb-0"><%=l10n("plans.hphc")%></p>
                 <p class="mb-0"><%=l10n("plans.hphc_hours")%></p>
-                <p><%=l10n("plans.call")%>: <a href=<%=l10n("plans.hphc_href_phone")%> ><%=l10n("plans.hphc_phone")%></a></p>
+                <p><%=l10n("plans.call")%> <a href=<%=l10n("plans.hphc_href_phone")%> ><%=l10n("plans.hphc_phone")%></a></p>
               </div>
             <% when "Northeast Delta Dental" %>
               <div>
                 <p class="bold mb-0"><%=l10n("plans.nedd")%></p>
                 <p class="mb-0"><%=l10n("plans.nedd_hours")%></p>
-                <p class="mb-0"><%=l10n("plans.call")%></>
+                <p class="mb-0"><%=l10n("plans.call")%></p>
                 <a href=<%=l10n("plans.nedd_href_phone_1")%> ><%=l10n("plans.nedd_phone_1")%></a><br>
                 <a href=<%=l10n("plans.nedd_href_phone_2")%> ><%=l10n("plans.nedd_phone_2")%></a>
                 <p><%=l10n("plans.nedd_contact_url")%></p>


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/188137458

# A brief description of the changes

Current behavior:  When clicking Plan Contact Info on health plan tiles, there are two colons after "Call" before the phone number. 

New behavior: There is only be one colon.
