### PR TITLE
restore date min/max checks on sep event date field

### DIFF
--- a/app/views/exchanges/hbx_profiles/update_effective_date.js.erb
+++ b/app/views/exchanges/hbx_profiles/update_effective_date.js.erb
@@ -42,48 +42,71 @@ else{
 
 function init_datepicker_for_qle_date(pre_event_sep_in_days, post_event_sep_in_days, eligibilty_start_date, eligibilty_end_date, cdate) {
   var target = $('.qle-date-picker');
-  <% if @bs4 %>
-    $(target).val('');
-    return
-  <% end %>
-  
-  if("<%= @qle.is_self_attested %>" == 'false'){
-    dateMin = '-110y';
-    dateMax = '+110y';
-  }
+  if("<%= @qle.is_self_attested %>" == 'false') {
+    <% if @bs4 %>
+      dateMin = '<%= date_field_value(110.years.ago) %>';
+      dateMax = '<%= date_field_value(110.years.from_now) %>';
+    <% else %>
+      dateMin = '-110y';
+      dateMax = '+110y';
+    <% end %>
+  } 
   else{
-    var splitdate = cdate.split('/');
-    var cur_date = new Date(splitdate[2], splitdate[0]-1, splitdate[1]);
-    var idays = Math.ceil((cur_date - new Date())/1000/60/60/24);
-    var post_days = (idays - post_event_sep_in_days);
-    var pre_days = (idays + pre_event_sep_in_days);
-    if (post_days >= 0){
-      dateMin = '+' + post_days + 'd';
-    }else{
-      dateMin = post_days + 'd';
-    }
-    if (pre_days >= 0){
-      dateMax = '+' + pre_days + 'd';
-    }else{
-      dateMax = pre_days + 'd';
-    }
+    <% if @bs4 %>
+      var preDate = new Date();
+      preDate.setTime(preDate.getTime() + pre_event_sep_in_days * 24 * 60 * 60 * 1000)
+      var postDate = new Date();
+      postDate.setTime(postDate.getTime() - post_event_sep_in_days * 24 * 60 * 60 * 1000)
+
+      dateMin = postDate.toISOString().split('T')[0]
+      dateMax = preDate.toISOString().split('T')[0]
+    <% else %>
+      var splitdate = cdate.split('/');
+      var cur_date = new Date(splitdate[2], splitdate[0]-1, splitdate[1]);
+      var idays = Math.ceil((cur_date - new Date())/1000/60/60/24);
+      var post_days = (idays - post_event_sep_in_days);
+      var pre_days = (idays + pre_event_sep_in_days);
+      if (post_days >= 0){
+        dateMin = '+' + post_days + 'd';
+      }else{
+        dateMin = post_days + 'd';
+      }
+      if (pre_days >= 0){
+        dateMax = '+' + pre_days + 'd';
+      }else{
+        dateMax = pre_days + 'd';
+      }
+    <% end %>
+
     if ("<%= @qle.coverage_start_on.present? && @qle.coverage_start_on.present? %>" == 'true'){
-      dateMin = eligibilty_start_date
-      dateMax = eligibilty_end_date
+      <% if @bs4 %>
+        dateMin = '<%= date_field_value(@qle.coverage_start_on) %>';
+        dateMax = '<%= date_field_value(@qle.coverage_end_on) %>';
+      <% else %>
+        dateMin = eligibilty_start_date
+        dateMax = eligibilty_end_date
+      <% end %>
     }
   }
+
   $(target).val('');
-  $(target).datepicker('destroy');
-  $(target).datepicker({
-    changeMonth: true,
-    changeYear: true,
-    dateFormat: 'mm/dd/yy',
-    defaultDate: cdate,
-    minDate: dateMin,
-    maxDate: dateMax});
-  $('input.floatlabel').floatlabel({
-      slideInput: false
-  });
+  
+  <% if @bs4 %>
+    target.attr('max', dateMax);
+    target.attr('min', dateMin);
+  <% else %>
+    $(target).datepicker('destroy');
+    $(target).datepicker({
+      changeMonth: true,
+      changeYear: true,
+      dateFormat: 'mm/dd/yy',
+      defaultDate: cdate,
+      minDate: dateMin,
+      maxDate: dateMax});
+    $('input.floatlabel').floatlabel({
+        slideInput: false
+    });
+  <% end %>
 };
 
 function getDate(){


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188390474

# A brief description of the changes

Current behavior: The JS which manages SEP date selection for Add SEP ignored legacy min/max checks.

New behavior: The JS which manages SEP date selection for Add SEP implements min/max checks.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: `BS4_ADMIN_FLOW_IS_ENABLED`

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
