### PR TITLE
improve create or update failure message

### DIFF
--- a/app/domain/operations/people/create_or_update.rb
+++ b/app/domain/operations/people/create_or_update.rb
@@ -52,7 +52,7 @@ module Operations
                         end
         Success(person_record)
       rescue StandardError => e
-        Failure(person.errors.messages)
+        Failure(e.message)
       end
 
       def create_new_person(person_entity)

--- a/spec/domain/operations/people/create_or_update_spec.rb
+++ b/spec/domain/operations/people/create_or_update_spec.rb
@@ -85,6 +85,33 @@ RSpec.describe Operations::People::CreateOrUpdate, type: :model, dbclean: :after
       end
     end
 
+    context 'for failure case when there is an existing ssn' do
+      let!(:person) {FactoryBot.create(:person, ssn: '345343243')}
+
+      let(:person_params) do
+        {first_name: 'ivl40', last_name: '41',
+         dob: '1940-09-17', ssn: '345343243',
+         gender: 'male', is_incarcerated: false,
+         person_hbx_id: '23232323',
+         same_with_primary: true, indian_tribe_member: true, citizen_status: 'true',
+         addresses: [kind: 'home', address_1: '123 NE', address_2: '', address_3: '',
+                     city: 'was', county: '', state: 'DC', location_state_code: nil,
+                     full_text: nil, zip: '12321', country_name: '', tracking_version: 1,
+                     modifier_id: nil], phones: [], emails: []}
+
+      end
+
+      context 'valid params' do
+        before :each do
+          @result = subject.call(params: person_params)
+        end
+
+        it 'should return failure' do
+          expect(@result).to be_a(Dry::Monads::Result::Failure)
+        end
+      end
+    end
+
     context 'for failed case' do
       let(:person_params) do
         {first_name: 'ivl40', last_name: '41',


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [ME-188312116](https://www.pivotaltracker.com/n/projects/2640060/stories/188312116)

# A brief description of the changes

Current behavior: When create or update fails and there is not a person record present, we get an unclear error message.

New behavior: Improves error message readability. 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
