### PR TITLE
feat: Add JavaScript and CSS packs for enrollment page

### DIFF
--- a/app/views/insured/families/home.html.erb
+++ b/app/views/insured/families/home.html.erb
@@ -1,4 +1,7 @@
 <% if @bs4 %>
+  <%= javascript_pack_tag "enrollment" %>
+  <%= stylesheet_pack_tag "enrollment" %>
+
   <% if pundit_allow(Family, :can_view_entire_family_enrollment_history?) %>
     <% enrollments = @all_hbx_enrollments_for_admin %>
   <% else %>


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/188137393

# A brief description of the changes

Current behavior: When viewing the Enrollment Details of a tile from the homepage and the enrollments page, the Status Transition History is displaying inconsistently across the two pages.

New behavior: Enrollment details displays consistently 
