### PR TITLE
add notices generation report operation

### DIFF
--- a/app/domain/operations/reports/generate_notices_report.rb
+++ b/app/domain/operations/reports/generate_notices_report.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'dry/monads/do'
+
+module Operations
+  module Reports
+    # Gets the people who has documents created in a specified date range and
+    # inserts those document information into a CSV file.
+    # Defaults to current day if no range is specified.
+    class GenerateNoticesReport
+      include Dry::Monads[:result, :do]
+
+      def call(params)
+        values            = yield validate(params)
+        people            = yield fetch_people(values)
+        report_status     = yield generate_report(people, values)
+
+        Success(report_status)
+      end
+
+      private
+
+      def validate(params)
+        start_date = params[:start_date].present? ? Date.strptime(params[:start_date].to_s, "%m/%d/%Y").beginning_of_day : TimeKeeper.date_of_record.beginning_of_day
+        end_date = params[:end_date].present? ? Date.strptime(params[:end_date].to_s, "%m/%d/%Y").end_of_day : TimeKeeper.date_of_record.end_of_day
+
+        Success(params.merge!(start_date: start_date, end_date: end_date))
+      end
+
+      def fetch_people(values)
+        people = Person.where(
+          :documents => {
+            :$elemMatch => {
+              :created_at.gte => values[:start_date],
+              :created_at.lte => values[:end_date]
+            }
+          }
+        )
+
+        Success(people)
+      end
+
+      def fetch_notice_report_file_name
+        "notices_list_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.csv"
+      end
+
+      def fetch_notice_report_headers
+        ['HBX ID', 'Notice Title', 'Notice Code', 'Date']
+      end
+
+      def notices_title_code_mapping
+        {"Your Plan Enrollment" => "IVL_ENR",
+         "Your Eligibility Results - Tax Credit" => "IVL_ERA",
+         "Your Eligibility Results - Medicaid" => "IVL_ERM",
+         "Your Eligibility Results - Marketplace Insurance" => "IVL_ERU",
+         "Action Needed - Submit Documents" => "IVL_DR0",
+         "Reminder - You Must Submit Documents" => "IVL_DR1",
+         "Don't Forget - You Must Submit Documents" => "IVL_DR2",
+         "Don't Miss the Deadline - You Must Submit Documents" => "IVL_DR3",
+         "Final Notice - You Must Submit Documents" => "IVL_DR4",
+         "Open Enrollment - Medicaid" => "IVL_OEM",
+         "Open Enrollment - Tax Credit" => "IVL_OEA",
+         "Open Enrollment - Marketplace Insurance" => "IVL_OEU",
+         "Review Your Insurance Plan Enrollment and Pay Your Bill Now" => "IVL_FRE",
+         "Your Eligibility Results Consent or Missing Information Needed" => "IVL_OEG"}
+      end
+
+      def generate_report(people, values)
+        CSV.open(fetch_notice_report_file_name, 'w+', headers: true) do |csv|
+          csv << fetch_notice_report_headers
+          people.each do |person|
+            documents = person.documents.where(:created_at.gte => values[:start_date])
+            documents.each do |document|
+              puts [person.hbx_id, document.title, notices_title_code_mapping[document.title], document.created_at] unless Rails.env.test?
+              csv << [person.hbx_id, document.title, notices_title_code_mapping[document.title], document.created_at]
+            end
+          end
+        rescue StandardError => e
+          Failure("Error generating report: #{e.message}")
+        end
+
+        Success("Generated Notices report successfully")
+      end
+    end
+  end
+end
+

--- a/lib/tasks/generate_notices_report.rake
+++ b/lib/tasks/generate_notices_report.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+desc "Task to generate notices report"
+# Example rake command with start and end dates:
+# rake generate_notices_report start_date="01/01/2021" end_date="01/31/2021"
+task :generate_notices_report => :environment do
+  start_date = ENV['start_date'] || TimeKeeper.date_of_record.beginning_of_day
+  end_date = ENV['end_date'] || TimeKeeper.date_of_record.end_of_day
+
+  log "Beginning notices report process for #{start_date} to #{end_date}"
+
+  result = Operations::Reports::GenerateNoticesReport.new.call({start_date: start_date, end_date: end_date})
+
+  log "Notices report process completed with status: #{result.success? ? 'Success' : 'Failure'}"
+end

