### PR TITLE
bs4 fix admin navbar

### DIFF
--- a/app/views/ui-components/v1/navs/_primary_nav.html.erb
+++ b/app/views/ui-components/v1/navs/_primary_nav.html.erb
@@ -3,8 +3,13 @@
     <nav id="admin-nav" class="<%= 'pre_prod_nav_color' if ENV['ENROLL_REVIEW_ENVIRONMENT'] == 'true' %>">
       <div class="container px-0">
         <ul id="myTab" class="list-unstyled list-inline m-0 p-0" role="tablist">
+          <li class="pl-0" role="presentation">
+            <a>
+              <%= h(link_to(l10n('layout.header.home'), main_app.exchanges_hbx_profiles_path, "aria-expanded" => "true", "aria-controls" => "hbx_profile", "role" => "tab" )) %>
+            </a>
+          </li>
           <% if individual_market_is_enabled? %>
-            <li class="nav-item" role="presentation">
+            <li class="dropdown pl-1" role="presentation">
               <button class="dropdown-toggle unstyled" data-toggle="dropdown" id="families_dropdown">Families</button>
               <ul class="dropdown-menu" aria-labelledby="families_dropdown">
                 <li>
@@ -145,15 +150,15 @@
     <nav id="uic-primary-nav" class="<%= 'pre_prod_nav_color' if ENV['ENROLL_REVIEW_ENVIRONMENT'] == 'true' %>">
       <div class="container">
         <ul id="myTab" class="list-unstyled list-inline" role="tablist">
-          <li class="nav-item pl-0" role="presentation">
+          <li class="pl-0" role="presentation">
             <a>
-              <%= h(link_to(main_app.exchanges_hbx_profiles_path, "aria-expanded" => "true", "aria-controls" => "hbx_profile", "role" => "tab" )) do %>
+              <%= h(link_to(main_app.exchanges_hbx_profiles_path, "aria-expanded" => "true", "aria-controls" => "hbx_profile", "role" => "tab") do %>
                 <i class="fas fa-home fa-lg" aria-hidden="true"></i>
-              <% end %>
+              <% end) %>
             </a>
           </li>
           <% if individual_market_is_enabled? %>
-            <li class="nav-item" role="presentation">
+            <li class="dropdown pl-1" role="presentation">
               <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" id="families_dropdown">Families <i class="fas fa-caret-down"></i></a>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
                 <li>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:
1. https://www.pivotaltracker.com/story/show/188334812
2. https://www.pivotaltracker.com/story/show/188334406

# A brief description of the changes

Current behavior:
1. Legacy Home tab is showing a URL string in place of the home icon [Flag Off]
2. Legacy Family tab is not responding [Flag Off]
3. Home tab is missing [Flag On]

New behavior: The above issues are corrected

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: `BS4_ADMIN_FLOW_IS_ENABLED`

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
