### PR TITLE
shift question placement on the coverage for your household page

### DIFF
--- a/app/views/insured/group_selection/new.html.erb
+++ b/app/views/insured/group_selection/new.html.erb
@@ -51,18 +51,11 @@
         <% end %>
       <% end %>
 
-      <h2><%= l10n("insured.group_selection.new.who_needs_coverage") %></h2>
-      <% if @adapter.can_shop_shop?(@person) || @adapter.can_shop_individual?(@person) || @adapter.can_shop_resident?(@person) && @coverage_household.coverage_household_members %>
-        <div id="coverage-household">
-          <%= render 'coverage_household' %>
-        </div>
-      <% end %>
-
       <% if @adapter.can_shop_both_markets?(@person) || @adapter.can_shop_individual?(@person) || @adapter.can_shop_resident?(@person) %>
         <div id="market_kinds" class="mb-3">
         <fieldset>
-          <legend class="text-reset"><h3><%= l10n("insured.group_selection.new.marketplace") %></h3></legend>
-          <div class="n-radio-group d-flex align-items-center my-2">
+          <legend class="text-reset mb-0"><h3><%= l10n("insured.group_selection.new.marketplace") %></h3></legend>
+          <div class="n-radio-group d-flex align-items-center mb-2">
             <% view_market_places(@person).each_with_index do |kind, index| %>
               <label class="n-radio weight-n" for="market_kind_<%= kind %>">
                 <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'market_kind_<%= kind %>')">
@@ -90,15 +83,11 @@
         <% end %>
       <% end %>
 
-      <% if @adapter.can_shop_shop?(@person) %>
-        <%= render partial: 'select_employer', locals: {effective_date: effective_date_for_display} %>
-      <% end %>
-
       <div id="coverage_kinds" class="mb-3">
       <fieldset>
-        <legend class="text-reset"><h3><%= l10n("benefit_type") %></h3></legend>
+        <legend class="text-reset mb-0"><h3><%= l10n("benefit_type") %></h3></legend>
 
-        <div class="n-radio-group d-flex align-items-center my-2">
+        <div class="n-radio-group d-flex align-items-center mb-2">
           <div tabindex="0" onkeydown="handleButtonKeyDown(event, 'coverage_kind_health')" class="n-radio-row mr-3">
             <label class="n-radio weight-n" for="coverage_kind_health">
               <%= radio_button_tag 'coverage_kind', 'health', is_coverage_kind_checked?("health"), disabled: is_coverage_kind_disabled?("health"), id: 'coverage_kind_health', required: true, class: "n-radio" %>
@@ -115,6 +104,19 @@
         </div>
       </fieldset>
       </div>
+
+      <h2><%= l10n("insured.group_selection.new.who_needs_coverage") %></h2>
+      <% if @adapter.can_shop_shop?(@person) || @adapter.can_shop_individual?(@person) || @adapter.can_shop_resident?(@person) && @coverage_household.coverage_household_members %>
+        <div id="coverage-household">
+          <%= render 'coverage_household' %>
+        </div>
+      <% end %>
+
+      <% if @adapter.can_shop_shop?(@person) %>
+        <%= render partial: 'select_employer', locals: {effective_date: effective_date_for_display} %>
+      <% end %>
+
+
       <% if @change_plan.present? %>
         <%= hidden_field_tag 'change_plan', @change_plan %>
         <%= hidden_field_tag 'effective_on_option_selected', params[:effective_on_option_selected] if params[:effective_on_option_selected].present? %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187979535

# A brief description of the changes

Current behavior: the marketplace question and the coverage type question are at the bottom of the page

New behavior: the marketplace question and the coverage type question are at the top of the page