### PR TITLE
update text to reflect button copy

### DIFF
--- a/components/financial_assistance/db/seedfiles/translations/en/me/financial_assistance.rb
+++ b/components/financial_assistance/db/seedfiles/translations/en/me/financial_assistance.rb
@@ -294,7 +294,7 @@ FINANCIAL_ASSISTANCE_TRANSLATIONS = {
   "en.faa.filing_as_head_of_household" => "Will this person be filing as head of household?",
   # Year Selection page
   "en.faa.year_selection_header" => "Which Year Would You Like To Apply For?",
-  "en.faa.year_selection_subheader" => "Select which plan year you would like to apply for and then select CONTINUE.",
+  "en.faa.year_selection_subheader" => "Select which plan year you would like to apply for and then select Continue to Next Step.",
   "en.faa.assitance_year_option1" => "%{year} Open Enrollment",
   "en.faa.assitance_year_option2" => "%{year} Report a Life Change",
   "en.faa.year_selection_oe_year" => " Open Enrollment",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187783209

# A brief description of the changes

Current behavior: the copy says continue, while the button say continue to next step

New behavior: the copy matched the button