### PR TITLE
fix aptc calculator

### DIFF
--- a/app/javascript/css/forms.scss
+++ b/app/javascript/css/forms.scss
@@ -371,3 +371,7 @@ input[type='date']:invalid::-webkit-datetime-edit {
     border: none;
   }
 }
+
+#update_tax_credit_section input[type="number"] {
+  width: 100px;
+}

--- a/app/views/insured/group_selection/_change_tax_credit_form.html.erb
+++ b/app/views/insured/group_selection/_change_tax_credit_form.html.erb
@@ -17,16 +17,16 @@
       <%= form_for locals[:hbx_enrollment],
         url: edit_aptc_insured_group_selections_path(hbx_enrollment_id: locals[:hbx_enrollment][:id]), method: :post do |f| %>
         <%= hidden_field_tag :bs4, true %>
-        <%= hidden_field_tag 'max_aptc', @self_term_or_cancel_form[:max_tax_credit] %>
+        <%= hidden_field_tag 'max_aptc', locals[:available_aptc] %>
         <p class="d-flex">
           <label for="effective_date" class="mr-2"><%= l10n("enrollment.effective_on") %></label>
           <%= locals[:new_effective_on_date] %>
         </p>
-        <p><%= l10n("total_tax_credit_amount") %>: $<span id="max_tax_credit" name="max_tax_credit"><%= '%.2f' % @self_term_or_cancel_form[:max_tax_credit]  %></span></p>
+        <p><%= l10n("total_tax_credit_amount") %>: $<span id="max_tax_credit" name="max_tax_credit"><%= '%.2f' % locals[:available_aptc]  %></span></p>
         <div class="d-flex mb-2 mt-2">
           <div class="mr-4">
             <label class="required" for="aptc_applied_total"> <%= l10n("amount") %></label>
-            <input type="number" step=".01" min="0" max="<%= @self_term_or_cancel_form[:max_tax_credit].to_i %>" name="aptc_applied_total" id="aptc_applied_total" data-initial-amount="<%= number_with_precision(@self_term_or_cancel_form[:max_tax_credit].to_i * locals[:hbx_enrollment].elected_aptc_pct, precision: 2) %>" class="form-control tax_credit_field_container" value="<%= number_with_precision(@self_term_or_cancel_form[:max_tax_credit].to_i * locals[:hbx_enrollment].elected_aptc_pct, precision: 2) %>" placeholder="0" required>
+            <input type="number" step=".01" min="0" max="<%= locals[:available_aptc] %>" name="aptc_applied_total" id="aptc_applied_total" data-initial-amount="<%= number_with_precision(locals[:available_aptc].to_f * locals[:hbx_enrollment].elected_aptc_pct, precision: 2) %>" class="form-control tax_credit_field_container" value="<%= number_with_precision(locals[:available_aptc].to_f * locals[:hbx_enrollment].elected_aptc_pct, precision: 2) %>" placeholder="0" required>
           </div>
           <div class="mr-4">
             <label class="required" for="update_tax_credit_percentage"> <%= l10n("percentage") %></label>
@@ -35,17 +35,17 @@
           <div class="mt-4">
             <div class="d-flex">
               <label for="available_monthly" class="mr-2"><%= l10n("available_monthly") %></label>
-              <%= number_to_currency(@self_term_or_cancel_form[:max_tax_credit]) %>
+              <%= number_to_currency(locals[:available_aptc].to_f) %>
             </div>
             <div class="d-flex">
               <label for="amount_applied" class="mr-3"><%= l10n("amount_applied") %></label>
-              <%= number_to_currency(@self_term_or_cancel_form[:max_tax_credit].to_i * locals[:hbx_enrollment].elected_aptc_pct) %>
+              <%= number_to_currency(locals[:available_aptc].to_f * locals[:hbx_enrollment].elected_aptc_pct) %>
             </div>
           </div>
         </div>
         <p class="d-flex">
           <label for="new_enrollment_premium" class="mr-1"> <%= l10n("new_monthly_premium") %></label>
-          <span id="calculated_amount_applied"><%= number_to_currency(float_fix(locals[:hbx_enrollment].total_premium) - (locals[:available_aptc] * locals[:hbx_enrollment].elected_aptc_pct)) %></span>
+          <span id="calculated_amount_applied"><%= locals[:hbx_enrollment].total_premium.to_f - (locals[:available_aptc].to_f * locals[:hbx_enrollment].elected_aptc_pct.to_f) %></span>
         </p>
         <div class="mt-4">
           <%= button_tag l10n("discard_changes"), class: "btn outline mr-2", id: "btn-discard-tax-credit", disabled: false, type: :reset %>
@@ -53,7 +53,7 @@
         </div>
       </div>
       <%= hidden_field_tag 'enrollment_premium', @self_term_or_cancel_form[:new_enrollment_premium], id: 'enrollment_premium' %>
