### PR TITLE
set all pregnancy questions required/not required when needed

### DIFF
--- a/components/financial_assistance/app/assets/javascripts/financial_assistance/step_conditionals.js
+++ b/components/financial_assistance/app/assets/javascripts/financial_assistance/step_conditionals.js
@@ -324,6 +324,7 @@ $(document).ready(function(){
   $("body").on("change", "#is_pregnant_yes", function(){
     if ($('#is_pregnant_yes').is(':checked')) {
       $('#children_expected_count, #applicant_pregnancy_due_on').parents('.row-form-wrapper').removeClass('hide');
+      $('#children_expected_count, #applicant_pregnancy_due_on').attr('required', true);
       if (!disable_selectric) {
         $('#children_expected_count').selectric();
       }
@@ -335,6 +336,7 @@ $(document).ready(function(){
   if($('#is_pregnant_yes').is(':checked')) {
     $('#children_expected_count, #applicant_pregnancy_due_on').parents('.row-form-wrapper').removeClass('hide');
     $('#medicaid_pregnancy_yes').parents('.row-form-wrapper').addClass('hide');
+    $('#children_expected_count, #applicant_pregnancy_due_on').attr('required', true);
   } else {
     $('#children_expected_count, #applicant_pregnancy_due_on').parents('.row-form-wrapper').addClass('hide');
     $('#medicaid_pregnancy_yes').parents('.row-form-wrapper').addClass('hide');
@@ -344,6 +346,7 @@ $(document).ready(function(){
     if ($('#is_pregnant_no').is(':checked')) {
       $('#is_post_partum_period_yes').parents('.row-form-wrapper').removeClass('hide');
       $('#is_post_partum_period_yes, #is_post_partum_period_no').attr('checked', false);
+      $('#children_expected_count, #applicant_pregnancy_due_on').removeAttr('required');
       $('#children_expected_count, #applicant_pregnancy_due_on').parents('.row-form-wrapper').addClass('hide');
       $('#medicaid_pregnancy_yes').parents('.row-form-wrapper').addClass('hide');
     };
@@ -352,27 +355,32 @@ $(document).ready(function(){
   if($('#is_pregnant_no').is(':checked')) {
     $('#is_post_partum_period_yes').parents('.row-form-wrapper').removeClass('hide');
     $('#medicaid_pregnancy_yes').parents('.row-form-wrapper').addClass('hide');
+    $('#children_expected_count, #applicant_pregnancy_due_on').removeAttr('required');
   } else {
     $('#is_post_partum_period_yes').parents('.row-form-wrapper').addClass('hide');
     $('#medicaid_pregnancy_yes').parents('.row-form-wrapper').addClass('hide');
   }
 
   if($('#is_post_partum_period_yes').is(':checked')) {
+    $('#medicaid_pregnancy_yes, #applicant_pregnancy_end_on').attr('required', true)
     $('#medicaid_pregnancy_yes, #applicant_pregnancy_end_on').parents('.row-form-wrapper').removeClass('hide');
   }
 
   $("body").on("change", "#is_post_partum_period_yes", function(){
     if ($('#is_post_partum_period_yes').is(':checked')) {
+      $('#medicaid_pregnancy_yes, #applicant_pregnancy_end_on').attr('required', true)
       $('#medicaid_pregnancy_yes, #applicant_pregnancy_end_on').parents('.row-form-wrapper').removeClass('hide');
     };
   });
 
   if($('#is_post_partum_period_no').is(':checked')) {
+    $('#medicaid_pregnancy_yes, #applicant_pregnancy_end_on').removeAttr('required')
     $('#medicaid_pregnancy_yes, #applicant_pregnancy_end_on').parents('.row-form-wrapper').addClass('hide');
   }
 
   $("body").on("change", "#is_post_partum_period_no", function(){
     if ($('#is_post_partum_period_no').is(':checked')) {
+      $('#medicaid_pregnancy_yes, #applicant_pregnancy_end_on').removeAttr('required')
       $('#medicaid_pregnancy_yes, #applicant_pregnancy_end_on').parents('.row-form-wrapper').addClass('hide');
     };
   });


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188326237

# A brief description of the changes

Current behavior: Some of the conditionally loaded fields never got the required attribute set on the input, just on the label

New behavior: All the conditionally loaded fields get the required attribute set/removed as needed so the form validation works as expected.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
