### PR TITLE
switch onblur to oninput so modal doesn't show if date hasn't changed

### DIFF
--- a/app/views/ui-components/bs4/v1/forms/broker/_personal_information.html.erb
+++ b/app/views/ui-components/bs4/v1/forms/broker/_personal_information.html.erb
@@ -34,7 +34,7 @@
       min: 110.years.ago,
       max: 16.years.ago.beginning_of_month,
       required: true,
-      onblur: 'validDob(this)'
+      oninput: 'validDob(this)'
     %>
     <div class="invalid-feedback">
       <%= l10n("invalid_dob") %>

--- a/app/views/ui-components/bs4/v1/forms/broker/_staff_registration.html.erb
+++ b/app/views/ui-components/bs4/v1/forms/broker/_staff_registration.html.erb
@@ -24,7 +24,7 @@
   </div>
   <div class="col-md-3 mb-2">
     <%= f.label :dob, l10n("broker_agencies.dob"), class: "required" %>
-    <%= f.date_field :dob, placeholder: l10n('dob_format'), min: 110.years.ago, max: 18.years.ago.end_of_month, required: true, class: 'form-control', onblur: 'validDob(this)' %>
+    <%= f.date_field :dob, placeholder: l10n('dob_format'), min: 110.years.ago, max: 18.years.ago.end_of_month, required: true, class: 'form-control', oninput: 'validDob(this)' %>
     <div class="invalid-feedback">
       <%= l10n("invalid_dob") %>
     </div>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188227909

# A brief description of the changes

Current behavior: the invalid dob popup shows any time it loses focus, even if the DOB hasn't changed.

New behavior: the invalid db shows up after the user has inputed a new value that is invalid.