### PR TITLE
default check box value to empty instead of false when unchecked

### DIFF
--- a/app/controllers/insured/family_members_controller.rb
+++ b/app/controllers/insured/family_members_controller.rb
@@ -74,6 +74,7 @@ class Insured::FamilyMembersController < ApplicationController
     @family = Family.find(params[:dependent][:family_id])
     authorize @family, :create?
 
+    reset_consumer_coverage_fields if params[:dependent][:is_applying_coverage] == "false"
     @dependent = ::Forms::FamilyMember.new(params[:dependent].merge({skip_consumer_role_callbacks: true}))
     @address_errors = validate_address_params(params)
 
@@ -179,6 +180,7 @@ class Insured::FamilyMembersController < ApplicationController
   def update
     authorize @family, :update?
 
+    reset_consumer_coverage_fields if params[:dependent][:is_applying_coverage] == "false"
     @dependent.skip_consumer_role_callbacks = true
     @address_errors = validate_address_params(params)
 
@@ -352,6 +354,26 @@ class Insured::FamilyMembersController < ApplicationController
 
   def dependent_person_params
     params.permit(:dependent => {})
+  end
+
+  def reset_consumer_coverage_fields
+    permitted_dependent_params = params.require(:dependent).permit!.to_h
+
+    if permitted_dependent_params["is_applying_coverage"] == "false"
+      fields_to_unset = {
+        us_citizen: nil,
+        naturalized_citizen: nil,
+        eligible_immigration_status: nil,
+        indian_tribe_member: nil,
+        is_incarcerated: nil
+      }
+
+      fields_to_unset.each do |field, value|
+        permitted_dependent_params[field.to_s] = value
+      end
+    end
+
+    params[:dependent] = permitted_dependent_params
   end
 
   def init_address_for_dependent

--- a/app/controllers/insured/family_members_controller.rb
+++ b/app/controllers/insured/family_members_controller.rb
@@ -357,9 +357,9 @@ class Insured::FamilyMembersController < ApplicationController
   end
 
   def reset_consumer_coverage_fields
-    permitted_dependent_params = params.require(:dependent).permit!.to_h
+    dependent_params = dependent_person_params[:dependent].to_h
 
-    if permitted_dependent_params["is_applying_coverage"] == "false"
+    if dependent_params["is_applying_coverage"] == "false"
       fields_to_unset = {
         us_citizen: nil,
         naturalized_citizen: nil,
@@ -369,11 +369,11 @@ class Insured::FamilyMembersController < ApplicationController
       }
 
       fields_to_unset.each do |field, value|
-        permitted_dependent_params[field.to_s] = value
+        dependent_params[field.to_s] = value
       end
     end
 
-    params[:dependent] = permitted_dependent_params
+    params[:dependent] = dependent_params
   end
 
   def init_address_for_dependent

--- a/app/views/shared/_consumer_fields.html.erb
+++ b/app/views/shared/_consumer_fields.html.erb
@@ -43,22 +43,18 @@
           <%= render partial: 'shared/modal_support_text_household', locals: {key: "naturalized_citizen"} %>
         </div>
 
-        <div class="<%= 'hidden_field' unless show_immigration_status_container(f.object) %> mb-4" id="immigration_status_container">
-          <% if EnrollRegistry[:immigration_status_checkbox].enabled? %>
-            <%= f.label :eligible_immigration_status do %>
-              <%= l10n('faa.question.eligible_immigration_status') %>
-              <div class="alert alert-info d-flex" role="info">
-                <div>
-                  <div class="info-icon icon" alt="info" aria-hidden="true">&nbsp;</div>
-                </div>
-                <div class="mt-1 mb-1">
-                  <%= l10n('faa.question.immigration_continue_note_1') %>
-                  <%= l10n('faa.question.immigration_continue_note_2') %>
-                </div>
-              </div>
-            <% end %>
-            <div id="immigration-checkbox">
-              <%= f.check_box :eligible_immigration_status, {}, "true", "false" %> <span class="ml-1"><%= l10n('yes') %></span>
+      <div class="row row-form-wrapper no-buffer <%= 'hidden_field' unless show_immigration_status_container(f.object) %>" id="immigration_status_container">
+        <div class="col-lg-6 col-md-6 col-sm-4 col-xs-6 form-group form-group-lg top-buffer">
+          <label>
+            <%= l10n('faa.question.eligible_immigration_status') %>
+            <%= l10n('faa.question.immigration_continue_note_1') %>
+            <%= l10n('faa.question.immigration_continue_note_2') %>
+          </label>
+        </div>
+        <% if EnrollRegistry[:immigration_status_checkbox].enabled? %>
+          <div class="col-lg-4 col-md-4 col-sm-8 col-xs-6 form-group form-group-lg no-pd">
+            <div id="immigration-checkbox" class="checkbox">
+              <%= f.check_box :eligible_immigration_status, {}, "true", "" %><%= l10n('yes') %>
             </div>
           <% else %>
             <fieldset>

--- a/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
+++ b/spec/controllers/insured/family_members_controller/family_members_controller_update_spec.rb
@@ -3,35 +3,35 @@
 require "rails_helper"
 
 RSpec.describe Insured::FamilyMembersController do
