### PR TITLE
bs4 fix add office

### DIFF
--- a/components/benefit_sponsors/app/views/layouts/bs4_application.html.erb
+++ b/components/benefit_sponsors/app/views/layouts/bs4_application.html.erb
@@ -1,5 +1,6 @@
 <% if @bs4 %>
   <% content_for :head do %>
+    <%= javascript_pack_tag 'benefit_sponsors', 'data-turbolinks-track': 'reload' %>
     <script src="https://unpkg.com/sweetalert/dist/sweetalert.min.js"></script>
   <% end %>
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188195238#

My [earlier fix](https://github.com/ideacrew/enroll/pull/4448) to solve for the JS errors causing the main app's `application.js.erb` to fail stripped too much away from benefit sponsors, causing the `office_locations_controller.js` to never load. I've restored the `benefit_sponsors` pack load in the layout so that this controller loads.