-      <%= hidden_field_tag 'total_premium', @self_term_or_cancel_form[:total_premium], id: 'enrollmentotal_premiumt_premium' %>
+      <%= hidden_field_tag 'total_premium', locals[:hbx_enrollment].total_premium, id: 'total_premium' %>
     <% end %>
   </div>
   <script>
@@ -67,14 +67,13 @@
       const radioButtonYes = document.getElementById('update_tax_credit_section_yes');
       const radioButtonNo = document.getElementById("update_tax_credit_section_no");
       const section = document.getElementById('update_tax_credit_section');
-      const maxTaxCredit = parseFloat('<%= @self_term_or_cancel_form[:max_tax_credit] %>');
+      const maxTaxCredit = parseFloat('<%= locals[:available_aptc] %>');
       const premiumTotal = parseFloat('<%= locals[:hbx_enrollment].total_premium %>');
 
       function updateCalculatedAmount() {
         const percentageValue = parseFloat(updateTaxCreditPercentage.value);
-        const totalValue = parseFloat(aptcAppliedTotal.value.replace(/[^0-9.-]+/g,""));
+        const totalValue = parseFloat(aptcAppliedTotal.value);
         if (!isNaN(totalValue) && !isNaN(percentageValue)) {
-          // we need to minus the total value from the premium
           const calculatedValue = premiumTotal - totalValue;
           calculatedAmountApplied.textContent = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(calculatedValue);
         } else {
@@ -143,8 +142,8 @@
         saveButton.disabled = true;
       }
 
-      updateTaxCreditPercentage.addEventListener('blur', handlePercentageInput);
-      aptcAppliedTotal.addEventListener('blur', handleTotalInput);
+      updateTaxCreditPercentage.addEventListener('input', handlePercentageInput);
+      aptcAppliedTotal.addEventListener('input', handleTotalInput);
       radioButtonYes.addEventListener("change", toggleSection);
       radioButtonNo.addEventListener("change", toggleSection);
       discardButton.addEventListener('click', function(e) {

--- a/app/views/insured/group_selection/_change_tax_credit_form.html.erb
+++ b/app/views/insured/group_selection/_change_tax_credit_form.html.erb
@@ -26,11 +26,11 @@
         <div class="d-flex mb-2 mt-2">
           <div class="mr-4">
             <label class="required" for="aptc_applied_total"> <%= l10n("amount") %></label>
-            <input type="text" name="aptc_applied_total" id="aptc_applied_total" data-initial-amount="<%= number_to_currency(@self_term_or_cancel_form[:max_tax_credit].to_i * locals[:hbx_enrollment].elected_aptc_pct) %>" class="form-control tax_credit_field_container" value="<%= number_to_currency(@self_term_or_cancel_form[:max_tax_credit].to_i * locals[:hbx_enrollment].elected_aptc_pct) %>" placeholder="0" required>
+            <input type="number" step=".01" min="0" max="<%= @self_term_or_cancel_form[:max_tax_credit].to_i %>" name="aptc_applied_total" id="aptc_applied_total" data-initial-amount="<%= number_with_precision(@self_term_or_cancel_form[:max_tax_credit].to_i * locals[:hbx_enrollment].elected_aptc_pct, precision: 2) %>" class="form-control tax_credit_field_container" value="<%= number_with_precision(@self_term_or_cancel_form[:max_tax_credit].to_i * locals[:hbx_enrollment].elected_aptc_pct, precision: 2) %>" placeholder="0" required>
           </div>
           <div class="mr-4">
             <label class="required" for="update_tax_credit_percentage"> <%= l10n("percentage") %></label>
-            <input type="text" name="update_tax_credit_percentage" id="update_tax_credit_percentage" class="form-control tax_credit_field_container" data-initial-percent="<%= number_with_precision(@self_term_or_cancel_form[:elected_aptc_pct].to_f * 100, precision: 2) %>%" value="<%= number_with_precision(@self_term_or_cancel_form[:elected_aptc_pct].to_f * 100, precision: 2) %>%" placeholder="0">
+            <input type="number" min="0" max="100" name="update_tax_credit_percentage" id="update_tax_credit_percentage" class="form-control tax_credit_field_container" data-initial-percent="<%= number_with_precision(@self_term_or_cancel_form[:elected_aptc_pct].to_f * 100) %>" value="<%= number_with_precision(@self_term_or_cancel_form[:elected_aptc_pct].to_f * 100, precision: 0) %>" placeholder="0">
           </div>
           <div class="mt-4">
             <div class="d-flex">
@@ -53,6 +53,7 @@
         </div>
       </div>
       <%= hidden_field_tag 'enrollment_premium', @self_term_or_cancel_form[:new_enrollment_premium], id: 'enrollment_premium' %>
+      <%= hidden_field_tag 'total_premium', @self_term_or_cancel_form[:total_premium], id: 'enrollmentotal_premiumt_premium' %>
     <% end %>
   </div>
   <script>
@@ -66,13 +67,15 @@
       const radioButtonYes = document.getElementById('update_tax_credit_section_yes');
       const radioButtonNo = document.getElementById("update_tax_credit_section_no");
       const section = document.getElementById('update_tax_credit_section');
+      const maxTaxCredit = parseFloat('<%= @self_term_or_cancel_form[:max_tax_credit] %>');
+      const premiumTotal = parseFloat('<%= locals[:hbx_enrollment].total_premium %>');
 
       function updateCalculatedAmount() {
-        const maxTaxCredit = parseFloat('<%= locals[:hbx_enrollment].total_premium %>');
-        const percentageValue = parseFloat(updateTaxCreditPercentage.value.replace('%', ''));
+        const percentageValue = parseFloat(updateTaxCreditPercentage.value);
         const totalValue = parseFloat(aptcAppliedTotal.value.replace(/[^0-9.-]+/g,""));
         if (!isNaN(totalValue) && !isNaN(percentageValue)) {
-          const calculatedValue = maxTaxCredit - totalValue;
+          // we need to minus the total value from the premium
+          const calculatedValue = premiumTotal - totalValue;
           calculatedAmountApplied.textContent = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(calculatedValue);
         } else {
           calculatedAmountApplied.textContent = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(maxTaxCredit);
@@ -80,13 +83,17 @@
       }
 
       function handlePercentageInput() {
-        const percentageValue = parseFloat(updateTaxCreditPercentage.value.replace('%', ''));
-        const maxTaxCredit = parseFloat('<%= @self_term_or_cancel_form[:max_tax_credit] %>');
+        const percentageValue = parseFloat(updateTaxCreditPercentage.value);
         if (!isNaN(percentageValue)) {
-          const newTotal = maxTaxCredit * (percentageValue / 100);
-          aptcAppliedTotal.value = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(newTotal);
+          if (percentageValue > 100) {
+            updateTaxCreditPercentage.value = 100;
+            aptcAppliedTotal.value = maxTaxCredit.toFixed(2);
+          } else {
+            const newTotal = Math.round(maxTaxCredit * (percentageValue / 100) * 100) / 100;
+            aptcAppliedTotal.value = newTotal.toFixed(2);
+          }
         } else {
-          aptcAppliedTotal.value = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(0);
+          aptcAppliedTotal.value = 0;
         }
 
         if (!isNaN(percentageValue) && percentageValue <= 100) {
@@ -94,23 +101,28 @@
         } else {
           saveButton.disabled = true;
         }
+        updateCalculatedAmount();
       }
 
       function handleTotalInput() {
-        const totalValue = parseFloat(aptcAppliedTotal.value.replace('$', ''));
-        const maxTaxCredit = parseFloat('<%= @self_term_or_cancel_form[:max_tax_credit] %>');
-        if (!isNaN(totalValue) && maxTaxCredit !== 0) {
-          const newPercentage = (totalValue / maxTaxCredit) * 100;
-          updateTaxCreditPercentage.value = newPercentage.toFixed(2) + '%';
+        const totalValue = parseFloat(aptcAppliedTotal.value);
+        if (totalValue > maxTaxCredit) {
+          updateTaxCreditPercentage.value = 100;
+          aptcAppliedTotal.value = maxTaxCredit;
         } else {
-          updateTaxCreditPercentage.value = '';
+          if (!isNaN(totalValue) && maxTaxCredit !== 0) {
+            const newPercentage = Math.round((totalValue / maxTaxCredit) * 100);
+            updateTaxCreditPercentage.value = newPercentage.toFixed(0);
+          } else {
+            updateTaxCreditPercentage.value = '';
+          }
         }
-
         if (!isNaN(totalValue) && totalValue <= maxTaxCredit) {
           saveButton.disabled = false;
         } else {
           saveButton.disabled = true;
         }
+        updateCalculatedAmount();
       }
 
       function toggleSection() {
@@ -131,10 +143,8 @@
         saveButton.disabled = true;
       }
 
-      updateTaxCreditPercentage.addEventListener('input', handlePercentageInput);
-      updateTaxCreditPercentage.addEventListener('input', updateCalculatedAmount);
-      aptcAppliedTotal.addEventListener('input', handleTotalInput);
-      aptcAppliedTotal.addEventListener('input', updateCalculatedAmount);
+      updateTaxCreditPercentage.addEventListener('blur', handlePercentageInput);
+      aptcAppliedTotal.addEventListener('blur', handleTotalInput);
       radioButtonYes.addEventListener("change", toggleSection);
       radioButtonNo.addEventListener("change", toggleSection);
       discardButton.addEventListener('click', function(e) {


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188199147
https://www.pivotaltracker.com/story/show/188198493

# A brief description of the changes

Current behavior: aptc form used text inputs that allowed for more aptc to be applied than the top premium 

New behavior: aptc form uses number inputs that don't allow for more aptc to be applied than the top premium 
