### PR TITLE
Adding attempted event handler fixes for chatbot - CSP Via Rails

### DIFF
--- a/app/javascript/packs/live_chat_widget.js
+++ b/app/javascript/packs/live_chat_widget.js
@@ -18,3 +18,8 @@ document.addEventListener("DOMContentLoaded", function() {
     }
   }
 });
+
+document.addEventListener("DOMContentLoaded", function() {
+  CXBus.configure({debug:false, pluginsPath:'https://apps.usw2.pure.cloud/widgets/9.0/plugins/'});
+  CXBus.loadPlugin('widgets-core');
+});

--- a/app/javascript/packs/live_chat_widget.js
+++ b/app/javascript/packs/live_chat_widget.js
@@ -1,0 +1,20 @@
+document.addEventListener("DOMContentLoaded", function() {
+  var qna_bot_open_click_buttons = document.getElementsByClassName("qna-bot-open-click-button");
+  if (qna_bot_open_click_buttons != null) {
+    for (var i = 0; i < qna_bot_open_click_buttons.length; i++) {
+      var qa_open_button = qna_bot_open_click_buttons[i];
+      qa_open_button.addEventListener("click", function() {
+        openQnaBot();
+      });
+    }
+  }
+  var live_webchat_open_click_buttons = document.getElementsByClassName("live-webchat-open-click-button");
+  if (live_webchat_open_click_buttons != null) {
+    for (var i = 0; i < live_webchat_open_click_buttons.length; i++) {
+      var live_webchat_open_button = live_webchat_open_click_buttons[i];
+      live_webchat_open_button.addEventListener("click", function() {
+        customPlugin.command('WebChat.open', getAdvancedConfig());
+      });
+    }
+  }
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
 		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
     <%= csrf_meta_tags %>
 
-
+    <meta name="csp-nonce" content="<%= content_security_policy_nonce %>"/>
 
     <%= javascript_pack_tag ENV['CLIENT'] %>
     <%= stylesheet_pack_tag ENV['CLIENT'] %>

--- a/app/views/layouts/bootstrap_4.html.erb
+++ b/app/views/layouts/bootstrap_4.html.erb
@@ -25,7 +25,7 @@
       <%= action_cable_meta_tag %>
       <%= csrf_meta_tags %>
 
-      <meta property="csp-nonce" content="<%= content_security_policy_nonce %>"/>
+      <meta name="csp-nonce" content="<%= content_security_policy_nonce %>"/>
 
       <% if EnrollRegistry.feature_enabled?(:live_chat_widget) %>
         <%= render "shared/customer_support/live_chat_scripts" unless EnrollRegistry.feature_enabled?(:external_qna_bot) %>

--- a/app/views/layouts/bootstrap_4.html.erb
+++ b/app/views/layouts/bootstrap_4.html.erb
@@ -25,6 +25,8 @@
       <%= action_cable_meta_tag %>
       <%= csrf_meta_tags %>
 
+      <meta property="csp-nonce" content="<%= content_security_policy_nonce %>"/>
+
       <% if EnrollRegistry.feature_enabled?(:live_chat_widget) %>
         <%= render "shared/customer_support/live_chat_scripts" unless EnrollRegistry.feature_enabled?(:external_qna_bot) %>
       <% end %>

--- a/app/views/layouts/bootstrap_4_two_column.html.erb
+++ b/app/views/layouts/bootstrap_4_two_column.html.erb
@@ -15,6 +15,8 @@
 
     <%= csrf_meta_tags %>
 
+    <meta property="csp-nonce" content="<%= content_security_policy_nonce %>"/>
+
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/app/views/layouts/bootstrap_4_two_column.html.erb
+++ b/app/views/layouts/bootstrap_4_two_column.html.erb
@@ -15,7 +15,7 @@
 
     <%= csrf_meta_tags %>
 
-    <meta property="csp-nonce" content="<%= content_security_policy_nonce %>"/>
+    <meta name="csp-nonce" content="<%= content_security_policy_nonce %>"/>
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/app/views/layouts/single_column.html.erb
+++ b/app/views/layouts/single_column.html.erb
@@ -23,6 +23,8 @@
     <% end %>
     <%= csrf_meta_tags %>
 
+    <meta name="csp-nonce" content="<%= content_security_policy_nonce %>"/>
+
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->

--- a/app/views/layouts/two_column.html.erb
+++ b/app/views/layouts/two_column.html.erb
@@ -21,6 +21,8 @@
     <% end %>
     <%= csrf_meta_tags %>
 
+    <meta name="csp-nonce" content="<%= content_security_policy_nonce %>"/>
+
     <% if EnrollRegistry.feature_enabled?(:contrast_level_aa) %>
       <%= javascript_pack_tag 'contrast_level_aa' %>
       <%= stylesheet_pack_tag 'contrast_level_aa' %>

--- a/app/views/shared/customer_support/_live_chat_scripts.html.erb
+++ b/app/views/shared/customer_support/_live_chat_scripts.html.erb
@@ -1,6 +1,5 @@
 <script
   src="https://apps.usw2.pure.cloud/widgets/9.0/cxbus.min.js"
-  onload="javascript:CXBus.configure({debug:false,pluginsPath:'https://apps.usw2.pure.cloud/widgets/9.0/plugins/'}); CXBus.loadPlugin('widgets-core');"
 ></script>
 
 <script>

--- a/app/views/shared/customer_support/_live_chat_scripts.html.erb
+++ b/app/views/shared/customer_support/_live_chat_scripts.html.erb
@@ -152,3 +152,5 @@
     });
   <% end %>
 </script>
