### PR TITLE
bs4 fix fa family info add new

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
@@ -1,5 +1,4 @@
-<% if @bs4 %>
-  <h1>dep form</h1>
+<% if @bs4 %>å
   <% dependent = @applicant %>
   <div id="<%= employee_dependent_form_id(dependent) %>" class="dependent_list py-5">
     <% is_editing = dependent.id.present? %>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
@@ -183,7 +183,11 @@
            $('#addressChangeConfirmation').modal('show');
         }
         else {
+          $(this).addClass("disabled").attr('tabindex', -1).blur();
           PersonValidations.manageRequiredValidations($('#confirm-dependent'));
+          if (!$(this).closest('form')[0].checkValidity()) {
+            $(this).removeClass("disabled");
+          }
         }
 
       });

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
@@ -1,4 +1,5 @@
 <% if @bs4 %>
+  <h1>dep form</h1>
   <% dependent = @applicant %>
   <div id="<%= employee_dependent_form_id(dependent) %>" class="dependent_list py-5">
     <% is_editing = dependent.id.present? %>
@@ -186,7 +187,7 @@
           $(this).addClass("disabled").attr('tabindex', -1).blur();
           PersonValidations.manageRequiredValidations($('#confirm-dependent'));
           if (!$(this).closest('form')[0].checkValidity()) {
-            $(this).removeClass("disabled");
+            $(this).removeClass("disabled").attr('tabindex', 0);
           }
         }
 

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_dependent_form.html.erb
@@ -1,4 +1,4 @@
-<% if @bs4 %>å
+<% if @bs4 %>
   <% dependent = @applicant %>
   <div id="<%= employee_dependent_form_id(dependent) %>" class="dependent_list py-5">
     <% is_editing = dependent.id.present? %>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -1,4 +1,4 @@
-<% if @bs4 %>å
+<% if @bs4 %>
   <%= form_for @applicant, url: application_applicant_path(@application, @applicant), method: :patch do |f|%>
     <%= hidden_field_tag :is_dependent, @applicant.is_dependent? %>
     <% readonly_status = @applicant.is_primary_applicant? %>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -213,16 +213,12 @@
         }
 
         $(".btn-confirmation").removeAttr('disabled');
-
-        var form = $('#new_dependent')[0] || $('#edit_dependent')[0];
-        if (!$("input#applicant_same_with_primary").is(":checked")) {
-          $('#addressChangeConfirmation').modal('show');
-        }
-        else {
-          PersonValidations.manageRequiredValidations($('#confirm_member'));
-        }
-      } else {
-        PersonValidations.manageRequiredValidations($('#confirm_member'));
+      }
+      $(this).addClass("disabled").attr('tabindex', -1).blur();
+      PersonValidations.manageRequiredValidations($('#confirm_member'));
+      if (!$(this).closest('form')[0].checkValidity()) {
+        $(this).removeClass("disabled");
+        $(this).addClass("disabled").attr('tabindex', 0);
       }
     });
   </script>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -139,7 +139,7 @@
       <%= f.button(id: 'confirm-member', class: "btn btn-primary hidden") do %>
         <%= l10n("confirm_member") %>
       <% end %>
-      <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'confirm_member')" id="confirm_member" class="btn btn-primary" onclick='PersonValidations.manageRequiredValidations($(this));'>
+      <span tabindex="0" onkeydown="handleButtonKeyDown(event, 'confirm_member')" id="confirm_member" class="btn btn-primary">
         <%= l10n("confirm_member") %>
       </span>
     </div>
@@ -202,9 +202,10 @@
       });
     }
 
