### PR TITLE
prevent keep plan from submitting form

### DIFF
--- a/app/views/insured/group_selection/_cancel_plan_form.html.erb
+++ b/app/views/insured/group_selection/_cancel_plan_form.html.erb
@@ -6,12 +6,12 @@
     <div class="row focus">
       <div class="col-auto">
         <%= label_tag :cancel_plan_yes do %>
-          <%= radio_button_tag :cancel_plan, "yes", class: 'mr-2' %><%= l10n("yes") %>
+          <%= radio_button_tag :cancel_plan, "yes", false, class: 'mr-2' %><%= l10n("yes") %>
         <% end %>
       </div>
       <div class="col-auto">
         <%= label_tag :cancel_plan_no do %>
-          <%= radio_button_tag :cancel_plan, "no", class: 'mr-2' %><%= l10n("no") %>
+          <%= radio_button_tag :cancel_plan, "no", false, class: 'mr-2' %><%= l10n("no") %>
         <% end %>
       </div>
     </div>
@@ -42,7 +42,7 @@
         <% end %>
 
         <div class="mt-3">
-          <%= button_tag l10n("keep_plan"), class: "btn outline", id: "btn-keep-plan", disabled: false %>
+          <%= button_tag l10n("keep_plan"), class: "btn outline", id: "btn-keep-plan", onkeydown: "handleButtonKeyDown(event, 'btn-keep-plan')", disabled: false %>
           <%= submit_tag l10n("cancel_plan"), class: "btn btn-error", id: "btn-cancel-plan", disabled: true %>
         </div>
       <% end %>
@@ -57,6 +57,7 @@
       var termDateField = document.getElementById("term_date");
       var selectField = document.getElementById("cancellation_reason");
       var button = document.getElementById("btn-cancel-plan");
+      var keepButton = document.getElementById("btn-keep-plan");
 
       form.addEventListener("submit", function(event) {
         // Prevent form submission if the button is disabled
@@ -107,9 +108,20 @@
         return `${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}-${year}`;
       }
 
+      function hideAndResetCancelForm(e) {
+        e.preventDefault();
+        radioButtonYes.checked = false;
+        radioButtonNo.checked = false;
+        document.getElementById('cancel-plan-form').classList.add("hidden");
+        document.getElementById('cancellation_section').classList.add("hidden");
+        if (termDateField) termDateField.value = "";
+        if (selectField) selectField.selectedIndex = 0;
+      }
+
       // Add event listeners for change events
       radioButtonYes.addEventListener("change", toggleSection);
       radioButtonNo.addEventListener("change", toggleSection);
+      keepButton.addEventListener('click', function(e) { hideAndResetCancelForm(e) });
       if (termDateField) termDateField.addEventListener("input", checkFields);
       if (selectField) selectField.addEventListener("change", checkFields);
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:
- https://www.pivotaltracker.com/story/show/188185281
- https://www.pivotaltracker.com/story/show/188186500

# A brief description of the changes

Current behavior:  'no' is selected by default for cancel plans, keep plan does cancel plan

New behavior: 'no' is not selected by default for cancel plans, keep plan does not cancel plan and closes the cancel form

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
