### PR TITLE
bs4 fix edit broker add address submit

### DIFF
--- a/app/javascript/benefit_sponsors/controllers/office_locations_controller.js
+++ b/app/javascript/benefit_sponsors/controllers/office_locations_controller.js
@@ -62,17 +62,16 @@ export default class extends Controller {
       });
 
       newLocation.querySelectorAll('input').forEach(function(input) {
-
-        var name = input.getAttribute('name').replace('[0]', `[${totalLocationsCount}]`);
-        input.setAttribute('name', name);
-        input.setAttribute('id', name);
-        if (input?.previousElementSibling) input.previousElementSibling.setAttribute('for', name);
-
         if (bs4 == "true" && input.id == "phoneType") {
           input.value = "work";
         } else {
           input.value = '';
         }
+
+        var name = input.getAttribute('name').replace('[0]', `[${totalLocationsCount}]`);
+        input.setAttribute('name', name);
+        input.setAttribute('id', name);
+        if (input?.previousElementSibling) input.previousElementSibling.setAttribute('for', name);
       })
 
       if (bs4 == "true") {
@@ -93,11 +92,6 @@ export default class extends Controller {
       }
 
       newLocation.querySelectorAll('select').forEach(function(input) {
-        var name = input.getAttribute('name').replace('[0]', `[${totalLocationsCount}]`);
-        input.setAttribute('name', name);
-        input.setAttribute('id', name);
-        input.previousElementSibling.setAttribute('for', name);
-
         if (input.value != "work" && input.id != "kindSelect") {
           input.value = '';
         }
@@ -105,6 +99,11 @@ export default class extends Controller {
         if (input.id == "kindSelect") {
           input[0].remove();
         }
+
+        var name = input.getAttribute('name').replace('[0]', `[${totalLocationsCount}]`);
+        input.setAttribute('name', name);
+        input.setAttribute('id', name);
+        input.previousElementSibling.setAttribute('for', name);
       })
 
       this.officeLocationsTarget.appendChild(newLocation);


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188235242

The error implicated in the bug is about some "kind" field missing. Unintuitively, this "kind" field is _not_ the `address.kind`, but rather the `phone.kind`. There's a hidden field within the contact_info form for this field, but it is not given a value in the HTML. Rather, the value is set in the JS which manages the new address field, `office_locations.js`. There's a check on the id of the input, which expects `id="phoneType"`. The issue here is that, we recently updated this JS to better account for WAVE label errors by selecting all inputs and overriding the cloned ids and names to match the index of the new address, thus enforcing unique label/input ids for the address forms. This is fine. Unfortunately, these writes to the input ids happened _before_ the "phoneType" id check, which meant that the phone kind field was never selected and therefore empty.

I've updated this check to occur before we change the input ids for WAVE.
