### PR TITLE
check flag before mapping to new dropdown

### DIFF
--- a/app/models/effective/datatables/outstanding_verification_data_table.rb
+++ b/app/models/effective/datatables/outstanding_verification_data_table.rb
@@ -53,7 +53,7 @@ module Effective
           dropdown = [
            ["Review", show_docs_documents_path(:person_id => eligibility_primary_family_member(row).person_id),"static"]
           ]
-          render partial: 'datatables/shared/dropdown', locals: {dropdowns: map_legacy_dropdown(dropdown), row_actions_id: "family_actions_#{row.id}"}, formats: :html
+          render partial: 'datatables/shared/dropdown', locals: {dropdowns: @bs4 ? map_legacy_dropdown(dropdown) : dropdown, row_actions_id: "family_actions_#{row.id}"}, formats: :html
         }, :filter => false, :sortable => false
       end
 


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188389585
# A brief description of the changes

Current behavior: Dropdowns in the datatable were unconditionally calling the map helper.

New behavior: Dropdowns in the datatable are only called if bs4 is toggled on.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: `BS4_ADMIN_FLOW_IS_ENABLED`

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
