### PR TITLE
remove plan shopping link, put text in flash into translation

### DIFF
--- a/app/views/insured/families/_qle_detail.html.erb
+++ b/app/views/insured/families/_qle_detail.html.erb
@@ -27,7 +27,6 @@
               <div class="success-icon icon align-self-start">&nbsp;</div>
               <div class="col px-0 py-1">
                 <p class="mb-1"><%= l10n("insured.qle_detail.eligible_to_enroll_limited_time") %></p>
-                <a id="shop-link" href="#"><%= l10n("insured.shop_for_plans") %></a>
               </div>
             </div>
             <div class="effective_on_kinds"></div>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -8,7 +8,7 @@
         <%= h(message) %>
       </div>
       <div class="d-flex pl-1">
-        <a class="close-icon icon icon-sm pr-1" alt="Close" href="#">&nbsp;<span class="sr-only">Close</span></a>
+        <a class="close-icon icon icon-sm pr-1" alt="<%= l10n("close") %>" href="#">&nbsp;<span class="sr-only"><%= l10n("close") %></span></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188059631

# A brief description of the changes

Current behavior: there is a link to the shop for plans when a new sep is added

New behavior: there should not be a link in the flash message when a new sep is added. (also, flash alt text should come from translation rather than plain text)