### PR TITLE
bs4 fix broker form kb nav office

### DIFF
--- a/app/javascript/benefit_sponsors/controllers/office_locations_controller.js
+++ b/app/javascript/benefit_sponsors/controllers/office_locations_controller.js
@@ -76,7 +76,11 @@ export default class extends Controller {
       })
 
       if (bs4 == "true") {
-        newLocation.querySelector('a.remove_fields').classList.remove('hidden');
+        var removeButton = newLocation.querySelector('a.remove_fields');
+        removeButton.classList.remove('hidden');
+        var removeButtonId = "remove-button-" + totalLocationsCount;
+        removeButton.id = removeButtonId;
+        removeButton.setAttribute('onkeydown', `handleButtonKeyDown(event, '${removeButtonId}')`);
         newLocation.querySelector('input[placeholder="00000"]').setAttribute('data-action', "");
         newLocation.querySelector(".phone_number").addEventListener('input', (event) => {
           event.target.value = this.fullPhoneMask(event.target.value);

--- a/app/views/ui-components/bs4/v1/forms/broker/contact_information/_address.html.erb
+++ b/app/views/ui-components/bs4/v1/forms/broker/contact_information/_address.html.erb
@@ -1,6 +1,7 @@
 <div class="pull-right d-flex align-items-center justify-content-between mb-2">
   <h2 class="ol_title"> <%= is_primary ? l10n('address.agency.primary_office_location') : l10n('address.agency.office_location') %></h2>
-  <a class="remove_fields close-2 <%= is_primary ? 'hidden' : ''%>" id="remove-location" tabindex="0" onkeydown="handleButtonKeyDown(event, 'remove-location')" data-action="click->office-locations#removeLocation"><i class="far fa-trash-alt fa-2x role-trashcan"></i></a>
+  <% remove_id ="remove-location-#{f.object.id}" %>
+  <a class="remove_fields close-2 <%= is_primary ? 'hidden' : ''%>" tabindex="0" data-action="click->office-locations#removeLocation"><i class="far fa-trash-alt fa-2x role-trashcan"></i></a>
 </div>
 <div id="address_info">
   <div class="row mb-2">

--- a/app/views/ui-components/bs4/v1/forms/broker/contact_information/_address.html.erb
+++ b/app/views/ui-components/bs4/v1/forms/broker/contact_information/_address.html.erb
@@ -1,6 +1,6 @@
 <div class="pull-right d-flex align-items-center justify-content-between mb-2">
   <h2 class="ol_title"> <%= is_primary ? l10n('address.agency.primary_office_location') : l10n('address.agency.office_location') %></h2>
-  <a class="remove_fields close-2 <%= is_primary ? 'hidden' : ''%>" data-action="click->office-locations#removeLocation"><i class="far fa-trash-alt fa-2x role-trashcan"></i></a>
+  <a class="remove_fields close-2 <%= is_primary ? 'hidden' : ''%>" id="remove-location" tabindex="0" onkeydown="handleButtonKeyDown(event, 'remove-location')" data-action="click->office-locations#removeLocation"><i class="far fa-trash-alt fa-2x role-trashcan"></i></a>
 </div>
 <div id="address_info">
   <div class="row mb-2">

--- a/app/views/ui-components/bs4/v1/forms/broker/contact_information/_contact_info_fields.html.erb
+++ b/app/views/ui-components/bs4/v1/forms/broker/contact_information/_contact_info_fields.html.erb
@@ -15,7 +15,7 @@
     <% end %>
   </div>
 
-  <a class="btn btn-default btn-secondary mb-4" tabindex="0" type="button" data-action="click->office-locations#addLocation"><%= l10n("add_office_location") %></a>
+  <a class="btn btn-default btn-secondary mb-4" id="add-location" tabindex="0" type="button" onkeydown="handleButtonKeyDown(event, 'add-location')" data-action="click->office-locations#addLocation"><%= l10n("add_office_location") %></a>
 </div>
 
 <script>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188193731

This PR fixes keyboard navigation on the Add Office button by adding an `onkeydown` attribute to handle the Enter press (not sure if this is the best solution/an anti-pattern in Stimulus?).

Additionally, it updates the Remove button to support keyboard navigation wholesale, adding the `tabindex` attr and following a similar approach to the above, adds an `onkeydown` attr. This ended up being more complicated due to how the additional forms are generated, requiring some extra JS to handle setting the `id` and `onkeydown` attributes to ensure uniqueness between any potential added forms.