--- a/script/oeg_oeq_notice_triggers.rb
+++ b/script/oeg_oeq_notice_triggers.rb
@@ -14,8 +14,8 @@ oeg_family_ids = if EnrollRegistry.feature_enabled?(:oeg_notice_income_verificat
                  else
                    faa_application_families - ::FinancialAssistance::Application.determined.by_year(renewal_year).distinct(:family_id)
                  end
-oeq_enrollments = HbxEnrollment.active.enrolled.current_year.where(:family_id.nin=> faa_application_families).distinct(:family_id)
-oeg_enrollments = HbxEnrollment.active.enrolled.current_year.where(:family_id.in=> oeg_family_ids).distinct(:family_id)
+oeq_enrollments = HbxEnrollment.individual_market.active.enrolled.current_year.where(:family_id.nin=> faa_application_families).distinct(:family_id)
+oeg_enrollments = HbxEnrollment.individual_market.active.enrolled.current_year.where(:family_id.in=> oeg_family_ids).distinct(:family_id)
 families = oeq_enrollments + oeg_enrollments
 
 families.each_with_index do |family_id, index|

--- a/script/oeg_oeq_notice_triggers.rb
+++ b/script/oeg_oeq_notice_triggers.rb
@@ -18,6 +18,7 @@ oeq_enrollments = HbxEnrollment.individual_market.active.enrolled.current_year.w
 oeg_enrollments = HbxEnrollment.individual_market.active.enrolled.current_year.where(:family_id.in=> oeg_family_ids).distinct(:family_id)
 families = oeq_enrollments + oeg_enrollments
 
+logger.info "Total number of families to trigger OEQ/OEG notices: #{families.size}"
 families.each_with_index do |family_id, index|
   family = Family.find_by(id: family_id)
   next unless family.present?

--- a/spec/domain/operations/reports/generate_notices_report_spec.rb
+++ b/spec/domain/operations/reports/generate_notices_report_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Operations::Reports::GenerateNoticesReport, dbclean: :after_each do
+  let!(:person) { FactoryBot.create(:person)}
+  let(:document) { Document.new(title: "Your Eligibility Results Consent or Missing Information Needed") }
+
+  before :each do
+    person.documents << document
+    Dir.glob("#{Rails.root}/notices_list_*.csv").each do |file|
+      FileUtils.rm(file)
+    end
+  end
+
+  context 'generate notices report' do
+    before do
+      Operations::Reports::GenerateNoticesReport.new.call({})
+      @file_content = File.read("#{Rails.root}/notices_list_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.csv")
+    end
+
+    it 'should include person hbx id in the report' do
+      expect(@file_content).to include(person.hbx_id)
+    end
+
+    it 'should include notice title in the report' do
+      expect(@file_content).to include(document.title)
+    end
+
+    it 'should include notice code in the report' do
+      expect(@file_content).to include("IVL_OEG")
+    end
+
+    it 'should include notice created_at in the report' do
+      expect(@file_content).to include(person.documents.first.created_at.to_s)
+    end
+  end
+end

--- a/spec/script/oeg_oeq_notice_triggers_spec.rb
+++ b/spec/script/oeg_oeq_notice_triggers_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'OEQ & OEG notice triggers script', dbclean: :after_each do
+  before :all do
+    DatabaseCleaner.clean
+  end
+
+  let(:primary) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+  let(:family)  { FactoryBot.create(:family, :with_primary_family_member, person: primary) }
+  let!(:application) do
+    FactoryBot.create(:financial_assistance_application,
+                      family_id: family.id,
+                      account_transferred: false,
+                      transfer_requested: true,
+                      assistance_year: TimeKeeper.date_of_record.next_year.year,
+                      aasm_state: 'applicants_update_required',
+                      hbx_id: "830293",
+                      submitted_at: Date.yesterday,
+                      created_at: Date.yesterday)
+  end
+  let!(:applicant) do
+    applicant = FactoryBot.create(:applicant,
+                                  first_name: primary.first_name,
+                                  last_name: primary.last_name,
+                                  dob: primary.dob,
+                                  gender: primary.gender,
+                                  application: application,
+                                  ethnicity: [])
+    applicant
+  end
+
+  let(:ivl_enrollment) do
+    FactoryBot.create(
+      :hbx_enrollment,
+      :individual_unassisted,
+      :with_product,
+      aasm_state: "coverage_selected",
+      effective_on: TimeKeeper.date_of_record.beginning_of_year,
+      household: family.households.first,
+      family: family,
+      coverage_kind: 'health'
+    )
+  end
+
+  let(:shop_enrollment) do
+    FactoryBot.create(
+      :hbx_enrollment,
+      :shop,
+      :with_product,
+      aasm_state: "coverage_enrolled",
+      effective_on: TimeKeeper.date_of_record.beginning_of_year,
+      household: family.households.first,
+      family: family,
+      coverage_kind: 'health'
+    )
+  end
+
+  before :each do
+    Dir.glob("#{Rails.root}/log/oeg_oeq_notice_triggers_*.log").each do |file|
+      FileUtils.rm(file)
+    end
+  end
+
+  context "IVL enrolled family" do
+    it 'triggers OEG/OEQ notice event' do
+      ivl_enrollment
+      load_script
+      log_file_path = "#{Rails.root}/log/oeg_oeq_notice_triggers_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+
+      expect(File.exist?(log_file_path)).to eq true
+      expect(File.read(log_file_path)).to include("Total number of families to trigger OEQ/OEG notices: 1")
+    end
+  end
+
+  context "Employer enrolled family" do
+    it 'should not trigger OEG/OEQ notice event' do
+      shop_enrollment
+      load_script
+      log_file_path = "#{Rails.root}/log/oeg_oeq_notice_triggers_#{TimeKeeper.date_of_record.strftime('%Y_%m_%d')}.log"
+
+      expect(File.exist?(log_file_path)).to eq true
+      expect(File.read(log_file_path)).to include("Total number of families to trigger OEQ/OEG notices: 0")
+    end
+  end
+
+  def load_script
+    load Rails.root.join('script/oeg_oeq_notice_triggers.rb')
+  end
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [X] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/n/projects/2640059/stories/188150480

# A brief description of the changes

Current behavior:  Notices generation report is currently run manually by devops

New behavior: Move notice generation reports into the codebase so that developers/devops can trigger them using a rake task.

*Rake task to generate the report:*

`RAILS_ENV="production" bundle exec rake generate_notices_report start_date="08/01/2024" end_date="08/31/2024"`

Start and End dates are optional, if no dates are provided it will take the current start and end dates.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
