### PR TITLE
discard button functionality for self service aptc

### DIFF
--- a/app/views/insured/group_selection/_change_tax_credit_form.html.erb
+++ b/app/views/insured/group_selection/_change_tax_credit_form.html.erb
@@ -14,9 +14,9 @@
       </div>
     </div>
     <div id="update_tax_credit_section" class="hidden">
-      <%= form_for locals[:hbx_enrollment], 
-        url: edit_aptc_insured_group_selections_path(hbx_enrollment_id: locals[:hbx_enrollment][:id]), method: :post do |f| %>  
-        <%= hidden_field_tag :bs4, true %>   
+      <%= form_for locals[:hbx_enrollment],
+        url: edit_aptc_insured_group_selections_path(hbx_enrollment_id: locals[:hbx_enrollment][:id]), method: :post do |f| %>
+        <%= hidden_field_tag :bs4, true %>
         <%= hidden_field_tag 'max_aptc', @self_term_or_cancel_form[:max_tax_credit] %>
         <p class="d-flex">
           <label for="effective_date" class="mr-2"><%= l10n("enrollment.effective_on") %></label>
@@ -26,11 +26,11 @@
         <div class="d-flex mb-2 mt-2">
           <div class="mr-4">
             <label class="required" for="aptc_applied_total"> <%= l10n("amount") %></label>
-            <input type="text" name="aptc_applied_total" id="aptc_applied_total" class="form-control tax_credit_field_container" value="<%= number_to_currency(@self_term_or_cancel_form[:max_tax_credit].to_i * locals[:hbx_enrollment].elected_aptc_pct) %>" placeholder="0" required>
+            <input type="text" name="aptc_applied_total" id="aptc_applied_total" data-initial-amount="<%= number_to_currency(@self_term_or_cancel_form[:max_tax_credit].to_i * locals[:hbx_enrollment].elected_aptc_pct) %>" class="form-control tax_credit_field_container" value="<%= number_to_currency(@self_term_or_cancel_form[:max_tax_credit].to_i * locals[:hbx_enrollment].elected_aptc_pct) %>" placeholder="0" required>
           </div>
           <div class="mr-4">
             <label class="required" for="update_tax_credit_percentage"> <%= l10n("percentage") %></label>
-            <input type="text" name="update_tax_credit_percentage" id="update_tax_credit_percentage" class="form-control tax_credit_field_container" value="<%= number_with_precision(@self_term_or_cancel_form[:elected_aptc_pct].to_f * 100, precision: 2) %>%" placeholder="0">
+            <input type="text" name="update_tax_credit_percentage" id="update_tax_credit_percentage" class="form-control tax_credit_field_container" data-initial-percent="<%= number_with_precision(@self_term_or_cancel_form[:elected_aptc_pct].to_f * 100, precision: 2) %>%" value="<%= number_with_precision(@self_term_or_cancel_form[:elected_aptc_pct].to_f * 100, precision: 2) %>%" placeholder="0">
           </div>
           <div class="mt-4">
             <div class="d-flex">
@@ -48,7 +48,7 @@
           <span id="calculated_amount_applied"><%= number_to_currency(float_fix(locals[:hbx_enrollment].total_premium) - (locals[:available_aptc] * locals[:hbx_enrollment].elected_aptc_pct)) %></span>
         </p>
         <div class="mt-4">
-          <%= button_tag l10n("discard_changes"), class: "btn outline mr-2", id: "btn-discard-tax-credit", disabled: false %>
+          <%= button_tag l10n("discard_changes"), class: "btn outline mr-2", id: "btn-discard-tax-credit", disabled: false, type: :reset %>
           <%= submit_tag l10n("save_changes"), class: "btn", id: "btn-save-tax-credit", disabled: true %>
         </div>
       </div>
@@ -56,12 +56,13 @@
     <% end %>
   </div>
   <script>
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('turbolinks:load', function() {
       const enrollmentPremium = parseFloat(document.getElementById('enrollment_premium').value);
       const aptcAppliedTotal = document.getElementById('aptc_applied_total');
       const updateTaxCreditPercentage = document.getElementById('update_tax_credit_percentage');
       const calculatedAmountApplied = document.getElementById('calculated_amount_applied');
       const saveButton = document.getElementById('btn-save-tax-credit');
+      const discardButton = document.getElementById('btn-discard-tax-credit');
       const radioButtonYes = document.getElementById('update_tax_credit_section_yes');
       const radioButtonNo = document.getElementById("update_tax_credit_section_no");
       const section = document.getElementById('update_tax_credit_section');
@@ -120,12 +121,26 @@
         }
       }
 
+      function resetForm() {
+        document.getElementById('change-tax-credit-form').classList.add('hidden');
+        radioButtonYes.removeAttribute("checked");
+        radioButtonNo.removeAttribute("checked");
+        aptcAppliedTotal.value = aptcAppliedTotal.dataset.initialAmount;
+        updateTaxCreditPercentage.value = updateTaxCreditPercentage.dataset.initialPercent;
+        calculatedAmountApplied.textContent = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(aptcAppliedTotal.dataset.initialAmount);
+        saveButton.disabled = true;
+      }
+
       updateTaxCreditPercentage.addEventListener('input', handlePercentageInput);
       updateTaxCreditPercentage.addEventListener('input', updateCalculatedAmount);
       aptcAppliedTotal.addEventListener('input', handleTotalInput);
       aptcAppliedTotal.addEventListener('input', updateCalculatedAmount);
       radioButtonYes.addEventListener("change", toggleSection);
       radioButtonNo.addEventListener("change", toggleSection);
+      discardButton.addEventListener('click', function(e) {
+        e.preventDefault();
+        resetForm();
+      });
 
       toggleSection();
     });


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188194674

# A brief description of the changes

Current behavior: the discard button saves the values

New behavior: the discard button resets and hides the form
