### PR TITLE
change check user role order in bs4 header helper

### DIFF
--- a/app/helpers/bs4/bs4_header_helper.rb
+++ b/app/helpers/bs4/bs4_header_helper.rb
@@ -59,11 +59,11 @@ module Bs4
         nil
       elsif current_user.try(:has_hbx_staff_role?)
         link_to(ltext, main_app.exchanges_hbx_profiles_root_path)
-      elsif display_i_am_broker_for_consumer?(current_user.person) && controller_path.exclude?('general_agencies')
-        link_to(ltext, get_broker_profile_path)
       elsif user_has_multiple_roles?
         roles = all_non_admin_roles
         render partial: 'ui-components/bs4/v1/navs/multi_role_my_portal_links', locals: roles
+      elsif display_i_am_broker_for_consumer?(current_user.person) && controller_path.exclude?('general_agencies')
+        link_to(ltext, get_broker_profile_path)
       elsif current_user.try(:person).try(:csr_role) || current_user.try(:person).try(:assister_role)
         link_to(ltext, main_app.home_exchanges_agents_path)
       elsif current_user.person&.active_employee_roles&.any?


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/188193026

# A brief description of the changes

Current behavior: broker_role taking precedence over multi-role user 

New behavior: changes order that user roles are checked

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
