### PR TITLE
bs4 fix effective on date plan shopping page

### DIFF
--- a/app/views/insured/family_members/index.html.erb
+++ b/app/views/insured/family_members/index.html.erb
@@ -7,12 +7,14 @@
   </div>
 
   <div id="plan-shopping-page-navigation-buttons" class="d-flex flex-column flex-md-row mt-4" >
-    <% group_selection_url = new_insured_group_selection_path(person_id: @person.id, employee_role_id: @employee_role.try(:id), consumer_role_id: @consumer_role.try(:id), change_plan: @change_plan, market_kind: @market_kind, sep_id: @sep.try(:id), qle_id: @qle.try(:id), effective_on_option_selected: params[:effective_on_option], resident_role_id: @resident_role.try(:id)) %>
-    <% find_sep_url = find_sep_insured_families_path(employee_role_id: @employee_role.try(:id), consumer_role_id: @consumer_role.try(:id), change_plan: @change_plan)%>
+    <% group_selection_params = {person_id: @person.id, employee_role_id: @employee_role.try(:id), consumer_role_id: @consumer_role.try(:id), change_plan: @change_plan, market_kind: @market_kind, sep_id: @sep.try(:id), qle_id: @qle.try(:id), effective_on_option_selected: params[:effective_on_option]} %>
     <% if @change_plan.present? %>
-      <% group_selection_url = main_app.new_insured_group_selection_path(person_id: @person.id, employee_role_id: @employee_role.try(:id), consumer_role_id: @consumer_role.try(:id), change_plan: @change_plan, market_kind: @market_kind, sep_id: @sep.try(:id), qle_id: @qle.try(:id), effective_on_date: @sep.try(:effective_on)) %>
+      <% group_selection_url = new_insured_group_selection_path(**group_selection_params) %>
       <%= render partial: "shared/progress_navigation_buttons", locals: { next_link: group_selection_url } %>
     <% else %>
+      <% group_selection_params[:resident_role_id] = @resident_role.try(:id) %>
+      <% group_selection_url = new_insured_group_selection_path(**group_selection_params) %>
+      <% find_sep_url = find_sep_insured_families_path(employee_role_id: @employee_role.try(:id), consumer_role_id: @consumer_role.try(:id), change_plan: @change_plan) %>
       <% url = (@consumer_role.present? && !is_under_open_enrollment? ? find_sep_url : group_selection_url) %>
       <%= render partial: "shared/progress_navigation_buttons", locals: { next_link: url } %>
     <% end %>

--- a/app/views/insured/family_members/index.html.erb
+++ b/app/views/insured/family_members/index.html.erb
@@ -9,8 +9,7 @@
   <div id="plan-shopping-page-navigation-buttons" class="d-flex flex-column flex-md-row mt-4" >
     <% group_selection_params = {person_id: @person.id, employee_role_id: @employee_role.try(:id), consumer_role_id: @consumer_role.try(:id), change_plan: @change_plan, market_kind: @market_kind, sep_id: @sep.try(:id), qle_id: @qle.try(:id), effective_on_option_selected: params[:effective_on_option]} %>
     <% if @change_plan.present? %>
-      <% group_selection_url = new_insured_group_selection_path(**group_selection_params) %>
-      <%= render partial: "shared/progress_navigation_buttons", locals: { next_link: group_selection_url } %>
+      <%= render partial: "shared/progress_navigation_buttons", locals: { next_link: main_app.new_insured_group_selection_path(**group_selection_params) } %>
     <% else %>
       <% group_selection_params[:resident_role_id] = @resident_role.try(:id) %>
       <% group_selection_url = new_insured_group_selection_path(**group_selection_params) %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188193300

The "effective on" date view element on the Choose Coverage page is driven by the `@new_effective_on` variable in the controller, which itself is driven by the `effective_on_option_selected` parameter passed in from the caller - in this case, the Family Info page.

The Family Info page, based on legacy logic, can direct to the Choose Coverage under two different flows. The uplifted version of the Family Info page did not correctly maintain this legacy logic, and for the change_plan flow, attempted to pass in a `effective_on_date` param instead of the `effective_on_option_selected` param. I've amended this to match the legacy logic for BS4, and also refactored the navigation code in the view to DRY up shared code.
