### PR TITLE
fix previous link issue on FAA tax info page

### DIFF
--- a/components/financial_assistance/app/views/financial_assistance/applicants/tax_info.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/applicants/tax_info.html.erb
@@ -95,7 +95,7 @@
         <%= submit_tag l10n("faa.tax_info.continue"), class: "btn", id: 'btn-continue', disabled: !@applicant.tax_info_complete? %>
       <% end %>
       <%= render partial: 'financial_assistance/shared/progress_navigation_buttons', locals: {
-        previous_link: edit_application_path(@application, @applicant), show_back_to_household_button: true } %>
+        previous_link: financial_assistance.edit_application_path(@application), show_back_to_household_button: true } %>
     </div>
   <% end %>
 <% else %>
@@ -219,7 +219,7 @@
       <% end %>
 
       <div class='col-md-3'>
-        <%= render partial: 'financial_assistance/shared/right_nav', locals: { previous_url: edit_application_path(@application, @applicant) } %>
+        <%= render partial: 'financial_assistance/shared/right_nav', locals: { previous_url: financial_assistance.edit_application_path(@application) } %>
       </div>
 
     </div>

--- a/features/financial_assistance/tax_info.feature
+++ b/features/financial_assistance/tax_info.feature
@@ -70,6 +70,11 @@ Feature: A dedicated page that gives the user access to Tax Info page for a give
     When the user clicks the BACK TO ALL HOUSEHOLD MEMBERS link
     Then a modal should show asking the user are you sure you want to leave this page
 
+  Scenario: Applicant can go to previous page
+    Given the user is on the Tax Info page for a given applicant
+    When the user clicks the PREVIOUS link1
+    Then the user will navigate to the FAA Household Infor: Family Members page
+
   Scenario: Can choose primary applicant claiming dependent from dropdown
     Given a plan year, with premium tables, exists
     And the user navigates to the Tax Info page for a given applicant


### PR DESCRIPTION
Please check if your PR fulfills the following requirements
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [ ] For all UI changes, there is cucumber coverage
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [ ] There are no inline styles added
- [ ] There are no inline javascript added
- [ ] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [ ] Code does not use .html_safe
- [ ] All images added/updated have alt text
- [ ] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix or migration (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket:  https://www.pivotaltracker.com/n/projects/2640060/stories/188391067

# A brief description of the changes

Current behavior: `Previous Step` button is not working as expected on FAA tax info page and throwing `Unsupported Format` error upon clicking the button

New behavior: Clicking `Previous Step` on FAA Tax Info page should redirect the user back to Applications Page and should not throw an error

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
