### PR TITLE
set minimum date for calendar field on cancel plan

### DIFF
--- a/app/views/insured/group_selection/_cancel_plan_form.html.erb
+++ b/app/views/insured/group_selection/_cancel_plan_form.html.erb
@@ -21,7 +21,7 @@
         <%= hidden_field_tag :bs4, true %>
         <p><%= l10n("choose_last_day") %></p>
         <label class="required" for="term_date"><%= l10n("coverage_end_date") %></label>
-        <%= date_field_tag :term_date, class: "date-field mt-2", :'data-date-max' => "+0", required: true %>
+        <%= date_field_tag :term_date, nil,{class: "date-field mt-2", min: TimeKeeper.date_of_record.strftime("%Y-%m-%d"), required: true} %>
         <% if show_cancellation_reason %>
           <p class="mt-4"><%= l10n("why_are_you_canceling") %><p>
           <label class="required" for="cancellation_reason"><%= l10n("cancelation_reason") %></label>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188157352

# A brief description of the changes

Current behavior: no minimum date is allowed

New behavior: minimum date is set in the ui
