### PR TITLE
chore: Update button styles for text buttons

### DIFF
--- a/app/javascript/css/_buttons.scss
+++ b/app/javascript/css/_buttons.scss
@@ -232,3 +232,20 @@ button.accordion-action {
   margin-top: 1rem;
   translate: 0.25rem 0;
 }
+
+button.text-button {
+  background-color: transparent;
+  border: none;
+  color: var(--button-primary-color);
+  cursor: pointer;
+  text-decoration: underline;
+  font-weight: normal;
+  padding: 0;
+  &:hover {
+    background-color: transparent;
+    color: var(--button-primary-active-color);
+  }
+  &:active {
+    color: var(--button-primary-active-color);
+  }
+}

--- a/app/views/shared/_shopping_nav_panel.html.erb
+++ b/app/views/shared/_shopping_nav_panel.html.erb
@@ -33,9 +33,9 @@
 
       <% if show_exit_button %>
         <li>
-          <a href=<%= main_app.destroy_user_session_path %>>
+          <button class="text-button" href=<%= main_app.destroy_user_session_path %>>
             <%= l10n("log_out") %>
-          </a>
+          </button>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/187912504

# A brief description of the changes

Current behavior: Wave tool gives a "Redundant Link" alert for the sidenav logout link

New behavior: Wave tool does not have an alert

The tab order of the top bar logout link and the sidenav logout link are next to each other causing the error. To fix, changed sidenav `<a>` tag to a `<button>` tag and gave the styles of a link.
