### PR TITLE
improve logging around individual determination verifications

### DIFF
--- a/app/domain/operations/consumer_roles/on_update.rb
+++ b/app/domain/operations/consumer_roles/on_update.rb
@@ -48,6 +48,7 @@ module Operations
           logger.info "ConsumerRole DetermineVerifications success: #{result.success}"
           Success("ConsumerRole DetermineVerifications success: #{result.success}")
         else
+          Rails.logger.info { "ConsumerRole DetermineVerifications for consumer role: #{role.id}; failure: #{result.failure}"}
           logger.info "ConsumerRole DetermineVerifications failure: #{result.failure}"
           Failure("ConsumerRole DetermineVerifications failure: #{result.failure}")
         end

--- a/app/event_source/subscribers/lawful_presence_determinations_subscriber.rb
+++ b/app/event_source/subscribers/lawful_presence_determinations_subscriber.rb
@@ -30,6 +30,7 @@ module Subscribers
 
       result = ::Operations::Individual::DetermineVerifications.new.call({id: payload[:consumer_role_id]})
       result_str = result.success? ? "Success: #{result.success}" : "Failure: #{result.failure}"
+      Rails.logger.info { "LawfulPresenceDeterminationsSubscriber, determine_verifications Failure for consumer role: #{consumer_role_id}; failure reason: #{result_str}" } if result.failure?
       subscriber_logger.info "LawfulPresenceDeterminationsSubscriber, determine_verifications result: #{result_str}"
     rescue StandardError => e
       subscriber_logger.error "Error: LawfulPresenceDeterminationsSubscriber, error message: #{e.message}, backtrace: #{e.backtrace}"

--- a/app/event_source/subscribers/lawful_presence_determinations_subscriber.rb
+++ b/app/event_source/subscribers/lawful_presence_determinations_subscriber.rb
@@ -30,7 +30,7 @@ module Subscribers
 
       result = ::Operations::Individual::DetermineVerifications.new.call({id: payload[:consumer_role_id]})
       result_str = result.success? ? "Success: #{result.success}" : "Failure: #{result.failure}"
-      Rails.logger.info { "LawfulPresenceDeterminationsSubscriber, determine_verifications Failure for consumer role: #{consumer_role_id}; failure reason: #{result_str}" } if result.failure?
+      Rails.logger.info { "LawfulPresenceDeterminationsSubscriber, determine_verifications Failure for consumer role: #{payload[:consumer_role_id]}; failure reason: #{result_str}" } if result.failure?
       subscriber_logger.info "LawfulPresenceDeterminationsSubscriber, determine_verifications result: #{result_str}"
     rescue StandardError => e
       subscriber_logger.error "Error: LawfulPresenceDeterminationsSubscriber, error message: #{e.message}, backtrace: #{e.backtrace}"


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:
- [x] The title follows our [guidelines](https://github.com/ideacrew/enroll/blob/trunk/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes/features), and they use `let` helpers and `before` blocks.
- [ ] For all UI changes, there is Cucumber coverage.
- [ ] Any endpoint touched in the PR has an appropriate Pundit policy. For open endpoints, the reasoning is documented in the PR and code.
- [ ] Any endpoint modified in the PR only responds to the expected MIME types.
- [ ] For all scripts or rake tasks, how to run them is documented in both the PR and the code.
- [ ] There are no inline styles added.
- [ ] There is no inline JavaScript added.
- [ ] There is no hard-coded text added/updated in helpers/views/JavaScript. New/updated translation strings do not include markup/styles unless there is supporting documentation.
- [ ] Code does not use `.html_safe`.
- [ ] All images added/updated have alt text.
- [ ] Does not bypass RuboCop rules in any way.

# PR Type
What kind of change does this PR introduce?:

- [ ] Bugfix
- [ ] Feature (requires Feature flag)
- [ ] Data fix, Migration, or Report (inert code, no impact until run)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Dependency updates (e.g., add a new gem or update to a version)

# What is the ticket # detailing the issue?

Ticket: [Pod of War-188448214](https://www.pivotaltracker.com/n/projects/2640060/stories/188448214)

# A brief description of the changes:

Current behavior: We are not logging determination verifications failure reasons to Graylog

New behavior: Improve logging when individual determination verifications fails

# Feature Flag

For all new feature development, a feature flag is required to control the exposure of the feature to our end users. A feature flag needs a corresponding environment variable to initialize the state of the flag. Please share the name of the environment variable below that would enable/disable the feature and indicate which client(s) it applies to.

Variable name:

- [ ] DC
- [ ] ME

# Additional Context
Include any additional context that may be relevant to the peer review process.
