### PR TITLE
change cloned member tobacco_use to default NA

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -364,7 +364,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
     old_enrollment_members.inject([]) do |members, hbx_enrollment_member|
       member = latest_enrollment.hbx_enrollment_members.where(applicant_id: hbx_enrollment_member.applicant_id).first
 
-      tobacco_use = EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage) ? "U" : (member&.tobacco_use || "N")
+      tobacco_use = EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage) ? "NA" : (member&.tobacco_use || "N")
 
       members << HbxEnrollmentMember.new({ applicant_id: hbx_enrollment_member.applicant_id,
                                            eligibility_date: renewal_coverage_start,

--- a/app/models/enrollments/replicator/reinstatement.rb
+++ b/app/models/enrollments/replicator/reinstatement.rb
@@ -221,7 +221,7 @@ module Enrollments
         enr_members.inject([]) do |members, hbx_enrollment_member|
           member = latest_enrollment.hbx_enrollment_members.where(applicant_id: hbx_enrollment_member.applicant_id).first
 
-          tobacco_use = EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage) ? "U" : (member&.tobacco_use || "N")
+          tobacco_use = EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage) ? "NA" : (member&.tobacco_use || "N")
 
           members << HbxEnrollmentMember.new({
                                                applicant_id: hbx_enrollment_member.applicant_id,

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -536,7 +536,7 @@ class Person
   end
 
   def set_default_tobacco_use
-    self.is_tobacco_user = "U" if EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage)
+    self.is_tobacco_user = "unknown" if EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage)
   end
 
   def strip_empty_fields

--- a/components/financial_assistance/app/models/financial_assistance/applicant.rb
+++ b/components/financial_assistance/app/models/financial_assistance/applicant.rb
@@ -391,7 +391,7 @@ module FinancialAssistance
     end
 
     def set_default_tobacco_use
-      self.is_tobacco_user = "U" if EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage)
+      self.is_tobacco_user = "unknown" if EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage)
     end
 
     def accept(visitor)
@@ -798,7 +798,7 @@ module FinancialAssistance
     end
 
     def tobacco_user
-      EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage) ? "U" : (person.is_tobacco_user || "unknown")
+      EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage) ? "unknown" : (person.is_tobacco_user || "unknown")
     end
 
     def eligibility_determination=(eg)

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/applicant/create_or_update_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/applicant/create_or_update_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe FinancialAssistance::Operations::Applicant::CreateOrUpdate, dbcle
       end
 
       let!(:applicant_params) do
-        default_tobacco_use = EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage) ? "U" : "unknown"
+        default_tobacco_use = "unknown"
         {:addresses => [{:address_1 => '1112 Awesome Street NE', :address_2 => '#112', :address_3 => '', :city => 'Washington', :country_name => '', :kind => 'home', :quadrant => "", :state => 'DC', :zip => '20001', county: ''},
                         {:address_1 => '1111 Awesome Street NE', :address_2 => '#111', :address_3 => '', :city => 'Washington', :country_name => '', :kind => 'work', :quadrant => "", :state => 'DC', :zip => '20001', county: ''}],
          :alien_number => nil,

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/application/create_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/application/create_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ::FinancialAssistance::Operations::Application::Create, dbclean: :after_each do
   let(:params) do
-    default_tobacco_use = EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage) ? "U" : "unknown"
+    default_tobacco_use = "unknown"
     {:family_id => BSON::ObjectId.new,
      :assistance_year => 2020,
      :benchmark_product_id => BSON::ObjectId.new,

--- a/components/financial_assistance/spec/domain/financial_assistance/operations/families/create_or_update_member_spec.rb
+++ b/components/financial_assistance/spec/domain/financial_assistance/operations/families/create_or_update_member_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe FinancialAssistance::Operations::Families::CreateOrUpdateMember, dbclean: :after_each do
 
   let(:params) do
-    default_tobacco_use = EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage) ? "U" : "unknown"
+    default_tobacco_use = "unknown"
     {applicant_params: {
         :first_name => "John",
         :last_name => "Smith5",

--- a/spec/domain/operations/families/add_financial_assistance_eligibility_determination_spec.rb
+++ b/spec/domain/operations/families/add_financial_assistance_eligibility_determination_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Operations::Families::AddFinancialAssistanceEligibilityDeterminat
     FactoryBot.create(:financial_assistance_application, params)
   end
   let(:params) do
-    default_tobacco_use = EnrollRegistry.feature_enabled?(:sensor_tobacco_carrier_usage) ? "U" : "unknown"
+    default_tobacco_use = "unknown"
     {:family_id => BSON::ObjectId(family.id),
      :assistance_year => 2020,
      :benchmark_product_id => BSON::ObjectId('5f6020f26e81d9c148d3db34'),


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: 
[188050157](https://www.pivotaltracker.com/n/projects/2640062/stories/188050157)

# A brief description of the changes
Cloned enrollment members for reinstatements and renewals are still defaulting to U instead of NA tobacco_use

Current behavior:
Cloned enrollment members for reinstatements and renewals will default to NA tobacco_use

New behavior:

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
