### PR TITLE
add json format for sep zip compare

### DIFF
--- a/app/views/insured/families/_moving_fields.html.erb
+++ b/app/views/insured/families/_moving_fields.html.erb
@@ -136,7 +136,7 @@
     $.ajax({
       type: "GET",
       data:{old_zip: $('.old_zip_code').val(), new_zip: $('.new_zip_code').val()},
-      url: "/insured/families/sep_zip_compare.js",
+      url: "/insured/families/sep_zip_compare.json",
       success: function(response){
         if (response.is_approved) {
           $.ajax({

--- a/spec/controllers/insured/families_controller_spec.rb
+++ b/spec/controllers/insured/families_controller_spec.rb
@@ -1372,7 +1372,7 @@ RSpec.describe Insured::FamiliesController, dbclean: :after_each do
 
           let(:old_zip) { '12312' }
 
-          it "should accept JS format" do
+          it "should accept JSON format" do
             expect(response).to have_http_status(:success)
           end
         end

--- a/spec/controllers/insured/families_controller_spec.rb
+++ b/spec/controllers/insured/families_controller_spec.rb
@@ -1306,13 +1306,6 @@ RSpec.describe Insured::FamiliesController, dbclean: :after_each do
     # TODO: Refactor this
     # Will need to make it work without this
     # Also for MA too
-
-    before(:each) do
-      allow()
-      sign_in(user)
-      get :sep_zip_compare, params: {old_zip: old_zip, new_zip: new_zip}, format: :json
-    end
-
     if EnrollRegistry[:enroll_app].setting(:site_key) == 'me'
       let!(:service_area) { FactoryBot.create(:benefit_markets_locations_service_area, covered_states: nil, county_zip_ids: [county_zip.id]) }
       let(:county_zip) { FactoryBot.create(:benefit_markets_locations_county_zip, zip: '04330', county_name: 'Kennebec')}
@@ -1321,6 +1314,10 @@ RSpec.describe Insured::FamiliesController, dbclean: :after_each do
       end
       let(:rejected_response) do
         {is_approved: false}.to_json
+      end
+      before(:each) do
+        sign_in(user)
+        get :sep_zip_compare, params: {old_zip: old_zip, new_zip: new_zip}, format: :json
       end
 
       context 'new zip is outside state' do

--- a/spec/controllers/insured/families_controller_spec.rb
+++ b/spec/controllers/insured/families_controller_spec.rb
@@ -1306,7 +1306,7 @@ RSpec.describe Insured::FamiliesController, dbclean: :after_each do
     # TODO: Refactor this
     # Will need to make it work without this
     # Also for MA too
-    if EnrollRegistry[:enroll_app].setting(:site_key) == 'me'
+    if EnrollRegistry[:enroll_app].setting(:site_key).item.to_s == 'me'
       let!(:service_area) { FactoryBot.create(:benefit_markets_locations_service_area, covered_states: nil, county_zip_ids: [county_zip.id]) }
       let(:county_zip) { FactoryBot.create(:benefit_markets_locations_county_zip, zip: '04330', county_name: 'Kennebec')}
       let(:approved_response) do
@@ -1317,7 +1317,7 @@ RSpec.describe Insured::FamiliesController, dbclean: :after_each do
       end
       before(:each) do
         sign_in(user)
-        get :sep_zip_compare, params: {old_zip: old_zip, new_zip: new_zip}
+        get :sep_zip_compare, params: {old_zip: old_zip, new_zip: new_zip}, format: :json
       end
 
       context 'new zip is outside state' do
@@ -1359,9 +1359,22 @@ RSpec.describe Insured::FamiliesController, dbclean: :after_each do
             )
           end
           let(:old_zip) { old_county_zip.zip }
+          let(:new_zip) { '04057' }
+
+          let(:county_zip) { BenefitMarkets::Locations::CountyZip.create(zip: '04057', county_name: 'Cumberland', state: 'ME') }
 
           it 'should return true' do
+            binding.irb
             expect(response.body).to eq approved_response
+          end
+        end
+
+        context "with valid mime types" do
+
+          let(:old_zip) { '12312' }
+
+          it "should accept JS format" do
+            expect(response).to have_http_status(:success)
           end
         end
       end

--- a/spec/controllers/insured/families_controller_spec.rb
+++ b/spec/controllers/insured/families_controller_spec.rb
@@ -1364,7 +1364,6 @@ RSpec.describe Insured::FamiliesController, dbclean: :after_each do
           let(:county_zip) { BenefitMarkets::Locations::CountyZip.create(zip: '04057', county_name: 'Cumberland', state: 'ME') }
 
           it 'should return true' do
-            binding.irb
             expect(response.body).to eq approved_response
           end
         end

--- a/spec/controllers/insured/families_controller_spec.rb
+++ b/spec/controllers/insured/families_controller_spec.rb
@@ -1306,7 +1306,14 @@ RSpec.describe Insured::FamiliesController, dbclean: :after_each do
     # TODO: Refactor this
     # Will need to make it work without this
     # Also for MA too
-    if EnrollRegistry[:enroll_app].setting(:site_key).item.to_s == 'me'
+
+    before(:each) do
+      allow()
+      sign_in(user)
+      get :sep_zip_compare, params: {old_zip: old_zip, new_zip: new_zip}, format: :json
+    end
+
+    if EnrollRegistry[:enroll_app].setting(:site_key) == 'me'
       let!(:service_area) { FactoryBot.create(:benefit_markets_locations_service_area, covered_states: nil, county_zip_ids: [county_zip.id]) }
       let(:county_zip) { FactoryBot.create(:benefit_markets_locations_county_zip, zip: '04330', county_name: 'Kennebec')}
       let(:approved_response) do
@@ -1314,10 +1321,6 @@ RSpec.describe Insured::FamiliesController, dbclean: :after_each do
       end
       let(:rejected_response) do
         {is_approved: false}.to_json
-      end
-      before(:each) do
-        sign_in(user)
-        get :sep_zip_compare, params: {old_zip: old_zip, new_zip: new_zip}, format: :json
       end
 
       context 'new zip is outside state' do


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes/features), and they use `let` helpers and `before` blocks.
- [ ] For all UI changes, there is Cucumber coverage.
- [x] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, the reasoning is documented in the PR and code.
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run them is documented in both the PR and the code.
- [x] There are no inline styles added.
- [x] There is no inline JavaScript added.
- [x] There is no hard-coded text added/updated in helpers/views/JavaScript. New/updated translation strings do not include markup/styles unless there is supporting documentation.
- [x] Code does not use `.html_safe`.
- [ ] All images added/updated have alt text.
- [x] Does not bypass RuboCop rules in any way.

# PR Type
What kind of change does this PR introduce?:

- [x] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix, Migration, or Report (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [Pod of War-188355124](https://www.pivotaltracker.com/n/projects/2640060/stories/188355124)

# A brief description of the changes:

Current behavior: The SEP moved or about to move does not allow the user to continue

New behavior: The SEP now allows the user to continue to the plan shopping page.

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and indicate which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
