### PR TITLE
open link from partial in new tab

### DIFF
--- a/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
+++ b/app/views/insured/fdsh_ridp_verifications/_outstanding_ridp_documents.html.erb
@@ -3,7 +3,7 @@
   <% show_faq_button = (defined? show_faq_button) ? show_faq_button : true %>
   <div class="mt-4 mb-4">
     <% if show_faq_button %>
-      <%= sanitize(link_to l10n("insured.consumer_roles.upload_ridp_documents.documents_faq"), ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, class: "button outline", target: '_blank', rel: 'noopener noreferrer') %>
+      <%= h(link_to l10n("insured.consumer_roles.upload_ridp_documents.documents_faq"), ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, class: "button outline", target: '_blank', rel: 'noopener noreferrer') %>
     <% end %>
     <h2 class="mt-4"><%= l10n("insured.consumer_roles.upload_ridp_documents.outstanding_header") %></h2>
     <section class="card">

--- a/app/views/insured/interactive_identity_verifications/_outstanding_ridp_documents.html.erb
+++ b/app/views/insured/interactive_identity_verifications/_outstanding_ridp_documents.html.erb
@@ -3,7 +3,7 @@
   <% show_faq_button = (defined? show_faq_button) ? show_faq_button : true %>
   <div class="mt-4 mb-4">
     <% if ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item.present? && show_faq_button %>
-      <%= sanitize (link_to l10n("insured.consumer_roles.upload_ridp_documents.documents_faq"), ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, class: "button outline", target: '_blank', rel: 'noopener noreferrer') %>
+      <%= h(link_to l10n("insured.consumer_roles.upload_ridp_documents.documents_faq"), ::EnrollRegistry[:enroll_app].setting(:submit_docs_url).item, class: "button outline", target: '_blank', rel: 'noopener noreferrer') %>
     <% end %>
     <h2 class="mt-4"><%= l10n("insured.consumer_roles.upload_ridp_documents.outstanding_header") %></h2>
     <section class="card">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188116863

# A brief description of the changes

Current behavior: the link to the documents faq in the outstanding document partial uses sanitize, stripping the html options

New behavior: the link to the documents faq in the outstanding document partial uses html sanitize, not stripping the html options