### PR TITLE
update plan tiles to match mockups

### DIFF
--- a/app/javascript/css/_buttons.scss
+++ b/app/javascript/css/_buttons.scss
@@ -143,7 +143,7 @@ button.outline,
   );
 }
 
-.button.secondary.outline {
+.button.secondary.outline, button.secondary.outline, .btn.secondary.outline, .btn-secondary.outline {
   color: var(--secondary-color);
   border-color: var(--secondary-color);
 

--- a/app/javascript/css/application.scss
+++ b/app/javascript/css/application.scss
@@ -15,3 +15,4 @@
 @import 'nav';
 @import 'admin_navbar';
 @import 'print';
+@import 'enrollment';

--- a/app/javascript/css/enrollment.scss
+++ b/app/javascript/css/enrollment.scss
@@ -87,6 +87,7 @@
                 font-weight: 700;
                 line-height: 1.5;
                 display: block;
+                text-decoration: none;
               }
 
             }
@@ -199,4 +200,36 @@
         }
       }
     }
+}
+
+.plan-card {
+  background: var(--grey-010);
+
+  .plan-footer {
+    a:not(.btn) {
+      text-decoration: none;
+      font-weight: 600;
+      color: var(--info-color);
+    }
+  }
+}
+
+.hbx-enrollment-refactored-panel, .plan-shopping-refactored-panel {
+  border-radius: 12px;
+  .panel-body, .plan-footer {
+    border-bottom-left-radius: 12px;
+    border-bottom-right-radius: 12px;
+  }
+  .plan-footer div a:not(.btn) {
+    color: var(--secondary-color);
+  }
+
+  h3 a {
+    color: var(--default-font-color);
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1.5;
+    display: block;
+    text-decoration: none;
+  }
 }

--- a/app/javascript/css/main.scss
+++ b/app/javascript/css/main.scss
@@ -677,18 +677,6 @@ a.disabled {
   border-bottom: 1px solid var(--body-divider);
 }
 
