### PR TITLE
rename close button text to previous button on assign an expert page

### DIFF
--- a/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_profiles/_broker_help.html.erb
+++ b/components/benefit_sponsors/app/views/benefit_sponsors/profiles/broker_agencies/broker_agency_profiles/_broker_help.html.erb
@@ -44,7 +44,7 @@
       <dt><%= l10n("language")%>:</dt>
       <dd><%= broker_agency_profile.languages %></dd>
     </dl>
-    <button type="button" class="outline close_broker_select"><%= l10n("close")%></button>
+    <button type="button" class="outline close_broker_select"><%= l10n("previous_step")%></button>
     <%= h(link_to "Go To My Expert", main_app.brokers_insured_families_path(tab: l10n("brokers_tab")), class: "button hidden go-to-expert mt-4") %>
     <button type="button" <%= 'disabled' if !broker_agency_profile.accept_new_clients %> class="select-broker" data-broker='<%=@staff.id%>'><%= l10n("broker_agencies.profiles.select_this_broker")%></button>
   </section>
@@ -121,7 +121,7 @@
         <p class="lg"> <b><%= l10n("broker_agencies.profiles.not_accepting_clients") if !broker_agency_profile.accept_new_clients %></b> </p>
         <p class="lg"> <b><%= l10n("broker_agencies.profiles.warning_for_existing_broker")%></b></p>
         <button type="button" <%= 'disabled' if !broker_agency_profile.accept_new_clients %> class="btn btn-primary btn-small help_button close_broker_select" data-cuke="select_this_broker" data-broker='<%=@staff.id%>'><%= l10n("broker_agencies.profiles.select_this_broker")%></button>
-        <button type="button" class="btn btn-default btn-default btn-small close_broker_select"><%= l10n("close")%></button>
+        <button type="button" class="btn btn-default btn-default btn-small close_broker_select"><%= l10n("previous_step") %></button>
       </div>
     </div>
   </div>

--- a/features/insured/contrast_level_aa/my_expert_page.feature
+++ b/features/insured/contrast_level_aa/my_expert_page.feature
@@ -38,3 +38,8 @@ Feature: Contrast level AA is enabled - existing consumer visits the my expert p
     And Individual clicks on close button
     And the page is refreshed
     And Individual sees your expert widget
+
+  Scenario: the user should see Previous step button
+    And Individual clicks on the Help from an Expert link
+    And Individual selects a broker
+    Then Individual should see a Previous step button

--- a/features/step_definitions/help_me_sign_up_steps.rb
+++ b/features/step_definitions/help_me_sign_up_steps.rb
@@ -37,6 +37,10 @@ And(/^Individual selects a broker?/) do
   find(".broker_select_button", wait: 5).click
 end
 
+And(/^Individual should see a Previous step button?/) do
+  expect(page).to have_content(l10n("previous_step"))
+end
+
 And(/^Individual confirms a broker/) do
   find(IvlHomepage.select_this_broker).click
 end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:
- [X] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bug fixes/features), and they use `let` helpers and `before` blocks.
- [ ] For all UI changes, there is Cucumber coverage.
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, the reasoning is documented in the PR and code.
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run them is documented in both the PR and the code.
- [ ] There are no inline styles added.
- [ ] There is no inline JavaScript added.
- [ ] There is no hard-coded text added/updated in helpers/views/JavaScript. New/updated translation strings do not include markup/styles unless there is supporting documentation.
- [ ] Code does not use `.html_safe`.
- [ ] All images added/updated have alt text.
- [ ] Does not bypass RuboCop rules in any way.

# PR Type
What kind of change does this PR introduce?:

- [X] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix, Migration, or Report (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188392368

# A brief description of the changes:

Current behavior: In assigning an expert modal pop, Upon clicking the 'Close' button after selecting the broker , the modal goes to the previous page instead of closing. This button is functioning as a 'back' button instead of a 'close' button.

New behavior: Rename the `close` button text as `Previous step` 

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and indicate which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
