### PR TITLE
set boundary attr

### DIFF
--- a/app/views/datatables/shared/_dropdown.html.erb
+++ b/app/views/datatables/shared/_dropdown.html.erb
@@ -1,7 +1,7 @@
 <% if @bs4 %>
   <% row_actions_id = local_assigns[:row_actions_id].present? ? local_assigns[:row_actions_id] : nil %>
    <div class="dropdown" id="<%= row_actions_id %>">
-    <button class="btn outline p-2 px-3 dropdown-toggle" type="button" data-display="static" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdown_for_<%= row_actions_id %>">
+    <button class="btn outline p-2 px-3 dropdown-toggle" type="button" data-boundary="window" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdown_for_<%= row_actions_id %>">
       <span class="pr-1"><%= l10n("actions") %></span>
     </button>
     <div class="actions-dropdown dropdown-menu dropdown-menu-right shadow-sm py-0" aria-labelledby="dropdown_for_<%= row_actions_id %>">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188347223

# A brief description of the changes

Current behavior: Dropdown is clipped at bottom of responsive table

New behavior: Dropdown is no longer clipped at bottom of responsive table

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: BS4_ADMIN_FLOW_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