+
+<%= javascript_pack_tag 'live_chat_widget', 'data-turbolinks-track': 'reload' %>

--- a/app/views/shared/customer_support/_live_chat_widget.html.erb
+++ b/app/views/shared/customer_support/_live_chat_widget.html.erb
@@ -79,9 +79,9 @@
       }
     }
   </script>
-  <button class="<% if @bs4 %>live-chat-button-bs4<% else %>live-chat-button<% end %>" type="button" data-cuke="bot-button" onclick="javascript: openQnaBot();">
+  <button class="<% if @bs4 %>live-chat-button-bs4<% else %>live-chat-button<% end %> qna-bot-open-click-button" type="button" data-cuke="bot-button">
 <% else %>
-  <button class="<% if @bs4 %>live-chat-button-bs4<% else %>live-chat-button<% end %>" type="button" data-cuke="chat-button" id="chat-button" onclick="customPlugin.command('WebChat.open', getAdvancedConfig());">
+  <button class="<% if @bs4 %>live-chat-button-bs4<% else %>live-chat-button<% end %> live-webchat-open-click-button" type="button" data-cuke="chat-button" id="chat-button">
 <% end %>
   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" style="transform: scale(-1,1)" xmlns="http://www.w3.org/2000/svg">
     <path d="M13.25 14C12.0074 14 11 15.0074 11 16.25V17.752L11.0079 17.8604C11.3186 19.9866 13.2285 21.009 16.4332 21.009C19.6264 21.009 21.5667 19.9983 21.9855 17.8966L22 17.75V16.25C22 15.0074 20.9926 14 19.75 14H13.25ZM16.5 6C14.567 6 13 7.567 13 9.5C13 11.433 14.567 13 16.5 13C18.433 13 20 11.433 20 9.5C20 7.567 18.433 6 16.5 6Z" fill="white"/>

--- a/app/views/ui-components/bs4/v1/navs/_header.html.erb
+++ b/app/views/ui-components/bs4/v1/navs/_header.html.erb
@@ -116,7 +116,7 @@
         url: "<%= main_app.check_time_until_logout_path(format: :js) %>",
         method: 'GET',
         dataType: 'script',
