### PR TITLE
getting tiles even closer, including dental

### DIFF
--- a/app/javascript/css/enrollment.scss
+++ b/app/javascript/css/enrollment.scss
@@ -224,6 +224,12 @@
     color: var(--secondary-color);
   }
 
+  .logo-column {
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-basis: 100px;
+  }
+
   h3 a {
     color: var(--default-font-color);
     font-size: 18px;

--- a/app/views/insured/families/_enrollment_refactored.html.erb
+++ b/app/views/insured/families/_enrollment_refactored.html.erb
@@ -27,8 +27,8 @@
 
       <div class="panel-body bg-white py-2 px-3">
         <div class="d-flex">
-          <div class="col-md-2 col-sm-2 align-self-center pl-0"><%= display_carrier_logo(Maybe.new(product), {width: 100}) %></div>
-          <div class="col-md-8">
+          <div class="logo-column"><%= display_carrier_logo(Maybe.new(product), {width: 100}) %></div>
+          <div class="flex-grow-1 px-3">
             <h3 class="no-buffer">
               <%= h(link_to product.title, summary_products_plans_path({plan_id: product.id, :standard_component_id => product.hios_id, hbx_enrollment_id: hbx_enrollment.id, market_kind: hbx_enrollment.market_name&.downcase, coverage_kind: hbx_enrollment.coverage_kind, active_year: product.active_year, bs4: @bs4}), remote: action_name != "home", class:"default-text") %>
             </h3>
@@ -69,7 +69,11 @@
             <dd><%= product.try(:product_type).try(:upcase) %></dd>
             <dt class="plan-metal-level"><%= l10n("metal_level") %>:</dt>
             <% plan_level = display_dental_metal_level(product) %>
-            <dd><span class="badge badge-pill badge-lg badge-<%= plan_level.downcase %>"><%= plan_level %></span></dd>
+            <% if product.kind.to_s == "dental" %>
+              <dd><%= plan_level %></dd>
+            <% else %>
+              <dd><span class="badge badge-pill badge-lg badge-<%= plan_level.downcase %>"><%= plan_level %></span></dd>
+            <% end %>
           </dl>
           <dl class="parent col-6 pl-0">
             <dt class="plan-id"><%= l10n("enrollment_id") %>:</dt>

--- a/app/views/insured/plan_shoppings/_plan_details.html.erb
+++ b/app/views/insured/plan_shoppings/_plan_details.html.erb
@@ -79,8 +79,8 @@
     </div>
     <div class="panel-body bg-white py-2 px-3">
       <div class="d-flex align-items-start">
-        <div class="col-md-2 col-sm-2 pl-0"><%= display_carrier_logo(Maybe.new(plan), {width: 100}) %></div>
-        <div class="col-md-8">
+        <div class="logo-column"><%= display_carrier_logo(Maybe.new(plan), {width: 100}) %></div>
+        <div class="flex-grow-1 px-3">
           <h3 class="no-buffer">
             <%= link_to summary_products_plans_path({plan_id: plan.id, :standard_component_id => plan.hios_id, hbx_enrollment_id: @hbx_enrollment.id, market_kind: @market_kind, coverage_kind: @coverage_kind, enrollment_kind: @enrollment_kind, active_year: plan.try(:active_year), bs4: @bs4}), {:remote => true, class: "default-text"} do %>
               <% if plan.is_csr?%>
@@ -90,7 +90,7 @@
             <% end %>
           </h3>
         </div>
-        <div class="col-md-2">
+        <div class="col-md-2 px-0">
           <div class="price-wrapper text-right">
             <strong class="text-secondary"><%= l10n("premium") %></strong>
             <p class="bold beta m-0"><%= number_to_currency(premium) %></p>
@@ -99,7 +99,7 @@
         </div>
       </div>
       <div class="d-flex">
-        <dl class="parent col-5 pl-0">
+        <dl class="parent col-6 pl-0">
           <dt>Carrier</dt>
           <dd><%= plan_carrier.legal_name %></dd>
           <dt><%= l10n("network") %></dt>
@@ -116,13 +116,17 @@
           <dt><%= l10n("deductible") %></dt>
           <dd><%= deductible_display(@hbx_enrollment, plan) %></dd>
         </dl>
-        <dl class="parent col-5 pl-0">
+        <dl class="parent col-6 pr-0">
           <dt><%= l10n("level") %></dt>
           <dd>
             <% plan_level = plan.metal_level.titleize %>
-            <span class="badge badge-pill badge-lg badge-<%= plan_level.downcase %>">
-              <%= plan_level != 'Dental' ? plan_level : display_dental_metal_level(plan).titleize %>
-            </span>
+            <% if plan.kind.to_s == "dental" %>
+              <%= display_dental_metal_level(plan).titleize %>
+            <% else %>
+              <span class="badge badge-pill badge-lg badge-<%= plan_level.downcase %>">
+                <%= plan_level %>
+              </span>
+            <% end %>
           </dd>
           <dt><%= l10n("type") %></dt>
           <dd><%= plan.product_type ? plan.product_type.upcase : "" %></dd>

--- a/app/views/shared/plan_shoppings/_sbc_link.html.erb
+++ b/app/views/shared/plan_shoppings/_sbc_link.html.erb
@@ -4,9 +4,9 @@
   <% plan_kind = (plan.try(:kind) || plan.try(:coverage_kind)).to_s %>
   <% link_text = hide_pdf_icon ? l10n("plans.view_summary_of_benefits") : l10n("plans.summary_of_benefits") %>
   <% link_text_class = "Summary-of-Benefits-and-Coverage" %>
-  <% link_text = "Plan Summary" unless plan_kind == "health" %>
-  <% link_text_class = "plan-summary" unless plan_kind == "health" %>
-  <% icon_class = "pull-left" unless plan_kind == "health" %>
+  <% link_text = "Plan Summary" unless plan_kind == "health" || @bs4 %>
+  <% link_text_class = "plan-summary" unless plan_kind == "health" || @bs4 %>
+  <% icon_class = "pull-left" unless plan_kind == "health" || @bs4 %>
   <% text_class = "health" %>
   <% text_class = "dental" unless plan_kind == "health" %>
 

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -320,7 +320,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.hired_on' => "Hired On",
   :'en.plan_end' => "Plan End",
   :'en.enrollment_status' => "Enrollment Status",
-  :'en.enrollment_id' => "ID",
+  :'en.enrollment_id' => "Plan ID",
   :'en.coverage_waived' => "Coverage Waived",
   :'en.waiver_reason' => "Waiver Reason",
   :'en.insured.families.future_enrollment_termination_date' => "Future Enrollment Termination Date",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188213417

# A brief description of the changes

Current behavior: health plan tiles said ID rather than plan id, dental metal levels appear bold, lots of empty space between the logos and the title, dental tiles said plan summary rather than "summary of benefits and coverage"

New behavior: health plan tiles say plan id, dental metal levels are not bold, the spacing between the logos and the titles matches the mockup, dental tiles say  "summary of benefits and coverage"