### PR TITLE
check for languages_spoken rather than language_options

### DIFF
--- a/components/benefit_sponsors/app/models/benefit_sponsors/organizations/organization_forms/profile_form.rb
+++ b/components/benefit_sponsors/app/models/benefit_sponsors/organizations/organization_forms/profile_form.rb
@@ -53,7 +53,7 @@ module BenefitSponsors
       end
 
       def office_locations_attributes=(locations_params)
-        self.office_locations=(locations_params.values)
+        self.office_locations = (locations_params.values)
       end
 
       def is_broker_profile?
@@ -86,9 +86,7 @@ module BenefitSponsors
       end
 
       def validate_routing_information
-        if ach_routing_number.present? && !(ach_routing_number == ach_routing_number_confirmation)
-          self.errors.add(:base, "can't have two different routing numbers, please make sure you have same routing numbers on both fields")
-        end
+        self.errors.add(:base, "can't have two different routing numbers, please make sure you have same routing numbers on both fields") if ach_routing_number.present? && !(ach_routing_number == ach_routing_number_confirmation)
       end
 
       def validate_profile_office_locations
@@ -104,7 +102,7 @@ module BenefitSponsors
 
       def validate_at_least_one_language_selected
         return true unless EnrollRegistry.feature_enabled?(:bs4_broker_flow)
-        return if self&.language_options&.any?
+        return true if self&.languages_spoken&.any?
 
         errors.add(:base, l10n("broker_agencies.profiles.errors.language_options"))
       end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188212744

# A brief description of the changes

Current behavior: the error message is added if there are no language_options

New behavior: the error messaged is added if there are no languages_spoken