### PR TITLE
bs4 fix thankyou aptc changing

### DIFF
--- a/app/assets/javascripts/plan_shopping.js.erb
+++ b/app/assets/javascripts/plan_shopping.js.erb
@@ -289,7 +289,6 @@ $(function() {
         }
         electedAptcAmount.value = electedAptc.toFixed(2);
       }
-      setUpdatedAptc(electedAptcAmount.value, updateUrl)
     });
 
     electedAptcAmount.addEventListener('blur', function(){
@@ -309,7 +308,6 @@ $(function() {
         }
         electedAptcPercentage.value = electedPct.toFixed(0);
       }
-      setUpdatedAptc(electedAptcAmount.value, updateUrl)
     });
 
     // submits the update aptc form on the thank you page


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188218888

The JS managing the APTC calculator on this page was making calls to the `setUpdatedAptc` function, which updates the value of the APTC Amount element in the table. Per the reqs, this should only occur when the user saves their inputs with the Update Applied APTC button. I've removed the two calls to `setUpdatedAptc` on the blur handlers for the two Percent/Amount Applied elements, keeping the call on the save button.
