### PR TITLE
chore: Update grid-template-columns in main.scss

### DIFF
--- a/app/javascript/css/main.scss
+++ b/app/javascript/css/main.scss
@@ -149,7 +149,7 @@ a {
 
 dl.parent {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto 1fr !important; // !important is needed to override the styles used in enrollment.scss that can be deleted when bs4 flag is removed and bs4 is default
   grid-row-gap: 4px;
   list-style: none;
   padding: 0;


### PR DESCRIPTION
Override styles used in enrollment.scss by adding !important to grid-template-columns in dl.parent. This can be deleted when bs4 flag is removed and bs4 is default.


Ticket: https://www.pivotaltracker.com/story/show/188137393