-    $(document).off('click', '#confirm-member');
-    $(document).on('click', '#confirm-member', function(e) {
-      if ($("input#applicant_same_with_primary")) {
+    $(document).off('click', '#confirm_member');
+    $(document).on('click', '#confirm_member', function(e) {
+      console.log('clicked');
+      if ($("input#applicant_same_with_primary").length) {
         if($("input#applicant_same_with_primary").is(":checked")){
           $("#applicant-home-address-area input.required, #applicant-home-address-area select.required, #applicant-home-address-area .address_required").removeAttr('required');
         } else {
@@ -218,8 +219,10 @@
           $('#addressChangeConfirmation').modal('show');
         }
         else {
-          PersonValidations.manageRequiredValidations($('#confirm-dependent'));
+          PersonValidations.manageRequiredValidations($('#confirm_member'));
         }
+      } else {
+        PersonValidations.manageRequiredValidations($('#confirm_member'));
       }
     });
   </script>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -1,5 +1,4 @@
-<% if @bs4 %>
-  <h1>edit HTML</h1>
+<% if @bs4 %>å
   <%= form_for @applicant, url: application_applicant_path(@application, @applicant), method: :patch do |f|%>
     <%= hidden_field_tag :is_dependent, @applicant.is_dependent? %>
     <% readonly_status = @applicant.is_primary_applicant? %>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -1,4 +1,5 @@
 <% if @bs4 %>
+  <h1>edit HTML</h1>
   <%= form_for @applicant, url: application_applicant_path(@application, @applicant), method: :patch do |f|%>
     <%= hidden_field_tag :is_dependent, @applicant.is_dependent? %>
     <% readonly_status = @applicant.is_primary_applicant? %>
@@ -216,8 +217,7 @@
       $(this).addClass("disabled").attr('tabindex', -1).blur();
       PersonValidations.manageRequiredValidations($('#confirm_member'));
       if (!$(this).closest('form')[0].checkValidity()) {
-        $(this).removeClass("disabled");
-        $(this).addClass("disabled").attr('tabindex', 0);
+        $(this).removeClass("disabled").attr('tabindex', 0);
       }
     });
   </script>

--- a/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/_edit.html.erb
@@ -204,7 +204,6 @@
 
     $(document).off('click', '#confirm_member');
     $(document).on('click', '#confirm_member', function(e) {
-      console.log('clicked');
       if ($("input#applicant_same_with_primary").length) {
         if($("input#applicant_same_with_primary").is(":checked")){
           $("#applicant-home-address-area input.required, #applicant-home-address-area select.required, #applicant-home-address-area .address_required").removeAttr('required');


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640062/stories/188235088#

This bug was caused by a recursive overflow. It requires knowing a couple things about how form submission works on the FA Family Info page:

1. Two similar form partials are used for edit vs add new dependent:
- `views/financial_assistance/applicants/_edit.html.erb`: The form partial used when editing a primary/dependent
- `views/financial_assistance/applicants/_dependent_form.html.erb`: The form partial used when creating a new dependent.
2. Both of these forms use the hidden submit button pattern for form validation, where a user-facing submit button serves to hit the `manageRequiredValidations` helper which itself will then click the hidden submit button following successful validation.
3. Both forms setup separate listeners on the submit button... however, it appears they were out of sync on this bit.
- `views/financial_assistance/applicants/_edit.html.erb` had a listener on its hidden submit button, `confirm-member`. Notably, this listener fired `manageRequiredValidations` on a button id (`confirm-dependent`) which only existed on the other form...
- `views/financial_assistance/applicants/_dependent_form.html.erb` has a listener on its visible button, `confirm-dependent`.

Note that both versions of the form had the same id for the hidden submit button, `confirm-member`. While both forms do technically unbind their respective listeners on their loads, the `confirm-member` from the edit form will persist on the add form because that form is listening on an entirely different id.

All this is to say that... in the edge case where a user went into the edit form, cancelled it (which reloads the page through ajax, maintaining any listeners), then went into the add new form and clicked Confirm, the JS would crash as its call stack would overflow. Pressing the visible button on this page in this case would result in the edit form's listener getting hit as well, and because (for whatever reason), that page fired `manageRequiredValidations` on a button id for this form, `manageRequiredValidations` was being called endlessly.

I've amended this by fixing the `manageRequiredValidations` call on edit so that it fires for the correct element, and fixed its listener to listen on the visible button instead of the hidden submit.

I've also updated both scripts to disable the button while submitting, and removed a modal check from the edit form as the modal didn't exist.