-        data:{bs4: <%= @bs4 || "" %>},
+        data:{ bs4: <%= @bs4 || "''" %> },
         success: function(response){
         },
         error: function(response){

--- a/config/application.rb
+++ b/config/application.rb
@@ -96,5 +96,7 @@ module Enroll
       config.acapi.add_amqp_worker("TransportProfiles::Subscribers::TransportArtifactSubscriber")
       config.acapi.add_async_subscription("Notifier::NotificationSubscriber")
     end
+
+    config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -96,7 +96,5 @@ module Enroll
       config.acapi.add_amqp_worker("TransportProfiles::Subscribers::TransportArtifactSubscriber")
       config.acapi.add_async_subscription("Notifier::NotificationSubscriber")
     end
-
-    config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
   end
 end

--- a/config/initializers/rails_csp_nonce.rb
+++ b/config/initializers/rails_csp_nonce.rb
@@ -14,21 +14,28 @@ module EnrollMiddleware
       request = ActionDispatch::Request.new env
       stat, headers, body = @app.call(env)
       nonce = request.content_security_policy_nonce
-      content_type_header = headers['Content-Type']
-      content_type = Mime::Type.lookup(content_type_header)
+      resp = ActionDispatch::Response.new(stat, headers, body)
+      content_type = Mime::Type.lookup(resp.content_type || Mime[:html])
       return [stat, headers, body] unless content_type&.html?
 
       doc = nil
-      if body.is_a?(ActionDispatch::Response::RackBody)
-        doc = Loofah.document(body.body)
-      else
-        doc = Loofah.document(body)
+      begin
+        if body.is_a?(ActionDispatch::Response::RackBody)
+          doc = Loofah.document(body.body)
+        else
+          doc = Loofah.document(body)
+        end
+      rescue
+        return [stat, headers, body]
       end
       doc.xpath("//script").each do |node|
         nonce_node(node, nonce, :script, request)
       end
-      doc.xpath("//style").each do |node|
-        nonce_node(node, nonce, :style, request)
+      #doc.xpath("//style").each do |node|
+      #  nonce_node(node, nonce, :style, request)
+      #end
+      doc.xpath("//*[@onclick]").each do |node|
+        request.logger.tagged("CSPTagMissingNonce").warn("Detected inline onclick event handler: #{node["onclick"]}")
       end
       response = ActionDispatch::Response.new(stat, headers, doc.to_s)
       response.to_a
@@ -43,7 +50,7 @@ module EnrollMiddleware
 end
 
 Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
-Rails.application.config.content_security_policy_nonce_directives = %w(script-src style-src)
+Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
 
 Rails.application.config.content_security_policy do |policy|
   csp_proto = Rails.env.production? ? :https : :http
@@ -52,8 +59,9 @@ Rails.application.config.content_security_policy do |policy|
   policy.font_src    :self, csp_proto, :data, "*.gstatic.com",  "*.fontawesome.com"
   policy.img_src     :self, csp_proto, :data, "*.google-analytics.com", "*.gstatic.com", "*.googletagmanager.com"
   policy.script_src  :self, csp_proto, "https://tagmanager.google.com", "https://www.googletagmanager.com", "https://apps.usw2.pure.cloud", "*.fontawesome.com", "*.google-analytics.com"
-  policy.style_src   :self, csp_proto, "unsafe-inline", "https://tagmanager.google.com", "https://www.googletagmanager.com", "https://fonts.googleapis.com", "*.fontawesome.com"
+  policy.style_src   :self, csp_proto, "'unsafe-inline'", "https://tagmanager.google.com", "https://www.googletagmanager.com", "https://fonts.googleapis.com", "*.fontawesome.com"
   policy.connect_src :self, csp_proto, "https://api.usw2.pure.cloud", "wss://streaming.usw2.pure.cloud"
+  policy.media_src   :self, csp_proto, :data
 end
 
 Rails.application.config.middleware.insert_after Browser::Middleware, EnrollMiddleware::RailsContentNonceRewrite

--- a/config/initializers/rails_csp_nonce.rb
+++ b/config/initializers/rails_csp_nonce.rb
@@ -1,19 +1,59 @@
 # frozen_string_literal: true
 
+require "loofah"
+
 module EnrollMiddleware
-  # Add the rails CSP nonce to a custom header, so we can
-  # construct our CSP around it using Nginx.
-  class RailsContentNonce
+  # Insert the rails content nonce into in-page script tags
+  # where it doesn't exist, and report the violation as a warning.
+  class RailsContentNonceRewrite
     def initialize(app)
       @app = app
     end
 
     def call(env)
       request = ActionDispatch::Request.new env
-      env["X-Rails-Content-Nonce"] = request.content_security_policy_nonce
-      @app.call(env)
+      stat, headers, body = @app.call(env)
+      nonce = request.content_security_policy_nonce
+      content_type_header = headers['Content-Type']
+      content_type = Mime::Type.lookup(content_type_header)
+      return [stat, headers, body] unless content_type&.html?
+
+      doc = nil
+      if body.is_a?(ActionDispatch::Response::RackBody)
+        doc = Loofah.document(body.body)
+      else
+        doc = Loofah.document(body)
+      end
+      doc.xpath("//script").each do |node|
+        nonce_node(node, nonce, :script, request)
+      end
+      doc.xpath("//style").each do |node|
+        nonce_node(node, nonce, :style, request)
+      end
+      response = ActionDispatch::Response.new(stat, headers, doc.to_s)
+      response.to_a
+    end
+
+    def nonce_node(node, nonce, kind, ad_request)
+      return if node["src"] || node["integrity"] || node["nonce"]
+      node["nonce"] = nonce
+      ad_request.logger.tagged("CSPTagMissingNonce").warn("#{kind} tag is missing a nonce: #{ad_request.original_url}")
     end
   end
 end
 
-Rails.application.config.middleware.insert_after ActionDispatch::ContentSecurityPolicy::Middleware, EnrollMiddleware::RailsContentNonce
+Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_directives = %w(script-src style-src)
+
+Rails.application.config.content_security_policy do |policy|
+  csp_proto = Rails.env.production? ? :https : :http
+  policy.default_src :self, csp_proto
+  policy.object_src  :none
+  policy.font_src    :self, csp_proto, :data, "*.gstatic.com",  "*.fontawesome.com"
+  policy.img_src     :self, csp_proto, :data, "*.google-analytics.com", "*.gstatic.com", "*.googletagmanager.com"
+  policy.script_src  :self, csp_proto, "https://tagmanager.google.com", "https://www.googletagmanager.com", "https://apps.usw2.pure.cloud", "*.fontawesome.com", "*.google-analytics.com"
+  policy.style_src   :self, csp_proto, "unsafe-inline", "https://tagmanager.google.com", "https://www.googletagmanager.com", "https://fonts.googleapis.com", "*.fontawesome.com"
+  policy.connect_src :self, csp_proto, "https://api.usw2.pure.cloud", "wss://streaming.usw2.pure.cloud"
+end
+
+Rails.application.config.middleware.insert_after Browser::Middleware, EnrollMiddleware::RailsContentNonceRewrite

--- a/config/initializers/rails_csp_nonce.rb
+++ b/config/initializers/rails_csp_nonce.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module EnrollMiddleware
+  # Add the rails CSP nonce to a custom header, so we can
+  # construct our CSP around it using Nginx.
+  class RailsContentNonce
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      request = ActionDispatch::Request.new env
+      env["X-Rails-Content-Nonce"] = request.content_security_policy_nonce
+      @app.call(env)
+    end
+  end
+end
+
+Rails.application.config.middleware.insert_after ActionDispatch::ContentSecurityPolicy::Middleware, EnrollMiddleware::RailsContentNonce


### PR DESCRIPTION
Attempt to check viability of moved event handlers and auto-generated nonce.

This approach doesn't require any changes or setup of a CSP at the Nginx level - it's done in Rails.