### PR TITLE
assign expert button should always show when modal is opened

### DIFF
--- a/app/assets/javascripts/help_me_sign_up.js
+++ b/app/assets/javascripts/help_me_sign_up.js
@@ -36,7 +36,7 @@ $(document).on('click', '.name_search_only', function() {
   $('#help_type').html(this.id)
   $('#back_to_help').removeClass('hide')
 })
-$(document).on('click', '[data-target="#help_with_plan_shopping"]',function(){$('.help_reset').addClass("hide"); $('#help_list').removeClass("hide"); $('#back_to_help').addClass("hide") })
+$(document).on('click', '[data-target="#help_with_plan_shopping"]',function(){$('.help_reset').addClass("hide"); $('#help_list').removeClass("hide"); $('#back_to_help').addClass("hide"); $('#bottom_expert_link').removeClass("hide") })
 
 $(document).on('click', '#back_to_help', function(){
   $('.help_reset').addClass("hide");


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188158718

# A brief description of the changes

Current behavior: the assign an expert button will disappear if you click it in the modal - which is expected. however if you leave the modal by clicking outside it rather than through using one of the close buttons, then the button stays hidden

New behavior:  if you leave the modal by clicking outside it rather than through using one of the close buttons, then the button is visibile