### PR TITLE
compare error pop up use modal styling

### DIFF
--- a/app/views/insured/plan_shoppings/_plan_details.html.erb
+++ b/app/views/insured/plan_shoppings/_plan_details.html.erb
@@ -155,7 +155,31 @@
 
     </div>
   </div>
-
+  <div class="modal" id="planComparisonCountExceeded" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+      <div class="container pt-2 pb-4 modal-content">
+        <div class="modal-header d-flex mb-4 align-items-center border-0">
+          <div class="col-auto px-0">
+            <div class="error-icon icon icon-sm" alt="error" aria-hidden="true">&nbsp;</div>
+          </div>
+          <div class="col pl-0 bold">
+            <%= l10n("plans.comparison_exceeded_modal.title") %>
+          </div>
+          <div class="col-auto px-0">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <div class="close-icon icon-sm align-self-start m-0" aria-hidden="true">&nbsp;</div>
+            </button>
+          </div>
+        </div>
+        <div class="modal-body border-0">
+          <%= l10n("plans.comparison_exceeded_modal.number_exceeded") %>
+        </div>
+        <div class="d-flex align-items-center mt-4 justify-content-end">
+          <button type="button" class="btn-primary mr-2" data-dismiss="modal"> <%= l10n("close") %> </button>
+        </div>
+      </div>
+    </div>
+  </div>
 
 
 
@@ -321,11 +345,15 @@
 
 				if (count > 3) {
 					checkbox.checked = false;
-					swal({
+          if (document.getElementById('planComparisonCountExceeded')) {
+            $('#planComparisonCountExceeded').modal('show');
+          } else {
+            swal({
 						title: "Plan count exceeded",
 						text: "You may only compare up to 3 plans at a time",
 						icon: "warning"
-					});
+					  });
+          }
 				}
 				if (count <= 3) {
           plansToCompareArray.push(hios)

--- a/db/seedfiles/translations/en/me/plan.rb
+++ b/db/seedfiles/translations/en/me/plan.rb
@@ -110,5 +110,7 @@ PLAN_TRANSLATIONS = {
   'en.plans.plan_shopping_options.modal.go_back' => "Go Back",
   'en.plans.plan_shopping_options.modal.proceed' => "Yes, Compare Plans",
   'en.plans.view_summary_of_benefits' => 'View Summary of Benefits and Coverage',
-  'en.plans.summary_of_benefits' => 'Summary of Benefits and Coverage'
+  'en.plans.summary_of_benefits' => 'Summary of Benefits and Coverage',
+  'en.plans.plan_shopping_options.modal.title' => "Plan Comparison",
+  'en.plans.comparison_modal.number_exceeded' => "You cannot select more than three (3) plans to compare."
 }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188057161

# A brief description of the changes

Current behavior: the alert for more than 3 plans selected is a sweetalert, so doesn't match our modal styling

New behavior: the alert for more than 3 plans selected is a modal with the standard styling
