### PR TITLE
fix closing popup canceling ssn form field

### DIFF
--- a/app/views/shared/person/_consumer_information.html.erb
+++ b/app/views/shared/person/_consumer_information.html.erb
@@ -39,7 +39,7 @@
         <%= f.label :ssn, "Social Security" %>
         <% if EnrollRegistry.feature_enabled?(:mask_ssn_ui_fields) %>
           <%= render partial: 'shared/person/ssn/consumer_ssn_field',
-            locals: { f: f, presenter: organize_ssn_params(f.object), default_disabled: readonly_status } 
+            locals: { f: f, presenter: organize_ssn_params(f.object), default_disabled: readonly_status }
           %>
         <% else %>
           <% if EnrollRegistry.feature_enabled?(:ssn_ui_validation) %>
@@ -54,10 +54,12 @@
       </div>
       <div class="col-sm col-md-6 col-lg-3 p-0 pt-md-4 no-ssn-container mr-auto">
         <%= f.label :no_ssn, class: "mt-1 d-inline-block" do %>
-          <%= f.check_box :no_ssn, disabled: readonly_status || @person.try(:ssn) %><span class='no_ssn'>&nbsp;<%= l10n("do_not_have_ssn") %>
-          <a href="#no_ssn_info" data-toggle="modal" data-target="#no_ssn_info" class="d-block"><%= l10n("not_sure") %></a>
-          <%= render partial: 'shared/modal_support_text_household', locals: {key: "no_ssn_info"} %>
-        <% end %><span>
+          <%= f.check_box :no_ssn, disabled: readonly_status || @person.try(:ssn) %>
+          <span class='no_ssn'>&nbsp;<%= l10n("do_not_have_ssn") %></span>
+        <% end %>
+
+        <a href="#no_ssn_info" data-toggle="modal" data-target="#no_ssn_info" class="d-block"><%= l10n("not_sure") %></a>
+        <%= render partial: 'shared/modal_support_text_household', locals: {key: "no_ssn_info"} %>
       </div>
       <div class="mr-auto col-sm col-md-6 p-0 sm-hide"></div>
     </div>


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/188178226

# A brief description of the changes

Current behavior: when we close the "Not Sure" popup on the SSN field, the SSN field is wiped & the "I don't have a SSN" checkbox becomes checked. This is the case only when the pop-up is closed by clicking outside of the box. This is not the case when the X is selected to close the box. Functionality should be consistent for either method of closing the popup. 

New behavior: Closing the popup will not clear the ssn form
