### PR TITLE
bs4 fix inbox header

### DIFF
--- a/app/views/insured/families/inbox.html.erb
+++ b/app/views/insured/families/inbox.html.erb
@@ -1,7 +1,7 @@
 <% if @bs4 %>
   <%= render partial: 'shared/family_side_nav' %>
-  <span class='text-right'>
-    <%= h(link_to l10n("upload_notices"), upload_notice_form_insured_families_path, class: "btn btn-primary mt-2 mt-lg-0", target: '_blank', rel: "noopener noreferrer") if current_user.has_hbx_staff_role? && EnrollRegistry.feature_enabled?(:show_upload_notices)  %>
+  <span class='text-right d-flex mt-2 mt-xl-0'>
+    <%= h(link_to l10n("upload_notices"), upload_notice_form_insured_families_path, class: "btn btn-primary mr-2", target: '_blank', rel: "noopener noreferrer") if current_user.has_hbx_staff_role? && EnrollRegistry.feature_enabled?(:show_upload_notices)  %>
     <%= h(link_to l10n(".download_tax_documents"), tax_info_url, class: "btn btn-primary", target: '_blank', rel: "noopener noreferrer") if show_download_tax_documents_button? %>
   </span>
   <%= render 'inbox', provider: @person %>

--- a/app/views/insured/families/inbox.html.erb
+++ b/app/views/insured/families/inbox.html.erb
@@ -1,7 +1,7 @@
 <% if @bs4 %>
   <%= render partial: 'shared/family_side_nav' %>
   <span class='text-right'>
-    <%= h(link_to l10n("upload_notices"), upload_notice_form_insured_families_path, class: "btn btn-primary", target: '_blank', rel: "noopener noreferrer") if current_user.has_hbx_staff_role? && EnrollRegistry.feature_enabled?(:show_upload_notices)  %>
+    <%= h(link_to l10n("upload_notices"), upload_notice_form_insured_families_path, class: "btn btn-primary mt-2 mt-lg-0", target: '_blank', rel: "noopener noreferrer") if current_user.has_hbx_staff_role? && EnrollRegistry.feature_enabled?(:show_upload_notices)  %>
     <%= h(link_to l10n(".download_tax_documents"), tax_info_url, class: "btn btn-primary", target: '_blank', rel: "noopener noreferrer") if show_download_tax_documents_button? %>
   </span>
   <%= render 'inbox', provider: @person %>

--- a/app/views/insured/inboxes/show.js.erb
+++ b/app/views/insured/inboxes/show.js.erb
@@ -1,8 +1,10 @@
 $("#message_list_form").hide();
 $("#inbox-nav-tabs").hide();
-$("#inbox-headers").hide();
 $("#inbox_form").show();
 $('#show_message_form').show().html("<%= escape_javascript(render "shared/inboxes/message", message: @message) %>");
