### PR TITLE
style: add .pre-line class for pre-formatted text

### DIFF
--- a/app/javascript/css/main.scss
+++ b/app/javascript/css/main.scss
@@ -718,3 +718,7 @@ a.disabled {
     color: var(--grey-100);
   }
 }
+
+.pre-line {
+  white-space: pre-line;
+}


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/188137393

# A brief description of the changes

Current behavior: When viewing the Enrollment Details of a tile from the homepage and the enrollments page, the Status Transition History is displaying inconsistently across the two pages. When viewing a tile from the enrollments page, the transitions are in separate lines as they are in PROD. When viewed from the homepage, the are all strung together with no break.

New behavior: Each transaction is on it's own line.
