### PR TITLE
fix list_class helper calls, fix qle label to be in dedicated element

### DIFF
--- a/app/views/insured/families/_qle_detail.html.erb
+++ b/app/views/insured/families/_qle_detail.html.erb
@@ -6,7 +6,7 @@
       <div class="col px-0">
         <div id='qle-date-chose'>
           <div class="mb-2" onkeydown="handleButtonKeyDown(event, 'qle_submit')">
-            <label for="qle_date" class='qle-label weight-n required'><%= l10n("insured.qle_detail.event_date") %></label>
+            <label for="qle_date" class='weight-n required'><span class="qle-label"><%= l10n("insured.qle_detail.event_date") %></span></label>
             <%= date_field_tag "qle_date", nil, placeholder: "MM/DD/YYYY", min: 110.years.ago, max:"9999-12-31", required: true %>
           </div>
           <div class="mt-4 <%= pundit_class Family,:updateable? %>">

--- a/app/views/insured/families/find_sep.html.erb
+++ b/app/views/insured/families/find_sep.html.erb
@@ -11,7 +11,7 @@
         <% def list_class(qles) "qle-menu #{'two-column' if qles.length > 5}" end %>
         <section>
           <h2><%= l10n('insured.families.special_enrollment_period.common_header') %></h2>
-          <ul class=<%= list_class(@common_seps) %>>
+          <ul class="<%= list_class(@common_seps) %>">
             <% @common_seps&.each_with_index do |qle, index| %>
               <li class="<%=pundit_class Family, :updateable?%> mb-3"><%= qle_link_generator(qle, index) %></li>
             <% end %>
@@ -21,7 +21,7 @@
           <button id="showMoreLink" class="button secondary my-3"><%= l10n('insured.families.special_enrollment_period.show_rare') %></button>
           <section class="hidden mt-3" id="showLifeChanges">
             <h2><%= l10n('insured.families.special_enrollment_period.rare_header') %></h2>
-            <ul class=<%= list_class(@rare_seps) %>>
+            <ul class="<%= list_class(@rare_seps) %>">
               <% @rare_seps.each_with_index do |qle, index| %>
                 <li class="<%=pundit_class Family, :updateable?%> mb-3"><%= qle_link_generator(qle, index) %></li>
               <% end %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Tickets:
1. https://www.pivotaltracker.com/story/show/188320182
2. https://www.pivotaltracker.com/n/projects/2640062/stories/188320325
3. https://www.pivotaltracker.com/n/projects/2640062/stories/188320238
4. https://www.pivotaltracker.com/n/projects/2640062/stories/188320431

# A brief description of the changes

Current behavior: QLE lists are missing the `two-column` class, labeled QLEs are missing secondary questions

New behavior: QLE lists apply the `two-column` class, labeled QLEs show the secondary questions

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