+<% if @bs4 %>
+  $('#inbox-headers h1').text("<%= l10n('message_detail') %>");
+<% end %>
 $(".btn-danger").click(function(){
   $('#show_message_form').hide();
   $('#profile-content .container').show().html("<%= escape_javascript(render "shared/inboxes/message_list", provider: @inbox_provider) %>");

--- a/components/benefit_sponsors/app/views/benefit_sponsors/inboxes/messages/show.js.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/inboxes/messages/show.js.erb
@@ -1,6 +1,8 @@
 $("#message_list_form").hide();
 $("#inbox_form").show();
 $('#show_message_form').show().html("<%= escape_javascript(render "benefit_sponsors/shared/inboxes/message", message: @message) %>");
-$('#header').text("<%= l10n('message_detail') %>");
+<% if @bs4 %>
+  $('#header').text("<%= l10n('message_detail') %>");
+<% end %>
 $("#myTab").load(location.href+" #myTab>*", "");
 $("#inbox_form").load(location.href+" #inbox_form>*", "");

--- a/components/benefit_sponsors/app/views/benefit_sponsors/inboxes/messages/show.js.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/inboxes/messages/show.js.erb
@@ -1,5 +1,6 @@
 $("#message_list_form").hide();
 $("#inbox_form").show();
 $('#show_message_form').show().html("<%= escape_javascript(render "benefit_sponsors/shared/inboxes/message", message: @message) %>");
+$('#header').text("<%= l10n('message_detail') %>");
 $("#myTab").load(location.href+" #myTab>*", "");
 $("#inbox_form").load(location.href+" #inbox_form>*", "");

--- a/components/benefit_sponsors/app/views/benefit_sponsors/inboxes/messages/show.js.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/inboxes/messages/show.js.erb
@@ -2,7 +2,7 @@ $("#message_list_form").hide();
 $("#inbox_form").show();
 $('#show_message_form').show().html("<%= escape_javascript(render "benefit_sponsors/shared/inboxes/message", message: @message) %>");
 <% if @bs4 %>
-  $('#header').text("<%= l10n('message_detail') %>");
+  $('#inbox-headers h1').text("<%= l10n('message_detail') %>");
 <% end %>
 $("#myTab").load(location.href+" #myTab>*", "");
 $("#inbox_form").load(location.href+" #inbox_form>*", "");

--- a/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_message_list.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_message_list.html.erb
@@ -23,7 +23,7 @@
 <% sorted_inbox_messages = provider.inbox.messages.select{|m| @folder == (m.folder.try(:capitalize) || 'Inbox') }.sort_by(&:created_at).reverse %>
 <div id="inbox-messages" class="mx-0 px-0">
 <div id="inbox-headers" class="tab-holder">
-  <h1 id="header"><%= l10n("messages") %></h1>
+  <h1><%= l10n("messages") %></h1>
 
   <div class="pl-3 inbox-sender row">
     <%= l10n("unread_messages")%>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_message_list.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_message_list.html.erb
@@ -23,7 +23,7 @@
 <% sorted_inbox_messages = provider.inbox.messages.select{|m| @folder == (m.folder.try(:capitalize) || 'Inbox') }.sort_by(&:created_at).reverse %>
 <div id="inbox-messages" class="mx-0 px-0">
 <div id="inbox-headers" class="tab-holder">
-  <h1><%= l10n("messages") %></h1>
+  <h1 id="header"><%= l10n("messages") %></h1>
 
   <div class="pl-3 inbox-sender row">
     <%= l10n("unread_messages")%>

--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -341,6 +341,7 @@ How to find the SEVIS ID: On the DS-2019, the number is on the top right hand si
   :'en.audit_log' => "Audit Log",
   :'en.messages' => "Messages",
   :'en.unread_messages' => "Unread messages",
+  :'en.message_detail' => "Message Detail",
   :'en.my_account' => "My Account",
   :'en.manage_family' => "Manage Family",
   :'en.personal' => "Personal",

--- a/db/seedfiles/translations/en/dc/insured.rb
+++ b/db/seedfiles/translations/en/dc/insured.rb
@@ -395,6 +395,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.audit_log' => "Audit Log",
   :'en.messages' => "Messages",
   :'en.unread_messages' => "Unread messages",
+  :'en.message_detail' => "Message Detail",
   :'en.my_account' => "My Account",
   :'en.manage_family' => "Manage Family",
   :'en.personal' => "Personal",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -394,6 +394,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.upload_paper_application' => "Upload Paper Application",
   :'en.audit_log' => "Audit Log",
   :'en.messages' => "Messages",
+  :'en.message_detail' => "Message Detail",
   :'en.unread_messages' => "Unread messages",
   :'en.my_account' => "My Account",
   :'en.manage_family' => "Manage Family",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
1. https://www.pivotaltracker.com/story/show/188156839
2. https://www.pivotaltracker.com/story/show/188155917

This PR updates both the consumer and broker inboxes to use the Message Detail header when viewing a message. It also updates the consumer inbox download/upload notice buttons to better support smaller breakpoints.
