### PR TITLE
copy should reflect the type of plan

### DIFF
--- a/app/views/insured/group_selection/_cancel_plan_form.html.erb
+++ b/app/views/insured/group_selection/_cancel_plan_form.html.erb
@@ -1,7 +1,7 @@
 <% if @bs4 %>
   <div class="confirmation hidden" id="cancel-plan-form">
     <h2><%= l10n("plan_cancelation") %></h2>
-    <p id="cancel-msg" class="action-msg hidden"><%= l10n("cancel_plan_confirmation") %></p>
+    <p id="cancel-msg" class="action-msg hidden"><%= l10n("cancel_plan_confirmation", coverage_kind: locals[:hbx_enrollment][:coverage_kind]) %></p>
     <label class="required" for="cancel_plan"> <%= l10n("cancel_your_plan") %></label>
     <div class="row focus">
       <div class="col-auto">

--- a/app/views/insured/group_selection/edit_plan.html.erb
+++ b/app/views/insured/group_selection/edit_plan.html.erb
@@ -5,7 +5,7 @@
       <li><%= l10n('edit_plan') %></li>
     </ul>
     <% if @self_term_or_cancel_form.hbx_enrollment.present? %>
-      <h1><%= @self_term_or_cancel_form.hbx_enrollment.coverage_year %> <%= l10n('health_coverage').titleize %></h1>
+      <h1><%= @self_term_or_cancel_form.hbx_enrollment.coverage_year %> <%= @self_term_or_cancel_form.hbx_enrollment.coverage_kind&.titleize %> <%= l10n('coverage').titleize %></h1>
       <% if EnrollRegistry.feature_enabled?(:enrollment_plan_tile_update) %>
         <%= render partial: "insured/families/enrollment_refactored", :collection => [@self_term_or_cancel_form.hbx_enrollment], :as => :hbx_enrollment, :layout => ("insured/families/partial_layouts/wrap_enrollments_by_year" if is_under_open_enrollment?) , locals: { read_only: false, edit_plan: true } %>
       <% end %>

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -602,7 +602,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.ID' => "ID",
   :'en.confirmation' => "Confirmation",
   :'en.do_you_want_to_cancel_this_plan' => "Do you want to cancel this plan? Cancelling means you will no longer have insurance. You will not be able to enroll in a new plan unless it’s open enrollment or you qualify for a special enrollment period.",
-  :'en.cancel_plan_confirmation' => "Canceling means you will no longer have health insurance thorugh CoverME.gov. You will not be able to enroll in a new plan unless it's Open Enrollment or if you have a special enrollment period due to a qualifying life event.",
+  :'en.cancel_plan_confirmation' => "Canceling means you will no longer have %{coverage_kind} insurance thorugh CoverME.gov. You will not be able to enroll in a new plan unless it's Open Enrollment or if you have a special enrollment period due to a qualifying life event.",
   :'en.are_you_sure_you_want_to_update_aptc' => "Are you sure you want to update your tax credit? If you make a change today, we’ll apply it to your premium starting on the date listed below.",
   :'en.total_tax_credit_amount' => "The total tax credit amount the people on this plan qualify for is",
   :'en.total_available_aptc_amount' => "The maximum amount you can use for this plan is",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188181107

# A brief description of the changes

Current behavior: the copy says text in two places, even when you're cancelling a dental plan

New behavior: the copy reflects the type of plan being cancelled
