### PR TITLE
bs4 fix staff required fields

### DIFF
--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/registrations/new.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/registrations/new.html.erb
@@ -51,6 +51,7 @@
               data: { profile_type: "broker_agency_staff" },
               success: function (data) {
                 $("#broker_agency_staff").html(data);
+                indicateRequiredFields();
                 setTimeout(function () {
                   initDatepicker('inputStaffDOB', new Date("<%= Date.today.beginning_of_month - 90.years %>"), new Date("<%= Date.today.end_of_month - 18.years %>"));
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188194071

My [earlier PR](https://github.com/ideacrew/enroll/pull/4448) fixed other broker pages, but as the staff form is loaded dynamically, the method for applying the asterisks must be call manually.