### PR TITLE
bs4 fix broker required without css

### DIFF
--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/broker_agencies/broker_agency_profiles_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/broker_agencies/broker_agency_profiles_controller.rb
@@ -99,7 +99,7 @@ module BenefitSponsors
 
           respond_to do |format|
             format.js
-            format.html { render "benefit_sponsors/profiles/broker_agencies/broker_agency_profiles/family_datatable.html.erb" }
+            format.html { render "benefit_sponsors/profiles/broker_agencies/broker_agency_profiles/family_datatable.html.erb" } if @bs4
           end
         end
 

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_profiles/family_datatable.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_profiles/family_datatable.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'benefit_sponsors/shared/profiles/broker_agency/menu', :locals => { broker_profile_id: @broker_agency_profile.id, :active_tab => "families-tab", families: true } %>
+<%= render partial: 'benefit_sponsors/shared/profiles/broker_agency/menu', :locals => { broker_profile_id: @broker_agency_profile.id, :active_tab => "families-tab" } %>
 <div class="profile-content">
   <div class="tab-row">
     <div class="tab-content" id="myTabContent">

--- a/components/benefit_sponsors/app/views/benefit_sponsors/shared/profiles/broker_agency/_menu.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/shared/profiles/broker_agency/_menu.html.erb
@@ -1,107 +1,97 @@
-<% families = local_assigns[:families] ? families : false %>
-<% if @bs4 || families %>
-<% if families %>
-  <%= javascript_include_tag "application" %>
-  <%= javascript_pack_tag 'legacy', 'data-turbolinks-track': 'reload' %>
-<% else %>
-  <% content_for :head do %>
-    <%= javascript_include_tag "benefit_sponsors/application" %>
-    <%= javascript_pack_tag 'benefit_sponsors', 'data-turbolinks-track': 'reload' %>
-  <% end %>
-<% end %>
-<% content_for :horizontal_menu do %>
-  <nav class="broker-nav">
-    <div class="container px-0">
-      <ul role="tablist" class="list-unstyled list-inline d-flex align-items-center mb-0 pb-0" id="myTab">
-        <li role="presentation" id="home-tab" <%= menu_tab_class(active_tab, "home-tab") %>>
-          <%= link_to(profiles_broker_agencies_broker_agency_profile_path(broker_profile_id), "aria-expanded" => "true", "aria-controls" => "home", "role" => "tab" ) do  %>
-            <span class="hidden-xs"><%= l10n("home")%></span>
-            <span title="Home" aria-hidden="true" class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg"></span>
-          <% end %>
-        </li>
-        <% if is_shop_or_fehb_market_enabled? %>
-          <li role="presentation" id="employers-tab" <%= menu_tab_class(active_tab, "employers-tab") %>>
-            <%= link_to(sponsored_benefits.employers_organizations_broker_agency_profile_path(broker_profile_id), "aria-expanded" => "true", :remote => true, "aria-controls" => "employers", "role" => "tab" ) do  %>
-              <span class="hidden-xs"><%= l10n("employers")%></span>
-              <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="Employers"></span>
-            <% end %>
-          </li>
-        <% end %>
-        <li role="presentation" id="families-tab" <%= menu_tab_class(active_tab, "families-tab") %>>
-          <%= link_to(family_index_profiles_broker_agencies_broker_agency_profiles_path(id: broker_profile_id ), "aria-expanded" => "true", :remote => false, "aria-controls" => "families", "role" => "tab" ) do  %>
-            <span class="hidden-xs"><%= l10n("families")%></span>
-            <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="Families"></span>
-          <% end %>
-        </li>
-        <% if @staff_role %>
-          <% if site_broker_claim_quoting_enabled? && !individual_market_is_enabled? %>
-            <li role="presentation" id="brokers-tab" <%= menu_tab_class(active_tab, "brokers-tab").present? || "class=hide" %>>
-              <%= link_to(main_app.broker_agencies_profile_applicants_path(broker_profile_id), :remote => true, "aria-expanded" => "true", "aria-controls" => "brokers", "role" => "tab" ) do  %>
-                <span class="hidden-xs">Brokers</span>
-                <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="Brokers"></span>
-              <% end %>
-            </li>
-          <% end %>
-
-        <% end %>
-        <% if general_agency_enabled? %>
-          <li role="presentation" id="general-agency-tab" <%= menu_tab_class(active_tab, "general-agency-tab") %>>
-            <!--TODO: Enable Link when GA is moved to the Engine-->
-            <%= link_to(general_agency_index_profiles_broker_agencies_broker_agency_profiles_path(id: @id), "aria-expanded" => "true", :remote => true, "aria-controls" => "general-agency", "role" => "tab" ) do  %>
-              <span class="hidden-xs">General Agencies</span>
-              <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="General Agencies"></span>
-            <% end %>
-          </li>
-        <% end %>
-        <% if site_broker_quoting_enabled? && individual_market_is_enabled? %>
-          <li role="presentation" id="assign-tab" <%= menu_tab_class(active_tab, "assign-tab") %>>
-            <%#= link_to(assign_profiles_broker_agencies_broker_agency_profile_path(id: @id), "aria-expanded" => "true", :remote => true, "aria-controls" => "assign", "role" => "tab" ) do  %>
-              <span class="hidden-xs">Assign</span>
-              <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="Assign"></span>
-            <%# end %>
-          </li>
-          <!--TODO: Fix link when Quotes Controller is implemented in the Engine -->
-          <li role="presentation" id="quote-roster-tab" <%= menu_tab_class(active_tab, "quote-roster-tab") %>>
-           <%= link_to main_app.my_quotes_broker_agencies_broker_role_quotes_path(@broker_agency_profile.primary_broker_role), "aria-expanded" => "true",  "role" => "tab", 'data-no-turbolink' => true  do  %>
-              <span class="hidden-xs">Quoting Tool</span>
-              <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="Quoting Tool"></span>
-            <% end %>
-          </li>
-        <% end %>
-
-        <li role="presentation" id="inbox-tab" <%= menu_tab_class(active_tab, "inbox-tab") %>>
-          <%= link_to(messages_profiles_broker_agencies_broker_agency_profiles_path(id: broker_profile_id), :remote => true, "aria-expanded" => "true", "aria-controls" => "inbox", "role" => "tab") do  %>
-            <%= l10n("broker_mail")%>
-            <span class="badge message-unread ml-half"><%= total_messages(broker_profile_id) %></span>
-          <% end %>
-        </li>
-
-        <% if aca_broker_routing_information %>
-          <li role="presentation" id="commissions-tab" <%= menu_tab_class(active_tab, "commissions-tab") %>>
-            <%= link_to(commission_statements_profiles_broker_agencies_broker_agency_profiles_path(id: @broker_agency_profile), :remote => true, "aria-expanded" => "true", "aria-controls" => "home", "role" => "tab" ) do  %>
-              <span class="hidden-xs">Commissions</span>
+<% if @bs4 %>
+  <% content_for :horizontal_menu do %>
+    <nav class="broker-nav">
+      <div class="container px-0">
+        <ul role="tablist" class="list-unstyled list-inline d-flex align-items-center mb-0 pb-0" id="myTab">
+          <li role="presentation" id="home-tab" <%= menu_tab_class(active_tab, "home-tab") %>>
+            <%= link_to(profiles_broker_agencies_broker_agency_profile_path(broker_profile_id), "aria-expanded" => "true", "aria-controls" => "home", "role" => "tab" ) do  %>
+              <span class="hidden-xs"><%= l10n("home")%></span>
               <span title="Home" aria-hidden="true" class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg"></span>
             <% end %>
           </li>
