### PR TITLE
add missing colon to messages pages

### DIFF
--- a/app/views/insured/families/_inbox.html.erb
+++ b/app/views/insured/families/_inbox.html.erb
@@ -6,8 +6,8 @@
 
     <div>
       <strong>
-        <%= l10n("unread_messages")%>
-        <span class="pl-2"><%= @person.inbox.unread_messages.size %></span>
+        <%= l10n("unread_messages")%>:
+        <span class="pl-1"><%= @person.inbox.unread_messages.size %></span>
       </strong>
     </div>
   </div>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_message_list.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/shared/inboxes/_message_list.html.erb
@@ -26,8 +26,8 @@
   <h1><%= l10n("messages") %></h1>
 
   <div class="pl-3 inbox-sender row">
-    <%= l10n("unread_messages")%>
-    <div class="pl-2"><%= provider.inbox.unread_messages.size %></div>
+    <%= l10n("unread_messages")%>:
+    <div class="pl-1"><%= provider.inbox.unread_messages.size %></div>
   </div>
 </div>
 <div class="mt-4 mb-1" id="inbox-nav-tabs">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188157840

# A brief description of the changes

Current behavior: there was no colon between the word "unread" and the number of unread messages

New behavior: there is now a colon between the word "unread" and the number of unread messages
