### PR TITLE
dont compare strings in aptc calc

### DIFF
--- a/app/assets/javascripts/plan_shopping.js.erb
+++ b/app/assets/javascripts/plan_shopping.js.erb
@@ -267,8 +267,8 @@ $(function() {
   // aptc form on thank you page
   const aptcForm = document.getElementById("updateAptcForm");
   if (aptcForm) {
-    const maxAptc = parseFloat(aptcForm.dataset.max).toFixed(2);
-    const minAptc = parseFloat(aptcForm.dataset.min).toFixed(2);
+    const maxAptc = parseFloat(aptcForm.dataset.max);
+    const minAptc = parseFloat(aptcForm.dataset.min);
     const updateUrl = aptcForm.dataset.url;
 
     // updates the aptc percentage on the thank you page
@@ -276,38 +276,38 @@ $(function() {
     const electedAptcAmount = document.getElementById("electedAptcAmount");
 
     electedAptcPercentage.addEventListener('blur', function(){
-      var electedPct = parseFloat(this.value).toFixed(2);
+      var electedPct = parseFloat(this.value);
       if (electedPct > 100) {
         this.value = 100;
         electedAptcAmount.value = maxAptc;
       } else {
-        let electedAptc = ((electedPct/100) * maxAptc).toFixed(2);
+        let electedAptc = ((electedPct/100) * maxAptc);
         electedAptc = electedAptc < 0 ? 0 : electedAptc;
-        if (electedAptc > maxAptc) {
-          electedAptc = maxAptc;
+        if (electedAptc > parseFloat(maxAptc)) {
+          electedAptc = maxAptc.toFixed(2);
           electedAptcPercentage.value = 100;
         }
-        electedAptcAmount.value = electedAptc;
+        electedAptcAmount.value = electedAptc.toFixed(2);
       }
       setUpdatedAptc(electedAptcAmount.value, updateUrl)
     });
 
     electedAptcAmount.addEventListener('blur', function(){
-      var electedAptc = parseFloat(this.value).toFixed(2);
+      var electedAptc = parseFloat(this.value);
       if (electedAptc > maxAptc) {
         this.value = maxAptc;
         electedAptcPercentage.value = 100;
       } else {
-        let electedPct = (electedAptc/maxAptc).toFixed(2) * 100;
+        let electedPct = (electedAptc/maxAptc) * 100;
         if (electedPct < minAptc) {
           electedPct = 100;
-          this.value = minAptc;
+          this.value = minAptc.toFixed(2);
         }
         if (electedPct > 100) {
           electedPct = 100;
-          this.value = maxAptc;
+          this.value = maxAptc.toFixed(2);
         }
-        electedAptcPercentage.value = electedPct;
+        electedAptcPercentage.value = electedPct.toFixed(0);
       }
       setUpdatedAptc(electedAptcAmount.value, updateUrl)
     });


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188152198

# A brief description of the changes

Current behavior: when percentages less than 60 are entered, the max aptc appears to be less than the elected, causing things to default to 100%

New behavior: when percentages less than 60 are entered, the elected aptc amount reflects that and it accurately is less than the max aptc
