### PR TITLE
fix whitespace in rating and service areas rakes

### DIFF
--- a/lib/tasks/migrations/products/load_catalog_data.rake
+++ b/lib/tasks/migrations/products/load_catalog_data.rake
@@ -28,7 +28,7 @@ namespace :products do
   task :load_rating_areas, [:year] => :environment do |t, args|
     puts ':::: Loading Rating Areas ::::'
 
-    files = Dir.glob(File.join(Rails.root, "db/seedfiles/plan_xmls/#{EnrollRegistry[:enroll_app].setting(:state_abbreviation).item.downcase}/xls_templates/rating_areas", args[:year], "*.{xlsx, xls}"))
+    files = Dir.glob(File.join(Rails.root, "db/seedfiles/plan_xmls/#{EnrollRegistry[:enroll_app].setting(:state_abbreviation).item.downcase}/xls_templates/rating_areas", args[:year], "*.{xlsx,xls}"))
 
     files.each do |file|
       puts "processing file: #{file}"
@@ -48,7 +48,7 @@ namespace :products do
   task :load_service_areas, [:year] => :environment do |t, args|
     puts ':::: Loading Service Areas ::::'
 
-    files = Dir.glob(File.join(Rails.root, "db/seedfiles/plan_xmls/#{EnrollRegistry[:enroll_app].setting(:state_abbreviation).item.downcase}/xls_templates/service_areas", args[:year], "*.{xlsx, xls}"))
+    files = Dir.glob(File.join(Rails.root, "db/seedfiles/plan_xmls/#{EnrollRegistry[:enroll_app].setting(:state_abbreviation).item.downcase}/xls_templates/service_areas", args[:year], "*.{xlsx,xls}"))
 
     files.each do |file|
       puts "processing file: #{file}"


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [Pod of War-188149290](https://www.pivotaltracker.com/n/projects/2640060/stories/188149290)

# A brief description of the changes

Current behavior: When loading rating and service areas via rake task, the script is only pulling the first file in xlsx format, when it should be pulling all files in xlsx or xls format.

New behavior: When loading rating and service areas via rake task, the script pulls all files in .xlsx or .xls format

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