+  let(:person) {FactoryBot.create(:person)}
+  let(:user) { FactoryBot.create(:user, person: person) }
+  let!(:family) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person) }
+
+  let(:dependent) do
+    instance_double(
+      Forms::FamilyMember,
+      addresses: [],
+      same_with_primary: 'true',
+      family_id: family.id,
+      family_member: family_member
+    )
+  end
+  let(:family_member) { family.family_members.where(:is_primary_applicant => false).first }
+  let(:consumer_role) { FactoryBot.create(:consumer_role, person: person) }
+  let!(:dependent_consumer_role) { FactoryBot.create(:consumer_role, person: family_member.person) }
+
+  let(:dependent_controller_parameters) do
+    ActionController::Parameters.new(dependent_update_properties).permit!
+  end
+
+  before(:each) do
+    consumer_role.move_identity_documents_to_verified
+    dependent_consumer_role.update!(is_applying_coverage: true)
+    allow(dependent).to receive(:skip_consumer_role_callbacks=).with(true)
+    sign_in(user)
+  end
+
   describe "PUT update, for an IVL market dependent with a consumer role" do
-    let(:person) {FactoryBot.create(:person)}
-    let(:user) { FactoryBot.create(:user, person: person) }
-    let!(:family) { FactoryBot.create(:family, :with_primary_family_member_and_dependent, person: person) }
-
-    let(:dependent) do
-      instance_double(
-        Forms::FamilyMember,
-        addresses: [],
-        same_with_primary: 'true',
-        family_id: family.id,
-        family_member: family_member
-      )
-    end
-    let(:family_member) { family.family_members.where(:is_primary_applicant => false).first }
-    let(:consumer_role) { FactoryBot.create(:consumer_role, person: person) }
-    let!(:dependent_consumer_role) { FactoryBot.create(:consumer_role, person: family_member.person) }
-
-    let(:dependent_controller_parameters) do
-      ActionController::Parameters.new(dependent_update_properties).permit!
-    end
-
-    before(:each) do
-      consumer_role.move_identity_documents_to_verified
-      dependent_consumer_role.update!(is_applying_coverage: true)
-      allow(dependent).to receive(:skip_consumer_role_callbacks=).with(true)
-      sign_in(user)
-    end
-
     describe "when the value for 'is_applying_coverage' is provided" do
       let(:dependent_update_properties) do
         { "first_name" => "Dependent First Name", "same_with_primary" => "true", "is_applying_coverage" => "false" }
@@ -54,6 +54,33 @@ RSpec.describe Insured::FamilyMembersController do
         expect(dependent_consumer_role).not_to receive(:update_attribute)
         put :update, params: {id: family_member.id, dependent: dependent_update_properties}
         expect(dependent_consumer_role.is_applying_coverage).to eq true
+      end
+    end
+  end
+
+  context "PUT update, consumer not applying for coverage" do
+    context "when the immigration fields are provided" do
+      let(:dependent_update_properties) do
+        {"first_name" => "Dependent First Name", "middle_name" => "", "last_name" => "test6", "name_sfx" => "", "dob" => "2024-10-01",
+         "gender" => "male", "no_ssn" => "[FILTERED]", "is_applying_coverage" => "false",
+         "relationship" => "child", "us_citizen" => "false", "eligible_immigration_status" => "true",
+         "indian_tribe_member" => "true", "tribal_state" => "AZ", "tribe_codes" => [""], "tribal_name" => "6554bge", "is_incarcerated" => "false",
+         "ethnicity" => ["", "", "", "", "", "", ""],
+         "is_consumer_role" => "true", "same_with_primary" => "false",
+         "addresses" => {"0" => {"kind" => "home", "_destroy" => "false", "address_1" => "123", "address_2" => "", "city" => "test",
+                                 "state" => "AR", "zip" => "04001", "county" => "York"},
+                         "1" => {"kind" => "mailing", "_destroy" => "false", "address_1" => "123", "address_2" => "", "city" => "mail", "state" => "AS",
+                                 "zip" => "01578", "county" => "Zip code outside supported area"}}, "is_homeless" => "0", "family_id" => family.id}
+      end
+
+      it "should set consumer fields values to nil" do
+        expect(dependent_consumer_role.is_applying_coverage).to eq true
+        expect(dependent_consumer_role.is_incarcerated).to eq false
+        put :update, params: {id: family_member.id, dependent: dependent_update_properties}
+        dependent_consumer_role.person.reload
+        dependent_consumer_role.reload
+        expect(dependent_consumer_role.is_applying_coverage).to eq false
+        expect(dependent_consumer_role.is_incarcerated).to eq nil
       end
     end
   end


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes/features), and they use `let` helpers and `before` blocks.
- [ ] For all UI changes, there is Cucumber coverage.
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, the reasoning is documented in the PR and code.
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run them is documented in both the PR and the code.
- [ ] There are no inline styles added.
- [ ] There is no inline JavaScript added.
- [ ] There is no hard-coded text added/updated in helpers/views/JavaScript. New/updated translation strings do not include markup/styles unless there is supporting documentation.
- [ ] Code does not use `.html_safe`.
- [ ] All images added/updated have alt text.
- [x] Does not bypass RuboCop rules in any way.

# PR Type
What kind of change does this PR introduce?:

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix, Migration, or Report (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/n/projects/2640060/stories/188303646

# A brief description of the changes:

Current behavior:  when consumer is not applying for coverage, the immigration fields are storing with default values

New behavior: when consumer is not applying for coverage, consumer fields will be defaulted to nil value.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and indicate which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
