### PR TITLE
family info bug in bs4

### DIFF
--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -574,7 +574,13 @@ jobs:
           COVERAGE: 'true'
           WD_VERSION: "124.0.6367.207"
           WD_CHROME_PATH: ${{ github.workspace }}/chrome-linux64/chrome
-        run: cucumber_booster --job ${{ matrix.group }}/${{ strategy.job-total }}
+        run: cucumber_booster --job ${{ matrix.group }}/${{ strategy.job-total }} > output.txt
+      - name: print cucumber errors on summary
+        if: failure()
+        run: |
+          cat output.txt
+          echo "Cucumber ${{ matrix.group }}/${{ strategy.job-total }}" >> $GITHUB_STEP_SUMMARY
+          cat output.txt  | sed -n '/Failing Scenarios/,$p'  >> $GITHUB_STEP_SUMMARY
       - name: copy coverage report
         if: (github.event_name == 'push') && (github.ref == 'refs/heads/trunk')
         run: |

--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -574,13 +574,7 @@ jobs:
           COVERAGE: 'true'
           WD_VERSION: "124.0.6367.207"
           WD_CHROME_PATH: ${{ github.workspace }}/chrome-linux64/chrome
-        run: cucumber_booster --job ${{ matrix.group }}/${{ strategy.job-total }} > output.txt
-      - name: print cucumber errors on summary
-        if: failure()
-        run: |
-          cat output.txt
-          echo "Cucumber ${{ matrix.group }}/${{ strategy.job-total }}" >> $GITHUB_STEP_SUMMARY
-          cat output.txt  | sed -n '/Failing Scenarios/,$p'  >> $GITHUB_STEP_SUMMARY
+        run: cucumber_booster --job ${{ matrix.group }}/${{ strategy.job-total }}
       - name: copy coverage report
         if: (github.event_name == 'push') && (github.ref == 'refs/heads/trunk')
         run: |

--- a/app/views/insured/family_members/_family_members.html.erb
+++ b/app/views/insured/family_members/_family_members.html.erb
@@ -61,11 +61,12 @@
         </svg>
         <span class="ml-2"><%= l10n("add_member_to_household") %></span>
       <% end) %>
-
+      <% if @application.present? %>
       <div class="help-to-decide align-content-around ml-3">
         <a href="#help_me_decide" data-toggle="modal" data-target="#help_me_decide" class="d-block"><%= l10n("help_me_decide_title") %></a>
         <%= render partial: 'financial_assistance/shared/modal_support_text', locals: {key: "help_me_decide"} %>
       </div>
+      <% end %>
   </div>
 
   <div class="fail-search add-member <%= 'hidden' if !@family.active_family_members.empty? %>">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 

# A brief description of the changes

Current behavior: error when try to go to the family info page in plan shopping

New behavior: successfully reach family info page during plan shopping

