### PR TITLE
chore: Update Medicaid cancelation text to reflect MaineCare (Medicaid)

### DIFF
--- a/db/seedfiles/translations/en/cca/insured.rb
+++ b/db/seedfiles/translations/en/cca/insured.rb
@@ -489,7 +489,7 @@ How to find the SEVIS ID: On the DS-2019, the number is on the top right hand si
   :'en.plan_cancelation' => "Plan Cancelation",
   :'en.cancel_your_plan' => "Cancel Your Plan?",
   :'en.medicare_cancel' => "I'm on Medicare",
-  :'en.medicaid_cancel' => "I'm on Medicaid",
+  :'en.medicaid_cancel' => "I'm on MaineCare (Medicaid)",
   :'en.employer_cancel' => "I have coverage through my employer",
   :'en.spouse_cancel' => "I have coverage through my spouse",
   :'en.parents_cancel' => "I have coverage through my parents",

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -579,7 +579,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.return_to_my_account' => "Return to My Account",
   :'en.plan_cancelation' => "Plan Cancelation",
   :'en.medicare_cancel' => "I'm on Medicare",
-  :'en.medicaid_cancel' => "I'm on Medicaid",
+  :'en.medicaid_cancel' => "I'm on MaineCare (Medicaid)",
   :'en.employer_cancel' => "I have coverage through my employer",
   :'en.spouse_cancel' => "I have coverage through my spouse",
   :'en.parents_cancel' => "I have coverage through my parents",


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/188186815

# A brief description of the changes

Current behavior: 2nd reason reads "I'm on Medicaid"

New behavior: 2nd reason reads "I'm on MaineCare (Medicaid)"
