### PR TITLE
refactor last alpha pagination to condense letters

### DIFF
--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/application_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/application_controller.rb
@@ -67,6 +67,7 @@ module BenefitSponsors
       false
     end
 
+    # rubocop:disable Lint/EmptyRescueClause
     def set_flash_by_announcement
       return if current_user.blank?
       if flash.blank? || flash[:warning].blank?
@@ -86,6 +87,7 @@ module BenefitSponsors
         end
       end
     end
+    # rubocop:enable Lint/EmptyRescueClause
 
     def set_ie_flash_by_announcement
       return unless check_browser_compatibility

--- a/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/broker_agencies/broker_agency_profiles_controller.rb
+++ b/components/benefit_sponsors/app/controllers/benefit_sponsors/profiles/broker_agencies/broker_agency_profiles_controller.rb
@@ -50,7 +50,12 @@ module BenefitSponsors
           @q = params.permit(:q)[:q]
 
           @staff = eligible_brokers
-          @page_alphabets = page_alphabets(@staff, "last_name")
+          @page_alphabets = if EnrollRegistry.feature_enabled?(:bs4_consumer_flow)
+                              grouped_alphabet(@staff, "last_name")
+                            else
+                              page_alphabets(@staff, "last_name")
+                            end
+          @alph_labels = @page_alphabets.map{|alph| [alph.first, alph.last].join("–")} if EnrollRegistry.feature_enabled?(:bs4_consumer_flow)
           page_no = cur_page_no(@page_alphabets.first)
           @staff = if @q.nil?
                      @staff.where(last_name: /^#{page_no}/i)

--- a/components/benefit_sponsors/app/helpers/benefit_sponsors/application_helper.rb
+++ b/components/benefit_sponsors/app/helpers/benefit_sponsors/application_helper.rb
@@ -221,5 +221,12 @@ module BenefitSponsors
       next_page_index = active_page_index.to_i + 1
       pages[next_page_index]
     end
+
+    def current_page(page_param, pages)
+      return pages.first unless page_param.present?
+      JSON.parse(page_param)
+    rescue JSON::ParserError, TypeError
+      page_param
+    end
   end
 end

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_profiles/_staff.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_profiles/_staff.html.erb
@@ -8,7 +8,7 @@
       <%= render 'benefit_sponsors/profiles/broker_agencies/broker_agency_profiles/staff_table'%>
     </table>
     <div>
-      <%= render 'benefit_sponsors/shared/profiles/broker_agency/alph_paginate_remote', url: benefit_sponsors.staff_index_profiles_broker_agencies_broker_agency_profiles_path(bs4: @bs4), alphs: @page_alphabets %>
+      <%= render 'benefit_sponsors/shared/profiles/broker_agency/alph_paginate_remote', url: benefit_sponsors.staff_index_profiles_broker_agencies_broker_agency_profiles_path(bs4: @bs4), alphs: @page_alphabets, alph_labels: @alph_labels %>
     </div>
   </div>
    <div id='help_index_status'></div>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/shared/profiles/broker_agency/_alph_paginate_remote.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/shared/profiles/broker_agency/_alph_paginate_remote.html.erb
@@ -1,24 +1,27 @@
+
 <% all ||= nil %>
+<% alph_labels ||= nil %>
 <% remote = remote.blank? ? false : remote %>
 <% status ||= nil %>
 <% url_params ||= {} %>
+<% url_params[:status] = status if status.present? %>
+<% url_param_string = url_params.inject([]){|arr, (k,v)| arr << "#{k}=#{v}"}.join("&") if !url_params.empty? %>
 <% if @bs4 %>
-  <% url += "&" + url_params.inject([]){|arr, (k,v)| arr << "#{k}=#{v}"}.join("&") if !url_params.empty? %>
-  <% url += "&status=#{status}" if status %>
-  <% current_page = params[:page] || alphs.first %>
+  <% url += "&" + url_param_string if url_param_string.present? %>
+  <% current_page = current_page(params[:page], alphs) %>
   <nav aria-label="broker navigation by last name">
     <ul class="pagination justify-content-center">
       <% prev_alph = previous_page(alphs, current_page) %>
       <li class="page-item <%= 'disabled' if current_page == alphs.first %>"><%= h(link_to l10n("previous"), (prev_alph.present? ? url + "&page=#{prev_alph}" : "#"), remote: true, class: 'page-link') %></li>
       <% if all %>
         <% all_url = all %>
-        <% all_url += "&" + url_params.inject([]){|arr, (k,v)| arr << "#{k}=#{v}"}.join("&") if !url_params.empty? %>
+        <% all_url += "&" + url_param_string if url_param_string.present? %>
         <li class="page-item"><%= h(link_to l10n("all"), all_url, remote: true, class:"page-link") %></li>
       <% end %>
       <% alphs.each_with_index do |alph, index| %>
         <% alph_url = url + "&page=#{alph}" %>
-        <% active = params[:page] ? alph == params[:page] : index == 0 %>
-        <li class="page-item <%= 'active' if active %>"><%= h(link_to alph, (alph_url), remote: true, class: 'page-link') %></li>
+        <% alph_label = alph_labels.present? ? alph_labels[index] : alph %>
+        <li class="page-item <%= 'active' if alph == current_page %>"><%= h(link_to alph_label, (alph_url), remote: true, class: 'page-link') %></li>
       <% end %>
       <% next_alph = next_page(alphs, current_page) %>
       <li class="page-item <%= 'disabled' if current_page == alphs.last %>"><%= h(link_to l10n("next"), (next_alph.present? ? url + "&page=#{next_alph}" : "#"), remote: true, class: 'page-link') %></li>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188226005#

# A brief description of the changes

Current behavior: all letters that had a broker whose last name started with that letter appeared in the pagination. This means in the modal you can't see all the options

New behavior: the letters are condensed into groups on letters instead.