-.plan-card {
-  background: var(--grey-010);
-
-  .plan-footer {
-    a:not(.btn) {
-      text-decoration: none;
-      font-weight: 600;
-      color: var(--info-color);
-    }
-  }
-}
-
 .actions-dropdown {
   border: 1px solid var(--grey-100);
 

--- a/app/views/insured/families/_enrollment_actions.html.erb
+++ b/app/views/insured/families/_enrollment_actions.html.erb
@@ -15,7 +15,7 @@
       <% key_index = hbx_enrollment.id %>
       <% unless read_only || !can_make_changes_for_enrollment %>
         <div class="dropdown">
-          <button class="btn btn-default dropdown-toggle interaction-click-control-actions button outline " type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <button class="btn btn-default dropdown-toggle interaction-click-control-actions button outline secondary" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= l10n("actions")%>
             <span class="caret"></span>
           </button>

--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -6,8 +6,8 @@
   <%= render partial: 'insured/families/waived_coverage_widget', locals: { read_only: read_only || hbx_enrollment.can_make_changes?, hbx_enrollment: hbx_enrollment } %>
 <% else %>
   <% if @bs4 %>
-    <div class="hbx-enrollment-refactored-panel plan-card plan-row border my-2 rounded-lg <%= "initially_hidden_enrollment hidden" if initially_hide_enrollment?(hbx_enrollment) %>">
-      <div class="panel-header p-2 d-flex justify-content-between">
+    <div class="hbx-enrollment-refactored-panel plan-card plan-row border my-2 <%= "initially_hidden_enrollment hidden" if initially_hide_enrollment?(hbx_enrollment) %>">
+      <div class="panel-header py-2 px-3 d-flex justify-content-between">
         <div class="plan-type">
           <% if product.kind.to_s == "dental" %>
             <svg width="20" height="18" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -20,17 +20,17 @@
               <path d="M10 3.25C9.0335 3.25 8.25 4.0335 8.25 5V8.25H5C4.0335 8.25 3.25 9.0335 3.25 10V14C3.25 14.9665 4.0335 15.75 5 15.75H8.25V19C8.25 19.9665 9.0335 20.75 10 20.75H14C14.9665 20.75 15.75 19.9665 15.75 19V15.75H19C19.9665 15.75 20.75 14.9665 20.75 14V10C20.75 9.0335 19.9665 8.25 19 8.25H15.75V5C15.75 4.0335 14.9665 3.25 14 3.25H10Z" fill="currentColor"/>
             </svg>
           <% end %>
-          <span><%= product.kind.to_s.titleize %></span>
+          <span class="pl-1"><%= product.kind.to_s.titleize %></span>
         </div>
         <div class="plan-status-container"><%= render partial: "insured/families/enrollment_status_label", locals: { step: hbx_enrollment.enroll_step, hbx_enrollment: hbx_enrollment } %></div>
       </div>
 
-      <div class="panel-body bg-white p-2">
+      <div class="panel-body bg-white py-2 px-3">
         <div class="d-flex">
-          <div class="col-md-2 col-sm-2 align-self-center"><%= display_carrier_logo(Maybe.new(product), {width: 100}) %></div>
+          <div class="col-md-2 col-sm-2 align-self-center pl-0"><%= display_carrier_logo(Maybe.new(product), {width: 100}) %></div>
           <div class="col-md-8">
             <h3 class="no-buffer">
-              <%= h(link_to product.title, summary_products_plans_path({plan_id: product.id, :standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, market_kind: hbx_enrollment.market_name&.downcase, coverage_kind: hbx_enrollment.coverage_kind, active_year: product.active_year, bs4: @bs4}), remote: action_name != "home") %>
+              <%= h(link_to product.title, summary_products_plans_path({plan_id: product.id, :standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, market_kind: hbx_enrollment.market_name&.downcase, coverage_kind: hbx_enrollment.coverage_kind, active_year: product.active_year, bs4: @bs4}), remote: action_name != "home", class:"default-text") %>
             </h3>
           </div>
         </div>
@@ -72,7 +72,7 @@
             <dd><span class="badge badge-pill badge-lg badge-<%= plan_level.downcase %>"><%= plan_level %></span></dd>
           </dl>
           <dl class="parent col-6 pl-0">
-            <dt class="plan-id"><%= HbxProfile::ShortName %> <%= l10n("enrollment_id") %>:</dt>
+            <dt class="plan-id"><%= l10n("enrollment_id") %>:</dt>
             <dd><%= hbx_enrollment.hbx_id %></dd>
             <dt class="enrollment-premium"><%= l10n("premium_you_pay") %>:</dt>
             <dd><%= number_to_currency(current_premium(hbx_enrollment), precision: 2) %> / <%= l10n("month").to_s.downcase %></dd>

--- a/app/views/insured/plan_shoppings/_plan_details.html.erb
+++ b/app/views/insured/plan_shoppings/_plan_details.html.erb
@@ -7,7 +7,7 @@
     <% premium = plan.total_employee_cost - plan.total_childcare_subsidy_amount %>
   <% end %>
 
-  <div class="plan-card plan-row border my-2  rounded-lg"
+  <div class="plan-shopping-refactored-panel plan-card plan-row border my-2"
     data-plan-id="<%= plan.id %>"
     data-plan-category="<%= plan.product_type ? plan.product_type.downcase : '' %>"
     data-plan-metal-level="<%= plan.metal_level.downcase %>"
@@ -22,7 +22,7 @@
     data-plan-osse-eligibility="<%= osse_status(plan) %>"
     data-plan-ehb="<%= plan.ehb %>"
     data-can-use-aptc="<%= plan.can_use_aptc? %>">
-    <div class="panel-header p-2 d-flex justify-content-between">
+    <div class="panel-header pt-2 px-3 d-flex justify-content-between">
       <div class="pl-0 col-3">
         <% if details_page %>
           <div class="plan-type">
@@ -37,7 +37,7 @@
                 <path d="M10 3.25C9.0335 3.25 8.25 4.0335 8.25 5V8.25H5C4.0335 8.25 3.25 9.0335 3.25 10V14C3.25 14.9665 4.0335 15.75 5 15.75H8.25V19C8.25 19.9665 9.0335 20.75 10 20.75H14C14.9665 20.75 15.75 19.9665 15.75 19V15.75H19C19.9665 15.75 20.75 14.9665 20.75 14V10C20.75 9.0335 19.9665 8.25 19 8.25H15.75V5C15.75 4.0335 14.9665 3.25 14 3.25H10Z" fill="currentColor"/>
               </svg>
             <% end %>
-            <span><%= plan.kind.to_s.titleize %></span>
+            <span class="pl-1"><%= plan.kind.to_s.titleize %></span>
           </div>
         <% else %>
           <label for="compare_plan_checkbox_<%= plan.id %>" data-cuke="compare_plan_checkbox" class="weight-n d-flex align-items-center">
@@ -47,19 +47,9 @@
         <% end %>
       </div>
       <div>
-        <div class="d-flex justify-content-between mb-3">
-          <% if plan.try(:is_standard_plan) %>
-            <span tabindex="0" compare_plans class="badge badge-pill badge-lg badge-standard d-flex align-items-center" data-toggle="tooltip" data-placement="top" data-container="body" title= "<%=l10n('insured.plan_shoppings.standard_plan_title_info') %>">
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-2">
-                <title>Checkmark</title>
-                <circle cx="10" cy="10" r="9" stroke="currentColor" stroke-width="2"/>
-                <path d="M14 7L8.46154 13L6 10.3333" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-              <%= plan.standard_plan_label.titleize %>
-            </span>
-          <% end %>
+        <div class="d-flex justify-content-between">
           <% if @person.primary_family.enrolled_hbx_enrollments.map(&:product).map(&:id).include?(plan.id) %>
-            <span class="badge badge-pill badge-lg badge-current-plan ml-2 d-flex align-items-center">
+            <span class="badge badge-pill badge-lg badge-current-plan d-flex align-items-center">
               <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <title>Star</title>
                 <g clip-path="url(#clip0_4990_3099)" class="mr-2">
@@ -74,15 +64,25 @@
               <%= l10n("your_current_plan", year: plan.try(:active_year)) %>
             </span>
           <% end %>
+          <% if plan.try(:is_standard_plan) %>
+            <span tabindex="0" compare_plans class="ml-2 badge badge-pill badge-lg badge-standard d-flex align-items-center" data-toggle="tooltip" data-placement="top" data-container="body" title= "<%=l10n('insured.plan_shoppings.standard_plan_title_info') %>">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-2">
+                <title>Checkmark</title>
+                <circle cx="10" cy="10" r="9" stroke="currentColor" stroke-width="2"/>
+                <path d="M14 7L8.46154 13L6 10.3333" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <%= plan.standard_plan_label.titleize %>
+            </span>
+          <% end %>
         </div>
       </div>
     </div>
-    <div class="panel-body bg-white p-2">
+    <div class="panel-body bg-white py-2 px-3">
       <div class="d-flex align-items-start">
-        <div class="col-md-2 col-sm-2"><%= display_carrier_logo(Maybe.new(plan), {width: 100}) %></div>
+        <div class="col-md-2 col-sm-2 pl-0"><%= display_carrier_logo(Maybe.new(plan), {width: 100}) %></div>
         <div class="col-md-8">
           <h3 class="no-buffer">
-            <%= link_to summary_products_plans_path({plan_id: plan.id, :standard_component_id => plan.hios_id, hbx_enrollment_id: @hbx_enrollment.id, market_kind: @market_kind, coverage_kind: @coverage_kind, enrollment_kind: @enrollment_kind, active_year: plan.try(:active_year), bs4: @bs4}), {:remote => true} do %>
+            <%= link_to summary_products_plans_path({plan_id: plan.id, :standard_component_id => plan.hios_id, hbx_enrollment_id: @hbx_enrollment.id, market_kind: @market_kind, coverage_kind: @coverage_kind, enrollment_kind: @enrollment_kind, active_year: plan.try(:active_year), bs4: @bs4}), {:remote => true, class: "default-text"} do %>
               <% if plan.is_csr?%>
                 <span tabindex="0" class="far fa-check-square" title="Eligible for Cost Sharing Reduction" data-toggle="tooltip"></span>
               <% end %>

--- a/app/views/shared/_comparison.html.erb
+++ b/app/views/shared/_comparison.html.erb
@@ -96,7 +96,7 @@
             <% qhps.each do |qhp|%>
               <td colspan="2" class="rb2">
                 <div class="plan_comparison">
-                  <%= render partial: "shared/plan_shoppings/sbc_link", locals: { plan: qhp.product_for(@market_kind) } %>
+                  <%= render partial: "shared/plan_shoppings/sbc_link", locals: { plan: qhp.product_for(@market_kind), hide_pdf_icon: true } %>
                 </div>
               </td>
             <% end %>

--- a/app/views/shared/plan_shoppings/_sbc_link.html.erb
+++ b/app/views/shared/plan_shoppings/_sbc_link.html.erb
@@ -1,7 +1,8 @@
 <% custom_css = (defined? custom_css) ? custom_css : false %>
+<% hide_pdf_icon = (defined? hide_pdf_icon) ? hide_pdf_icon : false %>
 <% if plan.sbc_document.present? %>
   <% plan_kind = (plan.try(:kind) || plan.try(:coverage_kind)).to_s %>
-  <% link_text = "Summary of Benefits and Coverage" %>
+  <% link_text = hide_pdf_icon ? l10n("plans.view_summary_of_benefits") : l10n("plans.summary_of_benefits") %>
   <% link_text_class = "Summary-of-Benefits-and-Coverage" %>
   <% link_text = "Plan Summary" unless plan_kind == "health" %>
   <% link_text_class = "plan-summary" unless plan_kind == "health" %>
@@ -14,7 +15,12 @@
   <% id = (defined? hbx_id) ? "plan_doc_#{hbx_id}" : "summary_benefits" %>
   <a href="<%= main_app.document_product_sbc_download_path(plan.sbc_document.id) + "?product_id=#{plan.id}&content_type=application/pdf&filename=#{plan_name.gsub(/[^0-9a-z]/i,'')}.pdf&disposition=inline" %>" class="sbc_link <%= text_class %> vertically-aligned-row" target="_blank" rel="noopener noreferrer" id="<%= id %>">
     <% if @bs4 %>
-      <% link_text = "View Summary of Benefits & Coverage (PDF)" %>
+      <% unless hide_pdf_icon %>
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="20" viewBox="0 0 18 20" fill="none" class="mr-2 ml-2">
+          <title>PDF</title>
+          <path d="M4.50269 11.0021C4.22654 11.0021 4.00269 11.2259 4.00269 11.5021V14.5021C4.00269 14.7782 4.22654 15.0021 4.50269 15.0021C4.77883 15.0021 5.00269 14.7782 5.00269 14.5021V14.0025H5.50004C6.32858 14.0025 7.00024 13.3308 7.00024 12.5023C7.00024 11.6737 6.32858 11.0021 5.50004 11.0021H4.50269ZM5.50004 13.0025H5.00269V12.0021H5.50004C5.77629 12.0021 6.00024 12.226 6.00024 12.5023C6.00024 12.7785 5.7763 13.0025 5.50004 13.0025ZM11.9977 11.5014C11.998 11.2255 12.2218 11.0021 12.4977 11.0021H14.0027C14.2788 11.0021 14.5027 11.2259 14.5027 11.5021C14.5027 11.7782 14.2788 12.0021 14.0027 12.0021H12.997L12.9958 13.0038H14.0027C14.2788 13.0038 14.5027 13.2277 14.5027 13.5038C14.5027 13.7799 14.2788 14.0038 14.0027 14.0038H12.9964L12.9977 14.5008C12.9984 14.7769 12.7751 15.0014 12.4989 15.0021C12.2228 15.0028 11.9984 14.7795 11.9977 14.5033L11.9951 13.5051L11.9951 13.5032L11.9977 11.5014ZM8.5 11.0021H8.99755C10.1021 11.0021 10.9976 11.8975 10.9976 13.0021C10.9975 14.1067 10.1021 15.0021 8.99755 15.0021H8.5C8.22386 15.0021 8 14.7782 8 14.5021V11.5021C8 11.2259 8.22386 11.0021 8.5 11.0021ZM9 14.0021C9.55116 14.0008 9.99755 13.5535 9.99755 13.0021C9.99755 12.4506 9.55116 12.0034 9 12.0021V14.0021ZM9 6V0H3C1.89543 0 1 0.895431 1 2V8.66841C0.408763 8.94927 0 9.5519 0 10.25V15.75C0 16.4481 0.408763 17.0507 1 17.3316V18C1 19.1046 1.89543 20 3 20H15C16.1046 20 17 19.1046 17 18V17.3316C17.5912 17.0507 18 16.4481 18 15.75V10.25C18 9.5519 17.5912 8.94927 17 8.66841V8H11C9.89543 8 9 7.10457 9 6ZM1.75 10H16.25C16.3881 10 16.5 10.1119 16.5 10.25V15.75C16.5 15.8881 16.3881 16 16.25 16H1.75C1.61193 16 1.5 15.8881 1.5 15.75V10.25C1.5 10.1119 1.61193 10 1.75 10ZM10.5 6V0.5L16.5 6.5H11C10.7239 6.5 10.5 6.27614 10.5 6Z" fill="currentColor"/>
+        </svg>
+      <% end %>
       <span class="<%= link_text_class %> col-xs-11 enrollment-tile-summary"><%= link_text %></span>
     <% elsif custom_css.present? %>
       <div class="fa-icon-label <%= text_class %> col-xs-11 enrollment-tile-summary" style="display: inline; font-size: 10px;"><%= link_text %></div>

--- a/db/seedfiles/translations/en/dc/plan.rb
+++ b/db/seedfiles/translations/en/dc/plan.rb
@@ -65,5 +65,7 @@ PLAN_TRANSLATIONS = {
   'en.plans.plan_shopping_options.question.compare' => "I want to compare plans while plan shopping",
   'en.plans.plan_shopping_options.question.know' => "I know the plan I want",
   'en.plans.plan_shopping_options.modal.go_back' => "Go Back",
-  'en.plans.plan_shopping_options.modal.proceed' => "Yes, Compare Plans"
+  'en.plans.plan_shopping_options.modal.proceed' => "Yes, Compare Plans",
+  'en.plans.view_summary_of_benefits' => 'View Summary of Benefits and Coverage',
+  'en.plans.summary_of_benefits' => 'Summary of Benefits and Coverage'
 }

--- a/db/seedfiles/translations/en/me/plan.rb
+++ b/db/seedfiles/translations/en/me/plan.rb
@@ -108,5 +108,7 @@ PLAN_TRANSLATIONS = {
   'en.plans.plan_shopping_options.question.compare' => "Yes, take me to the Plan Comparison Tool",
   'en.plans.plan_shopping_options.question.know' => "No, I know the plan I want",
   'en.plans.plan_shopping_options.modal.go_back' => "Go Back",
-  'en.plans.plan_shopping_options.modal.proceed' => "Yes, Compare Plans"
+  'en.plans.plan_shopping_options.modal.proceed' => "Yes, Compare Plans",
+  'en.plans.view_summary_of_benefits' => 'View Summary of Benefits and Coverage',
+  'en.plans.summary_of_benefits' => 'Summary of Benefits and Coverage'
 }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188213417#

# A brief description of the changes

Current behavior: the plan tiles had some slight differences with the mockups, the pdf icon isn't in the sbc_link partial

New behavior: the plan tiles match the mockups, the pdf icon is conditionally in the sbc_link partial.
