### PR TITLE
cancellation reason select should not span the entire page

### DIFF
--- a/app/views/insured/group_selection/_cancel_plan_form.html.erb
+++ b/app/views/insured/group_selection/_cancel_plan_form.html.erb
@@ -29,10 +29,10 @@
         <% if show_termination_calendar? %>
           <p class='mt-4 mb-2'><%= l10n("choose_last_day") %></p>
           <%= label_tag :term_date, l10n("coverage_end_date"), class: "required"%>
-          <%= date_field_tag :term_date, nil, { 
+          <%= date_field_tag :term_date, nil, {
             class: "date-field mt-2",
             min: TimeKeeper.date_of_record.strftime("%Y-%m-%d"),
-            max: TimeKeeper.date_of_record.end_of_year.strftime("%Y-%m-%d"), 
+            max: TimeKeeper.date_of_record.end_of_year.strftime("%Y-%m-%d"),
             required: true
           } %>
         <% end %>
@@ -40,7 +40,7 @@
         <% if show_cancellation_reason %>
           <p class="mt-4 mb-2"><%= l10n("why_are_you_canceling") %><p>
           <%= label_tag :cancellation_reason, l10n("cancelation_reason"), class:"required" %>
-          <%= select_tag :cancellation_reason, options_for_select(cancelation_reasons), prompt: l10n("select_reason"), class: "form-control mt-2", required: show_cancellation_reason %>
+          <%= select_tag :cancellation_reason, options_for_select(cancelation_reasons), prompt: l10n("select_reason"), class: "mt-2", required: show_cancellation_reason %>
         <% end %>
 
         <div class="mt-4">


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188377539

# A brief description of the changes

Current behavior: The cancellation reason select bar spans the entire width of the page

New behavior: The cancellation reason select only takes up a portion of the screen

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
