### PR TITLE
transfer history page to bs4

### DIFF
--- a/app/javascript/css/table.scss
+++ b/app/javascript/css/table.scss
@@ -225,3 +225,7 @@ table {
     margin: 0
   }
 }
+
+table caption {
+  color: var(--text-secondary);
+}

--- a/app/javascript/css/table.scss
+++ b/app/javascript/css/table.scss
@@ -61,6 +61,7 @@ table {
   caption {
     text-align: left;
     margin: 1em 0;
+    color: var(--text-secondary);
   }
 }
 
@@ -224,8 +225,4 @@ table {
   .row {
     margin: 0
   }
-}
-
-table caption {
-  color: var(--text-secondary);
 }

--- a/components/financial_assistance/app/controllers/financial_assistance/applications_controller.rb
+++ b/components/financial_assistance/app/controllers/financial_assistance/applications_controller.rb
@@ -417,6 +417,8 @@ module FinancialAssistance
         params.keys.include?('cur') ? "financial_assistance_nav" : "financial_assistance"
       when "wait_for_eligibility_response"
         EnrollRegistry.feature_enabled?(:bs4_consumer_flow) ? "bs4_financial_assistance" : "financial_assistance"
+      when "transfer_history"
+        EnrollRegistry.feature_enabled?(:bs4_admin_flow) ? "financial_assistance_progress" : "financial_assistance"
       else
         "financial_assistance"
       end

--- a/components/financial_assistance/app/views/financial_assistance/applications/transfer_history.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applications/transfer_history.html.erb
@@ -1,3 +1,39 @@
+<% if @bs4 %>
+ <%= render partial: 'shared/family_side_nav' %>
+<div class="tab-pane in active" id="home">
+  <h1><%= l10n('faa.transfer_history') %></h1>
+  <p><%= l10n('faa.transfer_history_desc', site_short_name: site_short_name) %></p>
+  <%= link_to l10n('back_to_applications'), applications_path, class: "btn btn-primary" %>
+  <h2 class="mt-4"><%= l10n('transactions_for') %> <%= @application.hbx_id %></h2>
+  <table>
+    <thead>
+      <tr>
+          <th><%= l10n('faa.transfer_history.column_header.transfer_id').upcase %></th>
+          <th><%= l10n('faa.transfer_history.column_header.in_out_bound').upcase %></th>
+          <th><%= l10n('faa.transfer_history.column_header.timestamp').upcase %></th>
+          <th><%= l10n('faa.transfer_history.column_header.reason').upcase %></th>
+          <th><%= l10n('faa.transfer_history.column_header.source').upcase %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @transfers.each do |transfer| %>
+          <tr>
+            <td><%= transfer[:transfer_id] %></td>
+            <td><%= transfer[:direction] %></td>
+            <td><%= to_est transfer[:timestamp] %></td>
+            <td><%= transfer[:reason] %></td>
+            <td><%= transfer[:source] %></td>
+          </tr>
+      <% end %>
+      <% if @transfers.empty? %>
+      <caption>
+        <%= l10n('faa.no_history_available').humanize %>
+      </caption>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+<% else %>
 <div aria-labelledby="aria-labelledby"class="tab-pane fade in active" id="home">
   <div class="container" class="mt-2">
     <div class="row">
@@ -7,11 +43,11 @@
       <div class="col-md-10">
         <h1 class="darkblue no-buffer"><%= l10n('faa.transfer_history') %></h1>
         <h4><%= l10n('faa.transfer_history_desc', site_short_name: site_short_name) %></h4>
-  
+
         <div style="text-align: right;">
             <%= link_to l10n('back_to_applications'), applications_path, class: "btn btn-small btn-primary" %>
         </div>
-        
+
         <h3><%= l10n('transactions_for') %> <%= @application.hbx_id %></h3>
         <table class="table table-striped">
             <thead class="form-heading">
@@ -46,3 +82,4 @@
     </div>
   </div>
 </div>
+<% end %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/187498569

# A brief description of the changes

Current behavior: The transfer history page uses the bs3 layouts/styles

New behavior: the transfer history page uses the bs4 styles / layout

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: code is behind the bs4 admin FF: `BS4_ADMIN_FLOW_IS_ENABLED`

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
