### PR TITLE
bs4 fix broker address text

### DIFF
--- a/app/views/ui-components/bs4/v1/forms/broker/contact_information/_address.html.erb
+++ b/app/views/ui-components/bs4/v1/forms/broker/contact_information/_address.html.erb
@@ -6,8 +6,8 @@
 <div id="address_info">
   <div class="row mb-2">
     <div class="col-md-6 col-sm-6 col-xs-12">
-      <%= f.label :address_1, l10n("address_1"), class: "required" %>
-      <%= f.text_field :address_1, class: "form-control mb-1", placeholder: l10n('address_1_placeholder'), required: true %>
+      <%= f.label :address_1, "#{l10n("address_1")} #{l10n("address_1_desc")}", class: "required" %>
+      <%= f.text_field :address_1, class: "form-control mb-1", placeholder: l10n('address_1'), required: true %>
       <div class="invalid-feedback">
         <%= l10n('address.address_1_error') %>
       </div>

--- a/db/seedfiles/translations/en/cca/address.rb
+++ b/db/seedfiles/translations/en/cca/address.rb
@@ -1,12 +1,9 @@
 # Address Translations
 ADDRESS_TRANSLATIONS = {
-    :'en.address.address_1_text' => 'ADDRESS LINE 1 (NUMBER, STREET, QUADRANT) *',
-    :'en.address.address_2_text' => 'ADDRESS LINE 2 (APT, UNIT, ETC.)',
     :'en.address.city_text' => 'City *',
     :'en.address.select_state_text' => 'Select State *',
     :'en.address.zip_text' => 'ZIP *',
     :'en.address.address_1_error' => 'Please provide a valid address.',
-    :'en.address.address_1_placeholder' => '123 Main St',
     :'en.address.city_error' => 'Please provide a valid city.',
     :'en.address.state_error' => 'Please select a state.',
     :'en.address.zip_code_error' => 'Please provide a valid zipcode.',

--- a/db/seedfiles/translations/en/dc/address.rb
+++ b/db/seedfiles/translations/en/dc/address.rb
@@ -6,7 +6,6 @@ ADDRESS_TRANSLATIONS = {
     :'en.address.select_state_text' => 'Select State *',
     :'en.address.zip_text' => 'ZIP *',
     :'en.address.address_1_error' => 'Please provide a valid address.',
-    :'en.address.address_1_placeholder' => '123 Main St',
     :'en.address.city_error' => 'Please provide a valid city.',
     :'en.address.state_error' => 'Please select a state.',
     :'en.address.zip_code_error' => 'Please provide a valid zipcode.',

--- a/db/seedfiles/translations/en/me/address.rb
+++ b/db/seedfiles/translations/en/me/address.rb
@@ -6,7 +6,6 @@ ADDRESS_TRANSLATIONS = {
     :'en.address.select_state_text' => 'Select State *',
     :'en.address.zip_text' => 'ZIP *',
     :'en.address.address_1_error' => 'Please provide a valid address.',
-    :'en.address.address_1_placeholder' => '123 Main St',
     :'en.address.city_error' => 'Please provide a valid city.',
     :'en.address.state_error' => 'Please select a state.',
     :'en.address.zip_code_error' => 'Please provide a valid zipcode.',


### PR DESCRIPTION
Updates the text used on the Broker address line 1 field.

# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188251389