### PR TITLE
fix contrast error on send secure message banner

### DIFF
--- a/app/views/exchanges/hbx_profiles/_new_secure_message.html.erb
+++ b/app/views/exchanges/hbx_profiles/_new_secure_message.html.erb
@@ -1,9 +1,22 @@
 <%if @error_on_save %>
-  <div class='alert alert-error'><a class='close' data-dismiss='alert'>x</a>
-    <%@error_on_save.each do |err|%>
-      <li><%=err[1][0]%></li>
-    <%end%>
-  </div>
+  <% if @bs4 %>
+    <div class="alert alert-error d-flex align-items-start">
+      <div class="col mr-auto p-0 align-self-center">
+        <%@error_on_save.each do |err|%>
+          <li><%=err[1][0]%></li>
+        <%end%>
+      </div>
+      <div class="d-flex pl-1">
+        <a class="close-icon icon icon-sm pr-1" data-dismiss="alert" alt="<%= l10n("close") %>" href="#">&nbsp;<span class="sr-only"><%= l10n("close") %></span></a>
+      </div>
+    </div>
+  <% else %>
+    <div class='alert alert-error'>
+      <%@error_on_save.each do |err|%>
+        <li><%=err[1][0]%></li>
+      <%end%>
+    </div>
+  <% end %>
 <%end%>
 
 <% if @bs4 %>


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bugfixes/features), they use let helpers and before blocks
- [x] For all UI changes, there is cucumber coverage
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, reasoning is documented in PR and code
- [x] Any endpoint modified in the PR only responds to the expected MIME types.
- [x] For all scripts or rake tasks, how to run it is documented on both the PR and in the code
- [x] There are no inline styles added
- [x] There are no inline javascript added
- [x] There is no hard coded text added/updated in helpers/views/Javascript. New/updated translation strings do not include markup/styles, unless there is supporting documentation
- [x] Code does not use .html_safe
- [x] All images added/updated have alt text
- [x] Doesn’t bypass rubocop rules in any way

# PR Type
What kind of change does this PR introduce?:

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix, Migration, or Report (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: https://www.pivotaltracker.com/story/show/188402649

# A brief description of the changes:

Current behavior: Legacy banner is used on error banner with contrast error.

New behavior: New banner UI is used instead without the contrast error.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and indicate which client(s) it applies to.

Variable name: `BS4_ADMIN_FLOW_IS_ENABLED`

- [ ] DC
- [X] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
