### PR TITLE
change quote style in cucumber expectation to match translation

### DIFF
--- a/features/financial_assistance/step_definitions/job_income_steps.rb
+++ b/features/financial_assistance/step_definitions/job_income_steps.rb
@@ -227,7 +227,7 @@ Then(/^the user should see the popup for the (.*) income question$/) do |income_
     popup_text = "Select ‘yes’ if this person is considered an employee of a business, or receives a W-2 federal form from any employer. " \
     "We need to know about all income this person receives from an employer, including wages, tips, salaries, and bonuses."
   when 'self employment'
-    popup_text = "Select 'yes' if this person owns a business or receives a federal form 1099 from any employer. " \
+    popup_text = "Select ‘yes’ if this person owns a business or receives a federal form 1099 from any employer. " \
     "We need to know about any income this person receives as an independent contractor or from a business they own."
   when 'unemployment'
     popup_text = "Select ‘yes’ if this person received one or more types of unemployment income"


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [ ] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: No ticket, spec failure

# A brief description of the changes

Current behavior: due to a translation change yesterday, the expectation for the popup text does not match what is in the translation file
