### PR TITLE
put broker registration flash message into translation and make banner green

### DIFF
--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/registrations_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/registrations_controller.rb
@@ -47,7 +47,7 @@ module BenefitSponsors
                                 "broker_agencies/broker_roles/extended_confirmation"
                               end
           if is_broker_profile? && saved
-            flash[:notice] = "Your registration has been submitted. A response will be sent to the email address you provided once your application is reviewed."
+            flash[:success] = l10n("broker_registration.registration_submitted_flash")
             respond_to do |format|
               format.html { render template_filename, :layout => resolve_layout }
             end

--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/registrations_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/registrations_controller.rb
@@ -47,7 +47,7 @@ module BenefitSponsors
                                 "broker_agencies/broker_roles/extended_confirmation"
                               end
           if is_broker_profile? && saved
-            flash[:success] = l10n("broker_registration.registration_submitted_flash")
+            flash[:success] = l10n("broker_agencies.broker_staff_role_success")
             respond_to do |format|
               format.html { render template_filename, :layout => resolve_layout }
             end

--- a/db/seedfiles/translations/en/me/broker_agencies.rb
+++ b/db/seedfiles/translations/en/me/broker_agencies.rb
@@ -30,7 +30,6 @@ BROKER_AGENCIES_TRANSLATIONS = {
 	"en.broker_agencies.dob" => "Date of Birth",
   "en.broker_agencies.message_deleted" => "Successfully deleted message.",
   "en.success" => "Success",
-  "en.broker_registration.registration_submitted_flash" => "Success",
 	"en.broker_agencies.broker_staff_role_success" => "Your registration has been submitted. A response will be sent to the email address you provided once your application is reviewed.",
 	"en.broker_agencies.broker_staff_role_error" => "Broker Staff Role was not added because",
 	"en.broker_agencies.profiles.broker_agency_message" => "Broker Agency Message",

--- a/db/seedfiles/translations/en/me/broker_agencies.rb
+++ b/db/seedfiles/translations/en/me/broker_agencies.rb
@@ -30,6 +30,7 @@ BROKER_AGENCIES_TRANSLATIONS = {
 	"en.broker_agencies.dob" => "Date of Birth",
   "en.broker_agencies.message_deleted" => "Successfully deleted message.",
   "en.success" => "Success",
+  "en.broker_registration.registration_submitted_flash" => "Success",
 	"en.broker_agencies.broker_staff_role_success" => "Your registration has been submitted. A response will be sent to the email address you provided once your application is reviewed.",
 	"en.broker_agencies.broker_staff_role_error" => "Broker Staff Role was not added because",
 	"en.broker_agencies.profiles.broker_agency_message" => "Broker Agency Message",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188159072

# A brief description of the changes

Current behavior: the text is hard coded in the controller and the flash type is informational (blue)

New behavior: the text in in a translation file and the flash type is success (green)