### PR TITLE
Correct SAMLLogout to use GET and proper encoding.

### DIFF
--- a/app/domain/operations/authentication/logout_saml_user.rb
+++ b/app/domain/operations/authentication/logout_saml_user.rb
@@ -10,51 +10,37 @@ module Operations
 
       def call(session)
         saml_settings = yield ConstructSamlSettings.new.call
-        saml_logout_xml = yield construct_saml_request_xml(saml_settings, session)
-        logout_url = yield parse_logout_service_url(saml_settings)
-        post_saml_logout_xml(logout_url, saml_logout_xml)
+        saml_logout_url = yield construct_saml_request(saml_settings, session)
+        execute_saml_logout(saml_logout_url)
       end
 
       protected
 
-      def construct_saml_request_xml(settings, session)
+      def construct_saml_request(settings, session)
         name_id = session[:__saml_name_id]
         saml_session_index = session[:__saml_session_index]
         return Failure("No SAML NameID available") if name_id.blank?
         request = OneLogin::RubySaml::Logoutrequest.new
         settings.name_identifier_value = name_id
         settings.sessionindex = saml_session_index unless saml_session_index.blank?
-        Success(request.create_logout_request_xml_doc(settings))
+        Try do
+          request.create(settings)
+        end.to_result
       end
 
-      def parse_logout_service_url(saml_settings)
-        logout_url = saml_settings.idp_slo_service_url
-
-        parse_result = Try do
-          URI.parse(logout_url)
-        end.or(Failure("Invalid SAML logout service URI"))
-
-        return parse_result unless parse_result.success?
-
-        parsed_url = parse_result.value!
-
-        return Failure("Empty SAML service path") if parsed_url.path.blank?
-
-        Success(parsed_url)
-      end
-
-      def post_saml_logout_xml(logout_url, saml_logout_xml)
+      def execute_saml_logout(saml_logout_url)
         logger = Rails.logger
-        request = Net::HTTP::Post.new logout_url.path
-        request.body = saml_logout_xml.to_s
-        request.content_type = 'text/xml'
+
         result = Try do
-          Net::HTTP.start(logout_url.hostname, logout_url.port, :use_ssl => logout_url.scheme == 'https') { |http| http.request request }
+          saml_url = URI(saml_logout_url)
+          http = Net::HTTP.new(saml_url.host, saml_url.port)
+          http.use_ssl = saml_url.scheme == 'https'
+          http.get(saml_url.request_uri)
         end.to_result
         logger.tagged("SAMLLogoutAttempt") do
           if result.success?
             response = result.value!
-            unless (200..299).include?(response.code.to_i)
+            unless (200..299).include?(response.code.to_i) || (300..399).include?(response.code.to_i)
               logger.error "Status: #{response.code}"
               logger.error "Body:\n#{response.body}"
             end

--- a/spec/domain/operations/authentication/logout_saml_user_spec.rb
+++ b/spec/domain/operations/authentication/logout_saml_user_spec.rb
@@ -54,7 +54,11 @@ RSpec.describe Operations::Authentication::LogoutSamlUser do
 
     before :each do
       allow(SamlInformation).to receive(:idp_slo_target_url).and_return("https://my.logout.example/saml/logout_endpoint")
-      stub_request(:post, "https://my.logout.example/saml/logout_endpoint").to_return(body: "OK")
+      stub_request(:get, %r{https://my.logout.example/saml/logout_endpoint}).with do |req|
+        path_matches = req.uri.path == "/saml/logout_endpoint"
+        query = Rack::Utils.parse_nested_query req.uri.query
+        path_matches && !query["SAMLRequest"].nil?
+      end.to_return(body: "OK")
     end
 
     it "constructs and submits the logout payload" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [X] For all UI changes, there is cucumber coverage
- [X] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [X] Any endpoint modified in the PR only responds to the expected MIME types.
- [X] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [X] There are no inline styles added
- [X] There are no inline javascript added
- [X] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [X] Code does not use .html_safe
- [X] All images added/updated have alt text
- [X] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188043288

# A brief description of the changes

Current behavior:  When using more recent versions of Keycloak, logout redirects to the identity provider, but still requires you click an additional button to 'actually' log out.

New behavior:  Log out means log out.