-        <% end %>
-
-        <% if current_user.has_hbx_staff_role? || current_user.has_broker_role? || current_user.has_broker_agency_staff_role? %>
-        <% else %>
-          <% if individual_market_is_enabled? %>
-            <li role="presentation" class="multi-line">
-              <%= link_to url_for(SamlInformation.curam_broker_dashboard) do %>
-                First Time Applications for Medicaid
-                <br/>
-                and Premium Tax Credits
+          <% if is_shop_or_fehb_market_enabled? %>
+            <li role="presentation" id="employers-tab" <%= menu_tab_class(active_tab, "employers-tab") %>>
+              <%= link_to(sponsored_benefits.employers_organizations_broker_agency_profile_path(broker_profile_id), "aria-expanded" => "true", :remote => true, "aria-controls" => "employers", "role" => "tab" ) do  %>
+                <span class="hidden-xs"><%= l10n("employers")%></span>
+                <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="Employers"></span>
               <% end %>
             </li>
           <% end %>
-        <% end %>
-      </ul>
-    </div>
-  </nav>
-<% end %>
-  <% else %>
+          <li role="presentation" id="families-tab" <%= menu_tab_class(active_tab, "families-tab") %>>
+            <%= link_to(family_index_profiles_broker_agencies_broker_agency_profiles_path(id: broker_profile_id ), "aria-expanded" => "true", :remote => false, "aria-controls" => "families", "role" => "tab" ) do  %>
+              <span class="hidden-xs"><%= l10n("families")%></span>
+              <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="Families"></span>
+            <% end %>
+          </li>
+          <% if @staff_role %>
+            <% if site_broker_claim_quoting_enabled? && !individual_market_is_enabled? %>
+              <li role="presentation" id="brokers-tab" <%= menu_tab_class(active_tab, "brokers-tab").present? || "class=hide" %>>
+                <%= link_to(main_app.broker_agencies_profile_applicants_path(broker_profile_id), :remote => true, "aria-expanded" => "true", "aria-controls" => "brokers", "role" => "tab" ) do  %>
+                  <span class="hidden-xs">Brokers</span>
+                  <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="Brokers"></span>
+                <% end %>
+              </li>
+            <% end %>
+
+          <% end %>
+          <% if general_agency_enabled? %>
+            <li role="presentation" id="general-agency-tab" <%= menu_tab_class(active_tab, "general-agency-tab") %>>
+              <!--TODO: Enable Link when GA is moved to the Engine-->
+              <%= link_to(general_agency_index_profiles_broker_agencies_broker_agency_profiles_path(id: @id), "aria-expanded" => "true", :remote => true, "aria-controls" => "general-agency", "role" => "tab" ) do  %>
+                <span class="hidden-xs">General Agencies</span>
+                <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="General Agencies"></span>
+              <% end %>
+            </li>
+          <% end %>
+          <% if site_broker_quoting_enabled? && individual_market_is_enabled? %>
+            <li role="presentation" id="assign-tab" <%= menu_tab_class(active_tab, "assign-tab") %>>
+              <%#= link_to(assign_profiles_broker_agencies_broker_agency_profile_path(id: @id), "aria-expanded" => "true", :remote => true, "aria-controls" => "assign", "role" => "tab" ) do  %>
+                <span class="hidden-xs">Assign</span>
+                <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="Assign"></span>
+              <%# end %>
+            </li>
+            <!--TODO: Fix link when Quotes Controller is implemented in the Engine -->
+            <li role="presentation" id="quote-roster-tab" <%= menu_tab_class(active_tab, "quote-roster-tab") %>>
+            <%= link_to main_app.my_quotes_broker_agencies_broker_role_quotes_path(@broker_agency_profile.primary_broker_role), "aria-expanded" => "true",  "role" => "tab", 'data-no-turbolink' => true  do  %>
+                <span class="hidden-xs">Quoting Tool</span>
+                <span class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg" title="Quoting Tool"></span>
+              <% end %>
+            </li>
+          <% end %>
+
+          <li role="presentation" id="inbox-tab" <%= menu_tab_class(active_tab, "inbox-tab") %>>
+            <%= link_to(messages_profiles_broker_agencies_broker_agency_profiles_path(id: broker_profile_id), :remote => true, "aria-expanded" => "true", "aria-controls" => "inbox", "role" => "tab") do  %>
+              <%= l10n("broker_mail")%>
+              <span class="badge message-unread ml-half"><%= total_messages(broker_profile_id) %></span>
+            <% end %>
+          </li>
+
+          <% if aca_broker_routing_information %>
+            <li role="presentation" id="commissions-tab" <%= menu_tab_class(active_tab, "commissions-tab") %>>
+              <%= link_to(commission_statements_profiles_broker_agencies_broker_agency_profiles_path(id: @broker_agency_profile), :remote => true, "aria-expanded" => "true", "aria-controls" => "home", "role" => "tab" ) do  %>
+                <span class="hidden-xs">Commissions</span>
+                <span title="Home" aria-hidden="true" class="glyphicon glyphicon-user hidden-md hidden-sm hidden-lg"></span>
+              <% end %>
+            </li>
+          <% end %>
+
+          <% if current_user.has_hbx_staff_role? || current_user.has_broker_role? || current_user.has_broker_agency_staff_role? %>
+          <% else %>
+            <% if individual_market_is_enabled? %>
+              <li role="presentation" class="multi-line">
+                <%= link_to url_for(SamlInformation.curam_broker_dashboard) do %>
+                  First Time Applications for Medicaid
+                  <br/>
+                  and Premium Tax Credits
+                <% end %>
+              </li>
+            <% end %>
+          <% end %>
+        </ul>
+      </div>
+    </nav>
+  <% end %>
+<% else %>
 <% content_for :horizontal_menu do %>
   <div class="mainmenu">
     <div class="container">

--- a/components/benefit_sponsors/app/views/layouts/bs4_application.html.erb
+++ b/components/benefit_sponsors/app/views/layouts/bs4_application.html.erb
@@ -1,7 +1,5 @@
 <% if @bs4 %>
   <% content_for :head do %>
-    <%= javascript_include_tag "benefit_sponsors/application" %>
-    <%= javascript_pack_tag 'benefit_sponsors', 'data-turbolinks-track': 'reload' %>
     <script src="https://unpkg.com/sweetalert/dist/sweetalert.min.js"></script>
   <% end %>
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Tickets:
1. https://www.pivotaltracker.com/story/show/188193986
2. https://www.pivotaltracker.com/story/show/188194071
3. https://www.pivotaltracker.com/story/show/188193998

The global helper used to enforce required fields without css, `indicateRequiredFields`, was never being called due to the document ready event not firing in JQuery. The pack which manages this call, `application.js.erb`, failed sometime after loading the listener on the event due to odd load order in the benefit sponsors app. Best I can tell, the legacy pack `benefit_sponsors/application.js.erb` is no longer needed, although it was being loaded in both the layout and some partial `_menu`. I refactored both views, and also unrelatedly added what seems like a missing flag in the controller.
