### PR TITLE
remove my portal link for single role users

### DIFF
--- a/app/helpers/bs4/bs4_header_helper.rb
+++ b/app/helpers/bs4/bs4_header_helper.rb
@@ -53,10 +53,9 @@ module Bs4
       end
     end
 
-    def my_portal_link(_controller)
+    def my_portal_link_roles
       return nil unless user_has_multiple_roles?
-      roles = all_non_admin_roles
-      render partial: 'ui-components/bs4/v1/navs/multi_role_my_portal_links', locals: roles
+      all_non_admin_roles
     end
 
     def get_broker_profile_path # rubocop:disable Naming/AccessorMethodName

--- a/app/helpers/bs4/bs4_header_helper.rb
+++ b/app/helpers/bs4/bs4_header_helper.rb
@@ -3,7 +3,7 @@
 # Here is a comment
 module Bs4
   # this is used with the new bs4 header
-  module Bs4HeaderHelper # rubocop:disable Metrics/ModuleLength
+  module Bs4HeaderHelper
     include L10nHelper
     include ApplicationHelper
 
@@ -53,50 +53,10 @@ module Bs4
       end
     end
 
-    def my_portal_link(controller) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-      ltext = l10n("layout.header.portal")
-      if current_user.nil?
-        nil
-      elsif current_user.try(:has_hbx_staff_role?)
-        link_to(ltext, main_app.exchanges_hbx_profiles_root_path)
-      elsif user_has_multiple_roles?
-        roles = all_non_admin_roles
-        render partial: 'ui-components/bs4/v1/navs/multi_role_my_portal_links', locals: roles
-      elsif display_i_am_broker_for_consumer?(current_user.person) && controller_path.exclude?('general_agencies')
-        link_to(ltext, get_broker_profile_path)
-      elsif current_user.try(:person).try(:csr_role) || current_user.try(:person).try(:assister_role)
-        link_to(ltext, main_app.home_exchanges_agents_path)
-      elsif current_user.person&.active_employee_roles&.any?
-        if controller_path.include?('broker_agencies')
-          link_to(ltext, get_broker_profile_path)
-        elsif controller_path.include?('general_agencies')
-          link_to(ltext, benefit_sponsors.profiles_general_agencies_general_agency_profile_path(id: current_user.person.general_agency_staff_roles.first.benefit_sponsors_general_agency_profile_id))
-        elsif controller == 'employer_profiles' || controller_path.include?('employers')
-          #current user has both broker_agency staff role and employee role but not employer_staff_roles
-          if current_user.person.active_employer_staff_roles.present?
-            employer_profile_path = benefit_sponsors.profiles_employers_employer_profile_path(id: current_user.person.active_employer_staff_roles.first.benefit_sponsor_employer_profile_id, :tab => 'home')
-            link_to(ltext, employer_profile_path)
-          elsif current_user.try(:has_broker_agency_staff_role?)
-            link_to(ltext, get_broker_profile_path)
-          end
-        else
-          link_to(ltext, main_app.family_account_path)
-        end
-      elsif current_user.try(:has_consumer_role?)
-        link_to(ltext, main_app.family_account_path) if current_user.try(:has_consumer_role?).try(:identity_validation) == "valid"
-      # rubocop:disable Lint/DuplicateBranch
-      elsif current_user.try(:has_broker_agency_staff_role?) && controller_path.exclude?('general_agencies') && controller_path.exclude?('employers')
-        link_to(ltext, get_broker_profile_path)
-      # rubocop:enable Lint/DuplicateBranch
-      elsif current_user.try(:has_general_agency_staff_role?)
-        if current_user.try(:has_employer_staff_role?) && controller_path.include?('employers')
-          link_to(ltext, benefit_sponsors.profiles_employers_employer_profile_path(id: current_user.person.active_employer_staff_roles.first.benefit_sponsor_employer_profile_id, :tab => 'home'))
-        else
-          link_to(ltext, benefit_sponsors.profiles_general_agencies_general_agency_profile_path(id: current_user.person.active_general_agency_staff_roles.first.benefit_sponsors_general_agency_profile_id))
-        end
-      elsif current_user.try(:has_employer_staff_role?)
-        link_to(ltext, benefit_sponsors.profiles_employers_employer_profile_path(id: current_user.person.active_employer_staff_roles.first.benefit_sponsor_employer_profile_id, :tab => 'home'))
-      end
+    def my_portal_link(_controller)
+      return nil unless user_has_multiple_roles?
+      roles = all_non_admin_roles
+      render partial: 'ui-components/bs4/v1/navs/multi_role_my_portal_links', locals: roles
     end
 
     def get_broker_profile_path # rubocop:disable Naming/AccessorMethodName

