### PR TITLE
dental plan missing during member clone

### DIFF
--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -13,6 +13,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   end
 
   def renew
+    @cross_walk_product = fetch_cross_product
     set_csr_value if enrollment.is_health_enrollment?
     renewal_enrollment = clone_enrollment
     populate_aptc_hash(renewal_enrollment) if renewal_enrollment.is_health_enrollment?
@@ -58,8 +59,6 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
     # TODO: Fetch proper csr product as the family might be eligible for a
     # different csr value than that of given externally.
     # Sets the cross walk product
-    @cross_walk_product = fetch_cross_product
-
     return renewal_product if has_catastrophic_product?
 
     if can_renew_assisted_product?(renewal_enrollment)
@@ -211,7 +210,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   # Eligibility determination CSR change
   def renewal_product
     if @enrollment.coverage_kind == 'dental'
-      renewal_product = (@cross_walk_product || @enrollment.product.renewal_product)&.id
+      renewal_product = @cross_walk_product&.id
     elsif has_catastrophic_product? && is_cat_product_ineligible?
       renewal_product = fetch_cat_age_off_product(@enrollment.product)
       raise "#{renewal_coverage_start.year} Catastrophic age off product missing on HIOS id #{@enrollment.product.hios_id}" if renewal_product.blank?

--- a/app/models/enrollments/individual_market/family_enrollment_renewal.rb
+++ b/app/models/enrollments/individual_market/family_enrollment_renewal.rb
@@ -211,7 +211,7 @@ class Enrollments::IndividualMarket::FamilyEnrollmentRenewal
   # Eligibility determination CSR change
   def renewal_product
     if @enrollment.coverage_kind == 'dental'
-      renewal_product = @cross_walk_product&.id
+      renewal_product = (@cross_walk_product || @enrollment.product.renewal_product)&.id
     elsif has_catastrophic_product? && is_cat_product_ineligible?
       renewal_product = fetch_cat_age_off_product(@enrollment.product)
       raise "#{renewal_coverage_start.year} Catastrophic age off product missing on HIOS id #{@enrollment.product.hios_id}" if renewal_product.blank?

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -1302,6 +1302,7 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
           family_assisted.active_household.reload
           update_age_off_excluded(family_assisted, false)
           allow(::BenefitMarkets::Products::ProductRateCache).to receive(:lookup_rate) {|_id, _start, age| age * 1.0}
+          subject.instance_variable_set(:@cross_walk_product, renewal_product)
         end
 
         it "should append APTC values" do

--- a/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
+++ b/spec/models/enrollments/individual_market/family_enrollment_renewal_spec.rb
@@ -358,6 +358,12 @@ if ExchangeTestingConfigurationHelper.individual_market_is_enabled?
           renewal = subject.renew
           expect(renewal.product.hios_id).to eq renewal_product.hios_id
         end
+
+        it "should fetch renewal product for renewal for dental" do
+          subject.enrollment.update_attributes(coverage_kind: "dental")
+          renewal = subject.renew
+          expect(renewal.product.hios_id).to eq renewal_product.hios_id
+        end
       end
 
       context "renew coverall product" do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188355646

# A brief description of the changes

Current behavior: renewing dental enrollment fails due to the product not being available at the time of cloning members

New behavior: renewing dental enrollment NOT fail due to the product not being available at the time of cloning members

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
