### PR TITLE
fix default option

### DIFF
--- a/app/domain/entities/qualifying_life_event_kind.rb
+++ b/app/domain/entities/qualifying_life_event_kind.rb
@@ -15,7 +15,6 @@ module Entities
     attribute :market_kind, Types::String
     attribute :effective_on_kinds, Types::Array.of(Types::String)
     attribute :ordinal_position, Types::Integer
-    attribute :is_common, Types::Bool
     attribute :coverage_start_on, Types::Date.optional
     attribute :coverage_end_on, Types::Date.optional
     attribute :event_kind_label, Types::String

--- a/app/domain/validators/qualifying_life_event_kind/qlek_contract.rb
+++ b/app/domain/validators/qualifying_life_event_kind/qlek_contract.rb
@@ -15,7 +15,6 @@ module Validators
         required(:market_kind).filled(:string)
         required(:effective_on_kinds).array(:string)
         optional(:ordinal_position).filled(:integer)
-        required(:is_common).filled(:bool)
         optional(:_id).maybe(:string)
         optional(:coverage_start_on).maybe(:date)
         optional(:coverage_end_on).maybe(:date)

--- a/app/javascript/controllers/sep_types_list_controller.js
+++ b/app/javascript/controllers/sep_types_list_controller.js
@@ -63,7 +63,7 @@ class UpdateListManager {
 
     let data = await response.json();
     let isSuccess = data["status"] === "success";
-    this.showBanner(data, data["message"], bannerDescription);
+    this.showBanner(isSuccess, data["message"], bannerDescription);
 
     return isSuccess;
   }
@@ -83,16 +83,17 @@ class UpdateListManager {
       var flashDiv = $("#sort_notification_msg");
       var flashHeader = flashDiv.find(".toast-header");
       flashDiv.show();
-      flashDiv.toggleClass("success", isSuccess);
-      flashDiv.toggleClass("error", !isSuccess);
-      flashHeader.toggleClass("success", isSuccess);
-      flashHeader.toggleClass("error", !isSuccess);
+      
+      flashDiv.removeClass("success").removeClass("error");
+      flashDiv.toggleClass("success", isSuccess).toggleClass("error", !isSuccess);
+      flashHeader.removeClass("success").removeClass("error");
+      flashHeader.toggleClass("success", isSuccess).toggleClass("error", !isSuccess);
       
       flashHeader.find("strong").text(bannerTitle);
+     
       var flashBody = flashDiv.find(".toast-body");
       if (bannerDescription) {
-        flashBody.removeClass("hidden");
-        flashBody.text(bannerDescription);
+        flashBody.removeClass("hidden").text(bannerDescription);
       } else {
         flashBody.addClass("hidden");
       }
@@ -142,7 +143,7 @@ class UpdateOrderManager extends UpdateListManager {
     }
 
     let sortData = [...enumeratedCards].map((entry) => { return { id: entry[1].dataset.id, position: entry[0] + 1 } });
-    super.updateList({sort_data: sortData}, bs4 ? nil : event.item.textContent);
+    super.updateList({sort_data: sortData}, event.item.textContent);
 	}
 }
 

--- a/app/javascript/controllers/sep_types_list_controller.js
+++ b/app/javascript/controllers/sep_types_list_controller.js
@@ -145,7 +145,7 @@ class UpdateOrderManager extends UpdateListManager {
       card.dataset.ordinal_position = index + 1;
     }
 
-    let sortData = [...enumeratedCards].map((entry) => { return { id: entry[1].dataset.id, position: entry[0] + 1 } });
+    let sortData = enumeratedCards.map((entry) => { return { id: entry[1].dataset.id, position: entry[0] + 1 } });
     super.updateList({sort_data: sortData}, event.item.textContent);
 	}
 }

