### PR TITLE
remove div around label text, remove debug element

### DIFF
--- a/app/views/datatables/_drop_enrollment_member.html.erb
+++ b/app/views/datatables/_drop_enrollment_member.html.erb
@@ -21,10 +21,9 @@
         <p class='title'><b><%= l10n('plan') %>:</b> <%= hbx.product.title %></p>
         <p>
           <% if @bs4 %>
-          <%= set_default_termination_date_value(hbx).class %>
             <label class="d-block weight-n">
-              <div><%= l10n("termination_date") %></div>
-              <%= date_field_tag "termination_date_#{hbx.id}", nil, value: set_default_termination_date_value(hbx).strftime("%Y-%m-%d"), id: "termination-date-picker_#{hbx.id}", min: set_date_min_to_beginning_of_year(hbx, 1), max: set_date_max_to_plan_end_of_year(hbx), 'data-cuke': 'drop_termination_date' %>
+              <%= l10n("termination_date") %>
+              <%= date_field_tag "termination_date_#{hbx.id}", nil, value: set_default_termination_date_value(hbx).strftime("%Y-%m-%d"), id: "termination-date-picker_#{hbx.id}", min: set_date_min_to_beginning_of_year(hbx, 1), max: set_date_max_to_plan_end_of_year(hbx), 'data-cuke': 'drop_termination_date', class: 'd-block' %>
             </label>
           <% else %>
             <%= l10n('termination_date') %>: 

--- a/app/views/datatables/_terminate_enrollment.html.erb
+++ b/app/views/datatables/_terminate_enrollment.html.erb
@@ -51,8 +51,8 @@ $( "[id^=edit_hbx_enrollment]" ).submit(function( event ) {
           <td>
             <% if @bs4 %>
               <label class="d-block weight-n">
-                <div><%= l10n("termination_date") %></div>
-                <%= date_field_tag "termination_date_#{hbx.id}", nil, value: set_default_termination_date_value(hbx).strftime('%Y-%m-%d'), id: "termination-date-picker_#{hbx.id}", min: set_date_min_to_effective_on(hbx).strftime('%Y-%m-%d'), max: set_date_max_to_plan_end_of_year(hbx).strftime('%Y-%m-%d') %>
+                <%= l10n("termination_date") %>
+                <%= date_field_tag "termination_date_#{hbx.id}", nil, value: set_default_termination_date_value(hbx).strftime('%Y-%m-%d'), id: "termination-date-picker_#{hbx.id}", min: set_date_min_to_effective_on(hbx).strftime('%Y-%m-%d'), max: set_date_max_to_plan_end_of_year(hbx).strftime('%Y-%m-%d'), class: 'd-block' %>
               </label>
             <% else %>
               <%= text_field_tag "termination_date_#{hbx.id}", nil, readonly: true, value:  set_default_termination_date_value(hbx), id: "termination-date-picker_#{hbx.id}", class: "form-control date-field date-picker", "data-date-min" =>  set_date_min_to_effective_on(hbx), "data-date-max" =>  set_date_max_to_plan_end_of_year(hbx) %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188376449
# A brief description of the changes

Current behavior: Debug `class` string left in markup, label text wrapped in divs

New behavior: Removed debug markup, removed wrapping divs

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name: `BS4_ADMIN_FLOW_IS_ENABLED`

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
