### PR TITLE
print title via datatables

### DIFF
--- a/project_gems/effective_datatables-2.6.14/app/assets/javascripts/dataTables/buttons/buttons.print.js
+++ b/project_gems/effective_datatables-2.6.14/app/assets/javascripts/dataTables/buttons/buttons.print.js
@@ -115,7 +115,7 @@ DataTable.ext.buttons.print = {
 			title= title.replace( '*', $('title').first().text() );
 		}
 
-		win.document.close($('title').text());
+		win.document.close();
 
 		// Inject the title and also a copy of the style and link tags from this
 		// document so the table can retain its base styling. Note that we have

--- a/project_gems/effective_datatables-2.6.14/app/assets/javascripts/dataTables/buttons/buttons.print.js
+++ b/project_gems/effective_datatables-2.6.14/app/assets/javascripts/dataTables/buttons/buttons.print.js
@@ -112,10 +112,10 @@ DataTable.ext.buttons.print = {
 		}
 
 		if ( title.indexOf( '*' ) !== -1 ) {
-			title= title.replace( '*', $('title').text() );
+			title= title.replace( '*', $('title').first().text() );
 		}
 
-		win.document.close();
+		win.document.close($('title').text());
 
 		// Inject the title and also a copy of the style and link tags from this
 		// document so the table can retain its base styling. Note that we have


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188188381#

# A brief description of the changes

Current behavior: the datatable print functionality grabs the content of all title elements it can find (including SVG titles)

New behavior: the datatable print functionality grabs the first title element on the page from the head