--- a/app/javascript/controllers/sep_types_list_controller.js
+++ b/app/javascript/controllers/sep_types_list_controller.js
@@ -50,7 +50,7 @@ class UpdateListManager {
    * @param {Object} body The request body containing the list update data.
    * @returns {Promise} The fetch request promise.
    */
-  async updateList(body) {
+  async updateList(body, bannerDescription) {
     body.market_kind = this.marketKind;
 		const response = await fetch('update_list', {
       method: 'PATCH',
@@ -60,19 +60,47 @@ class UpdateListManager {
         'X-CSRF-Token': Rails.csrfToken()
       }
     });
-    return await response.json();
+
+    let data = await response.json();
+    let isSuccess = data["status"] === "success";
+    this.showBanner(data, data["message"], bannerDescription);
+
+    return isSuccess;
   }
 
   /**
    * Show or hide the respective response banner.
    * @param {boolean} isSuccess The success status of the request.
    */
-  showBanner(isSuccess) {
-    const successBanner = $('#success-flash');
-    const errorBanner = $('#error-flash');
-    successBanner.toggleClass('hidden', !isSuccess)
-    errorBanner.toggleClass('hidden', isSuccess)
-    return isSuccess ? successBanner : errorBanner;
+  showBanner(isSuccess, bannerTitle, bannerDescription) {
+    if (bs4) {
+      const successBanner = $('#success-flash');
+      const errorBanner = $('#error-flash');
+      successBanner.toggleClass('hidden', !isSuccess)
+      errorBanner.toggleClass('hidden', isSuccess)
+      var flashDiv = isSuccess ? successBanner : errorBanner;
+    } else {
+      var flashDiv = $("#sort_notification_msg");
+      var flashHeader = flashDiv.find(".toast-header");
+      flashDiv.show();
+      flashDiv.toggleClass("success", isSuccess);
+      flashDiv.toggleClass("error", !isSuccess);
+      flashHeader.toggleClass("success", isSuccess);
+      flashHeader.toggleClass("error", !isSuccess);
+      
+      flashHeader.find("strong").text(bannerTitle);
+      var flashBody = flashDiv.find(".toast-body");
+      if (bannerDescription) {
+        flashBody.removeClass("hidden");
+        flashBody.text(bannerDescription);
+      } else {
+        flashBody.addClass("hidden");
+      }
+    }
+
+    setTimeout(function() {
+      flashDiv.addClass('hidden');
+    }, 3500);
   }
 }
 
@@ -107,35 +135,14 @@ class UpdateOrderManager extends UpdateListManager {
       return;
     }
 
-    // map the card elements to an array of card ids and their ordinal positions
-    let enumeratedCards = cards.entries();
+    let enumeratedCards = [...cards.entries()];
     for (const [index, card] of enumeratedCards) {
       card.dataset.index = index;
       card.dataset.ordinal_position = index + 1;
     }
-    let sortData = [...enumeratedCards].map((entry) => { return { id: entry[1].dataset.id, position: entry[0] + 1 } });
-    super.updateList({sort_data: sortData})
-      .then(data => {
-        let isSuccess = data['status'] === "success";
-        if (bs4) {
-          var flashDiv = super.showBanner(isSuccess);
-        } else {
-          var flashDiv = $("#sort_notification_msg");
-          var flashHeader = flashDiv.find(".toast-header");
-          flashDiv.show();
-          flashDiv.toggleClass("success", isSuccess);
-          flashDiv.removeClass("error", !isSuccess);
-          flashHeader.toggleClass("success", isSuccess);
-          flashHeader.removeClass("error", !isSuccess);
-          
-          flashHeader.find("strong").text(data['message']);
-          flashDiv.find(".toast-body").text(event.item.textContent);
-        }
 
-        setTimeout(function() {
-          flashDiv.addClass('hidden');
-        }, 3500);
-		})
+    let sortData = [...enumeratedCards].map((entry) => { return { id: entry[1].dataset.id, position: entry[0] + 1 } });
+    super.updateList({sort_data: sortData}, bs4 ? nil : event.item.textContent);
 	}
 }
 
