### PR TITLE
fix inner link for preview page badge

### DIFF
--- a/app/views/exchanges/bulk_notices/new.html.erb
+++ b/app/views/exchanges/bulk_notices/new.html.erb
@@ -7,7 +7,7 @@
     <strong><%= l10n('important') %>:</strong> <p><%= l10n("admin_actions.bulk_upload.new.description_sub_text") %></p>
 
     <%= form_for(@bulk_notice, url: exchanges_bulk_notices_path, html: { multipart: true }) do |f| %>
-        <%= f.label :audience_type, l10n('select') %>
+        <%= f.label :audience_type, l10n('admin_actions.bulk_upload.audience_type') %>
         <%= f.select :audience_type, Admin::BulkNotice::RECIPIENTS, { selected: @bulk_notice.audience_type }, class: 'form-control w-auto pr-4', data: { target: 'bulk-notice.audienceSelect', reflex: 'change->BulkNotice#audience_select' } %>
         <table>
           <tbody>

--- a/app/views/exchanges/bulk_notices/preview.html.erb
+++ b/app/views/exchanges/bulk_notices/preview.html.erb
@@ -8,6 +8,7 @@
     <strong><%= l10n('important') %>:</strong> <p><%= l10n("admin_actions.bulk_upload.new.description_sub_text") %></p>
 
     <%= form_for(@bulk_notice, url: exchanges_bulk_notice_path(@bulk_notice)) do |f| %>
+      <%= f.label :audience_type, l10n('admin_actions.bulk_upload.audience_type') %>
       <%= f.select :audience_type, { 'Broker Agency' => :broker_agency, 'Employer' => :employer, 'General Agency' => :general_agency, 'Employee' => :employee }, { selected: @bulk_notice.audience_type }, class: 'form-control col-2', data: { reflex: 'change->BulkNotice#audience_select' } %>
       <table>
         <tbody>
@@ -16,10 +17,10 @@
             <td>
               <div id='recipient-list' class='collapsed float-left' data-target="bulk-notice.recipientList">
                 <% @bulk_notice.audience_ids.each do |identifier| %>
-                  <span class="badge badge-secondary mr-1 mb-1 p-2">
+                  <span class="badge badge-status badge-grey mb-2 mr-1">
                     <%= f.hidden_field :audience_ids, multiple: true, value: identifier %>
                     <%= BenefitSponsors::Organizations::Organization.find(identifier).hbx_id %>&nbsp;
-                    <a data-action='bulk-notice#deleteIdentifier' class='text-white' href>
+                    <a data-action='bulk-notice#deleteIdentifier' class='text-white' aria-label="Close" href>
                       <i class="far fa-times-circle"></i>
                     </a>
                   </span>

--- a/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
+++ b/components/financial_assistance/app/views/financial_assistance/deductions/index.html.erb
@@ -1,6 +1,6 @@
 <% if @bs4 %>
   <%= render partial: '/financial_assistance/shared/faa_progress_options', locals: {step: 4} %>
-  <h1><%= l10n("faa.deductions") %></h2>
+  <h1><%= l10n("faa.deductions") %></h1>
   <% applicant_name = @applicant.first_name.capitalize %>
   <p><%= l10n("faa.deductions.tell_us", applicant_name: applicant_name) %></p>
 

--- a/db/seedfiles/translations/en/me/admin_actions.rb
+++ b/db/seedfiles/translations/en/me/admin_actions.rb
@@ -19,6 +19,7 @@ ADMIN_ACTIONS_TRANSLATIONS = {
   'en.admin.config.set_day_failure' => "Failed to set date of record, %{error_message}",
   'en.admin_actions.bulk_upload.new.description_text' => 'Use this tool to send the same message or notice to a specific set of users. Copy and paste the FEINs or HBX IDs for the users who should get the message in their secure inbox. Remember, each FEIN or HBX ID must be separated by a comma.',
   'en.admin_actions.bulk_upload.new.description_sub_text' => 'The message and any attachments will be the same for everyone on the recipient list – they cannot be personalized. You can attach files in PDF, JPEG, or PNG formats.',
+  'en.admin_actions.bulk_upload.audience_type' => 'Select audience type',
   'en.admin_actions.bulk_upload.new.zero_more' => '0 more...',
   'en.admin_actions.bulk_upload.new.less' => 'Less...',
   'en.admin_actions.bulk_upload.new.recipient_placeholder' => 'FEINs or HBX IDs, comma separated',


### PR DESCRIPTION

# PR Checklist

Please check if your PR fulfills the following requirements:
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?:

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix, Migration, or Report (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188422377

# A brief description of the changes:

Current behavior: The badge is missing styles and the inner link has no content.

New behavior: The badge has new styles and the inner link is aria labelled.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and indicate which client(s) it applies to.

Variable name: `BS4_ADMIN_FLOW_IS_ENABLED

- [ ] DC
- [x] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
