### PR TITLE
prevent request error on broker login after expert staff submission

### DIFF
--- a/app/assets/javascripts/help_me_sign_up.js
+++ b/app/assets/javascripts/help_me_sign_up.js
@@ -48,6 +48,10 @@ $(document).on('click', '#back_to_help', function(){
 })
 
 $(document).on('click', '.select-broker', function(){
+  let person = $('#help_requestor').html();
+  console.log('person', person);
+  console.log("HELP ME!!!!");
+
   $.ajax({
     type: 'GET',
     data: {assister: this.getAttribute('data-assister'), broker: this.getAttribute('data-broker'),

--- a/app/assets/javascripts/help_me_sign_up.js
+++ b/app/assets/javascripts/help_me_sign_up.js
@@ -48,10 +48,6 @@ $(document).on('click', '#back_to_help', function(){
 })
 
 $(document).on('click', '.select-broker', function(){
-  let person = $('#help_requestor').html();
-  console.log('person', person);
-  console.log("HELP ME!!!!");
-
   $.ajax({
     type: 'GET',
     data: {assister: this.getAttribute('data-assister'), broker: this.getAttribute('data-broker'),

--- a/app/javascript/benefit_sponsors/controllers/office_locations_controller.js
+++ b/app/javascript/benefit_sponsors/controllers/office_locations_controller.js
@@ -23,6 +23,10 @@ export default class extends Controller {
       if (bs4 != "true") {
         document.getElementById('kindSelect')[0].remove();
         document.getElementById('agency_organization_profile_attributes_office_locations_attributes_0_phone_attributes_kind')[0].remove();
+      } else {
+        document.querySelectorAll('.phone_number').forEach(inputField => {
+          this.addPhoneValidityCheck(inputField);
+        })
       }
     }
     this.officeLocationTargets.forEach(target => {
@@ -92,11 +96,10 @@ export default class extends Controller {
         // when copied from a preexisting lastLocation node, the timing with setting 'setCustomValidity'
         // and rendering a new office location form is off,
         // resulting in the onInvalid and onInput events not firing
-        ['input', 'invalid'].forEach(handler => {
-          newLocation.querySelector(".phone_number").addEventListener(handler, (event) => {
-            this.checkBrokerPhone(event.target);
-            if (handler == 'input') { event.target.value = this.fullPhoneMask(event.target.value) };
-          });
+        let newPhone = newLocation.querySelector(".phone_number");
+        this.addPhoneValidityCheck(newPhone);
+        newPhone.addEventListener('input', (event) => {
+          event.target.value = this.fullPhoneMask(event.target.value);
         });
       } else {
         newLocation.querySelector('input[placeholder="ZIP"]').setAttribute('data-action', "");
@@ -128,6 +131,14 @@ export default class extends Controller {
 
       this.officeLocationsTarget.appendChild(newLocation);
     }
+  }
+
+  addPhoneValidityCheck(inputField) {
+    ['input', 'invalid'].forEach(handler => {
+      inputField.addEventListener(handler, (event) => {
+        this.checkBrokerPhone(event.target);
+      });
+    });
   }
 
   removeLocation(event) {

--- a/app/javascript/css/table.scss
+++ b/app/javascript/css/table.scss
@@ -174,7 +174,7 @@ table {
         }
       }
 
-      tbody.select-broker {
+      tbody.staff-select-broker {
         &.agency-selected {
           border: 2px solid var(--button-tertiary-color);
 

--- a/app/views/ui-components/bs4/v1/forms/broker/contact_information/_phone.html.erb
+++ b/app/views/ui-components/bs4/v1/forms/broker/contact_information/_phone.html.erb
@@ -10,8 +10,6 @@
       minlength: '14',
       maxlength: '14',
       onkeypress: 'return isNumberKey(event)',
-      oninvalid: "this.setCustomValidity('#{phone_error}')",
-      oninput: "this.setCustomValidity('')",
       value: determine_phone_number(f.object),
       data: { :"error-message" => phone_error }
     %>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_staff_roles/_new_staff_applicant.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_staff_roles/_new_staff_applicant.html.erb
@@ -71,13 +71,13 @@
   function selectBrokereAgency(element) {
     var result = document.querySelectorAll('.result');
     result.forEach(function (result) {
-      var elements = result.querySelectorAll('.select-broker');
+      var elements = result.querySelectorAll('.staff-select-broker');
       elements.forEach(function (ele) {
         ele.classList.remove("agency-selected");
       });
     });
     document.getElementById('staff_profile_id').value = element.dataset.broker_agency_profile_id;
-    element.closest(".select-broker").classList.add('agency-selected');
+    element.closest(".staff-select-broker").classList.add('agency-selected');
     document.getElementById('broker-staff-btn').disabled = false;
   }
 </script>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_staff_roles/_search_broker_agency.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_staff_roles/_search_broker_agency.html.erb
@@ -11,7 +11,7 @@
           </tr>
         </thead>
         <% @broker_agency_profiles.each do |agency| %>
-          <tbody class="select-broker">
+          <tbody class="staff-select-broker">
             <tr>
               <td class="col-5"><%= agency.legal_name %></td>
               <td class="col-1"><%= agency.primary_broker_role&.npn %></td>
@@ -43,7 +43,7 @@
         <th style='width: 18%'> <%= l10n("select_this_broker_button") %></th>
         </thead>
         <% @broker_agency_profiles.each do |agency| %>
-          <tbody class="select-broker">
+          <tbody class="staff-select-broker">
           <tr style='border: 1px solid #d5d5d5; height: 50px;'>
             <td><%= agency.legal_name %></td>
             <td><%= agency.primary_broker_role&.npn %></td>

--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_staff_roles/new.html.slim
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_staff_roles/new.html.slim
@@ -56,12 +56,12 @@ javascript:
   function selectBrokereAgency(element) {
     var result = document.querySelectorAll('.result');
     result.forEach(function (result) {
-        var element = result.querySelectorAll('.select-broker')
+        var element = result.querySelectorAll('.staff-select-broker')
         element.forEach(function (ele) {
             ele.classList.remove("agency-selected");
         })
     });
     document.getElementById('staff_profile_id').value = element.dataset.broker_agency_profile_id;
-    element.closest(".select-broker").classList.add('agency-selected')
+    element.closest(".staff-select-broker").classList.add('agency-selected')
       document.getElementById('broker-staff-btn').disabled = false;
   }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188253758

# A brief description of the changes

Current behavior: After logging out and submitting a broker staff application, a broker attempting to login will get a `We couldn't process your request` screen, due to the `request_help` endpoint being hit by a javascript call.

New behavior: Renamed broker table class to avoid making `request_help` call on broker login. Also added method to check phone number validity on page load for brokers --> previously, `setCustomValidity` was being used `onInput` and `onInvalid`, which would occasionally not render in time in the prod environment.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
