### PR TITLE
bs4 fix family helper spec

### DIFF
--- a/spec/helpers/insured/families_helper_spec.rb
+++ b/spec/helpers/insured/families_helper_spec.rb
@@ -404,7 +404,7 @@ RSpec.describe Insured::FamiliesHelper, :type => :helper, dbclean: :after_each  
     }
     context "when building ShopForPlan link" do
       it "should have class 'existing-sep-item' for a SEP with date options QLE and optional_effective_on populated " do
-        expect(helper.build_link_for_sep_type(sep_with_date_options, family.id.to_s)).to include "class=\"existing-sep-item\""
+        expect(helper.build_link_for_sep_type(sep_with_date_options, family.id.to_s)).to include "class=\"existing-sep-item \""
       end
 
       it "should be a link to 'insured/family_members' for a QLE type without date options available" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

The failing test `when building ShopForPlan link` has an assert on the contract for `build_link_for_sep_type`, which originally ensured that the return string contained exactly a 

`class="existing-sep-item"` substring. 

I recently modified the contract of the function such that the return string had a dynamic substring: 

`class="existing-sep-item #{my_new_dynamic_piece_here}"`,

which caused this test to fail. Adding a space satisfies the new contract, maintaining legacy behavior when no dynamic substring is applied.
