### PR TITLE
chore: Update button styles for secondary outline buttons

### DIFF
--- a/app/javascript/css/_buttons.scss
+++ b/app/javascript/css/_buttons.scss
@@ -143,7 +143,30 @@ button.outline,
   );
 }
 
-a.button:hover {
+.button.secondary.outline {
+  color: var(--secondary-color);
+  border-color: var(--secondary-color);
+
+  &:hover {
+    color: var(--secondary-color-dark);
+    border-color: var(--secondary-color);
+    background-color: var(--button-outline-hover-bg);
+  }
+
+  &:active {
+    color: var(--secondary-color-darker);
+    border-color: var(--secondary-color-darker);
+    background-color: var(--button-outline-active-bg);
+  }
+
+  &:focus {
+    color: var(--secondary-color-dark);
+    border-color: var(--secondary-color-dark);
+    background-color: var(--button-outline-hover-bg);
+  }
+}
+
+a.button {
   text-decoration: none;
   cursor: pointer;
 }

--- a/app/javascript/css/colors.scss
+++ b/app/javascript/css/colors.scss
@@ -104,6 +104,9 @@
   --button-default-hover-color: var(--primary-hover-color);
   --button-default-active-color: var(--primary-color-darker);
 
+  --button-outline-hover-bg: #e2e9ee;
+  --button-outline-active-bg: #cedae3;
+
   --enrollment-status-red: #a21e1f;
   --enrollment-status-green: #027314;
   --enrollment-status-yellow: #e5a900;


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/187948652

# A brief description of the changes

Current behavior: Styles for the back to account button are incorrect.

New behavior: Styles should match the figma mock for `.secondary.outline` defined here: [Figma](https://www.figma.com/design/Z1WtgrjH3zB9Y7HQVn0hL5/EA-nuharbor-1?node-id=7449-113100&t=NGFRAUihqnIRnHTQ-1)
