### PR TITLE
fix aptc save button and zero input handling

### DIFF
--- a/app/views/insured/group_selection/_change_tax_credit_form.html.erb
+++ b/app/views/insured/group_selection/_change_tax_credit_form.html.erb
@@ -26,7 +26,7 @@
         <div class="d-flex mb-2 mt-2">
           <div class="mr-4">
             <label class="required" for="aptc_applied_total"> <%= l10n("amount") %></label>
-            <input type="number" step=".01" min="0" max="<%= locals[:available_aptc] %>" name="aptc_applied_total" id="aptc_applied_total" data-initial-amount="<%= number_with_precision(locals[:available_aptc].to_f * locals[:hbx_enrollment].elected_aptc_pct, precision: 2) %>" class="form-control tax_credit_field_container" value="<%= number_with_precision(locals[:available_aptc].to_f * locals[:hbx_enrollment].elected_aptc_pct, precision: 2) %>" placeholder="0" required>
+            <input type="number" step=".01" min="0" max="<%= locals[:available_aptc] %>" name="aptc_applied_total" id="aptc_applied_total" data-initial-amount="<%= number_with_precision(locals[:available_aptc].to_f * locals[:hbx_enrollment].elected_aptc_pct, precision: 2) %>" class="form-control tax_credit_field_container" value="<%= number_with_precision(locals[:available_aptc].to_f * locals[:hbx_enrollment].elected_aptc_pct, precision: 2) %>" placeholder="0.00" required>
           </div>
           <div class="mr-4">
             <label class="required" for="update_tax_credit_percentage"> <%= l10n("percentage") %></label>

--- a/app/views/insured/group_selection/_change_tax_credit_form.html.erb
+++ b/app/views/insured/group_selection/_change_tax_credit_form.html.erb
@@ -45,7 +45,7 @@
         </div>
         <p class="d-flex">
           <label for="new_enrollment_premium" class="mr-1"> <%= l10n("new_monthly_premium") %></label>
-          <span id="calculated_amount_applied"><%= locals[:hbx_enrollment].total_premium.to_f - (locals[:available_aptc].to_f * locals[:hbx_enrollment].elected_aptc_pct.to_f) %></span>
+          <span id="calculated_amount_applied"><%= number_to_currency(locals[:hbx_enrollment].total_premium.to_f - (locals[:available_aptc].to_f * locals[:hbx_enrollment].elected_aptc_pct.to_f)) %></span>
         </p>
         <div class="mt-4">
           <%= button_tag l10n("discard_changes"), class: "btn outline mr-2", id: "btn-discard-tax-credit", disabled: false, type: :reset %>
@@ -82,7 +82,7 @@
       }
 
       function handlePercentageInput() {
-        const percentageValue = parseFloat(updateTaxCreditPercentage.value);
+        const percentageValue = updateTaxCreditPercentage.value ? parseFloat(updateTaxCreditPercentage.value) : 0;
         if (!isNaN(percentageValue)) {
           if (percentageValue > 100) {
             updateTaxCreditPercentage.value = 100;
@@ -104,7 +104,7 @@
       }
 
       function handleTotalInput() {
-        const totalValue = parseFloat(aptcAppliedTotal.value);
+        const totalValue = aptcAppliedTotal.value ? parseFloat(aptcAppliedTotal.value) : 0;
         if (totalValue > maxTaxCredit) {
           updateTaxCreditPercentage.value = 100;
           aptcAppliedTotal.value = maxTaxCredit;


### PR DESCRIPTION
fix aptc save button and zero input handling

# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Tickets:
1. https://www.pivotaltracker.com/n/projects/2640062/stories/188211300
2. https://www.pivotaltracker.com/n/projects/2640062/stories/188211833

There were two issues with the APTC calculator following [this PR](https://github.com/ideacrew/enroll/pull/4467):

1. Following the refactors on that PR, there was a missed call to `number_to_currency` in the HTML for the Amount Applied element, which meant that while the JS was correctly handling displaying this amount for user inputs, this amount was not correctly rounded on page load. I've added this missing call.
2. The same JS handling user inputs on the Total and Percentage number inputs had a check on whether or the input was a number, `!isNaN`, which drives the save button, and which failed when the user had no input. This was misleading as the placeholders on both of these elements in the HTML was "0.0", but the underlying value was "". Thus, the number check failed, and the save button was disabled. I've fixed this to default the input value to 0 before doing the input handling on both fields.