@@ -156,11 +163,9 @@ class UpdateThresholdManager extends UpdateListManager {
     let threshold = this.thresholdInputTarget.value;
 
     super.updateList({commonality_threshold: threshold})
-      .then(data => {
-        let isSuccess = data['status'] === 'success';
+      .then(isSuccess => {
         if (isSuccess) {
           this.thresholdInputTarget.dataset.initialValue = threshold;
-          super.showBanner(true);
 
           // move the threshold marker to the new threshold index or hide it if out of bounds
           let thresholdMarker = this.qleList.find('#threshold-marker').removeClass('hidden');
@@ -172,7 +177,6 @@ class UpdateThresholdManager extends UpdateListManager {
           }
         } else {
           this.thresholdInputTarget.value = this.thresholdInputTarget.dataset.initialValue;
-          super.showBanner(false);
         }
       })
   }

--- a/app/javascript/controllers/sep_types_list_controller.js
+++ b/app/javascript/controllers/sep_types_list_controller.js
@@ -46,9 +46,10 @@ class UpdateListManager {
   }
 
   /**
-   * Perform a PATCH request to update the QLE list.
+   * Perform a PATCH request to update the QLE list and shows the response banner.
    * @param {Object} body The request body containing the list update data.
-   * @returns {Promise} The fetch request promise.
+   * @param {String} bannerDescription The message to use in the legacy response banner subheader.
+   * @returns {Bool} The success status of the request.
    */
   async updateList(body, bannerDescription) {
     body.market_kind = this.marketKind;
@@ -71,6 +72,8 @@ class UpdateListManager {
   /**
    * Show or hide the respective response banner.
    * @param {boolean} isSuccess The success status of the request.
+   * @param {string} bannerTitle The message to use in the legacy response banner header.
+   * @param {string} bannerDescription The message to use in the legacy response banner subheader.
    */
   showBanner(isSuccess, bannerTitle, bannerDescription) {
     if (bs4) {

--- a/app/models/forms/qualifying_life_event_kind_form.rb
+++ b/app/models/forms/qualifying_life_event_kind_form.rb
@@ -20,7 +20,6 @@ module Forms
     attribute :market_kind, Types::String
     attribute :effective_on_kinds, Types::Array.of(Types::String)
     attribute :ordinal_position, Types::Integer.default(0)
-    attribute :is_common, Types::Bool
     attribute :_id, Types::String.optional
     attribute :coverage_start_on, Types::Date
     attribute :coverage_end_on, Types::Date

--- a/app/models/qualifying_life_event_kind.rb
+++ b/app/models/qualifying_life_event_kind.rb
@@ -100,7 +100,7 @@ class QualifyingLifeEventKind
   field :date_options_available, type: Mongoid::Boolean
   field :post_event_sep_in_days, type: Integer
   field :ordinal_position, type: Integer
-  field :is_common, type: Mongoid::Boolean, default: true
+  field :is_common, type: Mongoid::Boolean, default: false
   field :aasm_state, type: Symbol, default: :draft
 
   field :is_active, type: Boolean, default: false
@@ -146,7 +146,7 @@ class QualifyingLifeEventKind
   scope :active,  ->{ where(is_active: true).by_date.where(:created_at.ne => nil).order(ordinal_position: :asc) }
   scope :by_market_kind, ->(market_kind){ where(market_kind: market_kind) }
   scope :non_draft, ->{ where(:aasm_state.nin => [:draft]) }
-  scope :common, -> { where(is_common: true) }
+  scope :common, -> { where.not(is_common: false) } # consider nil values as common to support existing data
   scope :rare, -> { where(is_common: false) }
   scope :by_date, lambda { |date = TimeKeeper.date_of_record|
                     where(

--- a/app/views/exchanges/manage_sep_types/_display_by_market.html.erb
+++ b/app/views/exchanges/manage_sep_types/_display_by_market.html.erb
@@ -1,9 +1,9 @@
+<% is_commonality_threshold_enabled = EnrollRegistry.feature_enabled?(:qle_commonality_threshold) %>
+<% qles = @sortable.by_market_kind(market_kind).active_by_state %> <%# TODO: possibly move this into the controller when we uplift this page %>
+<% common_number = qles.common.length %>
+<% threshold_index = common_number - 1 %>
 <% if @bs4 %>
   <div id="<%= market_kind %>" class="<%= display %>" data-controller="sep-types-list" data-target="sep-types-list.marketTab">
-    <% is_commonality_threshold_enabled = EnrollRegistry.feature_enabled?(:qle_commonality_threshold) %>
-    <% qles = @sortable.by_market_kind(market_kind).active_by_state %> <%# TODO: possibly move this into the controller when we uplift this page %>
-    <% common_number = qles.common.length %>
-    <% threshold_index = common_number - 1 %>
 
     <% if is_commonality_threshold_enabled %>
       <div class="my-3">
@@ -31,12 +31,24 @@
     <h3><%= l10n("exchange.manage_sep_types.titles")%></h3>
     <p><%= l10n("exchange.manage_sep_types.sort_description")%></p>
     <div class="container">
+      <% if is_commonality_threshold_enabled %>
+        <div class="row my-3">
+          <input type="number" min="1" max=<%= qles.length %> data-target="sep-types-list.thresholdInput" data-action="sep-types-list#setThreshold" data-initial-value="<%= common_number %>" value="<%= common_number %>">
+        </div>
+      <% end %>
+
       <div class="row">
         <div data-target="sep-types-list.qleList">
           <% @sortable.where(market_kind: market_kind).active_by_state.each_with_index do |sort, i|%>
               <div id='<%= "#{sort.reason}_#{sort.market_kind}" %>' data-id="<%= sort.id %>" data-ordinal_position="<%= sort.ordinal_position %>" data-index="<%=i%>" data-market_kind="<%=sort.market_kind%>" class="card card-body mb-4">
                 <%= sort.title%>
               </div>
+              <% if is_commonality_threshold_enabled && i == threshold_index %>
+                <div id="threshold-marker" class=<%= 'hidden' if i == qles.length - 1 %>>
+                  <hr>
+                  <h2><%= l10n('exchange.manage_sep_types.rare_header') %></h2>
+                </div>
+              <% end %>
           <%end%>
         </div>
       </div>

--- a/app/views/exchanges/manage_sep_types/edit.html.erb
+++ b/app/views/exchanges/manage_sep_types/edit.html.erb
@@ -75,7 +75,6 @@
               <%= f.hidden_field :published_by, value: current_user.id %>
               <%= f.hidden_field :created_by, value: current_user.id %>
               <%= f.hidden_field :updated_by, value: '' %>
-              <%= f.hidden_field :is_common %>
               <%= f.submit l10n("exchange.manage_sep_types.update_sep_types"), class:'btn btn-outline-primary' %>
               <%= f.submit l10n('exchange.manage_sep_types.publish'), name: (f&.object_name.to_s + "[publish]"), value: l10n('exchange.manage_sep_types.publish'), class:'btn btn-outline-primary' %>
             <% end %>

--- a/app/views/exchanges/manage_sep_types/new.html.erb
+++ b/app/views/exchanges/manage_sep_types/new.html.erb
@@ -71,7 +71,6 @@
           <%= f.hidden_field :created_by, value: current_user.id %>
           <%= f.hidden_field :updated_by, value: '' %>
           <%= f.hidden_field :published_by, value: '' %>
-          <%= f.hidden_field :is_common, value: false %>
           <%= f.submit l10n("exchange.manage_sep_types.create_draft"), class:"btn btn-outline-primary" %>
           <%= link_to l10n("exchange.manage_sep_types.cancel"), sep_types_dt_exchanges_manage_sep_types_path, class: 'btn btn-outline-primary' %>
         </div>

--- a/db/seedfiles/translations/en/me/insured.rb
+++ b/db/seedfiles/translations/en/me/insured.rb
@@ -473,7 +473,7 @@ The I-94 number is also called the admissions number. It is an 11 character sequ
   :'en.insured.families.specual_enrollment_period.disclaimer' => "You may be eligible to enroll in health insurance outside of Open Enrollment, or enroll with an earlier effective date, by qualifying for a Special Enrollment Period (SEP). In order to qualify for a Special Enrollment Period you must first be experiencing or have experienced a qualifying life event.",
   :'en.insured.families.special_enrollment_period.common_header' => "Common Life Events",
   :'en.insured.families.special_enrollment_period.rare_header' => "Other Qualifying Life Events",
-  :'en.insured.families.special_enrollment_period.show_rare' => "Show Other Qualifying Life Events",
+  :'en.insured.families.special_enrollment_period.show_rare' => "Show More Life Events",
   :'en.insured.families.final_sep_none_of_the_situations_listed' => "None of the situations listed above apply.",
   :'en.insured.families.open_enrollment' => "Open Enrollment",
   :'en.insured.families.final_sep_outside_open_enrollment_body' => "Open enrollment starts on %{next_ivl_open_enrollment_date}. To enroll before Open Enrollment, you must qualify for a Special Enrollment Period.",


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188244458

# A brief description of the changes

Current behavior: QLEs don't load correctly on fresh deploy without admin action, BS4 and commonality flags are tied.

New behavior: QLEs load correctly on a fresh deploy when the admin has not yet sorted/set the threshold, BS4 and commonality flags are untied.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: QLE_COMMONALITY_THRESHOLD_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
## Main fixes
Include any additional context that may be relevant to the peer review process.

There were two main issues with the original PR:
1. The admin UI for the threshold input was behind both the BS4 and commonality flag.
2. Consumer QLEs were empty on a fresh deploy without admin action.

For (1), I've untied the flags by moving the new commonality UI into the non-bs4 block on the admin page.

For (2), I've updated the model to now populate QLEs correctly. Before, the `common` scope on the model relied on `is_common` be true. Now, it relies on that field not being false, i.e. true _or_ nil. This is necessary because:
1. `is_common` on the QLEs is only ever set for all models when an admin takes action on the Sort SEPs page. When they sort, the field is set, and trivially when they set the threshold, the field is also set. Without an admin ever taking action, this field will be nil, and the `common` scope will be empty.
2. The `common` scope relies on the `MongoidCriteria::where` function, which critically does **not** filter on the `ActiveRecord` object's attributes but rather at the DB level on the columns. While we were applying the `default` option on the new attribute, this is only ever hit when an `ActiveRecord` is directly instantiated or queried from the DB. Hence, this scope returned empty because it wasn't filtering against attributes on the record, but rather the underlying nil DB column. I've updated this scope to consider nil attributes as common QLEs to account for the deployment case.

Notably, the intention always has been to default this field to false, as in practice any newly-created QLEs should not be considered common. This makes sense from a business perspective. Setting it true on the original PR was out of contrivance for (wrongly) accounting for the deploy case. I've reset this option to false, and also removed all logic from the view layer which originally achieved defaulting the attribute on newly instantiated QLE records to false.

## Other fixes

I also fixed a bug where QLEs were failing to sort due to using an exhausted iterator, and refactored the stimulus controller helper classes to consolidate the banner handling. Finally, I fixed a translation.