--- a/app/views/ui-components/bs4/v1/navs/_header.html.erb
+++ b/app/views/ui-components/bs4/v1/navs/_header.html.erb
@@ -50,7 +50,7 @@
                 <div class="bold m-0 p-0"><%= user_first_name_last_name_and_suffix %></div>
                 <div class="horizontal-links">
                   <% unless user_id.blank? %><span><%= l10n("id").upcase %>: <%= user_id %></span><% end %>
-                  <% if my_portal_link(controller).present? %><span class='position-relative'><%= my_portal_link(controller) %></span><% end %>
+                  <% if my_portal_link_roles.present? %><span class='position-relative'><%= render partial: 'ui-components/bs4/v1/navs/multi_role_my_portal_links', locals: my_portal_link_roles %></span><% end %>
                   <span><%= h(link_to l10n('layout.header.logout'), main_app.destroy_user_session_path, method: 'delete') %></span>
                 </div>
               </div>

--- a/spec/helpers/bs4/bs4_header_helper_spec.rb
+++ b/spec/helpers/bs4/bs4_header_helper_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bs4::Bs4HeaderHelper, :type => :helper, dbclean: :after_each do
+
+  context 'single role user' do
+    let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+    let(:consumer_role) { person.consumer_role }
+    let(:current_user) { FactoryBot.create(:user, person: person) }
+
+    describe 'my_portal_link_roles' do
+      it "should return nil" do
+        expect(my_portal_link_roles).to be_nil
+      end
+    end
+
+    describe 'user_has_multiple_roles?' do
+      it "should return false" do
+        expect(user_has_multiple_roles?).to eq(false)
+      end
+    end
+
+    describe 'bs4_portal_type' do
+      it "should return a link when the consumer is through identity_validation" do
+        consumer_role.update_attributes(identity_validation: 'valid', application_validation: 'valid')
+        expect(bs4_portal_type("")).to start_with("<a")
+      end
+
+      it "should not return a link when the consumer is not through identity_validation" do
+        consumer_role.update_attributes(identity_validation: 'na', application_validation: 'na')
+        expect(bs4_portal_type("")).not_to start_with("<a")
+      end
+    end
+  end
+
+  context 'multi role user' do
+    let(:person) { FactoryBot.create(:person, :with_consumer_role, :with_active_consumer_role) }
+    let(:consumer_role) { person.consumer_role }
+    let(:site) { create(:benefit_sponsors_site, :with_benefit_market, :as_hbx_profile, site_key: ::EnrollRegistry[:enroll_app].settings(:site_key).item) }
+    let(:broker_agency_organization) { FactoryBot.create(:benefit_sponsors_organizations_general_organization, :with_broker_agency_profile, site: site) }
+    let(:broker_agency_id) { broker_agency_organization.broker_agency_profile.id }
+    let(:current_user) { FactoryBot.create(:user, person: person) }
+
+    before do
+      consumer_role.update_attributes(identity_validation: 'valid', application_validation: 'valid')
+      person.broker_agency_staff_roles.create!(
+        {
+          aasm_state: 'active',
+          benefit_sponsors_broker_agency_profile_id: broker_agency_id
+        }
+      )
+    end
+
+    describe 'my_portal_link_roles' do
+      it "should return multiple values" do
+        expect(my_portal_link_roles.length).to be > 1
+      end
+    end
+
+    describe 'user_has_multiple_roles?' do
+      it "should return true" do
+        expect(user_has_multiple_roles?).to eq(true)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188219230

# A brief description of the changes

Current behavior: In the BS4 views, a my portal was added for all users. 

New behavior: During UAT, the client changed their mind and only wants the link to show for users with multiple roles.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: This work is under the BS4_CONSUMER_FLOW_IS_ENABLED flag

- [ ] DC
- [X] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
