### PR TITLE
deleted messages for brokers in bs4

### DIFF
--- a/components/benefit_sponsors/app/views/benefit_sponsors/inboxes/messages/destroy.js.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/inboxes/messages/destroy.js.erb
@@ -1,5 +1,10 @@
 $("#inbox_form, #message_list_form").hide();
 $('#inbox-messages').show().html("<%= escape_javascript(render "benefit_sponsors/shared/inboxes/message_list", provider: @inbox_provider) %>");
-<% if @inbox_provider != current_user.person%>
-location.reload();
-<% end %>
+var bs4 = document.documentElement.dataset.bs4 == "true";
+if (bs4) {
+  $("#messageDeleted").removeClass("hidden");
+} else {
+  <% if @inbox_provider != current_user.person%>
+    location.reload();
+  <% end %>
+}

--- a/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_individual_message.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_individual_message.html.erb
@@ -1,3 +1,31 @@
+<% if @bs4 %>
+  <tr
+    class='msg-inbox <%= message.message_read==true ? "msg-inbox-read" : "msg-inbox-unread" %>'
+    data-url="<%= retrieve_show_path(provider, message) %>">
+
+    <td tabindex="0" class="sender">
+      <div><%= message.try(:from) if @folder == "Inbox" || @folder == "Deleted" %></div>
+      <div><%= message.try(:to) if @folder == "Send" %></div>
+    </td>
+
+    <td>
+      <%= message.try(:subject) %>
+    </td>
+
+    <td>
+      <%= message.created_at.in_time_zone("Eastern Time (US & Canada)").strftime("%m/%d/%Y at %H:%M %Z") %>
+    </td>
+
+    <% unless @folder == 'Deleted' %>
+      <td data-msg-delete class="pl-4 <%=pundit_class(Family, :updateable?)%>">
+        <i tabindex="0" aria-hidden="true" class="far fa-trash-alt fa-2x delete-icon <%=pundit_class Family, :updateable?%>" data-toggle="tooltip">
+          <span class="hide"><%= l10n("Delete") %></span>
+        </i>
+      </td>
+    <% end %>
+  </tr>
+
+<% else %>
 <tr class='<%=message.message_read==true ? "msg-inbox-read" : "msg-inbox-unread"%>' onclick="showMessage('<%= retrieve_show(provider, message) %>');">
   <td>
     <%= message.try(:from) if @folder == 'Inbox' %>
@@ -17,6 +45,7 @@
   <% end %>
   </td>
 </tr>
+<% end %>
 <script>
   function showMessage(url) {
     $.ajax({type: "GET", url: url, dataType: 'script'});

--- a/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_message_list.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_message_list.html.erb
@@ -5,7 +5,7 @@
       <div class="info-icon icon" alt="info">&nbsp;</div>
     </div>
     <div class="col mr-auto p-0 align-self-center">
-      Successfully deleted message.
+      <%= l10n("broker_agencies.message_deleted") %>
     </div>
     <div class="d-flex pl-1">
       <span class="close-icon icon icon-sm pr-1" alt="Close" href="javascript;">&nbsp;<span class="sr-only">Close</span></span>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_message_list.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_message_list.html.erb
@@ -1,4 +1,24 @@
 <% if @bs4 %>
+<div class="hidden mb-4" id="messageDeleted">
+  <div class="alert alert-info d-flex align-items-start">
+    <div class="d-flex pl-1">
+      <div class="info-icon icon" alt="info">&nbsp;</div>
+    </div>
+    <div class="col mr-auto p-0 align-self-center">
+      Successfully deleted message.
+    </div>
+    <div class="d-flex pl-1">
+      <span class="close-icon icon icon-sm pr-1" alt="Close" href="javascript;">&nbsp;<span class="sr-only">Close</span></span>
+    </div>
+  </div>
+</div>
+
+<script>
+  $(".close-icon").on('click', function() {
+    $("#messageDeleted").addClass("hidden");
+  });
+</script>
+
 <% @folder = (params[:folder] || 'Inbox').capitalize %>
 <% sorted_inbox_messages = provider.inbox.messages.select{|m| @folder == (m.folder.try(:capitalize) || 'Inbox') }.sort_by(&:created_at).reverse %>
 <div id="inbox-messages" class="mx-0 px-0">

--- a/db/seedfiles/translations/en/me/broker_agencies.rb
+++ b/db/seedfiles/translations/en/me/broker_agencies.rb
@@ -19,6 +19,7 @@ BROKER_AGENCIES_TRANSLATIONS = {
 	"en.broker_agencies.first_name" => "First Name",
 	"en.broker_agencies.last_name" => "Last Name",
 	"en.broker_agencies.dob" => "Date of Birth",
+  "en.broker_agencies.message_deleted" => "Successfully deleted message.",
 	"en.broker_agencies.broker_staff_role_success" => "Your registration has been submitted. A response will be sent to the email address you provided once your application is reviewed.",
 	"en.broker_agencies.broker_staff_role_error" => "Broker Staff Role was not added because",
 	"en.broker_agencies.profiles.broker_agency_message" => "Broker Agency Message",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188128355

# A brief description of the changes

Current behavior: when clicking the trash icon, a non-bs4 styled page would appear

New behavior: you remain on the same page with the content refreshed and the flash message displaying as it does in prod
