### PR TITLE
style datatable alerts

### DIFF
--- a/project_gems/effective_datatables-2.6.14/app/assets/javascripts/dataTables/buttons/buttons.html5.js
+++ b/project_gems/effective_datatables-2.6.14/app/assets/javascripts/dataTables/buttons/buttons.html5.js
@@ -885,15 +885,14 @@ DataTable.ext.buttons.copyHtml5 = {
 			try {
 				var successful = document.execCommand( 'copy' );
 				hiddenDiv.remove();
-
 				if (successful) {
 					dt.buttons.info(
 						dt.i18n( 'buttons.copyTitle', 'Copy to clipboard' ),
 						dt.i18n( 'buttons.copySuccess', {
-							1: 'Copied one row to clipboard',
-							_: 'Copied %d rows to clipboard'
+							1: 'Row(s) copied to clipboard',
+							_: 'Row(s) copied to clipboard'
 						}, exportData.rows ),
-						2000
+						2000, "success"
 					);
 					return;
 				}

--- a/project_gems/effective_datatables-2.6.14/app/assets/javascripts/dataTables/buttons/dataTables.buttons.js
+++ b/project_gems/effective_datatables-2.6.14/app/assets/javascripts/dataTables/buttons/dataTables.buttons.js
@@ -194,7 +194,7 @@ $.extend( Buttons.prototype, {
 		// needed). Take a copy as the array is modified by `remove`
 		var buttons = this.s.buttons.slice();
 		var i, ien;
-		
+
 		for ( i=0, ien=buttons.length ; i<ien ; i++ ) {
 			this.remove( buttons[i].node );
 		}
@@ -515,7 +515,7 @@ $.extend( Buttons.prototype, {
 			config.action.call( dt.button( button ), e, dt, button, config );
 
 			$(dt.table().node()).triggerHandler( 'buttons-action.dt', [
-				dt.button( button ), dt, button, config 
+				dt.button( button ), dt, button, config
 			] );
 		};
 
@@ -860,7 +860,7 @@ $.extend( Buttons.prototype, {
 /**
  * Show / hide a background layer behind a collection
  * @param  {boolean} Flag to indicate if the background should be shown or
- *   hidden 
+ *   hidden
  * @param  {string} Class to assign to the background
  * @static
  */
@@ -938,7 +938,7 @@ Buttons.instanceSelector = function ( group, buttons )
 			ret.push( buttons[ input ].inst );
 		}
 	};
-	
+
 	process( group );
 
 	return ret;
@@ -1474,7 +1474,7 @@ DataTable.Api.registerPlural( 'buttons().remove()', 'buttons().remove()', functi
 
 // Information box that can be used by buttons
 var _infoTimer;
-DataTable.Api.register( 'buttons.info()', function ( title, message, time ) {
+DataTable.Api.register( 'buttons.info()', function ( title, message, time, type = "info") {
 	var that = this;
 
 	if ( title === false ) {
@@ -1497,12 +1497,23 @@ DataTable.Api.register( 'buttons.info()', function ( title, message, time ) {
 
 	title = title ? '<h2>'+title+'</h2>' : '';
 
+  var bs4 = document.documentElement.dataset.bs4;
+  if (bs4) {
+    $('<div id="datatables_buttons_info" class="alert d-flex align-items-start"/>')
+      .addClass( "alert-" + type )
+      .append($('<div class="d-flex pl-1" />')).html('<div class="'+type+'-icon icon" alt="alert-icon">&nbsp;</div>')
+      .append( $('<div class="col mr-auto p-0 align-self-center"/>').html( message ) )
+      .css( 'display', 'none' )
+      .insertBefore( '.dataTables_wrapper' )
+      .fadeIn();
+  } else {
 	$('<div id="datatables_buttons_info" class="dt-button-info"/>')
 		.html( title )
 		.append( $('<div/>')[ typeof message === 'string' ? 'html' : 'append' ]( message ) )
 		.css( 'display', 'none' )
 		.appendTo( 'body' )
 		.fadeIn();
+  }
 
 	if ( time !== undefined && time !== 0 ) {
 		_infoTimer = setTimeout( function () {


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188188361#

# A brief description of the changes

Current behavior: datatable button alerts are appended to the bottom of the body, and all are informational

New behavior: datatable button alerts are appended above the datatable, and the type of alert can be specified
